### PR TITLE
Add Int32ToFloat32Scale for audio PCM conversion

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ A high-performance SIMD (Single Instruction, Multiple Data) library for Go provi
 - **Pure Go assembly** - Native Go assembler, simple cross-compilation
 - **Runtime CPU detection** - Automatically selects optimal implementation (AVX-512, AVX+FMA, SSE2, NEON, or pure Go)
 - **Zero allocations** - All operations work on pre-allocated slices
-- **45 operations** - Arithmetic, reduction, statistical, vector, signal processing, activation functions, and complex number operations
+- **46 operations** - Arithmetic, reduction, statistical, vector, signal processing, activation functions, and complex number operations
 - **Multi-architecture** - AMD64 (AVX-512/AVX+FMA/SSE2) and ARM64 (NEON) with pure Go fallback
 - **Thread-safe** - All functions are safe for concurrent use
 
@@ -119,6 +119,7 @@ fmt.Println(cpu.HasNEON())   // true/false
 | **Audio**       | `Interleave2(dst, a, b)`            | Pack stereo: [L,R,L,R,...]    | 4x / 2x                             |
 |                 | `Deinterleave2(a, b, src)`          | Unpack stereo to channels     | 4x / 2x                             |
 |                 | `CubicInterpDot(hist,a,b,c,d,x)`    | Fused cubic interp dot product| 4x / 2x                             |
+|                 | `Int32ToFloat32Scale(dst,src,s)`    | PCM int32 to normalized float | 8x / 4x                             |
 
 ### `f32` - float32 Operations
 
@@ -269,6 +270,8 @@ c128.Abs(magnitude, signalFFT)                  // Extract magnitude for display
 | ConvolveValidMulti (f64) | 1000 sig × 64 ker × 2 | 13.4 µs | -       | -        |
 | CubicInterpDot (f64)     | 241 taps              | 47 ns   | 88 ns   | **1.9x** |
 | CubicInterpDot (f32)     | 241 taps              | 21 ns   | 66 ns   | **3.1x** |
+| Int32ToFloat32Scale      | 1024 elements         | 40 ns   | 364 ns  | **9.0x** |
+| Int32ToFloat32Scale      | 4096 elements         | 153 ns  | 1439 ns | **9.4x** |
 | Interleave2 (f64)        | 1000 pairs            | 216 ns  | -       | -        |
 | Deinterleave2 (f64)      | 1000 pairs            | 216 ns  | -       | -        |
 | Interleave2 (f32)        | 1000 pairs            | 109 ns  | -       | -        |

--- a/doc.go
+++ b/doc.go
@@ -50,7 +50,7 @@
 //
 // Activation functions: Sigmoid, ReLU, Tanh, Exp, ClampScale
 //
-// Audio DSP: Interleave2, Deinterleave2, ConvolveValid, ConvolveValidMulti, AccumulateAdd, CumulativeSum, CubicInterpDot
+// Audio DSP: Interleave2, Deinterleave2, ConvolveValid, ConvolveValidMulti, AccumulateAdd, CumulativeSum, CubicInterpDot, Int32ToFloat32Scale
 //
 // Complex (c128): Add, Sub, Mul, MulConj, Conj, Abs, AbsSq, Scale
 //

--- a/f32/benchmark_test.go
+++ b/f32/benchmark_test.go
@@ -553,3 +553,33 @@ func BenchmarkSummary(b *testing.B) {
 		})
 	}
 }
+
+// =============================================================================
+// Int32ToFloat32Scale Benchmarks
+// =============================================================================
+
+func BenchmarkInt32ToFloat32Scale(b *testing.B) {
+	for _, size := range benchSizes {
+		src := make([]int32, size)
+		dst := make([]float32, size)
+		for i := range src {
+			src[i] = int32((i % 65536) - 32768)
+		}
+		scale := float32(1.0 / 32768.0)
+
+		b.Run(fmt.Sprintf("SIMD_%d", size), func(b *testing.B) {
+			for i := 0; i < b.N; i++ {
+				Int32ToFloat32Scale(dst, src, scale)
+			}
+			// Read int32 (4 bytes) + write float32 (4 bytes) = 8 bytes per element
+			b.SetBytes(int64(size * 8))
+		})
+
+		b.Run(fmt.Sprintf("Go_%d", size), func(b *testing.B) {
+			for i := 0; i < b.N; i++ {
+				int32ToFloat32ScaleGo(dst, src, scale)
+			}
+			b.SetBytes(int64(size * 8))
+		})
+	}
+}

