### PR TITLE
Add CubicInterpDot for fused cubic interpolation dot product

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ A high-performance SIMD (Single Instruction, Multiple Data) library for Go provi
 - **Pure Go assembly** - Native Go assembler, simple cross-compilation
 - **Runtime CPU detection** - Automatically selects optimal implementation (AVX-512, AVX+FMA, SSE2, NEON, or pure Go)
 - **Zero allocations** - All operations work on pre-allocated slices
-- **39 operations** - Arithmetic, reduction, statistical, vector, signal processing, and complex number operations
+- **40 operations** - Arithmetic, reduction, statistical, vector, signal processing, and complex number operations
 - **Multi-architecture** - AMD64 (AVX-512/AVX+FMA/SSE2) and ARM64 (NEON) with pure Go fallback
 - **Thread-safe** - All functions are safe for concurrent use
 
@@ -113,6 +113,7 @@ fmt.Println(cpu.HasNEON())   // true/false
 |                 | `AccumulateAdd(dst, src, off)`      | Overlap-add: dst[off:] += src | 8x / 4x / 2x                        |
 | **Audio**       | `Interleave2(dst, a, b)`            | Pack stereo: [L,R,L,R,...]    | 4x / 2x                             |
 |                 | `Deinterleave2(a, b, src)`          | Unpack stereo to channels     | 4x / 2x                             |
+|                 | `CubicInterpDot(hist,a,b,c,d,x)`    | Fused cubic interp dot product| 4x / 2x                             |
 
 ### `f32` - float32 Operations
 
@@ -238,6 +239,8 @@ c128.Abs(magnitude, signalFFT)                  // Extract magnitude for display
 | ConvolveValid (f64)      | 4096 sig × 64 ker     | 26.6 µs | 169 µs  | **6.3x** |
 | ConvolveValid (f32)      | 4096 sig × 64 ker     | 17.9 µs | 80 µs   | **4.5x** |
 | ConvolveValidMulti (f64) | 1000 sig × 64 ker × 2 | 13.4 µs | -       | -        |
+| CubicInterpDot (f64)     | 241 taps              | 47 ns   | 88 ns   | **1.9x** |
+| CubicInterpDot (f32)     | 241 taps              | 21 ns   | 66 ns   | **3.1x** |
 | Interleave2 (f64)        | 1000 pairs            | 216 ns  | -       | -        |
 | Deinterleave2 (f64)      | 1000 pairs            | 216 ns  | -       | -        |
 | Interleave2 (f32)        | 1000 pairs            | 109 ns  | -       | -        |
@@ -247,8 +250,8 @@ c128.Abs(magnitude, signalFFT)                  // Extract magnitude for display
 
 | Package  | Average Speedup | Best         | Operations   |
 | -------- | --------------- | ------------ | ------------ |
-| **f32**  | **6.5x**        | 21.8x (Abs)  | 31 functions |
-| **f64**  | **3.2x**        | 7.9x (Clamp) | 31 functions |
+| **f32**  | **6.5x**        | 21.8x (Abs)  | 32 functions |
+| **f64**  | **3.2x**        | 7.9x (Clamp) | 32 functions |
 | **c128** | **1.77x**       | 2.2x (Mul)   | 8 functions  |
 
 ### ARM64 (Raspberry Pi 5, NEON)

