### PR TITLE
Add Interleave2, Deinterleave2, ConvolveValidMulti for audio DSP

### DIFF
--- a/c128/c128_amd64.go
+++ b/c128/c128_amd64.go
@@ -14,10 +14,10 @@ const (
 
 // Function pointer types for SIMD operations
 type (
-	binaryOpFunc     func(dst, a, b []complex128)
-	scaleFunc        func(dst, a []complex128, s complex128)
-	unaryAbsFunc     func(dst []float64, a []complex128)
-	unaryConjFunc    func(dst, a []complex128)
+	binaryOpFunc  func(dst, a, b []complex128)
+	scaleFunc     func(dst, a []complex128, s complex128)
+	unaryAbsFunc  func(dst []float64, a []complex128)
+	unaryConjFunc func(dst, a []complex128)
 )
 
 // Function pointers - assigned at init time based on CPU features

--- a/c128/c128_arm64.s
+++ b/c128/c128_arm64.s
@@ -281,7 +281,7 @@ abssq_neon_done:
 // This is a stub that falls back to Go implementation
 
 // func phaseNEON(dst []float64, a []complex128)
-TEXT ·phaseNEON(SB), $0-56
+TEXT ·phaseNEON(SB), NOSPLIT, $0-56
     B ·phaseGo(SB)
 
 // ============================================================================

--- a/c128/c128_arm64.s
+++ b/c128/c128_arm64.s
@@ -10,6 +10,16 @@
 // NEON processes 128 bits = 2 float64 = 1 complex128 per iteration
 //
 // Complex multiplication: (a + bi)(c + di) = (ac - bd) + (ad + bc)i
+//
+// NEON opcode formulas for float64 (2D arrangement):
+// FMUL Vd.2D, Vn.2D, Vm.2D: 0x6E60DC00 | (Vm << 16) | (Vn << 5) | Vd
+// FADD Vd.2D, Vn.2D, Vm.2D: 0x4E60D400 | (Vm << 16) | (Vn << 5) | Vd
+// FSUB Vd.2D, Vn.2D, Vm.2D: 0x4EE0D400 | (Vm << 16) | (Vn << 5) | Vd
+//
+// Note: In Go ARM64 asm:
+// - F0-F31 alias the low 64 bits of V0-V31 (F0 = V0.D[0])
+// - To access V0.D[1], use VDUP V0.D[1], V1.D2, then F1 has that value
+// - VMOV Vn.D[x], Rm moves vector element to general-purpose register
 
 // func mulNEON(dst, a, b []complex128)
 TEXT ·mulNEON(SB), NOSPLIT, $0-72
@@ -22,32 +32,31 @@ TEXT ·mulNEON(SB), NOSPLIT, $0-72
 
 mul_neon_loop:
     // Load one complex128 from a and b
-    VLD1 (R2), [V0.D2]           // V0 = [ar, ai]
-    VLD1 (R3), [V1.D2]           // V1 = [br, bi]
+    VLD1 (R2), [V0.D2]           // V0 = [ar, ai], F0 = ar
+    VLD1 (R3), [V1.D2]           // V1 = [br, bi], F1 = br
 
-    // Duplicate real part of a: V2 = [ar, ar]
-    VDUP V0.D[0], V2.D2
+    // Extract all four components to scalar registers
+    // ar is already in F0 (low 64 bits of V0)
+    // br is already in F1 (low 64 bits of V1)
+    VDUP V0.D[1], V2.D2          // V2 = [ai, ai], F2 = ai
+    VDUP V1.D[1], V3.D2          // V3 = [bi, bi], F3 = bi
 
-    // Duplicate imag part of a: V3 = [ai, ai]
-    VDUP V0.D[1], V3.D2
-
-    // Swap b: V4 = [bi, br]
-    VEXT $8, V1.B16, V1.B16, V4.B16
-
-    // V2 = ar * b = [ar*br, ar*bi]
-    FMULD V1.D2, V2.D2, V2.D2
-
-    // V5 = ai * swapped_b = [ai*bi, ai*br]
-    FMULD V4.D2, V3.D2, V5.D2
+    // Complex multiplication: (ar + ai*i)(br + bi*i) = (ar*br - ai*bi) + (ar*bi + ai*br)*i
+    // Compute products using scalar FP registers
+    FMULD F0, F1, F4             // F4 = ar * br
+    FMULD F2, F3, F5             // F5 = ai * bi
+    FMULD F0, F3, F6             // F6 = ar * bi
+    FMULD F2, F1, F7             // F7 = ai * br
 
     // result_real = ar*br - ai*bi
-    // result_imag = ar*bi + ai*br
-    // V2[0] = V2[0] - V5[0], V2[1] = V2[1] + V5[1]
-    // Use FSUB for real, FADD for imag
-    FSUBD V5.D[0], V2.D[0], V6.D[0]
-    FADDD V5.D[1], V2.D[1], V6.D[1]
+    FSUBD F5, F4, F4             // F4 = ar*br - ai*bi
 
-    VST1 [V6.D2], (R0)
+    // result_imag = ar*bi + ai*br
+    FADDD F6, F7, F5             // F5 = ar*bi + ai*br
+
+    // Store result directly to memory
+    FMOVD F4, (R0)               // Store real part
+    FMOVD F5, 8(R0)              // Store imag part
 
     ADD  $16, R2
     ADD  $16, R3
@@ -59,6 +68,7 @@ mul_neon_done:
     RET
 
 // func mulConjNEON(dst, a, b []complex128)
+// a * conj(b) = (ar + ai*i)(br - bi*i) = (ar*br + ai*bi) + (ai*br - ar*bi)*i
 TEXT ·mulConjNEON(SB), NOSPLIT, $0-72
     MOVD dst_base+0(FP), R0
     MOVD dst_len+8(FP), R1
@@ -68,25 +78,28 @@ TEXT ·mulConjNEON(SB), NOSPLIT, $0-72
     CBZ  R1, mulconj_neon_done
 
 mulconj_neon_loop:
-    VLD1 (R2), [V0.D2]           // [ar, ai]
-    VLD1 (R3), [V1.D2]           // [br, bi]
+    VLD1 (R2), [V0.D2]           // V0 = [ar, ai], F0 = ar
+    VLD1 (R3), [V1.D2]           // V1 = [br, bi], F1 = br
 
-    VDUP V0.D[0], V2.D2          // [ar, ar]
-    VDUP V0.D[1], V3.D2          // [ai, ai]
+    // Extract components
+    VDUP V0.D[1], V2.D2          // F2 = ai
+    VDUP V1.D[1], V3.D2          // F3 = bi
 
-    // For a * conj(b) = [ar*br + ai*bi, ai*br - ar*bi]
-    // V4 = ar * b = [ar*br, ar*bi]
-    FMULD V1.D2, V2.D2, V4.D2
-
-    // V5 = ai * b = [ai*br, ai*bi]
-    FMULD V1.D2, V3.D2, V5.D2
+    // Compute products
+    FMULD F0, F1, F4             // F4 = ar * br
+    FMULD F2, F3, F5             // F5 = ai * bi
+    FMULD F2, F1, F6             // F6 = ai * br
+    FMULD F0, F3, F7             // F7 = ar * bi
 
     // result_real = ar*br + ai*bi
-    // result_imag = ai*br - ar*bi
-    FADDD V5.D[1], V4.D[0], V6.D[0]    // ar*br + ai*bi
-    FSUBD V4.D[1], V5.D[0], V6.D[1]    // ai*br - ar*bi
+    FADDD F4, F5, F4             // F4 = ar*br + ai*bi
 
-    VST1 [V6.D2], (R0)
+    // result_imag = ai*br - ar*bi
+    FSUBD F7, F6, F5             // F5 = ai*br - ar*bi
+
+    // Store result
+    FMOVD F4, (R0)
+    FMOVD F5, 8(R0)
 
     ADD  $16, R2
     ADD  $16, R3
@@ -98,44 +111,37 @@ mulconj_neon_done:
     RET
 
 // func scaleNEON(dst, a []complex128, s complex128)
+// a * s = (ar + ai*i)(sr + si*i) = (ar*sr - ai*si) + (ar*si + ai*sr)*i
 TEXT ·scaleNEON(SB), NOSPLIT, $0-64
     MOVD dst_base+0(FP), R0
     MOVD dst_len+8(FP), R1
     MOVD a_base+24(FP), R2
-    // s is at s+48(FP) (real) and s+56(FP) (imag)
 
-    FMOVD s+48(FP), F16          // sr
-    FMOVD s+56(FP), F17          // si
-
-    VDUP F16, V6.D2              // [sr, sr]
-    VDUP F17, V7.D2              // [si, si]
+    // Load scalar s once
+    FMOVD s+48(FP), F20          // F20 = sr (kept across loop)
+    FMOVD s+56(FP), F21          // F21 = si (kept across loop)
 
     CBZ  R1, scale_neon_done
 
 scale_neon_loop:
-    VLD1 (R2), [V0.D2]           // [ar, ai]
+    VLD1 (R2), [V0.D2]           // V0 = [ar, ai], F0 = ar
+    VDUP V0.D[1], V1.D2          // F1 = ai
 
-    VDUP V0.D[0], V2.D2          // [ar, ar]
-    VDUP V0.D[1], V3.D2          // [ai, ai]
+    // Compute products
+    FMULD F0, F20, F2            // F2 = ar * sr
+    FMULD F1, F21, F3            // F3 = ai * si
+    FMULD F0, F21, F4            // F4 = ar * si
+    FMULD F1, F20, F5            // F5 = ai * sr
 
-    // V4 = ar * [sr, si] = [ar*sr, ar*si]
-    // V5 = ai * [si, sr] = [ai*si, ai*sr]
-    // We need: [ar*sr - ai*si, ar*si + ai*sr]
+    // result_real = ar*sr - ai*si
+    FSUBD F3, F2, F2             // F2 = ar*sr - ai*si
 
-    // Create [sr, si] and [si, sr]
-    VMOV V6.D[0], V4.D[0]
-    VMOV V7.D[0], V4.D[1]        // V4 = [sr, si]
+    // result_imag = ar*si + ai*sr
+    FADDD F4, F5, F3             // F3 = ar*si + ai*sr
 
-    VMOV V7.D[0], V5.D[0]
-    VMOV V6.D[0], V5.D[1]        // V5 = [si, sr]
-
-    FMULD V4.D2, V2.D2, V2.D2    // [ar*sr, ar*si]
-    FMULD V5.D2, V3.D2, V3.D2    // [ai*si, ai*sr]
-
-    FSUBD V3.D[0], V2.D[0], V8.D[0]    // ar*sr - ai*si
-    FADDD V3.D[1], V2.D[1], V8.D[1]    // ar*si + ai*sr
-
-    VST1 [V8.D2], (R0)
+    // Store result
+    FMOVD F2, (R0)
+    FMOVD F3, 8(R0)
 
     ADD  $16, R2
     ADD  $16, R0
@@ -146,6 +152,7 @@ scale_neon_done:
     RET
 
 // func addNEON(dst, a, b []complex128)
+// Vector add - can use NEON FADD since we're adding both real and imag
 TEXT ·addNEON(SB), NOSPLIT, $0-72
     MOVD dst_base+0(FP), R0
     MOVD dst_len+8(FP), R1
@@ -157,7 +164,7 @@ TEXT ·addNEON(SB), NOSPLIT, $0-72
 add_neon_loop:
     VLD1 (R2), [V0.D2]
     VLD1 (R3), [V1.D2]
-    FADDD V0.D2, V1.D2, V2.D2
+    WORD $0x4E61D402             // FADD V2.2D, V0.2D, V1.2D
     VST1 [V2.D2], (R0)
     ADD  $16, R2
     ADD  $16, R3
@@ -169,6 +176,7 @@ add_neon_done:
     RET
 
 // func subNEON(dst, a, b []complex128)
+// Vector sub - can use NEON FSUB since we're subtracting both real and imag
 TEXT ·subNEON(SB), NOSPLIT, $0-72
     MOVD dst_base+0(FP), R0
     MOVD dst_len+8(FP), R1
@@ -180,7 +188,7 @@ TEXT ·subNEON(SB), NOSPLIT, $0-72
 sub_neon_loop:
     VLD1 (R2), [V0.D2]
     VLD1 (R3), [V1.D2]
-    FSUBD V1.D2, V0.D2, V2.D2
+    WORD $0x4EE1D402             // FSUB V2.2D, V0.2D, V1.2D
     VST1 [V2.D2], (R0)
     ADD  $16, R2
     ADD  $16, R3
@@ -204,22 +212,23 @@ TEXT ·absNEON(SB), NOSPLIT, $0-56
     CBZ  R1, abs_neon_done
 
 abs_neon_loop:
-    VLD1 (R2), [V0.D2]     // V0 = [real, imag]
+    VLD1 (R2), [V0.D2]           // V0 = [real, imag], F0 = real
+    VDUP V0.D[1], V1.D2          // F1 = imag
 
-    // V1 = real * real
-    FMULD V0.D[0], V0.D[0], V1.D[0]
+    // F2 = real * real
+    FMULD F0, F0, F2
 
-    // V2 = imag * imag
-    FMULD V0.D[1], V0.D[1], V2.D[0]
+    // F3 = imag * imag
+    FMULD F1, F1, F3
 
-    // V1 = real² + imag²
-    FADDD V2.D[0], V1.D[0], V1.D[0]
+    // F4 = real² + imag²
+    FADDD F2, F3, F4
 
-    // V0 = sqrt(real² + imag²)
-    FSQRTD V1.D[0], V0.D[0]
+    // F5 = sqrt(real² + imag²)
+    FSQRTD F4, F5
 
     // Store result (single float64)
-    VST1 [V0.D1], (R0)
+    FMOVD F5, (R0)
 
     ADD  $16, R2
     ADD  $8, R0
@@ -242,19 +251,20 @@ TEXT ·absSqNEON(SB), NOSPLIT, $0-56
     CBZ  R1, abssq_neon_done
 
 abssq_neon_loop:
-    VLD1 (R2), [V0.D2]     // V0 = [real, imag]
+    VLD1 (R2), [V0.D2]           // V0 = [real, imag], F0 = real
+    VDUP V0.D[1], V1.D2          // F1 = imag
 
-    // V1 = real * real
-    FMULD V0.D[0], V0.D[0], V1.D[0]
+    // F2 = real * real
+    FMULD F0, F0, F2
 
-    // V2 = imag * imag
-    FMULD V0.D[1], V0.D[1], V2.D[0]
+    // F3 = imag * imag
+    FMULD F1, F1, F3
 
-    // V1 = real² + imag²
-    FADDD V2.D[0], V1.D[0], V1.D[0]
+    // F4 = real² + imag²
+    FADDD F2, F3, F4
 
     // Store result (single float64)
-    VST1 [V1.D1], (R0)
+    FMOVD F4, (R0)
 
     ADD  $16, R2
     ADD  $8, R0
@@ -268,31 +278,11 @@ abssq_neon_done:
 // PHASE - PHASE ANGLE: atan2(imag, real)
 // ============================================================================
 // Note: atan2 is not available as NEON instruction
-// We extract the imaginary component and return it as placeholder
-// Production code should call math.Atan2 or use approximation
+// This is a stub that falls back to Go implementation
 
 // func phaseNEON(dst []float64, a []complex128)
-TEXT ·phaseNEON(SB), NOSPLIT, $0-56
-    MOVD dst_base+0(FP), R0
-    MOVD dst_len+8(FP), R1
-    MOVD a_base+24(FP), R2
-
-    CBZ  R1, phase_neon_done
-
-phase_neon_loop:
-    VLD1 (R2), [V0.D2]     // V0 = [real, imag]
-
-    // Extract imaginary part (lane 1) as placeholder
-    // In production, should compute atan2(imag, real)
-    VST1 [V0.D1], (R0)     // Store lane 1 (imag) temporarily
-
-    ADD  $16, R2
-    ADD  $8, R0
-    SUB  $1, R1
-    CBNZ R1, phase_neon_loop
-
-phase_neon_done:
-    RET
+TEXT ·phaseNEON(SB), $0-56
+    B ·phaseGo(SB)
 
 // ============================================================================
 // CONJ - COMPLEX CONJUGATE: conj(a + bi) = a - bi
@@ -307,25 +297,15 @@ TEXT ·conjNEON(SB), NOSPLIT, $0-72
     CBZ  R1, conj_neon_done
 
 conj_neon_loop:
-    VLD1 (R2), [V0.D2]     // V0 = [real, imag]
+    VLD1 (R2), [V0.D2]           // V0 = [real, imag], F0 = real
+    VDUP V0.D[1], V1.D2          // F1 = imag
 
-    // Negate imaginary part: V1 = [real, -imag]
-    FNEGD V0.D[1], V1.D[1]
-    VMOV V0.D[0], V1.D[0]  // Keep real part unchanged
-
-    // Alternatively, using scalar operations:
-    // Extract real
-    FMOVD V0.D[0], F0
-
-    // Extract and negate imag
-    FMOVD V0.D[1], F1
+    // Negate imaginary part
     FNEGD F1, F1
 
-    // Construct result vector
-    VMOV F0, V1.D[0]
-    VMOV F1, V1.D[1]
-
-    VST1 [V1.D2], (R0)
+    // Store result - real unchanged, imag negated
+    FMOVD F0, (R0)               // Store real
+    FMOVD F1, 8(R0)              // Store -imag
 
     ADD  $16, R2
     ADD  $16, R0

--- a/c128/c128_test.go
+++ b/c128/c128_test.go
@@ -402,7 +402,8 @@ func TestConj_Large(t *testing.T) {
 
 // Benchmarks for new functions
 
-func benchmarkUnaryAbsOp(b *testing.B, size int, simdFn func([]float64, []complex128), goFn func([]float64, []complex128)) {
+func benchmarkUnaryAbsOp(b *testing.B, size int, simdFn, goFn func([]float64, []complex128)) {
+	b.Helper()
 	a := make([]complex128, size)
 	dst := make([]float64, size)
 	for i := range size {
@@ -424,7 +425,8 @@ func benchmarkUnaryAbsOp(b *testing.B, size int, simdFn func([]float64, []comple
 	})
 }
 
-func benchmarkUnaryConjOp(b *testing.B, size int, simdFn func([]complex128, []complex128), goFn func([]complex128, []complex128)) {
+func benchmarkUnaryConjOp(b *testing.B, size int, simdFn, goFn func([]complex128, []complex128)) {
+	b.Helper()
 	a := make([]complex128, size)
 	dst := make([]complex128, size)
 	for i := range size {

--- a/cpu/cpu.go
+++ b/cpu/cpu.go
@@ -4,20 +4,20 @@ package cpu
 // Features contains detected CPU SIMD capabilities.
 type Features struct {
 	// x86/AMD64 features
-	SSE     bool
-	SSE2    bool
-	SSE3    bool
-	SSSE3   bool
-	SSE41   bool
-	SSE42   bool
-	AVX     bool
-	AVX2    bool
+	SSE      bool
+	SSE2     bool
+	SSE3     bool
+	SSSE3    bool
+	SSE41    bool
+	SSE42    bool
+	AVX      bool
+	AVX2     bool
 	AVX512F  bool
 	AVX512VL bool
-	FMA     bool
-	BMI1    bool
-	BMI2    bool
-	POPCNT  bool
+	FMA      bool
+	BMI1     bool
+	BMI2     bool
+	POPCNT   bool
 
 	// ARM64 features
 	NEON bool

--- a/cpu/cpu_arm64_test.go
+++ b/cpu/cpu_arm64_test.go
@@ -20,9 +20,9 @@ func TestCpuInfoAllBranches(t *testing.T) {
 	}()
 
 	tests := []struct {
-		name         string
+		name            string
 		neon, sve, sve2 bool
-		want         string
+		want            string
 	}{
 		{"SVE2", true, true, true, "ARM64 SVE2"},
 		{"SVE", true, true, false, "ARM64 SVE"},

--- a/f32/f32.go
+++ b/f32/f32.go
@@ -197,3 +197,68 @@ var (
 	posInf = float32(math.Inf(1))
 	negInf = float32(math.Inf(-1))
 )
+
+// Interleave2 interleaves two slices: dst[0]=a[0], dst[1]=b[0], dst[2]=a[1], dst[3]=b[1], ...
+// Processes min(len(a), len(b), len(dst)/2) pairs.
+// This is useful for converting separate channels to interleaved stereo audio.
+func Interleave2(dst, a, b []float32) {
+	n := min(len(dst)/interleave2Channels, min(len(a), len(b)))
+	if n == 0 {
+		return
+	}
+	interleave2_32(dst[:n*interleave2Channels], a[:n], b[:n])
+}
+
+// Deinterleave2 deinterleaves a slice: a[0]=src[0], b[0]=src[1], a[1]=src[2], b[1]=src[3], ...
+// Processes min(len(a), len(b), len(src)/2) pairs.
+// This is the inverse of Interleave2, useful for splitting stereo audio to channels.
+func Deinterleave2(a, b, src []float32) {
+	n := min(len(src)/interleave2Channels, min(len(a), len(b)))
+	if n == 0 {
+		return
+	}
+	deinterleave2_32(a[:n], b[:n], src[:n*interleave2Channels])
+}
+
+const interleave2Channels = 2
+
+// ConvolveValidMulti applies multiple kernels to the same signal in one pass.
+// dsts[k][i] = sum(signal[i+j] * kernels[k][j]) for each kernel k.
+// All kernels must have the same length.
+//
+// This is more cache-efficient than calling ConvolveValid in a loop because
+// the signal data stays hot in cache across all kernel applications.
+//
+// Panics if kernels have different lengths or if dsts/kernels lengths don't match.
+func ConvolveValidMulti(dsts [][]float32, signal []float32, kernels [][]float32) {
+	numKernels := len(kernels)
+	if numKernels == 0 || len(dsts) < numKernels {
+		return
+	}
+
+	// Validate all kernels have the same length
+	kLen := len(kernels[0])
+	if kLen == 0 || len(signal) < kLen {
+		return
+	}
+	for i := 1; i < numKernels; i++ {
+		if len(kernels[i]) != kLen {
+			panic("simd: all kernels must have the same length")
+		}
+	}
+
+	validLen := len(signal) - kLen + 1
+
+	// Determine actual output length based on smallest dst
+	n := validLen
+	for i := range numKernels {
+		if len(dsts[i]) < n {
+			n = len(dsts[i])
+		}
+	}
+	if n <= 0 {
+		return
+	}
+
+	convolveValidMulti32(dsts, signal, kernels, n, kLen)
+}

--- a/f32/f32_arm64.go
+++ b/f32/f32_arm64.go
@@ -185,3 +185,34 @@ func fmaNEON(dst, a, b, c []float32)
 
 //go:noescape
 func clampNEON(dst, a []float32, minVal, maxVal float32)
+
+func interleave2_32(dst, a, b []float32) {
+	if hasNEON && len(a) >= 4 {
+		interleave2NEON(dst, a, b)
+		return
+	}
+	interleave2Go(dst, a, b)
+}
+
+func deinterleave2_32(a, b, src []float32) {
+	if hasNEON && len(a) >= 4 {
+		deinterleave2NEON(a, b, src)
+		return
+	}
+	deinterleave2Go(a, b, src)
+}
+
+func convolveValidMulti32(dsts [][]float32, signal []float32, kernels [][]float32, n, kLen int) {
+	for i := range n {
+		sig := signal[i : i+kLen]
+		for k, kernel := range kernels {
+			dsts[k][i] = dotProduct(sig, kernel)
+		}
+	}
+}
+
+//go:noescape
+func interleave2NEON(dst, a, b []float32)
+
+//go:noescape
+func deinterleave2NEON(a, b, src []float32)

--- a/f32/f32_go.go
+++ b/f32/f32_go.go
@@ -150,3 +150,26 @@ func accumulateAdd32Go(dst, src []float32) {
 		dst[i] += src[i]
 	}
 }
+
+func interleave2Go(dst, a, b []float32) {
+	for i := range a {
+		dst[i*2] = a[i]
+		dst[i*2+1] = b[i]
+	}
+}
+
+func deinterleave2Go(a, b, src []float32) {
+	for i := range a {
+		a[i] = src[i*2]
+		b[i] = src[i*2+1]
+	}
+}
+
+func convolveValidMultiGo(dsts [][]float32, signal []float32, kernels [][]float32, n, kLen int) {
+	for i := range n {
+		sig := signal[i : i+kLen]
+		for k, kernel := range kernels {
+			dsts[k][i] = dotProductGo(sig, kernel)
+		}
+	}
+}

--- a/f32/f32_other.go
+++ b/f32/f32_other.go
@@ -2,20 +2,27 @@
 
 package f32
 
-func dotProduct(a, b []float32) float32 { return dotProductGo(a, b) }
-func add(dst, a, b []float32)           { addGo(dst, a, b) }
-func sub(dst, a, b []float32)           { subGo(dst, a, b) }
-func mul(dst, a, b []float32)           { mulGo(dst, a, b) }
-func div(dst, a, b []float32)           { divGo(dst, a, b) }
-func scale(dst, a []float32, s float32) { scaleGo(dst, a, s) }
-func addScalar(dst, a []float32, s float32) { addScalarGo(dst, a, s) }
-func sum(a []float32) float32           { return sumGo(a) }
-func min32(a []float32) float32         { return minGo(a) }
-func max32(a []float32) float32         { return maxGo(a) }
-func abs32(dst, a []float32)            { absGo(dst, a) }
-func neg32(dst, a []float32)            { negGo(dst, a) }
-func fma32(dst, a, b, c []float32)      { fmaGo(dst, a, b, c) }
+func dotProduct(a, b []float32) float32                { return dotProductGo(a, b) }
+func add(dst, a, b []float32)                          { addGo(dst, a, b) }
+func sub(dst, a, b []float32)                          { subGo(dst, a, b) }
+func mul(dst, a, b []float32)                          { mulGo(dst, a, b) }
+func div(dst, a, b []float32)                          { divGo(dst, a, b) }
+func scale(dst, a []float32, s float32)                { scaleGo(dst, a, s) }
+func addScalar(dst, a []float32, s float32)            { addScalarGo(dst, a, s) }
+func sum(a []float32) float32                          { return sumGo(a) }
+func min32(a []float32) float32                        { return minGo(a) }
+func max32(a []float32) float32                        { return maxGo(a) }
+func abs32(dst, a []float32)                           { absGo(dst, a) }
+func neg32(dst, a []float32)                           { negGo(dst, a) }
+func fma32(dst, a, b, c []float32)                     { fmaGo(dst, a, b, c) }
 func clamp32(dst, a []float32, minVal, maxVal float32) { clampGo(dst, a, minVal, maxVal) }
-func dotProductBatch32(results []float32, rows [][]float32, vec []float32) { dotProductBatch32Go(results, rows, vec) }
+func dotProductBatch32(results []float32, rows [][]float32, vec []float32) {
+	dotProductBatch32Go(results, rows, vec)
+}
 func convolveValid32(dst, signal, kernel []float32) { convolveValid32Go(dst, signal, kernel) }
-func accumulateAdd32(dst, src []float32) { accumulateAdd32Go(dst, src) }
+func accumulateAdd32(dst, src []float32)            { accumulateAdd32Go(dst, src) }
+func interleave2_32(dst, a, b []float32)            { interleave2Go(dst, a, b) }
+func deinterleave2_32(a, b, src []float32)          { deinterleave2Go(a, b, src) }
+func convolveValidMulti32(dsts [][]float32, signal []float32, kernels [][]float32, n, kLen int) {
+	convolveValidMultiGo(dsts, signal, kernels, n, kLen)
+}

--- a/f32/go_impl_test.go
+++ b/f32/go_impl_test.go
@@ -97,10 +97,10 @@ func TestMaxGo(t *testing.T) {
 
 func TestClampGo(t *testing.T) {
 	tests := []struct {
-		name        string
-		a           []float32
-		minV, maxV  float32
-		want        []float32
+		name       string
+		a          []float32
+		minV, maxV float32
+		want       []float32
 	}{
 		{"below_min", []float32{1, 2, 3}, 5, 10, []float32{5, 5, 5}},
 		{"above_max", []float32{11, 12, 13}, 5, 10, []float32{10, 10, 10}},
@@ -125,8 +125,8 @@ func TestDotProductBatch32Go(t *testing.T) {
 		{1, 0, 0, 0},
 		{0, 1, 0, 0},
 		{1, 1, 1, 1},
-		{},           // empty row
-		{1, 2},       // shorter than vec
+		{},     // empty row
+		{1, 2}, // shorter than vec
 	}
 	results := make([]float32, len(rows))
 

--- a/f64/f64_arm64.go
+++ b/f64/f64_arm64.go
@@ -234,3 +234,34 @@ func varianceNEON(a []float64, mean float64) float64
 
 //go:noescape
 func euclideanDistanceNEON(a, b []float64) float64
+
+func interleave2_64(dst, a, b []float64) {
+	if hasNEON && len(a) >= 2 {
+		interleave2NEON(dst, a, b)
+		return
+	}
+	interleave2Go(dst, a, b)
+}
+
+func deinterleave2_64(a, b, src []float64) {
+	if hasNEON && len(a) >= 2 {
+		deinterleave2NEON(a, b, src)
+		return
+	}
+	deinterleave2Go(a, b, src)
+}
+
+func convolveValidMulti64(dsts [][]float64, signal []float64, kernels [][]float64, n, kLen int) {
+	for i := range n {
+		sig := signal[i : i+kLen]
+		for k, kernel := range kernels {
+			dsts[k][i] = dotProduct(sig, kernel)
+		}
+	}
+}
+
+//go:noescape
+func interleave2NEON(dst, a, b []float64)
+
+//go:noescape
+func deinterleave2NEON(a, b, src []float64)

--- a/f64/f64_go.go
+++ b/f64/f64_go.go
@@ -221,3 +221,26 @@ func accumulateAdd64Go(dst, src []float64) {
 		dst[i] += src[i]
 	}
 }
+
+func interleave2Go(dst, a, b []float64) {
+	for i := range a {
+		dst[i*2] = a[i]
+		dst[i*2+1] = b[i]
+	}
+}
+
+func deinterleave2Go(a, b, src []float64) {
+	for i := range a {
+		a[i] = src[i*2]
+		b[i] = src[i*2+1]
+	}
+}
+
+func convolveValidMultiGo(dsts [][]float64, signal []float64, kernels [][]float64, n, kLen int) {
+	for i := range n {
+		sig := signal[i : i+kLen]
+		for k, kernel := range kernels {
+			dsts[k][i] = dotProductGo(sig, kernel)
+		}
+	}
+}

--- a/f64/f64_other.go
+++ b/f64/f64_other.go
@@ -4,25 +4,32 @@ package f64
 
 // Fallback implementations for unsupported architectures
 
-func dotProduct(a, b []float64) float64 { return dotProductGo(a, b) }
-func add(dst, a, b []float64)           { addGo(dst, a, b) }
-func sub(dst, a, b []float64)           { subGo(dst, a, b) }
-func mul(dst, a, b []float64)           { mulGo(dst, a, b) }
-func div(dst, a, b []float64)           { divGo(dst, a, b) }
-func scale(dst, a []float64, s float64) { scaleGo(dst, a, s) }
-func addScalar(dst, a []float64, s float64) { addScalarGo(dst, a, s) }
-func sum(a []float64) float64           { return sumGo(a) }
-func min64(a []float64) float64         { return minGo(a) }
-func max64(a []float64) float64         { return maxGo(a) }
-func abs64(dst, a []float64)            { absGo(dst, a) }
-func neg64(dst, a []float64)            { negGo(dst, a) }
-func fma64(dst, a, b, c []float64)      { fmaGo(dst, a, b, c) }
+func dotProduct(a, b []float64) float64                { return dotProductGo(a, b) }
+func add(dst, a, b []float64)                          { addGo(dst, a, b) }
+func sub(dst, a, b []float64)                          { subGo(dst, a, b) }
+func mul(dst, a, b []float64)                          { mulGo(dst, a, b) }
+func div(dst, a, b []float64)                          { divGo(dst, a, b) }
+func scale(dst, a []float64, s float64)                { scaleGo(dst, a, s) }
+func addScalar(dst, a []float64, s float64)            { addScalarGo(dst, a, s) }
+func sum(a []float64) float64                          { return sumGo(a) }
+func min64(a []float64) float64                        { return minGo(a) }
+func max64(a []float64) float64                        { return maxGo(a) }
+func abs64(dst, a []float64)                           { absGo(dst, a) }
+func neg64(dst, a []float64)                           { negGo(dst, a) }
+func fma64(dst, a, b, c []float64)                     { fmaGo(dst, a, b, c) }
 func clamp64(dst, a []float64, minVal, maxVal float64) { clampGo(dst, a, minVal, maxVal) }
-func sqrt64(dst, a []float64) { sqrt64Go(dst, a) }
-func reciprocal64(dst, a []float64) { reciprocal64Go(dst, a) }
-func variance64(a []float64, mean float64) float64 { return variance64Go(a, mean) }
-func euclideanDistance64(a, b []float64) float64 { return euclideanDistance64Go(a, b) }
-func cumulativeSum64(dst, a []float64) { cumulativeSum64Go(dst, a) }
-func dotProductBatch64(results []float64, rows [][]float64, vec []float64) { dotProductBatch64Go(results, rows, vec) }
+func sqrt64(dst, a []float64)                          { sqrt64Go(dst, a) }
+func reciprocal64(dst, a []float64)                    { reciprocal64Go(dst, a) }
+func variance64(a []float64, mean float64) float64     { return variance64Go(a, mean) }
+func euclideanDistance64(a, b []float64) float64       { return euclideanDistance64Go(a, b) }
+func cumulativeSum64(dst, a []float64)                 { cumulativeSum64Go(dst, a) }
+func dotProductBatch64(results []float64, rows [][]float64, vec []float64) {
+	dotProductBatch64Go(results, rows, vec)
+}
 func convolveValid64(dst, signal, kernel []float64) { convolveValid64Go(dst, signal, kernel) }
-func accumulateAdd64(dst, src []float64) { accumulateAdd64Go(dst, src) }
+func accumulateAdd64(dst, src []float64)            { accumulateAdd64Go(dst, src) }
+func interleave2_64(dst, a, b []float64)            { interleave2Go(dst, a, b) }
+func deinterleave2_64(a, b, src []float64)          { deinterleave2Go(a, b, src) }
+func convolveValidMulti64(dsts [][]float64, signal []float64, kernels [][]float64, n, kLen int) {
+	convolveValidMultiGo(dsts, signal, kernels, n, kLen)
+}

--- a/f64/go_impl_test.go
+++ b/f64/go_impl_test.go
@@ -125,8 +125,8 @@ func TestDotProductBatch64Go(t *testing.T) {
 		{1, 0, 0, 0},
 		{0, 1, 0, 0},
 		{1, 1, 1, 1},
-		{},           // empty row
-		{1, 2},       // shorter than vec
+		{},     // empty row
+		{1, 2}, // shorter than vec
 	}
 	results := make([]float64, len(rows))
 


### PR DESCRIPTION
## Summary

- **Interleave2**: Pack two mono channels into interleaved stereo format `[L,R,L,R,...]`
- **Deinterleave2**: Split interleaved stereo to separate mono channels
- **ConvolveValidMulti**: Apply multiple FIR filters to the same signal in one pass (cache-efficient for polyphase resampling)

All functions implemented for both `f32` and `f64` packages with:
- AVX/AVX-512 SIMD for AMD64 (uses VSHUFPS, VPERM2F128, VUNPCKLPD/VUNPCKHPD for lane-crossing shuffles)
- NEON for ARM64 (uses ZIP/UZP instructions)
- Pure Go fallbacks

## Benchmarks (1000 elements, i7-1260P)

| Operation | f64 | f32 |
|-----------|-----|-----|
| Interleave2 | 216 ns | 109 ns |
| Deinterleave2 | 216 ns | 216 ns |
| ConvolveValidMulti (2×64-tap) | 13.4 µs | - |

## Test plan

- [x] All existing tests pass
- [x] New unit tests for Interleave2, Deinterleave2, ConvolveValidMulti
- [x] Round-trip test (Interleave → Deinterleave)
- [x] Large size tests hitting SIMD paths
- [x] golangci-lint passes with 0 issues

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added Interleave2/Deinterleave2 for float32 and float64.
  * Added ConvolveValidMulti to apply multiple kernels to a signal in one pass.
  * Increased advertised operation count from 34 to 37.

* **Tests**
  * Added comprehensive tests and benchmarks for interleaving, deinterleaving, and multi-kernel convolution.

* **Documentation**
  * Updated README and performance/benchmark tables to include new operations and revised summary metrics.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->