--- a/f32/f32.go
+++ b/f32/f32.go
@@ -538,3 +538,34 @@ func ExpInPlace(a []float32) {
 	}
 	exp32(a, a)
 }
+
+// Int32ToFloat32Scale converts int32 samples to float32 and scales in one pass.
+// dst[i] = float32(src[i]) * scale
+//
+// This is optimized for audio processing where PCM samples need to be converted
+// to normalized floating-point. For example, 16-bit audio uses scale = 1.0/32768.0
+// and 32-bit audio uses scale = 1.0/2147483648.0.
+//
+// Processes min(len(dst), len(src)) elements.
+//
+// Uses AVX on AMD64 (8x int32), NEON on ARM64 (4x int32).
+func Int32ToFloat32Scale(dst []float32, src []int32, scale float32) {
+	n := min(len(dst), len(src))
+	if n == 0 {
+		return
+	}
+	int32ToFloat32Scale(dst[:n], src[:n], scale)
+}
+
+// Int32ToFloat32ScaleUnsafe converts int32 samples to float32 and scales without
+// length validation. This is a low-overhead variant for performance-critical code paths.
+//
+// PRECONDITIONS (caller must ensure):
+//   - len(dst) >= len(src)
+//   - len(src) > 0
+//
+// Violating these preconditions results in undefined behavior.
+// Use Int32ToFloat32Scale for safe operation with automatic length handling.
+func Int32ToFloat32ScaleUnsafe(dst []float32, src []int32, scale float32) {
+	int32ToFloat32Scale(dst, src, scale)
+}

--- a/f32/f32.go
+++ b/f32/f32.go
@@ -567,5 +567,6 @@ func Int32ToFloat32Scale(dst []float32, src []int32, scale float32) {
 // Violating these preconditions results in undefined behavior.
 // Use Int32ToFloat32Scale for safe operation with automatic length handling.
 func Int32ToFloat32ScaleUnsafe(dst []float32, src []int32, scale float32) {
-	int32ToFloat32Scale(dst, src, scale)
+	// Slice dst to len(src) to ensure SIMD implementations don't read past src
+	int32ToFloat32Scale(dst[:len(src)], src, scale)
 }

--- a/f32/f32_amd64.go
+++ b/f32/f32_amd64.go
@@ -537,3 +537,15 @@ func exp32(dst, src []float32) {
 	// Can be optimized with AVX polynomial approximation later
 	exp32Go(dst, src)
 }
+
+func int32ToFloat32Scale(dst []float32, src []int32, scale float32) {
+	// Use AVX if available and have enough elements
+	if cpu.X86.AVX && len(dst) >= minAVXElements {
+		int32ToFloat32ScaleAVX(dst, src, scale)
+		return
+	}
+	int32ToFloat32ScaleGo(dst, src, scale)
+}
+
+//go:noescape
+func int32ToFloat32ScaleAVX(dst []float32, src []int32, scale float32)

--- a/f32/f32_arm64.go
+++ b/f32/f32_arm64.go
@@ -343,3 +343,14 @@ func tanhNEON(dst, src []float32)
 func exp32(dst, src []float32) {
 	exp32Go(dst, src)
 }
+
+func int32ToFloat32Scale(dst []float32, src []int32, scale float32) {
+	if hasNEON && len(dst) >= 4 {
+		int32ToFloat32ScaleNEON(dst, src, scale)
+		return
+	}
+	int32ToFloat32ScaleGo(dst, src, scale)
+}
+
+//go:noescape
+func int32ToFloat32ScaleNEON(dst []float32, src []int32, scale float32)

--- a/f32/f32_go.go
+++ b/f32/f32_go.go
@@ -352,3 +352,28 @@ func exp32Go(dst, src []float32) {
 		}
 	}
 }
