### PR TITLE
Add c64 package and split-format complex operations

### DIFF
--- a/c64/c64.go
+++ b/c64/c64.go
@@ -1,0 +1,144 @@
+// Package c64 provides SIMD-accelerated operations on complex64 slices.
+//
+// These operations are designed to accelerate FFT-based DSP pipelines
+// using float32 precision for higher throughput:
+// - Mul: Complex multiplication for frequency-domain convolution
+// - MulConj: Multiply by conjugate for correlation
+// - Scale: Scale by complex scalar
+// - Add/Sub: Complex addition/subtraction for FFT butterflies
+// - AbsSq: Magnitude squared for power spectrum computation
+// - FromReal: Convert real float32 to complex64
+//
+// Complex64 uses float32 internally, providing 2x the throughput of complex128
+// operations on SIMD registers (8 complex64 per AVX-512 vs 4 complex128).
+//
+// All functions automatically select the optimal implementation based on
+// runtime CPU feature detection. Functions gracefully fall back to pure Go
+// implementations on unsupported architectures.
+//
+// Thread Safety: All functions are safe for concurrent use.
+// Memory: All functions are zero-allocation (no heap allocations).
+package c64
+
+// Mul computes element-wise complex multiplication: dst[i] = a[i] * b[i].
+// Processes min(len(dst), len(a), len(b)) elements.
+//
+// Complex multiplication: (a + bi)(c + di) = (ac - bd) + (ad + bc)i
+//
+// This is the core operation for FFT-based convolution in frequency domain.
+func Mul(dst, a, b []complex64) {
+	n := minLen(len(dst), len(a), len(b))
+	if n == 0 {
+		return
+	}
+	mul64(dst[:n], a[:n], b[:n])
+}
+
+// MulConj computes element-wise multiplication by conjugate: dst[i] = a[i] * conj(b[i]).
+// Processes min(len(dst), len(a), len(b)) elements.
+//
+// MulConj: (a + bi)(c - di) = (ac + bd) + (bc - ad)i
+//
+// This is used for cross-correlation in frequency domain.
+func MulConj(dst, a, b []complex64) {
+	n := minLen(len(dst), len(a), len(b))
+	if n == 0 {
+		return
+	}
+	mulConj64(dst[:n], a[:n], b[:n])
+}
+
+// Scale multiplies each element by a complex scalar: dst[i] = a[i] * s.
+// Processes min(len(dst), len(a)) elements.
+func Scale(dst, a []complex64, s complex64) {
+	n := min(len(dst), len(a))
+	if n == 0 {
+		return
+	}
+	scale64(dst[:n], a[:n], s)
+}
+
+// Add computes element-wise complex addition: dst[i] = a[i] + b[i].
+// Processes min(len(dst), len(a), len(b)) elements.
+//
+// Essential for FFT butterfly operations.
+func Add(dst, a, b []complex64) {
+	n := minLen(len(dst), len(a), len(b))
+	if n == 0 {
+		return
+	}
+	add64(dst[:n], a[:n], b[:n])
+}
+
+// Sub computes element-wise complex subtraction: dst[i] = a[i] - b[i].
+// Processes min(len(dst), len(a), len(b)) elements.
+//
+// Essential for FFT butterfly operations.
+func Sub(dst, a, b []complex64) {
+	n := minLen(len(dst), len(a), len(b))
+	if n == 0 {
+		return
+	}
+	sub64(dst[:n], a[:n], b[:n])
+}
+
+// Abs computes element-wise complex magnitude: dst[i] = |a[i]|.
+// Processes min(len(dst), len(a)) elements.
+//
+// Magnitude: |a + bi| = sqrt(a^2 + b^2)
+func Abs(dst []float32, a []complex64) {
+	n := min(len(dst), len(a))
+	if n == 0 {
+		return
+	}
+	abs64(dst[:n], a[:n])
+}
+
+// AbsSq computes element-wise magnitude squared: dst[i] = |a[i]|^2.
+// Processes min(len(dst), len(a)) elements.
+//
+// Magnitude squared: |a + bi|^2 = a^2 + b^2
+//
+// This is faster than Abs (no sqrt) and is the core operation for
+// power spectrum computation in spectrograms.
+func AbsSq(dst []float32, a []complex64) {
+	n := min(len(dst), len(a))
+	if n == 0 {
+		return
+	}
+	absSq64(dst[:n], a[:n])
+}
+
+// Conj computes element-wise complex conjugate: dst[i] = conj(a[i]).
+// Processes min(len(dst), len(a)) elements.
+//
+// Conjugate: conj(a + bi) = a - bi
+func Conj(dst, a []complex64) {
+	n := min(len(dst), len(a))
+	if n == 0 {
+		return
+	}
+	conj64(dst[:n], a[:n])
+}
+
+// FromReal converts real float32 values to complex64: dst[i] = complex(src[i], 0).
+// Processes min(len(dst), len(src)) elements.
+//
+// This is used to convert real-valued signals to complex for FFT input.
+func FromReal(dst []complex64, src []float32) {
+	n := min(len(dst), len(src))
+	if n == 0 {
+		return
+	}
+	fromReal64(dst[:n], src[:n])
+}
+
+func minLen(a, b, c int) int {
+	if b < a {
+		a = b
+	}
+	if c < a {
+		a = c
+	}
+	return a
+}

--- a/c64/c64_amd64.go
+++ b/c64/c64_amd64.go
@@ -4,14 +4,6 @@ package c64
 
 import "github.com/tphakala/simd/cpu"
 
