### PR TITLE
Add RealFFTUnpack for real-valued FFT unpacking step

### DIFF
--- a/README.md
+++ b/README.md
@@ -142,6 +142,7 @@ Same API as `f64` but for `float32` with wider SIMD:
 |            | `MulConjComplex(dstRe,dstIm,aRe,aIm,bRe,bIm)` | Multiply by conjugate      | 8x / 4x          |
 |            | `AbsSqComplex(dst,aRe,aIm)`           | Magnitude squared                  | 8x / 4x          |
 |            | `ButterflyComplex(uRe,uIm,lRe,lIm,twRe,twIm)` | FFT butterfly with twiddle | 8x / 4x          |
+|            | `RealFFTUnpack(outRe,outIm,zRe,zIm,twRe,twIm)` | Real FFT unpack step     | 8x / 4x          |
 
 ### `f16` - float16 (Half-Precision) Operations
 

--- a/f32/f32_amd64.go
+++ b/f32/f32_amd64.go
@@ -590,6 +590,16 @@ func butterflyComplex32(upperRe, upperIm, lowerRe, lowerIm, twRe, twIm []float32
 	butterflyComplex32Go(upperRe, upperIm, lowerRe, lowerIm, twRe, twIm)
 }
 
+func realFFTUnpack32(outRe, outIm, zRe, zIm, twRe, twIm []float32, n int) {
+	// Use AVX+FMA if available and have enough elements
+	// Need at least 9 elements: process k=1..n-1 where n>=9 gives 8+ iterations
+	if cpu.X86.AVX && cpu.X86.FMA && n > minAVXElements {
+		realFFTUnpackAVX(outRe, outIm, zRe, zIm, twRe, twIm, n)
+		return
+	}
+	realFFTUnpack32Go(outRe, outIm, zRe, zIm, twRe, twIm, n)
+}
+
 // Split-format complex assembly function declarations
 //
 //go:noescape
@@ -603,3 +613,6 @@ func absSqComplexAVX(dst, aRe, aIm []float32)
 
 //go:noescape
 func butterflyComplexAVX(upperRe, upperIm, lowerRe, lowerIm, twRe, twIm []float32)
+
+//go:noescape
+func realFFTUnpackAVX(outRe, outIm, zRe, zIm, twRe, twIm []float32, n int)

--- a/f32/f32_arm64.go
+++ b/f32/f32_arm64.go
@@ -389,6 +389,16 @@ func butterflyComplex32(upperRe, upperIm, lowerRe, lowerIm, twRe, twIm []float32
 	butterflyComplex32Go(upperRe, upperIm, lowerRe, lowerIm, twRe, twIm)
 }
 
+func realFFTUnpack32(outRe, outIm, zRe, zIm, twRe, twIm []float32, n int) {
+	// Use NEON if available and have enough elements
+	// Need at least 5 elements: process k=1..n-1 where n>=5 gives 4+ iterations
+	if hasNEON && n > 4 {
+		realFFTUnpackNEON(outRe, outIm, zRe, zIm, twRe, twIm, n)
+		return
+	}
+	realFFTUnpack32Go(outRe, outIm, zRe, zIm, twRe, twIm, n)
+}
+
 //go:noescape
 func mulComplexNEON(dstRe, dstIm, aRe, aIm, bRe, bIm []float32)
 
@@ -400,3 +410,6 @@ func absSqComplexNEON(dst, aRe, aIm []float32)
 
 //go:noescape
 func butterflyComplexNEON(upperRe, upperIm, lowerRe, lowerIm, twRe, twIm []float32)
+
+//go:noescape
+func realFFTUnpackNEON(outRe, outIm, zRe, zIm, twRe, twIm []float32, n int)

--- a/f32/f32_arm64.s
+++ b/f32/f32_arm64.s
@@ -1891,7 +1891,6 @@ realfft_neon_loop4:
     // Compute even = 0.5 * (Z[k] + conj(Z[n-k]))
     // evenRe = 0.5 * (zkRe + znkRe)
     WORD $0x4E22D404                 // FADD V4.4S, V0.4S, V2.4S  (zkRe + znkRe)