+
+// int32ToFloat32ScaleGo converts int32 samples to float32 and scales.
+// dst[i] = float32(src[i]) * scale
+// Uses loop unrolling for better performance.
+func int32ToFloat32ScaleGo(dst []float32, src []int32, scale float32) {
+	n := len(src)
+	n8 := n &^ unrollMask // Round down to multiple of 8
+
+	// Unrolled loop: 8 elements per iteration
+	for i := 0; i < n8; i += 8 {
+		dst[i] = float32(src[i]) * scale
+		dst[i+1] = float32(src[i+1]) * scale
+		dst[i+2] = float32(src[i+2]) * scale
+		dst[i+3] = float32(src[i+3]) * scale
+		dst[i+4] = float32(src[i+4]) * scale
+		dst[i+5] = float32(src[i+5]) * scale
+		dst[i+6] = float32(src[i+6]) * scale
+		dst[i+7] = float32(src[i+7]) * scale
+	}
+
+	// Handle remainder
+	for i := n8; i < n; i++ {
+		dst[i] = float32(src[i]) * scale
+	}
+}

--- a/f32/f32_other.go
+++ b/f32/f32_other.go
@@ -42,5 +42,6 @@ func relu32(dst, src []float32)    { relu32Go(dst, src) }
 func clampScale32(dst, src []float32, minVal, maxVal, scale float32) {
 	clampScale32Go(dst, src, minVal, maxVal, scale)
 }
-func tanh32(dst, src []float32) { tanh32Go(dst, src) }
-func exp32(dst, src []float32)  { exp32Go(dst, src) }
+func tanh32(dst, src []float32)                                 { tanh32Go(dst, src) }
+func exp32(dst, src []float32)                                  { exp32Go(dst, src) }
+func int32ToFloat32Scale(dst []float32, src []int32, s float32) { int32ToFloat32ScaleGo(dst, src, s) }


### PR DESCRIPTION
## Summary

- Add `Int32ToFloat32Scale(dst []float32, src []int32, scale float32)` function for fused int32-to-float32 conversion with scaling
- Optimized for audio processing where PCM samples need normalization
- AVX implementation for AMD64 (8x int32 per iteration using VCVTDQ2PS)
- NEON implementation for ARM64 (4x int32 per iteration using SCVTF)
- Pure Go fallback with 8x loop unrolling

## Performance (AMD64 AVX, 12th Gen i7)

| Elements | Go | SIMD | Speedup |
|----------|-----|------|---------|
| 128 | 45.7ns | 8.7ns | **5.3x** |
| 512 | 183ns | 21.4ns | **8.6x** |
| 1024 | 364ns | 40.2ns | **9.0x** |
| 4096 | 1439ns | 153ns | **9.4x** |
| 65536 | 23015ns | 4070ns | **5.7x** |

Peak throughput: **214 GB/s** (vs 23 GB/s for pure Go)

## Usage

```go
// 16-bit audio conversion
src := []int32{-32768, 0, 32767, ...}
dst := make([]float32, len(src))
f32.Int32ToFloat32Scale(dst, src, 1.0/32768.0)
// Result: dst = [-1.0, 0.0, 0.9999...]

// 32-bit audio conversion
f32.Int32ToFloat32Scale(dst, src, 1.0/2147483648.0)
```

## Test plan

- [x] Unit tests for various sizes (empty, single, 4, 8, 9, 16, 17 elements)
- [x] Audio conversion tests (16-bit and 32-bit)
- [x] Large array tests (100, 1000, 10000 elements)
- [x] Unsafe variant test
- [x] All tests pass on AMD64
- [x] go vet passes for AMD64 and ARM64

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added Int32ToFloat32Scale and an unsafe variant to convert and scale int32 audio samples to float32 in one step; platform-optimized implementations included.

* **Tests**
  * Added comprehensive test suites covering empty, small, large, and audio-specific scenarios (including unsafe variant).

* **Benchmarks**
  * Added performance benchmarks for the new operation at multiple sizes.

* **Documentation**
  * Updated API docs to list the new function (operations count now 46).

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->