-// Minimum number of complex64 elements required for SIMD operations.
-// AVX processes 4 complex64 values per 256-bit register (8 float32).
-// AVX-512 processes 8 complex64 values per 512-bit register (16 float32).
-const (
-	minAVXElements    = 4
-	minAVX512Elements = 8
-)
-
 // Function pointer types for SIMD operations
 type (
 	binaryOpFunc  func(dst, a, b []complex64)
@@ -36,14 +28,15 @@ var (
 
 func init() {
 	// Select optimal implementation based on CPU features
-	// Priority: AVX-512 > AVX+FMA > SSE2 > Go
+	// Priority: AVX-512 > AVX+FMA > SSE4.1 > Go
+	// Note: "SSE2" routines use BLENDPS which requires SSE4.1
 	switch {
 	case cpu.X86.AVX512F && cpu.X86.AVX512VL:
 		initAVX512()
 	case cpu.X86.AVX && cpu.X86.FMA:
 		initAVX()
-	case cpu.X86.SSE2:
-		initSSE2()
+	case cpu.X86.SSE41:
+		initSSE2() // Misnamed - actually uses SSE4.1 (BLENDPS)
 	default:
 		initGo()
 	}

--- a/c64/c64_amd64.go
+++ b/c64/c64_amd64.go
@@ -1,0 +1,231 @@
+//go:build amd64
+
+package c64
+
+import "github.com/tphakala/simd/cpu"
+
+// Minimum number of complex64 elements required for SIMD operations.
+// AVX processes 4 complex64 values per 256-bit register (8 float32).
+// AVX-512 processes 8 complex64 values per 512-bit register (16 float32).
+const (
+	minAVXElements    = 4
+	minAVX512Elements = 8
+)
+
+// Function pointer types for SIMD operations
+type (
+	binaryOpFunc  func(dst, a, b []complex64)
+	scaleFunc     func(dst, a []complex64, s complex64)
+	unaryAbsFunc  func(dst []float32, a []complex64)
+	unaryConjFunc func(dst, a []complex64)
+	fromRealFunc  func(dst []complex64, src []float32)
+)
+
+// Function pointers - assigned at init time based on CPU features
+var (
+	mulImpl      binaryOpFunc
+	mulConjImpl  binaryOpFunc
+	scaleImpl    scaleFunc
+	addImpl      binaryOpFunc
+	subImpl      binaryOpFunc
+	absImpl      unaryAbsFunc
+	absSqImpl    unaryAbsFunc
+	conjImpl     unaryConjFunc
+	fromRealImpl fromRealFunc
+)
+
+func init() {
+	// Select optimal implementation based on CPU features
+	// Priority: AVX-512 > AVX+FMA > SSE2 > Go
+	switch {
+	case cpu.X86.AVX512F && cpu.X86.AVX512VL:
+		initAVX512()
+	case cpu.X86.AVX && cpu.X86.FMA:
+		initAVX()
+	case cpu.X86.SSE2:
+		initSSE2()
+	default:
+		initGo()
+	}
+}
+
+func initAVX512() {
+	mulImpl = mulAVX512
+	mulConjImpl = mulConjAVX512
+	scaleImpl = scaleAVX512
+	addImpl = addAVX512
+	subImpl = subAVX512
+	absImpl = absAVX512
+	absSqImpl = absSqAVX512
+	conjImpl = conjAVX512
+	fromRealImpl = fromRealAVX512
+}
+
+func initAVX() {
+	mulImpl = mulAVX
+	mulConjImpl = mulConjAVX
+	scaleImpl = scaleAVX
+	addImpl = addAVX
+	subImpl = subAVX
+	absImpl = absAVX
+	absSqImpl = absSqAVX
+	conjImpl = conjAVX
+	fromRealImpl = fromRealAVX
+}
+
+func initSSE2() {
+	mulImpl = mulSSE2
+	mulConjImpl = mulConjSSE2
+	scaleImpl = scaleSSE2
+	addImpl = addSSE2
+	subImpl = subSSE2
+	absImpl = absSSE2
+	absSqImpl = absSqSSE2
+	conjImpl = conjSSE2
+	fromRealImpl = fromRealSSE2
+}
+
+func initGo() {
+	mulImpl = mulGo
+	mulConjImpl = mulConjGo
+	scaleImpl = scaleGo
+	addImpl = addGo
+	subImpl = subGo
+	absImpl = absGo
+	absSqImpl = absSqGo
+	conjImpl = conjGo
+	fromRealImpl = fromRealGo
+}
+
+// Dispatch functions - call function pointers (zero overhead after init)
+
+func mul64(dst, a, b []complex64) {
+	mulImpl(dst, a, b)
+}
+
+func mulConj64(dst, a, b []complex64) {
+	mulConjImpl(dst, a, b)
+}
+
+func scale64(dst, a []complex64, s complex64) {
+	scaleImpl(dst, a, s)
+}
+
+func add64(dst, a, b []complex64) {
+	addImpl(dst, a, b)
+}
+
+func sub64(dst, a, b []complex64) {
+	subImpl(dst, a, b)
+}
+
+func abs64(dst []float32, a []complex64) {
+	absImpl(dst, a)
+}
+
+func absSq64(dst []float32, a []complex64) {
+	absSqImpl(dst, a)
+}
+
+func conj64(dst, a []complex64) {
+	conjImpl(dst, a)
+}
+
+func fromReal64(dst []complex64, src []float32) {
+	fromRealImpl(dst, src)
+}
+
+// AVX+FMA assembly function declarations (4x complex64 per iteration)
+//
+//go:noescape
+func mulAVX(dst, a, b []complex64)
+
+//go:noescape
+func mulConjAVX(dst, a, b []complex64)
+
+//go:noescape
+func scaleAVX(dst, a []complex64, s complex64)
+
+//go:noescape
+func addAVX(dst, a, b []complex64)
+
+//go:noescape
+func subAVX(dst, a, b []complex64)
+
+// AVX-512 assembly function declarations (8x complex64 per iteration)
+//
+//go:noescape
+func mulAVX512(dst, a, b []complex64)
+
+//go:noescape
+func mulConjAVX512(dst, a, b []complex64)
+
+//go:noescape
+func scaleAVX512(dst, a []complex64, s complex64)
+
+//go:noescape
+func addAVX512(dst, a, b []complex64)
+
+//go:noescape
+func subAVX512(dst, a, b []complex64)
+
+// SSE2 assembly function declarations (2x complex64 per iteration)
+//
+//go:noescape
+func mulSSE2(dst, a, b []complex64)
+
+//go:noescape
+func mulConjSSE2(dst, a, b []complex64)
+
+//go:noescape
+func scaleSSE2(dst, a []complex64, s complex64)
+
+//go:noescape
+func addSSE2(dst, a, b []complex64)
+
+//go:noescape
+func subSSE2(dst, a, b []complex64)
+
+// Abs assembly function declarations
+
+//go:noescape
+func absAVX512(dst []float32, a []complex64)
+
+//go:noescape
+func absAVX(dst []float32, a []complex64)
+
+//go:noescape
+func absSSE2(dst []float32, a []complex64)
+
+// AbsSq assembly function declarations
+
+//go:noescape
+func absSqAVX512(dst []float32, a []complex64)
+
+//go:noescape
+func absSqAVX(dst []float32, a []complex64)
+
+//go:noescape
+func absSqSSE2(dst []float32, a []complex64)
+
+// Conj assembly function declarations
+
+//go:noescape
+func conjAVX512(dst, a []complex64)
+
+//go:noescape
+func conjAVX(dst, a []complex64)
+
+//go:noescape
+func conjSSE2(dst, a []complex64)
+
+// FromReal assembly function declarations
+
+//go:noescape
+func fromRealAVX512(dst []complex64, src []float32)
+
+//go:noescape
+func fromRealAVX(dst []complex64, src []float32)
+
+//go:noescape
+func fromRealSSE2(dst []complex64, src []float32)

--- a/c64/c64_amd64.s
+++ b/c64/c64_amd64.s
@@ -1150,8 +1150,8 @@ DATA signmask64<>+0x08(SB)/4, $0x00000000
 DATA signmask64<>+0x0c(SB)/4, $0x80000000
 DATA signmask64<>+0x10(SB)/4, $0x00000000
 DATA signmask64<>+0x14(SB)/4, $0x80000000
-DATA signmask64<>+0x18(SB)/4, $0x80000000
-DATA signmask64<>+0x1c(SB)/4, $0x00000000
+DATA signmask64<>+0x18(SB)/4, $0x00000000
+DATA signmask64<>+0x1c(SB)/4, $0x80000000
 GLOBL signmask64<>(SB), RODATA|NOPTR, $32
 
 // func conjAVX512(dst, a []complex64)

--- a/c64/c64_amd64.s
+++ b/c64/c64_amd64.s
@@ -1,0 +1,1406 @@
+//go:build amd64
+
+#include "textflag.h"
+
+// ============================================================================
+// AVX+FMA IMPLEMENTATIONS (256-bit, 4x complex64 per iteration)
+// ============================================================================
+//
+// complex64 layout: [real, imag] pairs in memory (8 bytes per complex64)
+// YMM register holds 8 float32 = 4 complex64: [r0,i0,r1,i1,r2,i2,r3,i3]
+// Complex multiplication: (a + bi)(c + di) = (ac - bd) + (ad + bc)i
+
+// func mulAVX(dst, a, b []complex64)
+TEXT ·mulAVX(SB), NOSPLIT, $0-72
+    MOVQ dst_base+0(FP), DX
+    MOVQ dst_len+8(FP), CX
+    MOVQ a_base+24(FP), SI
+    MOVQ b_base+48(FP), DI
+
+    MOVQ CX, AX
+    SHRQ $2, AX              // Process 4 complex64 per iteration
+    JZ   mul_avx_remainder
+
+mul_avx_loop4:
+    // Load 4 complex64: Y0 = [ar0,ai0,ar1,ai1,ar2,ai2,ar3,ai3]
+    VMOVUPS (SI), Y0
+    VMOVUPS (DI), Y1         // Y1 = [br0,bi0,br1,bi1,br2,bi2,br3,bi3]
+
+    // Deinterleave a: get real parts duplicated
+    VMOVSLDUP Y0, Y2         // Y2 = [ar0,ar0,ar1,ar1,ar2,ar2,ar3,ar3]
+    VMOVSHDUP Y0, Y3         // Y3 = [ai0,ai0,ai1,ai1,ai2,ai2,ai3,ai3]
+
+    // Swap b pairs for cross products: [bi,br,bi,br,...]
+    VSHUFPS $0xB1, Y1, Y1, Y4  // Y4 = [bi0,br0,bi1,br1,bi2,br2,bi3,br3]
+
+    // Compute products
+    VMULPS Y1, Y2, Y2        // Y2 = [ar*br, ar*bi, ar*br, ar*bi, ...]
+    VMULPS Y4, Y3, Y5        // Y5 = [ai*bi, ai*br, ai*bi, ai*br, ...]
+
+    // Combine: real = ar*br - ai*bi, imag = ar*bi + ai*br
+    // Use VADDSUBPS: subtracts odd elements, adds even elements
+    // But we need: sub even (real), add odd (imag) - opposite of ADDSUBPS
+    // So use VFMSUBADD231PS or separate add/sub with blend
+    VSUBPS Y5, Y2, Y6        // Y6 = [ar*br-ai*bi, ar*bi-ai*br, ...]
+    VADDPS Y5, Y2, Y7        // Y7 = [ar*br+ai*bi, ar*bi+ai*br, ...]
+
+    // Blend: take even from Y6 (sub result), odd from Y7 (add result)
+    VBLENDPS $0xAA, Y7, Y6, Y2  // 0xAA = 10101010, take lanes 1,3,5,7 from Y7
+
+    VMOVUPS Y2, (DX)
+
+    ADDQ $32, SI
+    ADDQ $32, DI
+    ADDQ $32, DX
+    DECQ AX
+    JNZ  mul_avx_loop4
+
+mul_avx_remainder:
+    ANDQ $3, CX
+    JZ   mul_avx_done
+
+mul_avx_tail:
+    // Handle single complex64 using XMM registers
+    VMOVSD (SI), X0          // Load one complex64 (8 bytes)
+    VMOVSD (DI), X1
+
+    // X0 = [ar, ai, ?, ?], X1 = [br, bi, ?, ?]
+    VMOVSLDUP X0, X2         // X2 = [ar, ar, ?, ?]
+    VMOVSHDUP X0, X3         // X3 = [ai, ai, ?, ?]
+    VSHUFPS $0xB1, X1, X1, X4  // X4 = [bi, br, ?, ?]
+
+    VMULPS X1, X2, X2        // X2 = [ar*br, ar*bi, ?, ?]
+    VMULPS X4, X3, X5        // X5 = [ai*bi, ai*br, ?, ?]
+
+    VSUBPS X5, X2, X6        // X6 = [ar*br-ai*bi, ar*bi-ai*br, ?, ?]
+    VADDPS X5, X2, X7        // X7 = [ar*br+ai*bi, ar*bi+ai*br, ?, ?]
+
+    VBLENDPS $0x02, X7, X6, X2  // Take lane 1 from X7
+
+    VMOVSD X2, (DX)
+
+    ADDQ $8, SI
+    ADDQ $8, DI
+    ADDQ $8, DX
+    DECQ CX
+    JNZ  mul_avx_tail
+
+mul_avx_done:
+    VZEROUPPER
+    RET
+
+// func mulConjAVX(dst, a, b []complex64)
+// a * conj(b) = (ar + ai*i)(br - bi*i) = (ar*br + ai*bi) + (ai*br - ar*bi)*i
+TEXT ·mulConjAVX(SB), NOSPLIT, $0-72
+    MOVQ dst_base+0(FP), DX
+    MOVQ dst_len+8(FP), CX
+    MOVQ a_base+24(FP), SI
+    MOVQ b_base+48(FP), DI
+
+    MOVQ CX, AX
+    SHRQ $2, AX
+    JZ   mulconj_avx_remainder
+
+mulconj_avx_loop4:
+    VMOVUPS (SI), Y0
+    VMOVUPS (DI), Y1
+
+    VMOVSLDUP Y0, Y2         // [ar, ar, ...]
+    VMOVSHDUP Y0, Y3         // [ai, ai, ...]
+    VSHUFPS $0xB1, Y1, Y1, Y4  // [bi, br, ...]
+
+    VMULPS Y1, Y2, Y2        // [ar*br, ar*bi, ...]
+    VMULPS Y4, Y3, Y5        // [ai*bi, ai*br, ...]
+
+    // For conj: real = ar*br + ai*bi, imag = ai*br - ar*bi
+    VADDPS Y5, Y2, Y6        // [ar*br+ai*bi, ar*bi+ai*br, ...]
+    VSUBPS Y2, Y5, Y7        // [ai*bi-ar*br, ai*br-ar*bi, ...]
+
+    // Blend: even from Y6 (add result), odd from Y7 (sub result)
+    VBLENDPS $0xAA, Y7, Y6, Y2
+
+    VMOVUPS Y2, (DX)
+
+    ADDQ $32, SI
+    ADDQ $32, DI
+    ADDQ $32, DX
+    DECQ AX
+    JNZ  mulconj_avx_loop4
+
+mulconj_avx_remainder:
+    ANDQ $3, CX
+    JZ   mulconj_avx_done
+
+mulconj_avx_tail:
+    VMOVSD (SI), X0
+    VMOVSD (DI), X1
+
+    VMOVSLDUP X0, X2
+    VMOVSHDUP X0, X3
+    VSHUFPS $0xB1, X1, X1, X4
+
+    VMULPS X1, X2, X2
+    VMULPS X4, X3, X5
+
+    VADDPS X5, X2, X6
+    VSUBPS X2, X5, X7
+
+    VBLENDPS $0x02, X7, X6, X2
+
+    VMOVSD X2, (DX)
+
+    ADDQ $8, SI
+    ADDQ $8, DI
+    ADDQ $8, DX
+    DECQ CX
+    JNZ  mulconj_avx_tail
+
+mulconj_avx_done:
+    VZEROUPPER
+    RET
+
+// func scaleAVX(dst, a []complex64, s complex64)
+TEXT ·scaleAVX(SB), NOSPLIT, $0-56
+    MOVQ dst_base+0(FP), DX
+    MOVQ dst_len+8(FP), CX
+    MOVQ a_base+24(FP), SI
+
+    // Load scalar s and broadcast
+    // s is at offset 48 (complex64 = 8 bytes)
+    VMOVSD s+48(FP), X8      // X8 = [sr, si, ?, ?]
+    // Broadcast to YMM: [sr,si,sr,si,sr,si,sr,si]
+    VBROADCASTSD X8, Y1
+
+    // Create swapped [si,sr,si,sr,...] for cross products
+    VSHUFPS $0xB1, Y1, Y1, Y4
+
+    MOVQ CX, AX
+    SHRQ $2, AX
+    JZ   scale_avx_remainder
+
+scale_avx_loop4:
+    VMOVUPS (SI), Y0
+
+    VMOVSLDUP Y0, Y2         // [ar, ar, ...]
+    VMOVSHDUP Y0, Y3         // [ai, ai, ...]
+
+    VMULPS Y1, Y2, Y2        // [ar*sr, ar*si, ...]
+    VMULPS Y4, Y3, Y5        // [ai*si, ai*sr, ...]
+
+    VSUBPS Y5, Y2, Y6        // [ar*sr-ai*si, ar*si-ai*sr]
+    VADDPS Y5, Y2, Y7        // [ar*sr+ai*si, ar*si+ai*sr]
+
+    VBLENDPS $0xAA, Y7, Y6, Y2
+
+    VMOVUPS Y2, (DX)
+
+    ADDQ $32, SI
+    ADDQ $32, DX
+    DECQ AX
+    JNZ  scale_avx_loop4
+
+scale_avx_remainder:
+    ANDQ $3, CX
+    JZ   scale_avx_done
+
+scale_avx_tail:
+    VMOVSD (SI), X0
+    VMOVSD s+48(FP), X1
+    VSHUFPS $0xB1, X1, X1, X4
+
+    VMOVSLDUP X0, X2
+    VMOVSHDUP X0, X3
+
+    VMULPS X1, X2, X2
+    VMULPS X4, X3, X5
+
+    VSUBPS X5, X2, X6
+    VADDPS X5, X2, X7
+
+    VBLENDPS $0x02, X7, X6, X2
+
+    VMOVSD X2, (DX)
+
+    ADDQ $8, SI
+    ADDQ $8, DX
+    DECQ CX
+    JNZ  scale_avx_tail
+
+scale_avx_done:
+    VZEROUPPER
+    RET
+
+// func addAVX(dst, a, b []complex64)
+TEXT ·addAVX(SB), NOSPLIT, $0-72
+    MOVQ dst_base+0(FP), DX
+    MOVQ dst_len+8(FP), CX
+    MOVQ a_base+24(FP), SI
+    MOVQ b_base+48(FP), DI
+
+    MOVQ CX, AX
+    SHRQ $2, AX
+    JZ   add_avx_remainder
+
+add_avx_loop4:
+    VMOVUPS (SI), Y0
+    VMOVUPS (DI), Y1
+    VADDPS Y0, Y1, Y2
+    VMOVUPS Y2, (DX)
+    ADDQ $32, SI
+    ADDQ $32, DI
+    ADDQ $32, DX
+    DECQ AX
+    JNZ  add_avx_loop4
+
+add_avx_remainder:
+    ANDQ $3, CX
+    JZ   add_avx_done
+
+add_avx_tail:
+    VMOVSD (SI), X0
+    VMOVSD (DI), X1
+    VADDPS X0, X1, X2
+    VMOVSD X2, (DX)
+    ADDQ $8, SI
+    ADDQ $8, DI
+    ADDQ $8, DX
+    DECQ CX
+    JNZ  add_avx_tail
+
+add_avx_done:
+    VZEROUPPER
+    RET
+
+// func subAVX(dst, a, b []complex64)
+TEXT ·subAVX(SB), NOSPLIT, $0-72
+    MOVQ dst_base+0(FP), DX
+    MOVQ dst_len+8(FP), CX
+    MOVQ a_base+24(FP), SI
+    MOVQ b_base+48(FP), DI
+
+    MOVQ CX, AX
+    SHRQ $2, AX
+    JZ   sub_avx_remainder
+
+sub_avx_loop4:
+    VMOVUPS (SI), Y0
+    VMOVUPS (DI), Y1
+    VSUBPS Y1, Y0, Y2
+    VMOVUPS Y2, (DX)
+    ADDQ $32, SI
+    ADDQ $32, DI
+    ADDQ $32, DX
+    DECQ AX
+    JNZ  sub_avx_loop4
+
+sub_avx_remainder:
+    ANDQ $3, CX
+    JZ   sub_avx_done
+
+sub_avx_tail:
+    VMOVSD (SI), X0
+    VMOVSD (DI), X1
+    VSUBPS X1, X0, X2
+    VMOVSD X2, (DX)
+    ADDQ $8, SI
+    ADDQ $8, DI
+    ADDQ $8, DX
+    DECQ CX
+    JNZ  sub_avx_tail
+
+sub_avx_done:
+    VZEROUPPER
+    RET
+
+// ============================================================================
+// AVX-512 IMPLEMENTATIONS (512-bit, 8x complex64 per iteration)
+// ============================================================================
+
+// func mulAVX512(dst, a, b []complex64)
+TEXT ·mulAVX512(SB), NOSPLIT, $0-72
+    MOVQ dst_base+0(FP), DX
+    MOVQ dst_len+8(FP), CX
+    MOVQ a_base+24(FP), SI
+    MOVQ b_base+48(FP), DI
+
+    MOVQ CX, AX
+    SHRQ $3, AX              // Process 8 complex64 per iteration
+    JZ   mul_avx512_remainder
+
+mul_avx512_loop8:
+    VMOVUPS (SI), Z0         // 8 complex64
+    VMOVUPS (DI), Z1
+
+    // Deinterleave
+    VMOVSLDUP Z0, Z2         // Broadcast real parts
+    VMOVSHDUP Z0, Z3         // Broadcast imag parts
+    VSHUFPS $0xB1, Z1, Z1, Z4  // Swap pairs
+
+    VMULPS Z1, Z2, Z2        // [ar*br, ar*bi, ...]
+    VMULPS Z4, Z3, Z5        // [ai*bi, ai*br, ...]
+
+    VSUBPS Z5, Z2, Z6
+    VADDPS Z5, Z2, Z7
+
+    // Blend with mask 0xAAAA (alternating)
+    MOVW $0xAAAA, R8
+    KMOVW R8, K1
+    VBLENDMPS Z7, Z6, K1, Z2
+
+    VMOVUPS Z2, (DX)
+
+    ADDQ $64, SI
+    ADDQ $64, DI
+    ADDQ $64, DX
+    DECQ AX
+    JNZ  mul_avx512_loop8
+
+mul_avx512_remainder:
+    ANDQ $7, CX
+    JZ   mul_avx512_done
+
+mul_avx512_tail:
+    VMOVSD (SI), X0
+    VMOVSD (DI), X1
+
+    VMOVSLDUP X0, X2
+    VMOVSHDUP X0, X3
+    VSHUFPS $0xB1, X1, X1, X4
+
+    VMULPS X1, X2, X2
+    VMULPS X4, X3, X5
+
+    VSUBPS X5, X2, X6
+    VADDPS X5, X2, X7
+
+    VBLENDPS $0x02, X7, X6, X2
+
+    VMOVSD X2, (DX)
+
+    ADDQ $8, SI
+    ADDQ $8, DI
+    ADDQ $8, DX
+    DECQ CX
+    JNZ  mul_avx512_tail
+
+mul_avx512_done:
+    VZEROUPPER
+    RET
+
+// func mulConjAVX512(dst, a, b []complex64)
+TEXT ·mulConjAVX512(SB), NOSPLIT, $0-72
+    MOVQ dst_base+0(FP), DX
+    MOVQ dst_len+8(FP), CX
+    MOVQ a_base+24(FP), SI
+    MOVQ b_base+48(FP), DI
+
+    MOVQ CX, AX
+    SHRQ $3, AX
+    JZ   mulconj_avx512_remainder
+
+mulconj_avx512_loop8:
+    VMOVUPS (SI), Z0
+    VMOVUPS (DI), Z1
+
+    VMOVSLDUP Z0, Z2
+    VMOVSHDUP Z0, Z3
+    VSHUFPS $0xB1, Z1, Z1, Z4
+
+    VMULPS Z1, Z2, Z2
+    VMULPS Z4, Z3, Z5
+
+    VADDPS Z5, Z2, Z6
+    VSUBPS Z2, Z5, Z7
+
+    MOVW $0xAAAA, R8
+    KMOVW R8, K1
+    VBLENDMPS Z7, Z6, K1, Z2
+
+    VMOVUPS Z2, (DX)
+
+    ADDQ $64, SI
+    ADDQ $64, DI
+    ADDQ $64, DX
+    DECQ AX
+    JNZ  mulconj_avx512_loop8
+
+mulconj_avx512_remainder:
+    ANDQ $7, CX
+    JZ   mulconj_avx512_done
+
+mulconj_avx512_tail:
+    VMOVSD (SI), X0
+    VMOVSD (DI), X1
+
+    VMOVSLDUP X0, X2
+    VMOVSHDUP X0, X3
+    VSHUFPS $0xB1, X1, X1, X4
+
+    VMULPS X1, X2, X2
+    VMULPS X4, X3, X5
+
+    VADDPS X5, X2, X6
+    VSUBPS X2, X5, X7
+
+    VBLENDPS $0x02, X7, X6, X2
+
+    VMOVSD X2, (DX)
+
+    ADDQ $8, SI
+    ADDQ $8, DI
+    ADDQ $8, DX
+    DECQ CX
+    JNZ  mulconj_avx512_tail
+
+mulconj_avx512_done:
+    VZEROUPPER
+    RET
+
+// func scaleAVX512(dst, a []complex64, s complex64)
+TEXT ·scaleAVX512(SB), NOSPLIT, $0-56
+    MOVQ dst_base+0(FP), DX
+    MOVQ dst_len+8(FP), CX
+    MOVQ a_base+24(FP), SI
+
+    // Broadcast scalar to ZMM
+    VBROADCASTSD s+48(FP), Z1
+    VSHUFPS $0xB1, Z1, Z1, Z4
+
+    MOVQ CX, AX
+    SHRQ $3, AX
+    JZ   scale_avx512_remainder
+
+scale_avx512_loop8:
+    VMOVUPS (SI), Z0
+
+    VMOVSLDUP Z0, Z2
+    VMOVSHDUP Z0, Z3
+
+    VMULPS Z1, Z2, Z2
+    VMULPS Z4, Z3, Z5
+
+    VSUBPS Z5, Z2, Z6
+    VADDPS Z5, Z2, Z7
+
+    MOVW $0xAAAA, R8
+    KMOVW R8, K1
+    VBLENDMPS Z7, Z6, K1, Z2
+
+    VMOVUPS Z2, (DX)
+
+    ADDQ $64, SI
+    ADDQ $64, DX
+    DECQ AX
+    JNZ  scale_avx512_loop8
+
+scale_avx512_remainder:
+    ANDQ $7, CX
+    JZ   scale_avx512_done
+
+scale_avx512_tail:
+    VMOVSD (SI), X0
+    VMOVSD s+48(FP), X1
+    VSHUFPS $0xB1, X1, X1, X4
+
+    VMOVSLDUP X0, X2
+    VMOVSHDUP X0, X3
+
+    VMULPS X1, X2, X2
+    VMULPS X4, X3, X5
+
+    VSUBPS X5, X2, X6
+    VADDPS X5, X2, X7
+
+    VBLENDPS $0x02, X7, X6, X2
+
+    VMOVSD X2, (DX)
+
+    ADDQ $8, SI
+    ADDQ $8, DX
+    DECQ CX
+    JNZ  scale_avx512_tail
+
+scale_avx512_done:
+    VZEROUPPER
+    RET
+
+// func addAVX512(dst, a, b []complex64)
+TEXT ·addAVX512(SB), NOSPLIT, $0-72
+    MOVQ dst_base+0(FP), DX
+    MOVQ dst_len+8(FP), CX
+    MOVQ a_base+24(FP), SI
+    MOVQ b_base+48(FP), DI
+
+    MOVQ CX, AX
+    SHRQ $3, AX
+    JZ   add_avx512_remainder
+
+add_avx512_loop8:
+    VMOVUPS (SI), Z0
+    VMOVUPS (DI), Z1
+    VADDPS Z0, Z1, Z2
+    VMOVUPS Z2, (DX)
+    ADDQ $64, SI
+    ADDQ $64, DI
+    ADDQ $64, DX
+    DECQ AX
+    JNZ  add_avx512_loop8
+
+add_avx512_remainder:
+    ANDQ $7, CX
+    JZ   add_avx512_done
+
+add_avx512_tail:
+    VMOVSD (SI), X0
+    VMOVSD (DI), X1
+    VADDPS X0, X1, X2
+    VMOVSD X2, (DX)
+    ADDQ $8, SI
+    ADDQ $8, DI
+    ADDQ $8, DX
+    DECQ CX
+    JNZ  add_avx512_tail
+
+add_avx512_done:
+    VZEROUPPER
+    RET
+
+// func subAVX512(dst, a, b []complex64)
+TEXT ·subAVX512(SB), NOSPLIT, $0-72
+    MOVQ dst_base+0(FP), DX
+    MOVQ dst_len+8(FP), CX
+    MOVQ a_base+24(FP), SI
+    MOVQ b_base+48(FP), DI
+
+    MOVQ CX, AX
+    SHRQ $3, AX
+    JZ   sub_avx512_remainder
+
+sub_avx512_loop8:
+    VMOVUPS (SI), Z0
+    VMOVUPS (DI), Z1
+    VSUBPS Z1, Z0, Z2
+    VMOVUPS Z2, (DX)
+    ADDQ $64, SI
+    ADDQ $64, DI
+    ADDQ $64, DX
+    DECQ AX
+    JNZ  sub_avx512_loop8
+
+sub_avx512_remainder:
+    ANDQ $7, CX
+    JZ   sub_avx512_done
+
+sub_avx512_tail:
+    VMOVSD (SI), X0
+    VMOVSD (DI), X1
+    VSUBPS X1, X0, X2
+    VMOVSD X2, (DX)
+    ADDQ $8, SI
+    ADDQ $8, DI
+    ADDQ $8, DX
+    DECQ CX
+    JNZ  sub_avx512_tail
+
+sub_avx512_done:
+    VZEROUPPER
+    RET
+
+// ============================================================================
+// SSE2 IMPLEMENTATIONS (128-bit, 2x complex64 per iteration)
+// ============================================================================
+
+// func mulSSE2(dst, a, b []complex64)
+TEXT ·mulSSE2(SB), NOSPLIT, $0-72
+    MOVQ dst_base+0(FP), DX
+    MOVQ dst_len+8(FP), CX
+    MOVQ a_base+24(FP), SI
+    MOVQ b_base+48(FP), DI
+
+    MOVQ CX, AX
+    SHRQ $1, AX              // Process 2 complex64 per iteration
+    JZ   mul_sse2_remainder
+
+mul_sse2_loop2:
+    MOVUPS (SI), X0          // 2 complex64: [ar0,ai0,ar1,ai1]
+    MOVUPS (DI), X1          // [br0,bi0,br1,bi1]
+
+    MOVSLDUP X0, X2          // [ar0,ar0,ar1,ar1]
+    MOVSHDUP X0, X3          // [ai0,ai0,ai1,ai1]
+    MOVAPS X1, X4
+    SHUFPS $0xB1, X4, X4     // [bi0,br0,bi1,br1]
+
+    MULPS X1, X2             // [ar*br, ar*bi, ...]
+    MULPS X4, X3             // [ai*bi, ai*br, ...]
+
+    MOVAPS X2, X5
+    SUBPS X3, X5             // [ar*br-ai*bi, ar*bi-ai*br, ...]
+    ADDPS X3, X2             // [ar*br+ai*bi, ar*bi+ai*br, ...]
+
+    BLENDPS $0x0A, X2, X5    // Take lanes 1,3 from X2
+
+    MOVUPS X5, (DX)
+
+    ADDQ $16, SI
+    ADDQ $16, DI
+    ADDQ $16, DX
+    DECQ AX
+    JNZ  mul_sse2_loop2
+
+mul_sse2_remainder:
+    ANDQ $1, CX
+    JZ   mul_sse2_done
+
+    // Handle single complex64
+    MOVSD (SI), X0           // [ar, ai, ?, ?]
+    MOVSD (DI), X1           // [br, bi, ?, ?]
+
+    MOVSLDUP X0, X2
+    MOVSHDUP X0, X3
+    MOVAPS X1, X4
+    SHUFPS $0xB1, X4, X4
+
+    MULPS X1, X2
+    MULPS X4, X3
+
+    MOVAPS X2, X5
+    SUBPS X3, X5
+    ADDPS X3, X2
+
+    BLENDPS $0x02, X2, X5
+
+    MOVSD X5, (DX)
+
+mul_sse2_done:
+    RET
+
+// func mulConjSSE2(dst, a, b []complex64)
+TEXT ·mulConjSSE2(SB), NOSPLIT, $0-72
+    MOVQ dst_base+0(FP), DX
+    MOVQ dst_len+8(FP), CX
+    MOVQ a_base+24(FP), SI
+    MOVQ b_base+48(FP), DI
+
+    MOVQ CX, AX
+    SHRQ $1, AX
+    JZ   mulconj_sse2_remainder
+
+mulconj_sse2_loop2:
+    MOVUPS (SI), X0
+    MOVUPS (DI), X1
+
+    MOVSLDUP X0, X2
+    MOVSHDUP X0, X3
+    MOVAPS X1, X4
+    SHUFPS $0xB1, X4, X4
+
+    MULPS X1, X2
+    MULPS X4, X3
+
+    MOVAPS X2, X5
+    ADDPS X3, X5             // [ar*br+ai*bi, ar*bi+ai*br, ...]
+    MOVAPS X3, X6
+    SUBPS X2, X6             // [ai*bi-ar*br, ai*br-ar*bi, ...]
+
+    BLENDPS $0x0A, X6, X5    // Take lanes 1,3 from X6
+
+    MOVUPS X5, (DX)
+
+    ADDQ $16, SI
+    ADDQ $16, DI
+    ADDQ $16, DX
+    DECQ AX
+    JNZ  mulconj_sse2_loop2
+
+mulconj_sse2_remainder:
+    ANDQ $1, CX
+    JZ   mulconj_sse2_done
+
+    MOVSD (SI), X0
+    MOVSD (DI), X1
+
+    MOVSLDUP X0, X2
+    MOVSHDUP X0, X3
+    MOVAPS X1, X4
+    SHUFPS $0xB1, X4, X4
+
+    MULPS X1, X2
+    MULPS X4, X3
+
+    MOVAPS X2, X5
+    ADDPS X3, X5
+    MOVAPS X3, X6
+    SUBPS X2, X6
+
+    BLENDPS $0x02, X6, X5
+
+    MOVSD X5, (DX)
+
+mulconj_sse2_done:
+    RET
+
+// func scaleSSE2(dst, a []complex64, s complex64)
+TEXT ·scaleSSE2(SB), NOSPLIT, $0-56
+    MOVQ dst_base+0(FP), DX
+    MOVQ dst_len+8(FP), CX
+    MOVQ a_base+24(FP), SI
+
+    // Load scalar and broadcast to [sr,si,sr,si]
+    MOVSD s+48(FP), X6
+    MOVLHPS X6, X6           // X6 = [sr,si,sr,si]
+    MOVAPS X6, X7
+    SHUFPS $0xB1, X7, X7     // X7 = [si,sr,si,sr]
+
+    MOVQ CX, AX
+    SHRQ $1, AX
+    JZ   scale_sse2_remainder
+
+scale_sse2_loop2:
+    MOVUPS (SI), X0
+
+    MOVSLDUP X0, X2
+    MOVSHDUP X0, X3
+
+    MULPS X6, X2
+    MULPS X7, X3
+
+    MOVAPS X2, X4
+    SUBPS X3, X4
+    ADDPS X3, X2
+
+    BLENDPS $0x0A, X2, X4
+
+    MOVUPS X4, (DX)
+
+    ADDQ $16, SI
+    ADDQ $16, DX
+    DECQ AX
+    JNZ  scale_sse2_loop2
+
+scale_sse2_remainder:
+    ANDQ $1, CX
+    JZ   scale_sse2_done
+
+    MOVSD (SI), X0
+    MOVSD s+48(FP), X1
+    SHUFPS $0xB1, X1, X1
+
+    MOVSLDUP X0, X2
+    MOVSHDUP X0, X3
+
+    MULPS X6, X2
+    MULPS X1, X3
+
+    MOVAPS X2, X4
+    SUBPS X3, X4
+    ADDPS X3, X2
+
+    BLENDPS $0x02, X2, X4
+
+    MOVSD X4, (DX)
+
+scale_sse2_done:
+    RET
+
+// func addSSE2(dst, a, b []complex64)
+TEXT ·addSSE2(SB), NOSPLIT, $0-72
+    MOVQ dst_base+0(FP), DX
+    MOVQ dst_len+8(FP), CX
+    MOVQ a_base+24(FP), SI
+    MOVQ b_base+48(FP), DI
+
+    MOVQ CX, AX
+    SHRQ $1, AX
+    JZ   add_sse2_remainder
+
+add_sse2_loop2:
+    MOVUPS (SI), X0
+    MOVUPS (DI), X1
+    ADDPS X1, X0
+    MOVUPS X0, (DX)
+    ADDQ $16, SI
+    ADDQ $16, DI
+    ADDQ $16, DX
+    DECQ AX
+    JNZ  add_sse2_loop2
+
+add_sse2_remainder:
+    ANDQ $1, CX
+    JZ   add_sse2_done
+
+    MOVSD (SI), X0
+    MOVSD (DI), X1
+    ADDPS X1, X0
+    MOVSD X0, (DX)
+
+add_sse2_done:
+    RET
+
+// func subSSE2(dst, a, b []complex64)
+TEXT ·subSSE2(SB), NOSPLIT, $0-72
+    MOVQ dst_base+0(FP), DX
+    MOVQ dst_len+8(FP), CX
+    MOVQ a_base+24(FP), SI
+    MOVQ b_base+48(FP), DI
+
+    MOVQ CX, AX
+    SHRQ $1, AX
+    JZ   sub_sse2_remainder
+
+sub_sse2_loop2:
+    MOVUPS (SI), X0
+    MOVUPS (DI), X1
+    SUBPS X1, X0
+    MOVUPS X0, (DX)
+    ADDQ $16, SI
+    ADDQ $16, DI
+    ADDQ $16, DX
+    DECQ AX
+    JNZ  sub_sse2_loop2
+
+sub_sse2_remainder:
+    ANDQ $1, CX
+    JZ   sub_sse2_done
+
+    MOVSD (SI), X0
+    MOVSD (DI), X1
+    SUBPS X1, X0
+    MOVSD X0, (DX)
+
+sub_sse2_done:
+    RET
+
+// ============================================================================
+// ABS - COMPLEX MAGNITUDE: |a + bi| = sqrt(a^2 + b^2)
+// ============================================================================
+
+// func absAVX512(dst []float32, a []complex64)
+// Process using YMM registers since VHADDPS doesn't exist for ZMM
+TEXT ·absAVX512(SB), NOSPLIT, $0-48
+    MOVQ dst_base+0(FP), DX
+    MOVQ dst_len+8(FP), CX
+    MOVQ a_base+24(FP), SI
+
+    MOVQ CX, AX
+    SHRQ $2, AX              // Process 4 complex64 per iteration
+    JZ   abs_avx512_remainder
+
+abs_avx512_loop4:
+    // Load 4 complex64 = 8 float32
+    VMOVUPS (SI), Y0         // [r0,i0,r1,i1,r2,i2,r3,i3]
+
+    // Square all elements
+    VMULPS Y0, Y0, Y0        // [r0^2,i0^2,r1^2,i1^2,r2^2,i2^2,r3^2,i3^2]
+
+    // Horizontal add pairs
+    // After VHADDPS Y0,Y0,Y0:
+    //   Lane 0: [mag0, mag1, mag0, mag1]
+    //   Lane 1: [mag2, mag3, mag2, mag3]
+    VHADDPS Y0, Y0, Y0
+
+    // Extract high 128 bits and pack results
+    // X0 (low 128 bits) = [mag0, mag1, mag0, mag1]
+    // X1 (high 128 bits) = [mag2, mag3, mag2, mag3]
+    VEXTRACTF128 $1, Y0, X1
+    // VSHUFPS to get [mag0, mag1, mag2, mag3]
+    VSHUFPS $0x44, X1, X0, X0
+
+    // Take sqrt
+    VSQRTPS X0, X0
+
+    // Store 4 float32 results
+    VMOVUPS X0, (DX)
+
+    ADDQ $32, SI             // 4 complex64 = 32 bytes
+    ADDQ $16, DX             // 4 float32 = 16 bytes
+    DECQ AX
+    JNZ  abs_avx512_loop4
+
+abs_avx512_remainder:
+    ANDQ $3, CX
+    JZ   abs_avx512_done
+
+abs_avx512_tail:
+    // Load one complex64
+    VMOVSD (SI), X0          // [r, i, ?, ?]
+    VMULPS X0, X0, X0        // [r^2, i^2, ?, ?]
+    VHADDPS X0, X0, X0       // [r^2+i^2, r^2+i^2, ...]
+    VSQRTSS X0, X0, X0
+    VMOVSS X0, (DX)
+
+    ADDQ $8, SI
+    ADDQ $4, DX
+    DECQ CX
+    JNZ  abs_avx512_tail
+
+abs_avx512_done:
+    VZEROUPPER
+    RET
+
+// func absAVX(dst []float32, a []complex64)
+TEXT ·absAVX(SB), NOSPLIT, $0-48
+    MOVQ dst_base+0(FP), DX
+    MOVQ dst_len+8(FP), CX
+    MOVQ a_base+24(FP), SI
+
+    MOVQ CX, AX
+    SHRQ $2, AX              // Process 4 complex64 per iteration
+    JZ   abs_avx_remainder
+
+abs_avx_loop4:
+    // Load 4 complex64 = 8 float32
+    VMOVUPS (SI), Y0         // [r0,i0,r1,i1,r2,i2,r3,i3]
+
+    // Square all
+    VMULPS Y0, Y0, Y0        // [r0^2,i0^2,r1^2,i1^2,r2^2,i2^2,r3^2,i3^2]
+
+    // Horizontal add pairs
+    // After VHADDPS: Lane 0: [mag0, mag1, mag0, mag1], Lane 1: [mag2, mag3, mag2, mag3]
+    VHADDPS Y0, Y0, Y0
+
+    // Extract and pack results
+    VEXTRACTF128 $1, Y0, X1
+    VSHUFPS $0x44, X1, X0, X0  // [mag0, mag1, mag2, mag3]
+
+    // Take sqrt
+    VSQRTPS X0, X0
+
+    // Store 4 float32 results
+    VMOVUPS X0, (DX)
+
+    ADDQ $32, SI             // 4 complex64 = 32 bytes
+    ADDQ $16, DX             // 4 float32 = 16 bytes
+    DECQ AX
+    JNZ  abs_avx_loop4
+
+abs_avx_remainder:
+    ANDQ $3, CX
+    JZ   abs_avx_done
+
+abs_avx_tail:
+    VMOVSD (SI), X0
+    VMULPS X0, X0, X0
+    VHADDPS X0, X0, X0
+    VSQRTSS X0, X0, X0
+    VMOVSS X0, (DX)
+
+    ADDQ $8, SI
+    ADDQ $4, DX
+    DECQ CX
+    JNZ  abs_avx_tail
+
+abs_avx_done:
+    VZEROUPPER
+    RET
+
+// func absSSE2(dst []float32, a []complex64)
+TEXT ·absSSE2(SB), NOSPLIT, $0-48
+    MOVQ dst_base+0(FP), DX
+    MOVQ dst_len+8(FP), CX
+    MOVQ a_base+24(FP), SI
+
+    TESTQ CX, CX
+    JZ   abs_sse2_done
+
+abs_sse2_loop:
+    MOVSD (SI), X0           // [r, i, ?, ?]
+    MULPS X0, X0             // [r^2, i^2, ?, ?]
+    HADDPS X0, X0            // [r^2+i^2, r^2+i^2, ...]
+    SQRTSS X0, X0
+    MOVSS X0, (DX)
+
+    ADDQ $8, SI
+    ADDQ $4, DX
+    DECQ CX
+    JNZ  abs_sse2_loop
+
+abs_sse2_done:
+    RET
+
+// ============================================================================
+// ABSSQ - MAGNITUDE SQUARED: |a + bi|^2 = a^2 + b^2
+// ============================================================================
+
+// func absSqAVX512(dst []float32, a []complex64)
+// Process using YMM registers since VHADDPS doesn't exist for ZMM
+TEXT ·absSqAVX512(SB), NOSPLIT, $0-48
+    MOVQ dst_base+0(FP), DX
+    MOVQ dst_len+8(FP), CX
+    MOVQ a_base+24(FP), SI
+
+    MOVQ CX, AX
+    SHRQ $2, AX
+    JZ   abssq_avx512_remainder
+
+abssq_avx512_loop4:
+    VMOVUPS (SI), Y0
+    VMULPS Y0, Y0, Y0
+    // After VHADDPS: Lane 0: [mag0, mag1, mag0, mag1], Lane 1: [mag2, mag3, mag2, mag3]
+    VHADDPS Y0, Y0, Y0
+
+    // Extract and pack results
+    VEXTRACTF128 $1, Y0, X1
+    VSHUFPS $0x44, X1, X0, X0  // [mag0, mag1, mag2, mag3]
+
+    // Store 4 float32 results (no sqrt needed)
+    VMOVUPS X0, (DX)
+
+    ADDQ $32, SI
+    ADDQ $16, DX
+    DECQ AX
+    JNZ  abssq_avx512_loop4
+
+abssq_avx512_remainder:
+    ANDQ $3, CX
+    JZ   abssq_avx512_done
+
+abssq_avx512_tail:
+    VMOVSD (SI), X0
+    VMULPS X0, X0, X0
+    VHADDPS X0, X0, X0
+    VMOVSS X0, (DX)
+
+    ADDQ $8, SI
+    ADDQ $4, DX
+    DECQ CX
+    JNZ  abssq_avx512_tail
+
+abssq_avx512_done:
+    VZEROUPPER
+    RET
+
+// func absSqAVX(dst []float32, a []complex64)
+TEXT ·absSqAVX(SB), NOSPLIT, $0-48
+    MOVQ dst_base+0(FP), DX
+    MOVQ dst_len+8(FP), CX
+    MOVQ a_base+24(FP), SI
+
+    MOVQ CX, AX
+    SHRQ $2, AX
+    JZ   abssq_avx_remainder
+
+abssq_avx_loop4:
+    VMOVUPS (SI), Y0
+    VMULPS Y0, Y0, Y0
+    // After VHADDPS: Lane 0: [mag0, mag1, mag0, mag1], Lane 1: [mag2, mag3, mag2, mag3]
+    VHADDPS Y0, Y0, Y0
+
+    // Extract and pack results
+    VEXTRACTF128 $1, Y0, X1
+    VSHUFPS $0x44, X1, X0, X0  // [mag0, mag1, mag2, mag3]
+
+    // Store 4 float32 (no sqrt)
+    VMOVUPS X0, (DX)
+
+    ADDQ $32, SI
+    ADDQ $16, DX
+    DECQ AX
+    JNZ  abssq_avx_loop4
+
+abssq_avx_remainder:
+    ANDQ $3, CX
+    JZ   abssq_avx_done
+
+abssq_avx_tail:
+    VMOVSD (SI), X0
+    VMULPS X0, X0, X0
+    VHADDPS X0, X0, X0
+    VMOVSS X0, (DX)
+
+    ADDQ $8, SI
+    ADDQ $4, DX
+    DECQ CX
+    JNZ  abssq_avx_tail
+
+abssq_avx_done:
+    VZEROUPPER
+    RET
+
+// func absSqSSE2(dst []float32, a []complex64)
+TEXT ·absSqSSE2(SB), NOSPLIT, $0-48
+    MOVQ dst_base+0(FP), DX
+    MOVQ dst_len+8(FP), CX
+    MOVQ a_base+24(FP), SI
+
+    TESTQ CX, CX
+    JZ   abssq_sse2_done
+
+abssq_sse2_loop:
+    MOVSD (SI), X0
+    MULPS X0, X0
+    HADDPS X0, X0
+    MOVSS X0, (DX)
+
+    ADDQ $8, SI
+    ADDQ $4, DX
+    DECQ CX
+    JNZ  abssq_sse2_loop
+
+abssq_sse2_done:
+    RET
+
+// ============================================================================
+// CONJ - COMPLEX CONJUGATE: conj(a + bi) = a - bi
+// ============================================================================
+
+// Sign mask for negating imaginary parts: negate odd float32 elements
+DATA signmask64<>+0x00(SB)/4, $0x00000000  // +0 for real
+DATA signmask64<>+0x04(SB)/4, $0x80000000  // -0 for imag (flip sign)
+DATA signmask64<>+0x08(SB)/4, $0x00000000
+DATA signmask64<>+0x0c(SB)/4, $0x80000000
+DATA signmask64<>+0x10(SB)/4, $0x00000000
+DATA signmask64<>+0x14(SB)/4, $0x80000000
+DATA signmask64<>+0x18(SB)/4, $0x80000000
+DATA signmask64<>+0x1c(SB)/4, $0x00000000
+GLOBL signmask64<>(SB), RODATA|NOPTR, $32
+
+// func conjAVX512(dst, a []complex64)
+TEXT ·conjAVX512(SB), NOSPLIT, $0-48
+    MOVQ dst_base+0(FP), DX
+    MOVQ dst_len+8(FP), CX
+    MOVQ a_base+24(FP), SI
+
+    // Load sign mask for negating imag parts
+    VBROADCASTSD signmask64<>+0(SB), Z15  // [+0,-0,+0,-0,...]
+
+    MOVQ CX, AX
+    SHRQ $3, AX
+    JZ   conj_avx512_remainder
+
+conj_avx512_loop8:
+    VMOVUPS (SI), Z0
+    VXORPS Z15, Z0, Z0       // Negate imag parts via sign bit XOR
+    VMOVUPS Z0, (DX)
+
+    ADDQ $64, SI
+    ADDQ $64, DX
+    DECQ AX
+    JNZ  conj_avx512_loop8
+
+conj_avx512_remainder:
+    ANDQ $7, CX
+    JZ   conj_avx512_done
+
+conj_avx512_tail:
+    VMOVSD (SI), X0
+    VXORPS X15, X0, X0
+    VMOVSD X0, (DX)
+
+    ADDQ $8, SI
+    ADDQ $8, DX
+    DECQ CX
+    JNZ  conj_avx512_tail
+
+conj_avx512_done:
+    VZEROUPPER
+    RET
+
+// func conjAVX(dst, a []complex64)
+TEXT ·conjAVX(SB), NOSPLIT, $0-48
+    MOVQ dst_base+0(FP), DX
+    MOVQ dst_len+8(FP), CX
+    MOVQ a_base+24(FP), SI
+
+    // Load sign mask
+    VBROADCASTSD signmask64<>+0(SB), Y15
+
+    MOVQ CX, AX
+    SHRQ $2, AX
+    JZ   conj_avx_remainder
+
+conj_avx_loop4:
+    VMOVUPS (SI), Y0
+    VXORPS Y15, Y0, Y0
+    VMOVUPS Y0, (DX)
+
+    ADDQ $32, SI
+    ADDQ $32, DX
+    DECQ AX
+    JNZ  conj_avx_loop4
+
+conj_avx_remainder:
+    ANDQ $3, CX
+    JZ   conj_avx_done
+
+conj_avx_tail:
+    VMOVSD (SI), X0
+    VXORPS X15, X0, X0
+    VMOVSD X0, (DX)
+
+    ADDQ $8, SI
+    ADDQ $8, DX
+    DECQ CX
+    JNZ  conj_avx_tail
+
+conj_avx_done:
+    VZEROUPPER
+    RET
+
+// func conjSSE2(dst, a []complex64)
+TEXT ·conjSSE2(SB), NOSPLIT, $0-48
+    MOVQ dst_base+0(FP), DX
+    MOVQ dst_len+8(FP), CX
+    MOVQ a_base+24(FP), SI
+
+    // Load sign mask
+    MOVUPS signmask64<>+0(SB), X15
+
+    TESTQ CX, CX
+    JZ   conj_sse2_done
+
+conj_sse2_loop:
+    MOVSD (SI), X0
+    XORPS X15, X0
+    MOVSD X0, (DX)
+
+    ADDQ $8, SI
+    ADDQ $8, DX
+    DECQ CX
+    JNZ  conj_sse2_loop
+
+conj_sse2_done:
+    RET
+
+// ============================================================================
+// FROMREAL - CONVERT REAL TO COMPLEX: complex(x, 0)
+// ============================================================================
+
+// func fromRealAVX512(dst []complex64, src []float32)
+// Process using YMM registers since VPERM2F128 doesn't support ZMM
+TEXT ·fromRealAVX512(SB), NOSPLIT, $0-48
+    MOVQ dst_base+0(FP), DX
+    MOVQ dst_len+8(FP), CX
+    MOVQ src_base+24(FP), SI
+
+    // Process 4 elements per iteration using YMM
+    MOVQ CX, AX
+    SHRQ $2, AX
+    JZ   fromreal_avx512_remainder
+
+    VXORPS Y15, Y15, Y15      // Zero for interleaving
+
+fromreal_avx512_loop4:
+    // Load 4 float32 from src
+    VMOVUPS (SI), X0          // X0 = [r0,r1,r2,r3]
+
+    // Interleave with zeros
+    VUNPCKLPS X15, X0, X1     // X1 = [r0,0,r1,0]
+    VUNPCKHPS X15, X0, X2     // X2 = [r2,0,r3,0]
+
+    // Combine into YMM
+    VINSERTF128 $1, X2, Y1, Y0
+
+    // Store 4 complex64 = 32 bytes
+    VMOVUPS Y0, (DX)
+
+    ADDQ $16, SI              // 4 float32 = 16 bytes
+    ADDQ $32, DX              // 4 complex64 = 32 bytes
+    DECQ AX
+    JNZ  fromreal_avx512_loop4
+
+fromreal_avx512_remainder:
+    ANDQ $3, CX
+    JZ   fromreal_avx512_done
+
+fromreal_avx512_tail:
+    VMOVSS (SI), X0           // Load one float32
+    VXORPS X1, X1, X1         // Zero
+    VUNPCKLPS X1, X0, X0      // Interleave: [r, 0, ?, ?]
+    VMOVSD X0, (DX)           // Store one complex64
+
+    ADDQ $4, SI
+    ADDQ $8, DX
+    DECQ CX
+    JNZ  fromreal_avx512_tail
+
+fromreal_avx512_done:
+    VZEROUPPER
+    RET
+
+// func fromRealAVX(dst []complex64, src []float32)
+TEXT ·fromRealAVX(SB), NOSPLIT, $0-48
+    MOVQ dst_base+0(FP), DX
+    MOVQ dst_len+8(FP), CX
+    MOVQ src_base+24(FP), SI
+
+    MOVQ CX, AX
+    SHRQ $2, AX
+    JZ   fromreal_avx_remainder
+
+    VXORPS Y15, Y15, Y15
+
+fromreal_avx_loop4:
+    // Load 4 float32
+    VMOVUPS (SI), X0          // X0 = [r0,r1,r2,r3]
+
+    // Interleave with zeros
+    VUNPCKLPS X15, X0, X1     // X1 = [r0,0,r1,0]
+    VUNPCKHPS X15, X0, X2     // X2 = [r2,0,r3,0]
+
+    // Combine into YMM
+    VINSERTF128 $1, X2, Y1, Y0
+
+    // Store 4 complex64 = 32 bytes
+    VMOVUPS Y0, (DX)
+
+    ADDQ $16, SI
+    ADDQ $32, DX
+    DECQ AX
+    JNZ  fromreal_avx_loop4
+
+fromreal_avx_remainder:
+    ANDQ $3, CX
+    JZ   fromreal_avx_done
+
+fromreal_avx_tail:
+    VMOVSS (SI), X0
+    VXORPS X1, X1, X1
+    VUNPCKLPS X1, X0, X0
+    VMOVSD X0, (DX)
+
+    ADDQ $4, SI
+    ADDQ $8, DX
+    DECQ CX
+    JNZ  fromreal_avx_tail
+
+fromreal_avx_done:
+    VZEROUPPER
+    RET
+
+// func fromRealSSE2(dst []complex64, src []float32)
+TEXT ·fromRealSSE2(SB), NOSPLIT, $0-48
+    MOVQ dst_base+0(FP), DX
+    MOVQ dst_len+8(FP), CX
+    MOVQ src_base+24(FP), SI
+
+    XORPS X15, X15            // Zero register
+
+    MOVQ CX, AX
+    SHRQ $1, AX
+    JZ   fromreal_sse2_remainder
+
+fromreal_sse2_loop2:
+    // Load 2 float32
+    MOVSD (SI), X0            // X0 = [r0, r1, ?, ?]
+
+    // Interleave with zeros
+    UNPCKLPS X15, X0          // X0 = [r0, 0, r1, 0]
+
+    // Store 2 complex64 = 16 bytes
+    MOVUPS X0, (DX)
+
+    ADDQ $8, SI
+    ADDQ $16, DX
+    DECQ AX
+    JNZ  fromreal_sse2_loop2
+
+fromreal_sse2_remainder:
+    ANDQ $1, CX
+    JZ   fromreal_sse2_done
+
+    MOVSS (SI), X0
+    UNPCKLPS X15, X0
+    MOVSD X0, (DX)
+
+fromreal_sse2_done:
+    RET

--- a/c64/c64_arm64.go
+++ b/c64/c64_arm64.go
@@ -4,12 +4,10 @@ package c64
 
 import "github.com/tphakala/simd/cpu"
 
-var (
-	hasNEON = cpu.ARM64.NEON
-)
+var hasNEON = cpu.ARM64.NEON
 
 func mul64(dst, a, b []complex64) {
-	if hasNEON && len(dst) >= 1 {
+	if hasNEON {
 		mulNEON(dst, a, b)
 		return
 	}
@@ -17,7 +15,7 @@ func mul64(dst, a, b []complex64) {
 }
 
 func mulConj64(dst, a, b []complex64) {
-	if hasNEON && len(dst) >= 1 {
+	if hasNEON {
 		mulConjNEON(dst, a, b)
 		return
 	}
@@ -25,7 +23,7 @@ func mulConj64(dst, a, b []complex64) {
 }
 
 func scale64(dst, a []complex64, s complex64) {
-	if hasNEON && len(dst) >= 1 {
+	if hasNEON {
 		scaleNEON(dst, a, s)
 		return
 	}
@@ -33,7 +31,7 @@ func scale64(dst, a []complex64, s complex64) {
 }
 
 func add64(dst, a, b []complex64) {
-	if hasNEON && len(dst) >= 1 {
+	if hasNEON {
 		addNEON(dst, a, b)
 		return
 	}
@@ -41,7 +39,7 @@ func add64(dst, a, b []complex64) {
 }
 
 func sub64(dst, a, b []complex64) {
-	if hasNEON && len(dst) >= 1 {
+	if hasNEON {
 		subNEON(dst, a, b)
 		return
 	}
@@ -49,7 +47,7 @@ func sub64(dst, a, b []complex64) {
 }
 
 func abs64(dst []float32, a []complex64) {
-	if hasNEON && len(dst) >= 1 {
+	if hasNEON {
 		absNEON(dst, a)
 		return
 	}
@@ -57,7 +55,7 @@ func abs64(dst []float32, a []complex64) {
 }
 
 func absSq64(dst []float32, a []complex64) {
-	if hasNEON && len(dst) >= 1 {
+	if hasNEON {
 		absSqNEON(dst, a)
 		return
 	}
@@ -65,7 +63,7 @@ func absSq64(dst []float32, a []complex64) {
 }
 
 func conj64(dst, a []complex64) {
-	if hasNEON && len(dst) >= 1 {
+	if hasNEON {
 		conjNEON(dst, a)
 		return
 	}
@@ -73,7 +71,7 @@ func conj64(dst, a []complex64) {
 }
 
 func fromReal64(dst []complex64, src []float32) {
-	if hasNEON && len(dst) >= 1 {
+	if hasNEON {
 		fromRealNEON(dst, src)
 		return
 	}

--- a/c64/c64_arm64.go
+++ b/c64/c64_arm64.go
@@ -1,0 +1,108 @@
+//go:build arm64
+
+package c64
+
+import "github.com/tphakala/simd/cpu"
+
+var (
+	hasNEON = cpu.ARM64.NEON
+)
+
+func mul64(dst, a, b []complex64) {
+	if hasNEON && len(dst) >= 1 {
+		mulNEON(dst, a, b)
+		return
+	}
+	mulGo(dst, a, b)
+}
+
+func mulConj64(dst, a, b []complex64) {
+	if hasNEON && len(dst) >= 1 {
+		mulConjNEON(dst, a, b)
+		return
+	}
+	mulConjGo(dst, a, b)
+}
+
+func scale64(dst, a []complex64, s complex64) {
+	if hasNEON && len(dst) >= 1 {
+		scaleNEON(dst, a, s)
+		return
+	}
+	scaleGo(dst, a, s)
+}
+
+func add64(dst, a, b []complex64) {
+	if hasNEON && len(dst) >= 1 {
+		addNEON(dst, a, b)
+		return
+	}
+	addGo(dst, a, b)
+}
+
+func sub64(dst, a, b []complex64) {
+	if hasNEON && len(dst) >= 1 {
+		subNEON(dst, a, b)
+		return
+	}
+	subGo(dst, a, b)
+}
+
+func abs64(dst []float32, a []complex64) {
+	if hasNEON && len(dst) >= 1 {
+		absNEON(dst, a)
+		return
+	}
+	absGo(dst, a)
+}
+
+func absSq64(dst []float32, a []complex64) {
+	if hasNEON && len(dst) >= 1 {
+		absSqNEON(dst, a)
+		return
+	}
+	absSqGo(dst, a)
+}
+
+func conj64(dst, a []complex64) {
+	if hasNEON && len(dst) >= 1 {
+		conjNEON(dst, a)
+		return
+	}
+	conjGo(dst, a)
+}
+
+func fromReal64(dst []complex64, src []float32) {
+	if hasNEON && len(dst) >= 1 {
+		fromRealNEON(dst, src)
+		return
+	}
+	fromRealGo(dst, src)
+}
+
+//go:noescape
+func mulNEON(dst, a, b []complex64)
+
+//go:noescape
+func mulConjNEON(dst, a, b []complex64)
+
+//go:noescape
+func scaleNEON(dst, a []complex64, s complex64)
+
+//go:noescape
+func addNEON(dst, a, b []complex64)
+
+//go:noescape
+func subNEON(dst, a, b []complex64)
+
+//go:noescape
+func absNEON(dst []float32, a []complex64)
+
+//go:noescape
+func absSqNEON(dst []float32, a []complex64)
+
+//go:noescape
+func conjNEON(dst, a []complex64)
+
+//go:noescape
+func fromRealNEON(dst []complex64, src []float32)

--- a/c64/c64_arm64.s
+++ b/c64/c64_arm64.s
@@ -1,0 +1,605 @@
+//go:build arm64
+
+#include "textflag.h"
+
+// ============================================================================
+// ARM64 NEON IMPLEMENTATIONS FOR COMPLEX64
+// ============================================================================
+//
+// complex64 layout: [real, imag] pairs in memory (8 bytes per complex64)
+// NEON V register (128-bit) holds 4 float32 = 2 complex64
+// Process 4 complex64 per iteration using 2 V registers
+//
+// Strategy: Deinterleave real/imag -> compute -> interleave back
+//
+// NEON opcodes for float32 (4S arrangement):
+// FMUL Vd.4S, Vn.4S, Vm.4S: 0x6E20DC00 | (Vm << 16) | (Vn << 5) | Vd
+// FADD Vd.4S, Vn.4S, Vm.4S: 0x4E20D400 | (Vm << 16) | (Vn << 5) | Vd
+// FSUB Vd.4S, Vn.4S, Vm.4S: 0x4EA0D400 | (Vm << 16) | (Vn << 5) | Vd
+// UZP1 Vd.4S, Vn.4S, Vm.4S: 0x4E801800 | (Vm << 16) | (Vn << 5) | Vd
+// UZP2 Vd.4S, Vn.4S, Vm.4S: 0x4E805800 | (Vm << 16) | (Vn << 5) | Vd
+// ZIP1 Vd.4S, Vn.4S, Vm.4S: 0x4E803800 | (Vm << 16) | (Vn << 5) | Vd
+// ZIP2 Vd.4S, Vn.4S, Vm.4S: 0x4E807800 | (Vm << 16) | (Vn << 5) | Vd
+// FNEG Vd.4S, Vn.4S:        0x6EA0F800 | (Vn << 5) | Vd
+// FSQRT Vd.4S, Vn.4S:       0x6EA1F800 | (Vn << 5) | Vd
+
+// func mulNEON(dst, a, b []complex64)
+// Complex multiplication: (a + bi)(c + di) = (ac - bd) + (ad + bc)i
+TEXT ·mulNEON(SB), NOSPLIT, $0-72
+    MOVD dst_base+0(FP), R0      // dst pointer
+    MOVD dst_len+8(FP), R1       // length
+    MOVD a_base+24(FP), R2       // a pointer
+    MOVD b_base+48(FP), R3       // b pointer
+
+    CBZ  R1, mul_neon_done
+
+    // Check if we have at least 4 elements for vectorized loop
+    CMP  $4, R1
+    BLT  mul_neon_tail
+
+mul_neon_loop4:
+    // Load 4 complex64 from a: V0=[ar0,ai0,ar1,ai1], V1=[ar2,ai2,ar3,ai3]
+    VLD1.P 16(R2), [V0.S4]
+    VLD1.P 16(R2), [V1.S4]
+
+    // Load 4 complex64 from b: V2=[br0,bi0,br1,bi1], V3=[br2,bi2,br3,bi3]
+    VLD1.P 16(R3), [V2.S4]
+    VLD1.P 16(R3), [V3.S4]
+
+    // Deinterleave a: V4=[ar0,ar1,ar2,ar3], V5=[ai0,ai1,ai2,ai3]
+    WORD $0x4E811804             // UZP1 V4.4S, V0.4S, V1.4S
+    WORD $0x4E815805             // UZP2 V5.4S, V0.4S, V1.4S
+
+    // Deinterleave b: V6=[br0,br1,br2,br3], V7=[bi0,bi1,bi2,bi3]
+    WORD $0x4E831846             // UZP1 V6.4S, V2.4S, V3.4S
+    WORD $0x4E835847             // UZP2 V7.4S, V2.4S, V3.4S
+
+    // Compute products using vector operations
+    // V8 = ar * br
+    WORD $0x6E26DC88             // FMUL V8.4S, V4.4S, V6.4S
+    // V9 = ai * bi
+    WORD $0x6E27DCA9             // FMUL V9.4S, V5.4S, V7.4S
+    // V10 = ar * bi
+    WORD $0x6E27DC8A             // FMUL V10.4S, V4.4S, V7.4S
+    // V11 = ai * br
+    WORD $0x6E26DCAB             // FMUL V11.4S, V5.4S, V6.4S
+
+    // result_real = ar*br - ai*bi (V12)
+    WORD $0x4EA9D50C             // FSUB V12.4S, V8.4S, V9.4S
+    // result_imag = ar*bi + ai*br (V13)
+    WORD $0x4E2BD54D             // FADD V13.4S, V10.4S, V11.4S
+
+    // Interleave results: V14=[r0,i0,r1,i1], V15=[r2,i2,r3,i3]
+    WORD $0x4E8D398E             // ZIP1 V14.4S, V12.4S, V13.4S
+    WORD $0x4E8D798F             // ZIP2 V15.4S, V12.4S, V13.4S
+
+    // Store 4 complex64 results
+    VST1.P [V14.S4], 16(R0)
+    VST1.P [V15.S4], 16(R0)
+
+    SUB  $4, R1
+    CMP  $4, R1
+    BGE  mul_neon_loop4
+
+    // Handle remaining elements (0-3)
+    CBZ  R1, mul_neon_done
+
+mul_neon_tail:
+    // Process 1 element at a time using scalar FP
+    // Load complex64 as 2 float32
+    FMOVS (R2), F0               // ar
+    FMOVS 4(R2), F1              // ai
+    FMOVS (R3), F2               // br
+    FMOVS 4(R3), F3              // bi
+
+    // Compute products
+    FMULS F0, F2, F4             // ar * br
+    FMULS F1, F3, F5             // ai * bi
+    FMULS F0, F3, F6             // ar * bi
+    FMULS F1, F2, F7             // ai * br
+
+    FSUBS F5, F4, F4             // ar*br - ai*bi
+    FADDS F6, F7, F5             // ar*bi + ai*br
+
+    FMOVS F4, (R0)
+    FMOVS F5, 4(R0)
+
+    ADD  $8, R2
+    ADD  $8, R3
+    ADD  $8, R0
+    SUB  $1, R1
+    CBNZ R1, mul_neon_tail
+
+mul_neon_done:
+    RET
+
+// func mulConjNEON(dst, a, b []complex64)
+// a * conj(b) = (ar + ai*i)(br - bi*i) = (ar*br + ai*bi) + (ai*br - ar*bi)*i
+TEXT ·mulConjNEON(SB), NOSPLIT, $0-72
+    MOVD dst_base+0(FP), R0
+    MOVD dst_len+8(FP), R1
+    MOVD a_base+24(FP), R2
+    MOVD b_base+48(FP), R3
+
+    CBZ  R1, mulconj_neon_done
+
+    CMP  $4, R1
+    BLT  mulconj_neon_tail
+
+mulconj_neon_loop4:
+    VLD1.P 16(R2), [V0.S4]
+    VLD1.P 16(R2), [V1.S4]
+    VLD1.P 16(R3), [V2.S4]
+    VLD1.P 16(R3), [V3.S4]
+
+    // Deinterleave a: V4=[ar], V5=[ai]
+    WORD $0x4E811804             // UZP1 V4.4S, V0.4S, V1.4S
+    WORD $0x4E815805             // UZP2 V5.4S, V0.4S, V1.4S
+
+    // Deinterleave b: V6=[br], V7=[bi]
+    WORD $0x4E831846             // UZP1 V6.4S, V2.4S, V3.4S
+    WORD $0x4E835847             // UZP2 V7.4S, V2.4S, V3.4S
+
+    // V8 = ar * br
+    WORD $0x6E26DC88             // FMUL V8.4S, V4.4S, V6.4S
+    // V9 = ai * bi
+    WORD $0x6E27DCA9             // FMUL V9.4S, V5.4S, V7.4S
+    // V10 = ai * br
+    WORD $0x6E26DCAA             // FMUL V10.4S, V5.4S, V6.4S
+    // V11 = ar * bi
+    WORD $0x6E27DC8B             // FMUL V11.4S, V4.4S, V7.4S
+
+    // result_real = ar*br + ai*bi (V12)
+    WORD $0x4E29D50C             // FADD V12.4S, V8.4S, V9.4S
+    // result_imag = ai*br - ar*bi (V13)
+    WORD $0x4EABD54D             // FSUB V13.4S, V10.4S, V11.4S
+
+    // Interleave results
+    WORD $0x4E8D398E             // ZIP1 V14.4S, V12.4S, V13.4S
+    WORD $0x4E8D798F             // ZIP2 V15.4S, V12.4S, V13.4S
+
+    VST1.P [V14.S4], 16(R0)
+    VST1.P [V15.S4], 16(R0)
+
+    SUB  $4, R1
+    CMP  $4, R1
+    BGE  mulconj_neon_loop4
+
+    CBZ  R1, mulconj_neon_done
+
+mulconj_neon_tail:
+    FMOVS (R2), F0
+    FMOVS 4(R2), F1
+    FMOVS (R3), F2
+    FMOVS 4(R3), F3
+
+    FMULS F0, F2, F4             // ar * br
+    FMULS F1, F3, F5             // ai * bi
+    FMULS F1, F2, F6             // ai * br
+    FMULS F0, F3, F7             // ar * bi
+
+    FADDS F4, F5, F4             // ar*br + ai*bi
+    FSUBS F7, F6, F5             // ai*br - ar*bi
+
+    FMOVS F4, (R0)
+    FMOVS F5, 4(R0)
+
+    ADD  $8, R2
+    ADD  $8, R3
+    ADD  $8, R0
+    SUB  $1, R1
+    CBNZ R1, mulconj_neon_tail
+
+mulconj_neon_done:
+    RET
+
+// func scaleNEON(dst, a []complex64, s complex64)
+TEXT ·scaleNEON(SB), NOSPLIT, $0-56
+    MOVD dst_base+0(FP), R0
+    MOVD dst_len+8(FP), R1
+    MOVD a_base+24(FP), R2
+
+    // Load scalar s and broadcast to vectors
+    FMOVS s+48(FP), F20          // F20 = sr
+    FMOVS s+52(FP), F21          // F21 = si
+
+    // Broadcast to vectors
+    VDUP V20.S[0], V20.S4        // V20 = [sr, sr, sr, sr]
+    VDUP V21.S[0], V21.S4        // V21 = [si, si, si, si]
+
+    CBZ  R1, scale_neon_done
+
+    CMP  $4, R1
+    BLT  scale_neon_tail
+
+scale_neon_loop4:
+    VLD1.P 16(R2), [V0.S4]
+    VLD1.P 16(R2), [V1.S4]
+
+    // Deinterleave: V4=[ar], V5=[ai]
+    WORD $0x4E811804             // UZP1 V4.4S, V0.4S, V1.4S
+    WORD $0x4E815805             // UZP2 V5.4S, V0.4S, V1.4S
+
+    // V8 = ar * sr
+    WORD $0x6E34DC88             // FMUL V8.4S, V4.4S, V20.4S
+    // V9 = ai * si
+    WORD $0x6E35DCA9             // FMUL V9.4S, V5.4S, V21.4S
+    // V10 = ar * si
+    WORD $0x6E35DC8A             // FMUL V10.4S, V4.4S, V21.4S
+    // V11 = ai * sr
+    WORD $0x6E34DCAB             // FMUL V11.4S, V5.4S, V20.4S
+
+    // result_real = ar*sr - ai*si (V12)
+    WORD $0x4EA9D50C             // FSUB V12.4S, V8.4S, V9.4S
+    // result_imag = ar*si + ai*sr (V13)
+    WORD $0x4E2BD54D             // FADD V13.4S, V10.4S, V11.4S
+
+    // Interleave results
+    WORD $0x4E8D398E             // ZIP1 V14.4S, V12.4S, V13.4S
+    WORD $0x4E8D798F             // ZIP2 V15.4S, V12.4S, V13.4S
+
+    VST1.P [V14.S4], 16(R0)
+    VST1.P [V15.S4], 16(R0)
+
+    SUB  $4, R1
+    CMP  $4, R1
+    BGE  scale_neon_loop4
+
+    CBZ  R1, scale_neon_done
+
+scale_neon_tail:
+    FMOVS (R2), F0               // ar
+    FMOVS 4(R2), F1              // ai
+
+    FMULS F0, F20, F2            // ar * sr
+    FMULS F1, F21, F3            // ai * si
+    FMULS F0, F21, F4            // ar * si
+    FMULS F1, F20, F5            // ai * sr
+
+    FSUBS F3, F2, F2             // ar*sr - ai*si
+    FADDS F4, F5, F3             // ar*si + ai*sr
+
+    FMOVS F2, (R0)
+    FMOVS F3, 4(R0)
+
+    ADD  $8, R2
+    ADD  $8, R0
+    SUB  $1, R1
+    CBNZ R1, scale_neon_tail
+
+scale_neon_done:
+    RET
+
+// func addNEON(dst, a, b []complex64)
+TEXT ·addNEON(SB), NOSPLIT, $0-72
+    MOVD dst_base+0(FP), R0
+    MOVD dst_len+8(FP), R1
+    MOVD a_base+24(FP), R2
+    MOVD b_base+48(FP), R3
+
+    CBZ  R1, add_neon_done
+
+    CMP  $4, R1
+    BLT  add_neon_tail
+
+add_neon_loop4:
+    VLD1.P 16(R2), [V0.S4]
+    VLD1.P 16(R2), [V1.S4]
+    VLD1.P 16(R3), [V2.S4]
+    VLD1.P 16(R3), [V3.S4]
+
+    // FADD V4.4S, V0.4S, V2.4S
+    WORD $0x4E22D404
+    // FADD V5.4S, V1.4S, V3.4S
+    WORD $0x4E23D425
+
+    VST1.P [V4.S4], 16(R0)
+    VST1.P [V5.S4], 16(R0)
+
+    SUB  $4, R1
+    CMP  $4, R1
+    BGE  add_neon_loop4
+
+    CBZ  R1, add_neon_done
+
+add_neon_tail:
+    FMOVS (R2), F0
+    FMOVS 4(R2), F1
+    FMOVS (R3), F2
+    FMOVS 4(R3), F3
+
+    FADDS F0, F2, F4
+    FADDS F1, F3, F5
+
+    FMOVS F4, (R0)
+    FMOVS F5, 4(R0)
+
+    ADD  $8, R2
+    ADD  $8, R3
+    ADD  $8, R0
+    SUB  $1, R1
+    CBNZ R1, add_neon_tail
+
+add_neon_done:
+    RET
+
+// func subNEON(dst, a, b []complex64)
+TEXT ·subNEON(SB), NOSPLIT, $0-72
+    MOVD dst_base+0(FP), R0
+    MOVD dst_len+8(FP), R1
+    MOVD a_base+24(FP), R2
+    MOVD b_base+48(FP), R3
+
+    CBZ  R1, sub_neon_done
+
+    CMP  $4, R1
+    BLT  sub_neon_tail
+
+sub_neon_loop4:
+    VLD1.P 16(R2), [V0.S4]
+    VLD1.P 16(R2), [V1.S4]
+    VLD1.P 16(R3), [V2.S4]
+    VLD1.P 16(R3), [V3.S4]
+
+    // FSUB V4.4S, V0.4S, V2.4S
+    WORD $0x4EA2D404
+    // FSUB V5.4S, V1.4S, V3.4S
+    WORD $0x4EA3D425
+
+    VST1.P [V4.S4], 16(R0)
+    VST1.P [V5.S4], 16(R0)
+
+    SUB  $4, R1
+    CMP  $4, R1
+    BGE  sub_neon_loop4
+
+    CBZ  R1, sub_neon_done
+
+sub_neon_tail:
+    FMOVS (R2), F0
+    FMOVS 4(R2), F1
+    FMOVS (R3), F2
+    FMOVS 4(R3), F3
+
+    FSUBS F2, F0, F4
+    FSUBS F3, F1, F5
+
+    FMOVS F4, (R0)
+    FMOVS F5, 4(R0)
+
+    ADD  $8, R2
+    ADD  $8, R3
+    ADD  $8, R0
+    SUB  $1, R1
+    CBNZ R1, sub_neon_tail
+
+sub_neon_done:
+    RET
+
+// ============================================================================
+// ABS - COMPLEX MAGNITUDE: |a + bi| = sqrt(a^2 + b^2)
+// ============================================================================
+
+// func absNEON(dst []float32, a []complex64)
+TEXT ·absNEON(SB), NOSPLIT, $0-48
+    MOVD dst_base+0(FP), R0
+    MOVD dst_len+8(FP), R1
+    MOVD a_base+24(FP), R2
+
+    CBZ  R1, abs_neon_done
+
+    CMP  $4, R1
+    BLT  abs_neon_tail
+
+abs_neon_loop4:
+    // Load 4 complex64
+    VLD1.P 16(R2), [V0.S4]
+    VLD1.P 16(R2), [V1.S4]
+
+    // Deinterleave: V4=[r0,r1,r2,r3], V5=[i0,i1,i2,i3]
+    WORD $0x4E811804             // UZP1 V4.4S, V0.4S, V1.4S
+    WORD $0x4E815805             // UZP2 V5.4S, V0.4S, V1.4S
+
+    // V6 = r^2
+    WORD $0x6E24DC86             // FMUL V6.4S, V4.4S, V4.4S
+    // V7 = i^2
+    WORD $0x6E25DCA7             // FMUL V7.4S, V5.4S, V5.4S
+    // V8 = r^2 + i^2
+    WORD $0x4E27D4C8             // FADD V8.4S, V6.4S, V7.4S
+
+    // V8 = sqrt(V8) using FSQRT.4S
+    WORD $0x6EA1F908             // FSQRT V8.4S, V8.4S
+
+    // Store 4 float32 results
+    VST1.P [V8.S4], 16(R0)
+
+    SUB  $4, R1
+    CMP  $4, R1
+    BGE  abs_neon_loop4
+
+    CBZ  R1, abs_neon_done
+
+abs_neon_tail:
+    FMOVS (R2), F0               // r
+    FMOVS 4(R2), F1              // i
+
+    FMULS F0, F0, F2             // r^2
+    FMULS F1, F1, F3             // i^2
+    FADDS F2, F3, F4             // r^2 + i^2
+    FSQRTS F4, F5                // sqrt
+
+    FMOVS F5, (R0)
+
+    ADD  $8, R2
+    ADD  $4, R0
+    SUB  $1, R1
+    CBNZ R1, abs_neon_tail
+
+abs_neon_done:
+    RET
+
+// ============================================================================
+// ABSSQ - MAGNITUDE SQUARED: |a + bi|^2 = a^2 + b^2
+// ============================================================================
+
+// func absSqNEON(dst []float32, a []complex64)
+TEXT ·absSqNEON(SB), NOSPLIT, $0-48
+    MOVD dst_base+0(FP), R0
+    MOVD dst_len+8(FP), R1
+    MOVD a_base+24(FP), R2
+
+    CBZ  R1, abssq_neon_done
+
+    CMP  $4, R1
+    BLT  abssq_neon_tail
+
+abssq_neon_loop4:
+    VLD1.P 16(R2), [V0.S4]
+    VLD1.P 16(R2), [V1.S4]
+
+    // Deinterleave
+    WORD $0x4E811804             // UZP1 V4.4S, V0.4S, V1.4S
+    WORD $0x4E815805             // UZP2 V5.4S, V0.4S, V1.4S
+
+    // V6 = r^2
+    WORD $0x6E24DC86             // FMUL V6.4S, V4.4S, V4.4S
+    // V7 = i^2
+    WORD $0x6E25DCA7             // FMUL V7.4S, V5.4S, V5.4S
+    // V8 = r^2 + i^2
+    WORD $0x4E27D4C8             // FADD V8.4S, V6.4S, V7.4S
+
+    // Store 4 float32 (no sqrt needed)
+    VST1.P [V8.S4], 16(R0)
+
+    SUB  $4, R1
+    CMP  $4, R1
+    BGE  abssq_neon_loop4
+
+    CBZ  R1, abssq_neon_done
+
+abssq_neon_tail:
+    FMOVS (R2), F0
+    FMOVS 4(R2), F1
+
+    FMULS F0, F0, F2
+    FMULS F1, F1, F3
+    FADDS F2, F3, F4
+
+    FMOVS F4, (R0)
+
+    ADD  $8, R2
+    ADD  $4, R0
+    SUB  $1, R1
+    CBNZ R1, abssq_neon_tail
+
+abssq_neon_done:
+    RET
+
+// ============================================================================
+// CONJ - COMPLEX CONJUGATE: conj(a + bi) = a - bi
+// ============================================================================
+
+// func conjNEON(dst, a []complex64)
+TEXT ·conjNEON(SB), NOSPLIT, $0-48
+    MOVD dst_base+0(FP), R0
+    MOVD dst_len+8(FP), R1
+    MOVD a_base+24(FP), R2
+
+    CBZ  R1, conj_neon_done
+
+    CMP  $4, R1
+    BLT  conj_neon_tail
+
+conj_neon_loop4:
+    VLD1.P 16(R2), [V0.S4]
+    VLD1.P 16(R2), [V1.S4]
+
+    // Deinterleave: V4=[r], V5=[i]
+    WORD $0x4E811804             // UZP1 V4.4S, V0.4S, V1.4S
+    WORD $0x4E815805             // UZP2 V5.4S, V0.4S, V1.4S
+
+    // Negate imaginary parts: FNEG V5.4S, V5.4S
+    WORD $0x6EA0F8A5             // FNEG V5.4S, V5.4S
+
+    // Interleave back: V6=[r0,-i0,r1,-i1], V7=[r2,-i2,r3,-i3]
+    WORD $0x4E853886             // ZIP1 V6.4S, V4.4S, V5.4S
+    WORD $0x4E857887             // ZIP2 V7.4S, V4.4S, V5.4S
+
+    VST1.P [V6.S4], 16(R0)
+    VST1.P [V7.S4], 16(R0)
+
+    SUB  $4, R1
+    CMP  $4, R1
+    BGE  conj_neon_loop4
+
+    CBZ  R1, conj_neon_done
+
+conj_neon_tail:
+    FMOVS (R2), F0               // r
+    FMOVS 4(R2), F1              // i
+
+    FNEGS F1, F1                 // -i
+
+    FMOVS F0, (R0)
+    FMOVS F1, 4(R0)
+
+    ADD  $8, R2
+    ADD  $8, R0
+    SUB  $1, R1
+    CBNZ R1, conj_neon_tail
+
+conj_neon_done:
+    RET
+
+// ============================================================================
+// FROMREAL - CONVERT REAL TO COMPLEX: complex(x, 0)
+// ============================================================================
+
+// func fromRealNEON(dst []complex64, src []float32)
+TEXT ·fromRealNEON(SB), NOSPLIT, $0-48
+    MOVD dst_base+0(FP), R0
+    MOVD dst_len+8(FP), R1
+    MOVD src_base+24(FP), R2
+
+    CBZ  R1, fromreal_neon_done
+
+    CMP  $4, R1
+    BLT  fromreal_neon_tail
+
+    // Zero register for interleaving
+    VEOR V15.B16, V15.B16, V15.B16
+
+fromreal_neon_loop4:
+    // Load 4 float32: V0=[r0,r1,r2,r3]
+    VLD1.P 16(R2), [V0.S4]
+
+    // Interleave with zeros: V1=[r0,0,r1,0], V2=[r2,0,r3,0]
+    // ZIP1 V1.4S, V0.4S, V15.4S
+    WORD $0x4E8F3801             // ZIP1 V1.4S, V0.4S, V15.4S
+    // ZIP2 V2.4S, V0.4S, V15.4S
+    WORD $0x4E8F7802             // ZIP2 V2.4S, V0.4S, V15.4S
+
+    // Store 4 complex64 = 32 bytes
+    VST1.P [V1.S4], 16(R0)
+    VST1.P [V2.S4], 16(R0)
+
+    SUB  $4, R1
+    CMP  $4, R1
+    BGE  fromreal_neon_loop4
+
+    CBZ  R1, fromreal_neon_done
+
+fromreal_neon_tail:
+    FMOVS (R2), F0               // r
+    FMOVS ZR, F1                 // 0
+
+    FMOVS F0, (R0)
+    FMOVS F1, 4(R0)
+
+    ADD  $4, R2
+    ADD  $8, R0
+    SUB  $1, R1
+    CBNZ R1, fromreal_neon_tail
+
+fromreal_neon_done:
+    RET

--- a/c64/c64_go.go
+++ b/c64/c64_go.go
@@ -1,0 +1,79 @@
+package c64
+
+import "math"
+
+// Pure Go implementations - used as fallback on all architectures
+
+// mulGo computes element-wise complex multiplication.
+// (a + bi)(c + di) = (ac - bd) + (ad + bc)i
+func mulGo(dst, a, b []complex64) {
+	for i := range dst {
+		dst[i] = a[i] * b[i]
+	}
+}
+
+// mulConjGo computes element-wise multiplication by conjugate.
+// (a + bi)(c - di) = (ac + bd) + (bc - ad)i
+func mulConjGo(dst, a, b []complex64) {
+	for i := range dst {
+		ar, ai := real(a[i]), imag(a[i])
+		br, bi := real(b[i]), imag(b[i])
+		// conj(b) = br - bi*i
+		// a * conj(b) = (ar + ai*i)(br - bi*i)
+		//             = ar*br + ai*bi + (ai*br - ar*bi)*i
+		dst[i] = complex(ar*br+ai*bi, ai*br-ar*bi)
+	}
+}
+
+// scaleGo multiplies each element by a complex scalar.
+func scaleGo(dst, a []complex64, s complex64) {
+	for i := range dst {
+		dst[i] = a[i] * s
+	}
+}
+
+// addGo computes element-wise complex addition.
+func addGo(dst, a, b []complex64) {
+	for i := range dst {
+		dst[i] = a[i] + b[i]
+	}
+}
+
+// subGo computes element-wise complex subtraction.
+func subGo(dst, a, b []complex64) {
+	for i := range dst {
+		dst[i] = a[i] - b[i]
+	}
+}
+
+// absGo computes element-wise complex magnitude: |a + bi| = sqrt(a^2 + b^2).
+func absGo(dst []float32, a []complex64) {
+	for i := range dst {
+		r := float64(real(a[i]))
+		im := float64(imag(a[i]))
+		dst[i] = float32(math.Hypot(r, im))
+	}
+}
+
+// absSqGo computes element-wise magnitude squared: |a + bi|^2 = a^2 + b^2.
+func absSqGo(dst []float32, a []complex64) {
+	for i := range dst {
+		r := real(a[i])
+		im := imag(a[i])
+		dst[i] = r*r + im*im
+	}
+}
+
+// conjGo computes element-wise complex conjugate: conj(a + bi) = a - bi.
+func conjGo(dst, a []complex64) {
+	for i := range dst {
+		dst[i] = complex(real(a[i]), -imag(a[i]))
+	}
+}
+
+// fromRealGo converts real float32 values to complex64.
+func fromRealGo(dst []complex64, src []float32) {
+	for i := range dst {
+		dst[i] = complex(src[i], 0)
+	}
+}

--- a/c64/c64_other.go
+++ b/c64/c64_other.go
@@ -1,0 +1,15 @@
+//go:build !amd64 && !arm64
+
+package c64
+
+// Fallback implementations for unsupported architectures
+
+func mul64(dst, a, b []complex64)               { mulGo(dst, a, b) }
+func mulConj64(dst, a, b []complex64)           { mulConjGo(dst, a, b) }
+func scale64(dst, a []complex64, s complex64)   { scaleGo(dst, a, s) }
+func add64(dst, a, b []complex64)               { addGo(dst, a, b) }
+func sub64(dst, a, b []complex64)               { subGo(dst, a, b) }
+func abs64(dst []float32, a []complex64)        { absGo(dst, a) }
+func absSq64(dst []float32, a []complex64)      { absSqGo(dst, a) }
+func conj64(dst, a []complex64)                 { conjGo(dst, a) }
+func fromReal64(dst []complex64, src []float32) { fromRealGo(dst, src) }

--- a/c64/c64_test.go
+++ b/c64/c64_test.go
@@ -1,6 +1,7 @@
 package c64
 
 import (
+	"fmt"
 	"math"
 	"testing"
 
@@ -176,7 +177,7 @@ func TestSub(t *testing.T) {
 // Test various sizes to exercise SIMD remainder handling
 func TestMul_Sizes(t *testing.T) {
 	for size := 1; size <= 17; size++ {
-		t.Run("", func(t *testing.T) {
+		t.Run(fmt.Sprintf("size=%d", size), func(t *testing.T) {
 			a := make([]complex64, size)
 			b := make([]complex64, size)
 			for i := range size {

--- a/c64/c64_test.go
+++ b/c64/c64_test.go
@@ -1,0 +1,715 @@
+package c64
+
+import (
+	"math"
+	"testing"
+
+	"github.com/tphakala/simd/cpu"
+)
+
+const epsilon = 1e-5 // float32 has ~7 decimal digits precision
+
+func complexClose(a, b complex64) bool {
+	return math.Abs(float64(real(a)-real(b))) < epsilon && math.Abs(float64(imag(a)-imag(b))) < epsilon
+}
+
+func floatClose(a, b float32) bool {
+	return math.Abs(float64(a-b)) < epsilon
+}
+
+func TestMul(t *testing.T) {
+	t.Logf("CPU: %s", cpu.Info())
+
+	tests := []struct {
+		name string
+		a, b []complex64
+		want []complex64
+	}{
+		{"empty", nil, nil, nil},
+		{"single", []complex64{1 + 2i}, []complex64{3 + 4i}, []complex64{-5 + 10i}},
+		{"two", []complex64{1 + 2i, 3 + 4i}, []complex64{5 + 6i, 7 + 8i}, []complex64{-7 + 16i, -11 + 52i}},
+		{"pure_real", []complex64{2 + 0i, 3 + 0i}, []complex64{4 + 0i, 5 + 0i}, []complex64{8 + 0i, 15 + 0i}},
+		{"pure_imag", []complex64{0 + 2i, 0 + 3i}, []complex64{0 + 4i, 0 + 5i}, []complex64{-8 + 0i, -15 + 0i}},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if len(tt.a) == 0 {
+				dst := make([]complex64, 0)
+				Mul(dst, tt.a, tt.b)
+				return
+			}
+			dst := make([]complex64, len(tt.a))
+			Mul(dst, tt.a, tt.b)
+			for i := range dst {
+				if !complexClose(dst[i], tt.want[i]) {
+					t.Errorf("Mul()[%d] = %v, want %v", i, dst[i], tt.want[i])
+				}
+			}
+		})
+	}
+}
+
+func TestMul_Large(t *testing.T) {
+	n := 100
+	a := make([]complex64, n)
+	b := make([]complex64, n)
+	for i := range n {
+		a[i] = complex(float32(i+1), float32(i+2))
+		b[i] = complex(float32(i+3), float32(i+4))
+	}
+
+	dst := make([]complex64, n)
+	Mul(dst, a, b)
+
+	// Verify against Go's complex multiplication
+	for i := range n {
+		expected := a[i] * b[i]
+		if !complexClose(dst[i], expected) {
+			t.Errorf("Mul_Large()[%d] = %v, want %v", i, dst[i], expected)
+		}
+	}
+}
+
+func TestMulConj(t *testing.T) {
+	tests := []struct {
+		name string
+		a, b []complex64
+	}{
+		{"single", []complex64{1 + 2i}, []complex64{3 + 4i}},
+		{"two", []complex64{1 + 2i, 3 + 4i}, []complex64{5 + 6i, 7 + 8i}},
+		{"mixed", []complex64{-1 + 2i, 3 - 4i, 5 + 0i}, []complex64{1 + 1i, 2 - 2i, 0 + 3i}},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			dst := make([]complex64, len(tt.a))
+			MulConj(dst, tt.a, tt.b)
+			for i := range dst {
+				// conj(b) = real(b) - imag(b)i
+				conjB := complex(real(tt.b[i]), -imag(tt.b[i]))
+				expected := tt.a[i] * conjB
+				if !complexClose(dst[i], expected) {
+					t.Errorf("MulConj()[%d] = %v, want %v", i, dst[i], expected)
+				}
+			}
+		})
+	}
+}
+
+func TestMulConj_Large(t *testing.T) {
+	n := 100
+	a := make([]complex64, n)
+	b := make([]complex64, n)
+	for i := range n {
+		a[i] = complex(float32(i+1), float32(i+2))
+		b[i] = complex(float32(i+3), float32(i+4))
+	}
+
+	dst := make([]complex64, n)
+	MulConj(dst, a, b)
+
+	for i := range n {
+		conjB := complex(real(b[i]), -imag(b[i]))
+		expected := a[i] * conjB
+		if !complexClose(dst[i], expected) {
+			t.Errorf("MulConj_Large()[%d] = %v, want %v", i, dst[i], expected)
+		}
+	}
+}
+
+func TestScale(t *testing.T) {
+	tests := []struct {
+		name string
+		a    []complex64
+		s    complex64
+	}{
+		{"single", []complex64{1 + 2i}, 3 + 4i},
+		{"two", []complex64{1 + 2i, 3 + 4i}, 2 + 0i},
+		{"by_i", []complex64{1 + 0i, 0 + 1i, 1 + 1i}, 0 + 1i},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			dst := make([]complex64, len(tt.a))
+			Scale(dst, tt.a, tt.s)
+			for i := range dst {
+				expected := tt.a[i] * tt.s
+				if !complexClose(dst[i], expected) {
+					t.Errorf("Scale()[%d] = %v, want %v", i, dst[i], expected)
+				}
+			}
+		})
+	}
+}
+
+func TestAdd(t *testing.T) {
+	a := []complex64{1 + 2i, 3 + 4i, 5 + 6i}
+	b := []complex64{7 + 8i, 9 + 10i, 11 + 12i}
+	dst := make([]complex64, len(a))
+
+	Add(dst, a, b)
+
+	for i := range dst {
+		expected := a[i] + b[i]
+		if !complexClose(dst[i], expected) {
+			t.Errorf("Add()[%d] = %v, want %v", i, dst[i], expected)
+		}
+	}
+}
+
+func TestSub(t *testing.T) {
+	a := []complex64{10 + 20i, 30 + 40i, 50 + 60i}
+	b := []complex64{1 + 2i, 3 + 4i, 5 + 6i}
+	dst := make([]complex64, len(a))
+
+	Sub(dst, a, b)
+
+	for i := range dst {
+		expected := a[i] - b[i]
+		if !complexClose(dst[i], expected) {
+			t.Errorf("Sub()[%d] = %v, want %v", i, dst[i], expected)
+		}
+	}
+}
+
+// Test various sizes to exercise SIMD remainder handling
+func TestMul_Sizes(t *testing.T) {
+	for size := 1; size <= 17; size++ {
+		t.Run("", func(t *testing.T) {
+			a := make([]complex64, size)
+			b := make([]complex64, size)
+			for i := range size {
+				a[i] = complex(float32(i+1), float32(i+2))
+				b[i] = complex(float32(i+3), float32(i+4))
+			}
+
+			dst := make([]complex64, size)
+			Mul(dst, a, b)
+
+			for i := range size {
+				expected := a[i] * b[i]
+				if !complexClose(dst[i], expected) {
+					t.Errorf("size=%d, Mul()[%d] = %v, want %v", size, i, dst[i], expected)
+				}
+			}
+		})
+	}
+}
+
+// ============================================================================
+// Tests for Abs, AbsSq, Conj, FromReal
+// ============================================================================
+
+func TestAbs(t *testing.T) {
+	t.Logf("CPU: %s", cpu.Info())
+
+	tests := []struct {
+		name string
+		a    []complex64
+	}{
+		{"single_1_0", []complex64{1 + 0i}},
+		{"single_3_4", []complex64{3 + 4i}},    // Should give 5
+		{"pair", []complex64{3 + 4i, 5 + 12i}}, // 5, 13
+		{"pure_real", []complex64{5 + 0i, 10 + 0i}},
+		{"pure_imag", []complex64{0 + 5i, 0 + 10i}},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			dst := make([]float32, len(tt.a))
+			Abs(dst, tt.a)
+			for i := range dst {
+				r := float64(real(tt.a[i]))
+				im := float64(imag(tt.a[i]))
+				expected := float32(math.Sqrt(r*r + im*im))
+				if !floatClose(dst[i], expected) {
+					t.Errorf("Abs()[%d] = %v, want %v", i, dst[i], expected)
+				}
+			}
+		})
+	}
+}
+
+func TestAbs_Large(t *testing.T) {
+	n := 100
+	a := make([]complex64, n)
+	for i := range n {
+		a[i] = complex(float32(i+1), float32(i+2))
+	}
+
+	dst := make([]float32, n)
+	Abs(dst, a)
+
+	for i := range n {
+		r := float64(real(a[i]))
+		im := float64(imag(a[i]))
+		expected := float32(math.Sqrt(r*r + im*im))
+		if !floatClose(dst[i], expected) {
+			t.Errorf("Abs_Large()[%d] = %v, want %v", i, dst[i], expected)
+		}
+	}
+}
+
+func TestAbsSq(t *testing.T) {
+	tests := []struct {
+		name string
+		a    []complex64
+	}{
+		{"single_3_4", []complex64{3 + 4i}},    // 25
+		{"pair", []complex64{3 + 4i, 5 + 12i}}, // 25, 169
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			dst := make([]float32, len(tt.a))
+			AbsSq(dst, tt.a)
+			for i := range dst {
+				r := real(tt.a[i])
+				im := imag(tt.a[i])
+				expected := r*r + im*im
+				if !floatClose(dst[i], expected) {
+					t.Errorf("AbsSq()[%d] = %v, want %v", i, dst[i], expected)
+				}
+			}
+		})
+	}
+}
+
+func TestAbsSq_Large(t *testing.T) {
+	n := 100
+	a := make([]complex64, n)
+	for i := range n {
+		a[i] = complex(float32(i+1), float32(i+2))
+	}
+
+	dst := make([]float32, n)
+	AbsSq(dst, a)
+
+	for i := range n {
+		r := real(a[i])
+		im := imag(a[i])
+		expected := r*r + im*im
+		if !floatClose(dst[i], expected) {
+			t.Errorf("AbsSq_Large()[%d] = %v, want %v", i, dst[i], expected)
+		}
+	}
+}
+
+func TestConj(t *testing.T) {
+	tests := []struct {
+		name string
+		a    []complex64
+		want []complex64
+	}{
+		{"empty", nil, nil},
+		{"single", []complex64{1 + 2i}, []complex64{1 - 2i}},
+		{"pair", []complex64{1 + 2i, 3 + 4i}, []complex64{1 - 2i, 3 - 4i}},
+		{"pure_real", []complex64{5 + 0i}, []complex64{5 + 0i}},
+		{"pure_imag", []complex64{0 + 5i}, []complex64{0 - 5i}},
+		{"zero", []complex64{0 + 0i}, []complex64{0 + 0i}},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if len(tt.a) == 0 {
+				dst := make([]complex64, 0)
+				Conj(dst, tt.a)
+				return
+			}
+			dst := make([]complex64, len(tt.a))
+			Conj(dst, tt.a)
+			for i := range dst {
+				if !complexClose(dst[i], tt.want[i]) {
+					t.Errorf("Conj()[%d] = %v, want %v", i, dst[i], tt.want[i])
+				}
+			}
+		})
+	}
+}
+
+func TestConj_Large(t *testing.T) {
+	n := 100
+	a := make([]complex64, n)
+	for i := range n {
+		a[i] = complex(float32(i+1), float32(i+2))
+	}
+
+	dst := make([]complex64, n)
+	Conj(dst, a)
+
+	for i := range n {
+		expected := complex(real(a[i]), -imag(a[i]))
+		if !complexClose(dst[i], expected) {
+			t.Errorf("Conj_Large()[%d] = %v, want %v", i, dst[i], expected)
+		}
+	}
+}
+
+func TestFromReal(t *testing.T) {
+	tests := []struct {
+		name string
+		src  []float32
+		want []complex64
+	}{
+		{"empty", nil, nil},
+		{"single", []float32{1}, []complex64{1 + 0i}},
+		{"pair", []float32{1, 2}, []complex64{1 + 0i, 2 + 0i}},
+		{"negative", []float32{-1, -2}, []complex64{-1 + 0i, -2 + 0i}},
+		{"zero", []float32{0, 0}, []complex64{0 + 0i, 0 + 0i}},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if len(tt.src) == 0 {
+				dst := make([]complex64, 0)
+				FromReal(dst, tt.src)
+				return
+			}
+			dst := make([]complex64, len(tt.src))
+			FromReal(dst, tt.src)
+			for i := range dst {
+				if !complexClose(dst[i], tt.want[i]) {
+					t.Errorf("FromReal()[%d] = %v, want %v", i, dst[i], tt.want[i])
+				}
+			}
+		})
+	}
+}
+
+func TestFromReal_Large(t *testing.T) {
+	n := 100
+	src := make([]float32, n)
+	for i := range n {
+		src[i] = float32(i + 1)
+	}
+
+	dst := make([]complex64, n)
+	FromReal(dst, src)
+
+	for i := range n {
+		expected := complex(src[i], 0)
+		if !complexClose(dst[i], expected) {
+			t.Errorf("FromReal_Large()[%d] = %v, want %v", i, dst[i], expected)
+		}
+	}
+}
+
+// ============================================================================
+// Benchmarks
+// ============================================================================
+
+func benchmarkBinaryOp(b *testing.B, size int, simdFn, goFn func(dst, a, bb []complex64)) {
+	b.Helper()
+	a := make([]complex64, size)
+	bb := make([]complex64, size)
+	dst := make([]complex64, size)
+	for i := range size {
+		a[i] = complex(float32(i+1), float32(i+2))
+		bb[i] = complex(float32(i+3), float32(i+4))
+	}
+
+	b.Run("SIMD", func(b *testing.B) {
+		b.SetBytes(int64(size * 8 * 3)) // 3 slices, 8 bytes per complex64
+		for i := 0; i < b.N; i++ {
+			simdFn(dst, a, bb)
+		}
+	})
+
+	b.Run("Go", func(b *testing.B) {
+		b.SetBytes(int64(size * 8 * 3))
+		for i := 0; i < b.N; i++ {
+			goFn(dst, a, bb)
+		}
+	})
+}
+
+func BenchmarkMul(b *testing.B) {
+	benchmarkBinaryOp(b, 1024, Mul, mulGo)
+}
+
+func BenchmarkMulConj(b *testing.B) {
+	benchmarkBinaryOp(b, 1024, MulConj, mulConjGo)
+}
+
+func BenchmarkAdd(b *testing.B) {
+	benchmarkBinaryOp(b, 1024, Add, addGo)
+}
+
+func BenchmarkScale(b *testing.B) {
+	size := 1024
+	a := make([]complex64, size)
+	dst := make([]complex64, size)
+	s := complex64(1.5 + 2.5i)
+	for i := range size {
+		a[i] = complex(float32(i+1), float32(i+2))
+	}
+
+	b.Run("SIMD", func(b *testing.B) {
+		b.SetBytes(int64(size * 8 * 2))
+		for i := 0; i < b.N; i++ {
+			Scale(dst, a, s)
+		}
+	})
+
+	b.Run("Go", func(b *testing.B) {
+		b.SetBytes(int64(size * 8 * 2))
+		for i := 0; i < b.N; i++ {
+			scaleGo(dst, a, s)
+		}
+	})
+}
+
+func benchmarkUnaryAbsOp(b *testing.B, size int, simdFn, goFn func([]float32, []complex64)) {
+	b.Helper()
+	a := make([]complex64, size)
+	dst := make([]float32, size)
+	for i := range size {
+		a[i] = complex(float32(i+1), float32(i+2))
+	}
+
+	b.Run("SIMD", func(b *testing.B) {
+		b.SetBytes(int64(size * 8)) // Input: complex64 (8 bytes)
+		for i := 0; i < b.N; i++ {
+			simdFn(dst, a)
+		}
+	})
+
+	b.Run("Go", func(b *testing.B) {
+		b.SetBytes(int64(size * 8))
+		for i := 0; i < b.N; i++ {
+			goFn(dst, a)
+		}
+	})
+}
+
+func benchmarkUnaryConjOp(b *testing.B, size int, simdFn, goFn func([]complex64, []complex64)) {
+	b.Helper()
+	a := make([]complex64, size)
+	dst := make([]complex64, size)
+	for i := range size {
+		a[i] = complex(float32(i+1), float32(i+2))
+	}
+
+	b.Run("SIMD", func(b *testing.B) {
+		b.SetBytes(int64(size * 8 * 2))
+		for i := 0; i < b.N; i++ {
+			simdFn(dst, a)
+		}
+	})
+
+	b.Run("Go", func(b *testing.B) {
+		b.SetBytes(int64(size * 8 * 2))
+		for i := 0; i < b.N; i++ {
+			goFn(dst, a)
+		}
+	})
+}
+
+func BenchmarkAbs(b *testing.B) {
+	benchmarkUnaryAbsOp(b, 1024, Abs, absGo)
+}
+
+func BenchmarkAbsSq(b *testing.B) {
+	benchmarkUnaryAbsOp(b, 1024, AbsSq, absSqGo)
+}
+
+func BenchmarkConj(b *testing.B) {
+	benchmarkUnaryConjOp(b, 1024, Conj, conjGo)
+}
+
+func BenchmarkFromReal(b *testing.B) {
+	size := 1024
+	src := make([]float32, size)
+	dst := make([]complex64, size)
+	for i := range size {
+		src[i] = float32(i + 1)
+	}
+
+	b.Run("SIMD", func(b *testing.B) {
+		b.SetBytes(int64(size * 4)) // Input: float32 (4 bytes)
+		for i := 0; i < b.N; i++ {
+			FromReal(dst, src)
+		}
+	})
+
+	b.Run("Go", func(b *testing.B) {
+		b.SetBytes(int64(size * 4))
+		for i := 0; i < b.N; i++ {
+			fromRealGo(dst, src)
+		}
+	})
+}
+
+// ============================================================================
+// Tests for Go fallback implementations
+// ============================================================================
+
+func TestMulGo(t *testing.T) {
+	a := []complex64{1 + 2i, 3 + 4i}
+	b := []complex64{5 + 6i, 7 + 8i}
+	dst := make([]complex64, 2)
+	mulGo(dst, a, b)
+	for i := range dst {
+		expected := a[i] * b[i]
+		if !complexClose(dst[i], expected) {
+			t.Errorf("mulGo()[%d] = %v, want %v", i, dst[i], expected)
+		}
+	}
+}
+
+func TestMulConjGo(t *testing.T) {
+	a := []complex64{1 + 2i, 3 + 4i}
+	b := []complex64{5 + 6i, 7 + 8i}
+	dst := make([]complex64, 2)
+	mulConjGo(dst, a, b)
+	for i := range dst {
+		conjB := complex(real(b[i]), -imag(b[i]))
+		expected := a[i] * conjB
+		if !complexClose(dst[i], expected) {
+			t.Errorf("mulConjGo()[%d] = %v, want %v", i, dst[i], expected)
+		}
+	}
+}
+
+func TestScaleGo(t *testing.T) {
+	a := []complex64{1 + 2i, 3 + 4i}
+	s := complex64(2 + 1i)
+	dst := make([]complex64, 2)
+	scaleGo(dst, a, s)
+	for i := range dst {
+		expected := a[i] * s
+		if !complexClose(dst[i], expected) {
+			t.Errorf("scaleGo()[%d] = %v, want %v", i, dst[i], expected)
+		}
+	}
+}
+
+func TestAddGo(t *testing.T) {
+	a := []complex64{1 + 2i, 3 + 4i}
+	b := []complex64{5 + 6i, 7 + 8i}
+	dst := make([]complex64, 2)
+	addGo(dst, a, b)
+	for i := range dst {
+		expected := a[i] + b[i]
+		if !complexClose(dst[i], expected) {
+			t.Errorf("addGo()[%d] = %v, want %v", i, dst[i], expected)
+		}
+	}
+}
+
+func TestSubGo(t *testing.T) {
+	a := []complex64{5 + 6i, 7 + 8i}
+	b := []complex64{1 + 2i, 3 + 4i}
+	dst := make([]complex64, 2)
+	subGo(dst, a, b)
+	for i := range dst {
+		expected := a[i] - b[i]
+		if !complexClose(dst[i], expected) {
+			t.Errorf("subGo()[%d] = %v, want %v", i, dst[i], expected)
+		}
+	}
+}
+
+func TestAbsGo(t *testing.T) {
+	a := []complex64{3 + 4i, 5 + 12i}
+	dst := make([]float32, 2)
+	absGo(dst, a)
+	want := []float32{5, 13}
+	for i := range dst {
+		if !floatClose(dst[i], want[i]) {
+			t.Errorf("absGo()[%d] = %v, want %v", i, dst[i], want[i])
+		}
+	}
+}
+
+func TestAbsSqGo(t *testing.T) {
+	a := []complex64{3 + 4i, 5 + 12i}
+	dst := make([]float32, 2)
+	absSqGo(dst, a)
+	want := []float32{25, 169}
+	for i := range dst {
+		if !floatClose(dst[i], want[i]) {
+			t.Errorf("absSqGo()[%d] = %v, want %v", i, dst[i], want[i])
+		}
+	}
+}
+
+func TestConjGo(t *testing.T) {
+	a := []complex64{1 + 2i, 3 + 4i}
+	dst := make([]complex64, 2)
+	conjGo(dst, a)
+	want := []complex64{1 - 2i, 3 - 4i}
+	for i := range dst {
+		if !complexClose(dst[i], want[i]) {
+			t.Errorf("conjGo()[%d] = %v, want %v", i, dst[i], want[i])
+		}
+	}
+}
+
+func TestFromRealGo(t *testing.T) {
+	src := []float32{1, 2, 3}
+	dst := make([]complex64, 3)
+	fromRealGo(dst, src)
+	want := []complex64{1 + 0i, 2 + 0i, 3 + 0i}
+	for i := range dst {
+		if !complexClose(dst[i], want[i]) {
+			t.Errorf("fromRealGo()[%d] = %v, want %v", i, dst[i], want[i])
+		}
+	}
+}
+
+// ============================================================================
+// Tests for empty slice edge cases
+// ============================================================================
+
+func TestMulConj_Empty(_ *testing.T) {
+	var a, b, dst []complex64
+	MulConj(dst, a, b)
+}
+
+func TestScale_Empty(_ *testing.T) {
+	var a, dst []complex64
+	Scale(dst, a, 1+1i)
+}
+
+func TestAdd_Empty(_ *testing.T) {
+	var a, b, dst []complex64
+	Add(dst, a, b)
+}
+
+func TestSub_Empty(_ *testing.T) {
+	var a, b, dst []complex64
+	Sub(dst, a, b)
+}
+
+func TestAbs_Empty(_ *testing.T) {
+	var a []complex64
+	var dst []float32
+	Abs(dst, a)
+}
+
+func TestAbsSq_Empty(_ *testing.T) {
+	var a []complex64
+	var dst []float32
+	AbsSq(dst, a)
+}
+
+func TestMinLen(t *testing.T) {
+	tests := []struct {
+		a, b, c int
+		want    int
+	}{
+		{1, 2, 3, 1},
+		{3, 2, 1, 1},
+		{2, 1, 3, 1},
+		{5, 5, 5, 5},
+		{0, 1, 2, 0},
+	}
+	for _, tt := range tests {
+		got := minLen(tt.a, tt.b, tt.c)
+		if got != tt.want {
+			t.Errorf("minLen(%d, %d, %d) = %d, want %d", tt.a, tt.b, tt.c, got, tt.want)
+		}
+	}
+}

--- a/f32/f32_amd64.go
+++ b/f32/f32_amd64.go
@@ -549,3 +549,45 @@ func int32ToFloat32Scale(dst []float32, src []int32, scale float32) {
 
 //go:noescape
 func int32ToFloat32ScaleAVX(dst []float32, src []int32, scale float32)
+
+// ============================================================================
+// SPLIT-FORMAT COMPLEX OPERATIONS
+// ============================================================================
+
+func mulComplex32(dstRe, dstIm, aRe, aIm, bRe, bIm []float32) {
+	// Use AVX+FMA if available and have enough elements
+	if cpu.X86.AVX && cpu.X86.FMA && len(dstRe) >= minAVXElements {
+		mulComplexAVX(dstRe, dstIm, aRe, aIm, bRe, bIm)
+		return
+	}
+	mulComplex32Go(dstRe, dstIm, aRe, aIm, bRe, bIm)
+}
+
+func mulConjComplex32(dstRe, dstIm, aRe, aIm, bRe, bIm []float32) {
+	// Use AVX+FMA if available and have enough elements
+	if cpu.X86.AVX && cpu.X86.FMA && len(dstRe) >= minAVXElements {
+		mulConjComplexAVX(dstRe, dstIm, aRe, aIm, bRe, bIm)
+		return
+	}
+	mulConjComplex32Go(dstRe, dstIm, aRe, aIm, bRe, bIm)
+}
+
+func absSqComplex32(dst, aRe, aIm []float32) {
+	// Use AVX+FMA if available and have enough elements
+	if cpu.X86.AVX && cpu.X86.FMA && len(dst) >= minAVXElements {
+		absSqComplexAVX(dst, aRe, aIm)
+		return
+	}
+	absSqComplex32Go(dst, aRe, aIm)
+}
+
+// Split-format complex assembly function declarations
+//
+//go:noescape
+func mulComplexAVX(dstRe, dstIm, aRe, aIm, bRe, bIm []float32)
+
+//go:noescape
+func mulConjComplexAVX(dstRe, dstIm, aRe, aIm, bRe, bIm []float32)
+
+//go:noescape
+func absSqComplexAVX(dst, aRe, aIm []float32)

--- a/f32/f32_arm64.go
+++ b/f32/f32_arm64.go
@@ -352,3 +352,40 @@ func int32ToFloat32Scale(dst []float32, src []int32, scale float32) {
 
 //go:noescape
 func int32ToFloat32ScaleNEON(dst []float32, src []int32, scale float32)
+
+// ============================================================================
+// SPLIT-FORMAT COMPLEX OPERATIONS
+// ============================================================================
+
+func mulComplex32(dstRe, dstIm, aRe, aIm, bRe, bIm []float32) {
+	if hasNEON && len(dstRe) >= 4 {
+		mulComplexNEON(dstRe, dstIm, aRe, aIm, bRe, bIm)
+		return
+	}
+	mulComplex32Go(dstRe, dstIm, aRe, aIm, bRe, bIm)
+}
+
+func mulConjComplex32(dstRe, dstIm, aRe, aIm, bRe, bIm []float32) {
+	if hasNEON && len(dstRe) >= 4 {
+		mulConjComplexNEON(dstRe, dstIm, aRe, aIm, bRe, bIm)
+		return
+	}
+	mulConjComplex32Go(dstRe, dstIm, aRe, aIm, bRe, bIm)
+}
+
+func absSqComplex32(dst, aRe, aIm []float32) {
+	if hasNEON && len(dst) >= 4 {
+		absSqComplexNEON(dst, aRe, aIm)
+		return
+	}
+	absSqComplex32Go(dst, aRe, aIm)
+}
+
+//go:noescape
+func mulComplexNEON(dstRe, dstIm, aRe, aIm, bRe, bIm []float32)
+
+//go:noescape
+func mulConjComplexNEON(dstRe, dstIm, aRe, aIm, bRe, bIm []float32)
+
+//go:noescape
+func absSqComplexNEON(dst, aRe, aIm []float32)

--- a/f32/f32_arm64.s
+++ b/f32/f32_arm64.s
@@ -1555,9 +1555,10 @@ mulcplx_neon_scalar_loop:
     FMOVS (R7), F3                 // F3 = bIm
 
     // dstRe = aRe*bRe - aIm*bIm (avoid FMA for clarity)
+    // Go ARM64: FSUBS Fa, Fb, Fd → Fd = Fb - Fa
     FMULS F0, F2, F4               // F4 = aRe * bRe
     FMULS F1, F3, F5               // F5 = aIm * bIm
-    FSUBS F4, F5, F4               // F4 = F4 - F5 = aRe*bRe - aIm*bIm
+    FSUBS F5, F4, F4               // F4 = F4 - F5 = aRe*bRe - aIm*bIm
 
     // dstIm = aRe*bIm + aIm*bRe (avoid FMA for clarity)
     FMULS F0, F3, F5               // F5 = aRe * bIm
@@ -1640,9 +1641,10 @@ mulconjcplx_neon_scalar_loop:
     FADDS F4, F5, F4               // F4 = aRe*bRe + aIm*bIm
 
     // dstIm = aIm*bRe - aRe*bIm (avoid FMA for clarity)
+    // Go ARM64: FSUBS Fa, Fb, Fd → Fd = Fb - Fa
     FMULS F1, F2, F5               // F5 = aIm * bRe
     FMULS F0, F3, F6               // F6 = aRe * bIm
-    FSUBS F5, F6, F5               // F5 = aIm*bRe - aRe*bIm
+    FSUBS F6, F5, F5               // F5 = F5 - F6 = aIm*bRe - aRe*bIm
 
     FMOVS F4, (R0)
     FMOVS F5, (R1)

--- a/f32/f32_arm64.s
+++ b/f32/f32_arm64.s
@@ -1554,13 +1554,15 @@ mulcplx_neon_scalar_loop:
     FMOVS (R6), F2                 // F2 = bRe
     FMOVS (R7), F3                 // F3 = bIm
 
-    // dstRe = aRe*bRe - aIm*bIm
+    // dstRe = aRe*bRe - aIm*bIm (avoid FMA for clarity)
     FMULS F0, F2, F4               // F4 = aRe * bRe
-    FMSUBS F1, F3, F4, F4          // F4 = F4 - aIm*bIm
+    FMULS F1, F3, F5               // F5 = aIm * bIm
+    FSUBS F4, F5, F4               // F4 = F4 - F5 = aRe*bRe - aIm*bIm
 
-    // dstIm = aRe*bIm + aIm*bRe
+    // dstIm = aRe*bIm + aIm*bRe (avoid FMA for clarity)
     FMULS F0, F3, F5               // F5 = aRe * bIm
-    FMADDS F1, F2, F5, F5          // F5 = F5 + aIm*bRe
+    FMULS F1, F2, F6               // F6 = aIm * bRe
+    FADDS F5, F6, F5               // F5 = F5 + F6 = aRe*bIm + aIm*bRe
 
     // Store results
     FMOVS F4, (R0)
@@ -1632,13 +1634,15 @@ mulconjcplx_neon_scalar_loop:
     FMOVS (R6), F2                 // F2 = bRe
     FMOVS (R7), F3                 // F3 = bIm
 
-    // dstRe = aRe*bRe + aIm*bIm
+    // dstRe = aRe*bRe + aIm*bIm (avoid FMA for clarity)
     FMULS F0, F2, F4               // F4 = aRe * bRe
-    FMADDS F1, F3, F4, F4          // F4 = F4 + aIm*bIm
+    FMULS F1, F3, F5               // F5 = aIm * bIm
+    FADDS F4, F5, F4               // F4 = aRe*bRe + aIm*bIm
 
-    // dstIm = aIm*bRe - aRe*bIm
+    // dstIm = aIm*bRe - aRe*bIm (avoid FMA for clarity)
     FMULS F1, F2, F5               // F5 = aIm * bRe
-    FMSUBS F0, F3, F5, F5          // F5 = F5 - aRe*bIm
+    FMULS F0, F3, F6               // F6 = aRe * bIm
+    FSUBS F5, F6, F5               // F5 = aIm*bRe - aRe*bIm
 
     FMOVS F4, (R0)
     FMOVS F5, (R1)
@@ -1694,9 +1698,10 @@ abssqcplx_neon_scalar_loop:
     FMOVS (R4), F0                 // F0 = aRe
     FMOVS (R5), F1                 // F1 = aIm
 
-    // dst = aRe^2 + aIm^2
+    // dst = aRe^2 + aIm^2 (avoid FMA for clarity)
     FMULS F0, F0, F2               // F2 = aRe^2
-    FMADDS F1, F1, F2, F2          // F2 = F2 + aIm^2
+    FMULS F1, F1, F3               // F3 = aIm^2
+    FADDS F2, F3, F2               // F2 = aRe^2 + aIm^2
 
     FMOVS F2, (R0)
 

--- a/f32/f32_arm64.s
+++ b/f32/f32_arm64.s
@@ -1484,3 +1484,227 @@ i32tof32_neon_scalar_loop:
 
 i32tof32_neon_done:
     RET
+
+// ============================================================================
+// SPLIT-FORMAT COMPLEX OPERATIONS
+// ============================================================================
+//
+// These operate on split real/imag arrays - much simpler than interleaved
+// because we can load real and imag values directly without shuffling.
+//
+// NEON opcodes used:
+// FMUL Vd.4S, Vn.4S, Vm.4S: 0x6E20DC00 | (Vm << 16) | (Vn << 5) | Vd
+// FSUB Vd.4S, Vn.4S, Vm.4S: 0x4EA0D400 | (Vm << 16) | (Vn << 5) | Vd
+// FADD Vd.4S, Vn.4S, Vm.4S: 0x4E20D400 | (Vm << 16) | (Vn << 5) | Vd
+// FMLA Vd.4S, Vn.4S, Vm.4S: 0x4E20CC00 | (Vm << 16) | (Vn << 5) | Vd (Vd += Vn * Vm)
+// FMLS Vd.4S, Vn.4S, Vm.4S: 0x4EA0CC00 | (Vm << 16) | (Vn << 5) | Vd (Vd -= Vn * Vm)
+
+// func mulComplexNEON(dstRe, dstIm, aRe, aIm, bRe, bIm []float32)
+// Computes element-wise complex multiplication using split arrays:
+//   dstRe[i] = aRe[i]*bRe[i] - aIm[i]*bIm[i]
+//   dstIm[i] = aRe[i]*bIm[i] + aIm[i]*bRe[i]
+// Frame: dstRe(24) + dstIm(24) + aRe(24) + aIm(24) + bRe(24) + bIm(24) = 144 bytes
+TEXT ·mulComplexNEON(SB), NOSPLIT, $0-144
+    MOVD dstRe_base+0(FP), R0      // R0 = dstRe pointer
+    MOVD dstRe_len+8(FP), R3       // R3 = length
+    MOVD dstIm_base+24(FP), R1     // R1 = dstIm pointer
+    MOVD aRe_base+48(FP), R4       // R4 = aRe pointer
+    MOVD aIm_base+72(FP), R5       // R5 = aIm pointer
+    MOVD bRe_base+96(FP), R6       // R6 = bRe pointer
+    MOVD bIm_base+120(FP), R7      // R7 = bIm pointer
+
+    // Process 4 elements per iteration
+    LSR $2, R3, R8                 // R8 = len / 4
+    CBZ R8, mulcplx_neon_scalar
+
+mulcplx_neon_loop4:
+    // Load inputs
+    VLD1.P 16(R4), [V0.S4]         // V0 = aRe[0:4]
+    VLD1.P 16(R5), [V1.S4]         // V1 = aIm[0:4]
+    VLD1.P 16(R6), [V2.S4]         // V2 = bRe[0:4]
+    VLD1.P 16(R7), [V3.S4]         // V3 = bIm[0:4]
+
+    // dstRe = aRe*bRe - aIm*bIm
+    // V4 = aRe * bRe
+    WORD $0x6E22DC04               // FMUL V4.4S, V0.4S, V2.4S
+    // V4 = V4 - aIm*bIm (FMLS: Vd -= Vn*Vm)
+    WORD $0x4EA3CC24               // FMLS V4.4S, V1.4S, V3.4S
+
+    // dstIm = aRe*bIm + aIm*bRe
+    // V5 = aRe * bIm
+    WORD $0x6E23DC05               // FMUL V5.4S, V0.4S, V3.4S
+    // V5 = V5 + aIm*bRe (FMLA: Vd += Vn*Vm)
+    WORD $0x4E22CC25               // FMLA V5.4S, V1.4S, V2.4S
+
+    // Store results
+    VST1.P [V4.S4], 16(R0)         // dstRe[0:4]
+    VST1.P [V5.S4], 16(R1)         // dstIm[0:4]
+
+    SUB $1, R8
+    CBNZ R8, mulcplx_neon_loop4
+
+mulcplx_neon_scalar:
+    AND $3, R3                     // remainder
+    CBZ R3, mulcplx_neon_done
+
+mulcplx_neon_scalar_loop:
+    // Load single elements
+    FMOVS (R4), F0                 // F0 = aRe
+    FMOVS (R5), F1                 // F1 = aIm
+    FMOVS (R6), F2                 // F2 = bRe
+    FMOVS (R7), F3                 // F3 = bIm
+
+    // dstRe = aRe*bRe - aIm*bIm
+    FMULS F0, F2, F4               // F4 = aRe * bRe
+    FMSUBS F1, F3, F4, F4          // F4 = F4 - aIm*bIm
+
+    // dstIm = aRe*bIm + aIm*bRe
+    FMULS F0, F3, F5               // F5 = aRe * bIm
+    FMADDS F1, F2, F5, F5          // F5 = F5 + aIm*bRe
+
+    // Store results
+    FMOVS F4, (R0)
+    FMOVS F5, (R1)
+
+    ADD $4, R0
+    ADD $4, R1
+    ADD $4, R4
+    ADD $4, R5
+    ADD $4, R6
+    ADD $4, R7
+    SUB $1, R3
+    CBNZ R3, mulcplx_neon_scalar_loop
+
+mulcplx_neon_done:
+    RET
+
+// func mulConjComplexNEON(dstRe, dstIm, aRe, aIm, bRe, bIm []float32)
+// Computes element-wise multiplication by conjugate using split arrays:
+//   dstRe[i] = aRe[i]*bRe[i] + aIm[i]*bIm[i]
+//   dstIm[i] = aIm[i]*bRe[i] - aRe[i]*bIm[i]
+// Frame: dstRe(24) + dstIm(24) + aRe(24) + aIm(24) + bRe(24) + bIm(24) = 144 bytes
+TEXT ·mulConjComplexNEON(SB), NOSPLIT, $0-144
+    MOVD dstRe_base+0(FP), R0      // R0 = dstRe pointer
+    MOVD dstRe_len+8(FP), R3       // R3 = length
+    MOVD dstIm_base+24(FP), R1     // R1 = dstIm pointer
+    MOVD aRe_base+48(FP), R4       // R4 = aRe pointer
+    MOVD aIm_base+72(FP), R5       // R5 = aIm pointer
+    MOVD bRe_base+96(FP), R6       // R6 = bRe pointer
+    MOVD bIm_base+120(FP), R7      // R7 = bIm pointer
+
+    // Process 4 elements per iteration
+    LSR $2, R3, R8
+    CBZ R8, mulconjcplx_neon_scalar
+
+mulconjcplx_neon_loop4:
+    // Load inputs
+    VLD1.P 16(R4), [V0.S4]         // V0 = aRe[0:4]
+    VLD1.P 16(R5), [V1.S4]         // V1 = aIm[0:4]
+    VLD1.P 16(R6), [V2.S4]         // V2 = bRe[0:4]
+    VLD1.P 16(R7), [V3.S4]         // V3 = bIm[0:4]
+
+    // dstRe = aRe*bRe + aIm*bIm
+    // V4 = aRe * bRe
+    WORD $0x6E22DC04               // FMUL V4.4S, V0.4S, V2.4S
+    // V4 = V4 + aIm*bIm (FMLA)
+    WORD $0x4E23CC24               // FMLA V4.4S, V1.4S, V3.4S
+
+    // dstIm = aIm*bRe - aRe*bIm
+    // V5 = aIm * bRe
+    WORD $0x6E22DC25               // FMUL V5.4S, V1.4S, V2.4S
+    // V5 = V5 - aRe*bIm (FMLS)
+    WORD $0x4EA3CC05               // FMLS V5.4S, V0.4S, V3.4S
+
+    // Store results
+    VST1.P [V4.S4], 16(R0)
+    VST1.P [V5.S4], 16(R1)
+
+    SUB $1, R8
+    CBNZ R8, mulconjcplx_neon_loop4
+
+mulconjcplx_neon_scalar:
+    AND $3, R3
+    CBZ R3, mulconjcplx_neon_done
+
+mulconjcplx_neon_scalar_loop:
+    FMOVS (R4), F0                 // F0 = aRe
+    FMOVS (R5), F1                 // F1 = aIm
+    FMOVS (R6), F2                 // F2 = bRe
+    FMOVS (R7), F3                 // F3 = bIm
+
+    // dstRe = aRe*bRe + aIm*bIm
+    FMULS F0, F2, F4               // F4 = aRe * bRe
+    FMADDS F1, F3, F4, F4          // F4 = F4 + aIm*bIm
+
+    // dstIm = aIm*bRe - aRe*bIm
+    FMULS F1, F2, F5               // F5 = aIm * bRe
+    FMSUBS F0, F3, F5, F5          // F5 = F5 - aRe*bIm
+
+    FMOVS F4, (R0)
+    FMOVS F5, (R1)
+
+    ADD $4, R0
+    ADD $4, R1
+    ADD $4, R4
+    ADD $4, R5
+    ADD $4, R6
+    ADD $4, R7
+    SUB $1, R3
+    CBNZ R3, mulconjcplx_neon_scalar_loop
+
+mulconjcplx_neon_done:
+    RET
+
+// func absSqComplexNEON(dst, aRe, aIm []float32)
+// Computes element-wise magnitude squared using split arrays:
+//   dst[i] = aRe[i]^2 + aIm[i]^2
+// Frame: dst(24) + aRe(24) + aIm(24) = 72 bytes
+TEXT ·absSqComplexNEON(SB), NOSPLIT, $0-72
+    MOVD dst_base+0(FP), R0        // R0 = dst pointer
+    MOVD dst_len+8(FP), R3         // R3 = length
+    MOVD aRe_base+24(FP), R4       // R4 = aRe pointer
+    MOVD aIm_base+48(FP), R5       // R5 = aIm pointer
+
+    // Process 4 elements per iteration
+    LSR $2, R3, R8
+    CBZ R8, abssqcplx_neon_scalar
+
+abssqcplx_neon_loop4:
+    // Load inputs
+    VLD1.P 16(R4), [V0.S4]         // V0 = aRe[0:4]
+    VLD1.P 16(R5), [V1.S4]         // V1 = aIm[0:4]
+
+    // dst = aRe^2 + aIm^2
+    // V2 = aRe * aRe
+    WORD $0x6E20DC02               // FMUL V2.4S, V0.4S, V0.4S
+    // V2 = V2 + aIm*aIm (FMLA)
+    WORD $0x4E21CC22               // FMLA V2.4S, V1.4S, V1.4S
+
+    // Store result
+    VST1.P [V2.S4], 16(R0)
+
+    SUB $1, R8
+    CBNZ R8, abssqcplx_neon_loop4
+
+abssqcplx_neon_scalar:
+    AND $3, R3
+    CBZ R3, abssqcplx_neon_done
+
+abssqcplx_neon_scalar_loop:
+    FMOVS (R4), F0                 // F0 = aRe
+    FMOVS (R5), F1                 // F1 = aIm
+
+    // dst = aRe^2 + aIm^2
+    FMULS F0, F0, F2               // F2 = aRe^2
+    FMADDS F1, F1, F2, F2          // F2 = F2 + aIm^2
+
+    FMOVS F2, (R0)
+
+    ADD $4, R0
+    ADD $4, R4
+    ADD $4, R5
+    SUB $1, R3
+    CBNZ R3, abssqcplx_neon_scalar_loop
+
+abssqcplx_neon_done:
+    RET

--- a/f32/f32_go.go
+++ b/f32/f32_go.go
@@ -377,3 +377,43 @@ func int32ToFloat32ScaleGo(dst []float32, src []int32, scale float32) {
 		dst[i] = float32(src[i]) * scale
 	}
 }
+
+// ============================================================================
+// SPLIT-FORMAT COMPLEX OPERATIONS (Pure Go)
+// ============================================================================
+
+// mulComplex32Go computes element-wise complex multiplication:
+//
+//	dstRe[i] = aRe[i]*bRe[i] - aIm[i]*bIm[i]
+//	dstIm[i] = aRe[i]*bIm[i] + aIm[i]*bRe[i]
+func mulComplex32Go(dstRe, dstIm, aRe, aIm, bRe, bIm []float32) {
+	for i := range dstRe {
+		ar, ai := aRe[i], aIm[i]
+		br, bi := bRe[i], bIm[i]
+		dstRe[i] = ar*br - ai*bi
+		dstIm[i] = ar*bi + ai*br
+	}
+}
+
+// mulConjComplex32Go computes element-wise multiplication by conjugate:
+//
+//	dstRe[i] = aRe[i]*bRe[i] + aIm[i]*bIm[i]
+//	dstIm[i] = aIm[i]*bRe[i] - aRe[i]*bIm[i]
+func mulConjComplex32Go(dstRe, dstIm, aRe, aIm, bRe, bIm []float32) {
+	for i := range dstRe {
+		ar, ai := aRe[i], aIm[i]
+		br, bi := bRe[i], bIm[i]
+		dstRe[i] = ar*br + ai*bi
+		dstIm[i] = ai*br - ar*bi
+	}
+}
+
+// absSqComplex32Go computes element-wise magnitude squared:
+//
+//	dst[i] = aRe[i]^2 + aIm[i]^2
+func absSqComplex32Go(dst, aRe, aIm []float32) {
+	for i := range dst {
+		r, im := aRe[i], aIm[i]
+		dst[i] = r*r + im*im
+	}
+}

--- a/f32/f32_other.go
+++ b/f32/f32_other.go
@@ -45,3 +45,12 @@ func clampScale32(dst, src []float32, minVal, maxVal, scale float32) {
 func tanh32(dst, src []float32)                                 { tanh32Go(dst, src) }
 func exp32(dst, src []float32)                                  { exp32Go(dst, src) }
 func int32ToFloat32Scale(dst []float32, src []int32, s float32) { int32ToFloat32ScaleGo(dst, src, s) }
+
+// Split-format complex operations
+func mulComplex32(dstRe, dstIm, aRe, aIm, bRe, bIm []float32) {
+	mulComplex32Go(dstRe, dstIm, aRe, aIm, bRe, bIm)
+}
+func mulConjComplex32(dstRe, dstIm, aRe, aIm, bRe, bIm []float32) {
+	mulConjComplex32Go(dstRe, dstIm, aRe, aIm, bRe, bIm)
+}
+func absSqComplex32(dst, aRe, aIm []float32) { absSqComplex32Go(dst, aRe, aIm) }


### PR DESCRIPTION
## Summary

- **New c64 package**: SIMD-accelerated operations for interleaved `[]complex64` arrays
- **Split-format complex operations in f32**: SIMD-optimized operations for separate real/imaginary arrays

### c64 Package (Interleaved Complex64)

Operations for `[]complex64` with AVX/AVX-512 (AMD64) and NEON (ARM64):
- Arithmetic: Add, Sub, Mul, MulConj, Scale, AddScalar
- Magnitude: Abs, AbsSq
- Transforms: Neg, Conj
- Conversions: FromReal, Real, Imag
- Reduction: DotProduct (complex dot product)

### f32 Split-Format Complex Operations

For FFT implementations where split format is more efficient:
- **MulComplex**: `(a * b)` for frequency-domain convolution
- **MulConjComplex**: `(a * conj(b))` for cross-correlation  
- **AbsSqComplex**: `|a|²` for power spectrum computation

Split format (separate `[]float32` for real and imaginary) allows direct SIMD loads without shuffle/deinterleave overhead.

## Performance

**f32 split-format (AMD64 AVX+FMA):**
- MulComplex: 5.6x-10.6x faster than Go
- AbsSqComplex: 3.7x-8.1x faster than Go

## Architecture Recommendation

- Use **split format** (f32 operations) for FFT internals and DSP pipelines
- Use **c64 package** for API boundaries and when working with Go's `complex64` type
- Both can interoperate via conversion functions

## Test plan

- [x] All tests pass on AMD64 (AVX path)
- [x] All tests pass on ARM64 (NEON path) 
- [x] Pure Go fallback tests pass
- [x] golangci-lint passes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a c64 package with element-wise complex64 vector ops (mul, mul‑conj, scale, add, sub, abs, abs², conj, from‑real).
  * Added split-format f32 ops for separate real/imag arrays (mul, mul‑conj, abs²).

* **Performance**
  * Runtime-selected SIMD implementations for amd64/arm64 with safe zero‑allocation fallbacks to pure‑Go paths.

* **Tests**
  * Extensive tests and benchmarks validating correctness, edge cases, and SIMD vs Go parity.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->