-    WORD $0x6E3EDE04                 // FMUL V4.4S, V16.4S, V30.4S  -- wrong, redo
     WORD $0x6E3EDC84                 // FMUL V4.4S, V4.4S, V30.4S  (evenRe)
 
     // evenIm = 0.5 * (zkIm + znkIm)

--- a/f32/f32_arm64.s
+++ b/f32/f32_arm64.s
@@ -1880,9 +1880,9 @@ realfft_neon_loop4:
 
     // Reverse V2 and V3: [0,1,2,3] -> [3,2,1,0]
     // Use REV64 + EXT to reverse 4 elements
-    WORD $0x4E200842                 // REV64 V2.4S, V2.4S  (swap pairs: [1,0,3,2])
+    WORD $0x4EA00842                 // REV64 V2.4S, V2.4S  (swap pairs: [1,0,3,2])
     WORD $0x6E024042                 // EXT V2.16B, V2.16B, V2.16B, #8  (swap halves: [3,2,1,0])
-    WORD $0x4E200863                 // REV64 V3.4S, V3.4S
+    WORD $0x4EA00863                 // REV64 V3.4S, V3.4S
     WORD $0x6E034063                 // EXT V3.16B, V3.16B, V3.16B, #8
 
     // For conjugate: znkIm = -zIm[n-k]

--- a/f32/f32_arm64.s
+++ b/f32/f32_arm64.s
@@ -1867,7 +1867,7 @@ TEXT ·realFFTUnpackNEON(SB), NOSPLIT, $0-152
     // Load 0.5 constant into V30
     MOVW $0x3F000000, R11            // 0.5 in IEEE 754
     FMOVS R11, F30
-    WORD $0x4F809FDE                 // DUP V30.4S, V30.S[0]
+    WORD $0x4E0407DE                 // DUP V30.4S, V30.S[0]
 
 realfft_neon_loop4:
     // Load forward Z[k:k+4]

--- a/f32/f32_other.go
+++ b/f32/f32_other.go
@@ -57,3 +57,6 @@ func absSqComplex32(dst, aRe, aIm []float32) { absSqComplex32Go(dst, aRe, aIm) }
 func butterflyComplex32(upperRe, upperIm, lowerRe, lowerIm, twRe, twIm []float32) {
 	butterflyComplex32Go(upperRe, upperIm, lowerRe, lowerIm, twRe, twIm)
 }
+func realFFTUnpack32(outRe, outIm, zRe, zIm, twRe, twIm []float32, n int) {
+	realFFTUnpack32Go(outRe, outIm, zRe, zIm, twRe, twIm, n)
+}


### PR DESCRIPTION
## Summary

- Add `RealFFTUnpack` function for the unpacking step of real-valued FFT
- AVX+FMA implementation using VPERM2F128+VPERMILPS for efficient 8-element vector reversal
- NEON implementation using REV64+EXT for 4-element vector reversal
- Pure Go fallback with clear mathematical documentation

## Algorithm

Computes for bins k = 1 to n-1:
```
X[k] = 0.5*(Z[k] + conj(Z[n-k])) + W[k]*(-0.5i)*(Z[k] - conj(Z[n-k]))
```

The key challenge is the mirror access pattern (Z[k] and Z[n-k] simultaneously), solved using SIMD shuffle instructions for vector reversal.

## Performance (AMD64 AVX+FMA, n=4096)

| Implementation | Throughput | 
|---------------|------------|
| SIMD | 28910 MB/s |
| Pure Go | 8555 MB/s |
| **Speedup** | **~3.4x** |

## Test plan

- [x] Unit tests for various sizes (2-1000)
- [x] Edge case tests (n=0, n=1)
- [x] Go vs SIMD comparison tests
- [x] Known values verification
- [x] Benchmarks pass
- [x] Linter passes (0 issues)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added real-valued FFT unpacking operation with SIMD acceleration on x86-64 (AVX) and ARM64 (NEON), plus automatic scalar fallback on other platforms.

* **Documentation**
  * README updated to document the new real FFT unpack operation.

* **Tests**
  * Comprehensive test suite and benchmarks covering correctness, edge cases, and cross-architecture validation (duplicate test entries detected).

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->