--- a/f32/f32.go
+++ b/f32/f32.go
@@ -353,6 +353,50 @@ func EuclideanDistance(a, b []float32) float32 {
 
 const normalizeMagnitudeThreshold32 = 1e-7
 
+// CubicInterpDot computes the fused cubic interpolation dot product:
+//
+//	Σ hist[i] * (a[i] + x*(b[i] + x*(c[i] + x*d[i])))
+//
+// This is the hot inner loop for polyphase resampling with cubic coefficient
+// interpolation. The polynomial a + x*(b + x*(c + x*d)) is evaluated using
+// Horner's method for numerical stability, then multiplied by hist and summed.
+//
+// Parameters:
+//   - hist: history buffer (signal samples)
+//   - a, b, c, d: cubic polynomial coefficient arrays
+//   - x: fractional phase, typically in [0, 1)
+//
+// All slices must have equal length. Returns 0 for empty slices.
+//
+// This fused operation is more efficient than 4 separate DotProduct calls
+// because it reads the hist array only once (37% less memory bandwidth).
+//
+// Uses AVX+FMA on AMD64, NEON on ARM64, with pure Go fallback.
+func CubicInterpDot(hist, a, b, c, d []float32, x float32) float32 {
+	n := minLen5(len(hist), len(a), len(b), len(c), len(d))
+	if n == 0 {
+		return 0
+	}
+	return cubicInterpDot32(hist[:n], a[:n], b[:n], c[:n], d[:n], x)
+}
+
+// CubicInterpDotUnsafe computes the fused cubic interpolation dot product
+// without length validation.
+//
+// PRECONDITIONS (caller must ensure):
+//   - len(hist) == len(a) == len(b) == len(c) == len(d)
+//   - len(hist) > 0
+//
+// Violating these preconditions results in undefined behavior.
+// Use CubicInterpDot for safe operation with automatic length handling.
+func CubicInterpDotUnsafe(hist, a, b, c, d []float32, x float32) float32 {
+	return cubicInterpDot32(hist, a, b, c, d, x)
+}
+
+func minLen5(a, b, c, d, e int) int {
+	return min(a, b, c, d, e)
+}
+
 // ConvolveValidMulti applies multiple kernels to the same signal.
 // dsts[k][i] = sum(signal[i+j] * kernels[k][j]) for each kernel k.
 // All kernels must have the same length.

--- a/f32/f32_amd64.go
+++ b/f32/f32_amd64.go
@@ -471,3 +471,16 @@ func variance32(a []float32, mean float32) float32 {
 func euclideanDistance32(a, b []float32) float32 {
 	return euclideanDistance32Go(a, b)
 }
+
+func cubicInterpDot32(hist, a, b, c, d []float32, x float32) float32 {
+	// Use AVX+FMA if available and have enough elements
+	if cpu.X86.AVX && cpu.X86.FMA && len(hist) >= minAVXElements {
+		return cubicInterpDotAVX(hist, a, b, c, d, x)
+	}
+	return cubicInterpDotGo(hist, a, b, c, d, x)
+}
+
+// CubicInterpDot assembly function declaration
+//
+//go:noescape
+func cubicInterpDotAVX(hist, a, b, c, d []float32, x float32) float32

--- a/f32/f32_arm64.go
+++ b/f32/f32_arm64.go
@@ -279,3 +279,13 @@ func varianceNEON32(a []float32, mean float32) float32
 
 //go:noescape
 func euclideanDistanceNEON32(a, b []float32) float32
+
+func cubicInterpDot32(hist, a, b, c, d []float32, x float32) float32 {
+	if hasNEON && len(hist) >= 4 {
+		return cubicInterpDotNEON(hist, a, b, c, d, x)
+	}
+	return cubicInterpDotGo(hist, a, b, c, d, x)
+}
+
+//go:noescape
+func cubicInterpDotNEON(hist, a, b, c, d []float32, x float32) float32

--- a/f32/f32_arm64.s
+++ b/f32/f32_arm64.s
@@ -723,7 +723,8 @@ recip32_done:
 
 // func addScaledNEON(dst []float32, alpha float32, s []float32)
 // dst[i] += alpha * s[i] - AXPY operation
-TEXT ·addScaledNEON(SB), NOSPLIT, $0-52
+// Frame: dst(24) + alpha(4) + pad(4) + s(24) = 56 bytes
+TEXT ·addScaledNEON(SB), NOSPLIT, $0-56
     MOVD dst_base+0(FP), R0
     MOVD dst_len+8(FP), R2
     FMOVS alpha+24(FP), F3
@@ -873,8 +874,10 @@ euclid32_sqrt:
 //   c:    base+72, len+80
 //   d:    base+96, len+104
 //   x:    +120 (float32)
-//   ret:  +124 (float32)
-TEXT ·cubicInterpDotNEON(SB), NOSPLIT, $0-128
+//   pad:  +124 (4 bytes alignment)
+//   ret:  +128 (float32)
+// Frame: 5 slices(120) + x(4) + pad(4) + ret(4) = 132 bytes
+TEXT ·cubicInterpDotNEON(SB), NOSPLIT, $0-132
     MOVD hist_base+0(FP), R0   // R0 = hist pointer
     MOVD hist_len+8(FP), R6    // R6 = length
     MOVD a_base+24(FP), R1     // R1 = a pointer
@@ -987,5 +990,5 @@ cubic32_neon_scalar:
     CBNZ R7, cubic32_neon_scalar
 
 cubic32_neon_done:
-    FMOVS F0, ret+124(FP)
+    FMOVS F0, ret+128(FP)
     RET

--- a/f32/f32_other.go
+++ b/f32/f32_other.go
@@ -34,3 +34,6 @@ func convolveValidMulti32(dsts [][]float32, signal []float32, kernels [][]float3
 }
 func variance32(a []float32, mean float32) float32 { return variance32Go(a, mean) }
 func euclideanDistance32(a, b []float32) float32   { return euclideanDistance32Go(a, b) }
+func cubicInterpDot32(hist, a, b, c, d []float32, x float32) float32 {
+	return cubicInterpDotGo(hist, a, b, c, d, x)
+}

--- a/f64/f64_amd64.go
+++ b/f64/f64_amd64.go
@@ -319,6 +319,14 @@ func addScaled64(dst []float64, alpha float64, s []float64) {
 	addScaledImpl(dst, alpha, s)
 }
 
+func cubicInterpDot64(hist, a, b, c, d []float64, x float64) float64 {
+	// Use AVX+FMA if available and have enough elements
+	if cpu.X86.AVX && cpu.X86.FMA && len(hist) >= minAVXElements {
+		return cubicInterpDotAVX(hist, a, b, c, d, x)
+	}
+	return cubicInterpDotGo(hist, a, b, c, d, x)
+}
+
 // AVX+FMA assembly function declarations (4x float64 per iteration)
 //
 //go:noescape
@@ -509,3 +517,8 @@ func interleave2SSE2(dst, a, b []float64)
 
 //go:noescape
 func deinterleave2SSE2(a, b, src []float64)
+
+// CubicInterpDot assembly function declaration
+//
+//go:noescape
+func cubicInterpDotAVX(hist, a, b, c, d []float64, x float64) float64

--- a/f64/f64_arm64.go
+++ b/f64/f64_arm64.go
@@ -282,3 +282,13 @@ func addScaled64(dst []float64, alpha float64, s []float64) {
 
 //go:noescape
 func addScaledNEON(dst []float64, alpha float64, s []float64)
+
+func cubicInterpDot64(hist, a, b, c, d []float64, x float64) float64 {
+	if hasNEON && len(hist) >= 2 {
+		return cubicInterpDotNEON(hist, a, b, c, d, x)
+	}
+	return cubicInterpDotGo(hist, a, b, c, d, x)
+}
+
+//go:noescape
+func cubicInterpDotNEON(hist, a, b, c, d []float64, x float64) float64

--- a/f64/f64_other.go
+++ b/f64/f64_other.go
@@ -36,3 +36,6 @@ func convolveValidMulti64(dsts [][]float64, signal []float64, kernels [][]float6
 func minIdx64(a []float64) int                              { return minIdxGo64(a) }
 func maxIdx64(a []float64) int                              { return maxIdxGo64(a) }
 func addScaled64(dst []float64, alpha float64, s []float64) { addScaledGo64(dst, alpha, s) }
+func cubicInterpDot64(hist, a, b, c, d []float64, x float64) float64 {
+	return cubicInterpDotGo(hist, a, b, c, d, x)
+}


### PR DESCRIPTION
## Summary

- Add `CubicInterpDot` function for polyphase resampling with cubic coefficient interpolation
- Computes: `Σ hist[i] * (a[i] + x*(b[i] + x*(c[i] + x*d[i])))` using Horner's method
- AVX+FMA implementation for AMD64, NEON for ARM64, pure Go fallback
- Both safe (`CubicInterpDot`) and unsafe (`CubicInterpDotUnsafe`) variants

## Performance (AMD64 AVX+FMA, n=241)

| Package | SIMD | Go | Speedup |
|---------|------|-----|---------|
| f32 | 21 ns | 66 ns | **3.1x** |
| f64 | 47 ns | 88 ns | **1.9x** |

## Test plan

- [x] Unit tests for various sizes (1-1000 elements)
- [x] Edge cases (empty, x=0, x=1)
- [x] Different length slices (uses minimum)
- [x] Comparison against reference implementation
- [x] Benchmarks for f32 and f64
- [x] All tests pass on AMD64

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added CubicInterpDot and CubicInterpDotUnsafe for float32 and float64 to compute fused cubic interpolation dot products.

* **Performance**
  * Optimized implementations added for x86-64 and ARM64 to accelerate large workloads.

* **Documentation**
  * Updated feature list and performance tables to include new cubic interpolation entries and revised totals.

* **Tests**
  * Added comprehensive tests and benchmarks covering edge cases, varied sizes, and unsafe vs. safe variants.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->