### PR TITLE
Add Reverse and AddSub SIMD operations for f32

### DIFF
--- a/README.md
+++ b/README.md
@@ -143,6 +143,8 @@ Same API as `f64` but for `float32` with wider SIMD:
 |            | `AbsSqComplex(dst,aRe,aIm)`           | Magnitude squared                  | 8x / 4x          |
 |            | `ButterflyComplex(uRe,uIm,lRe,lIm,twRe,twIm)` | FFT butterfly with twiddle | 8x / 4x          |
 |            | `RealFFTUnpack(outRe,outIm,zRe,zIm,twRe,twIm)` | Real FFT unpack step     | 8x / 4x          |
+| **Utility**| `Reverse(dst, src)`                   | Reverse slice order                | 8x / 4x          |
+|            | `AddSub(sum, diff, a, b)`             | Fused sum and difference           | 8x / 4x          |
 
 ### `f16` - float16 (Half-Precision) Operations
 

--- a/f32/f32_amd64.go
+++ b/f32/f32_amd64.go
@@ -616,3 +616,27 @@ func butterflyComplexAVX(upperRe, upperIm, lowerRe, lowerIm, twRe, twIm []float3
 
 //go:noescape
 func realFFTUnpackAVX(outRe, outIm, zRe, zIm, twRe, twIm []float32, n int)
+
+func reverse32(dst, src []float32) {
+	// Use AVX if available and have enough elements
+	if cpu.X86.AVX && len(dst) >= minAVXElements {
+		reverseAVX(dst, src)
+		return
+	}
+	reverse32Go(dst, src)
+}
+
+func addSub32(sumDst, diffDst, a, b []float32) {
+	// Use AVX if available and have enough elements
+	if cpu.X86.AVX && len(sumDst) >= minAVXElements {
+		addSubAVX(sumDst, diffDst, a, b)
+		return
+	}
+	addSub32Go(sumDst, diffDst, a, b)
+}
+
+//go:noescape
+func reverseAVX(dst, src []float32)
+
+//go:noescape
+func addSubAVX(sumDst, diffDst, a, b []float32)

--- a/f32/f32_arm64.go
+++ b/f32/f32_arm64.go
@@ -413,3 +413,25 @@ func butterflyComplexNEON(upperRe, upperIm, lowerRe, lowerIm, twRe, twIm []float
 
 //go:noescape
 func realFFTUnpackNEON(outRe, outIm, zRe, zIm, twRe, twIm []float32, n int)
+
+func reverse32(dst, src []float32) {
+	if hasNEON && len(dst) >= 4 {
+		reverseNEON(dst, src)
+		return
+	}
+	reverse32Go(dst, src)
+}
+
+func addSub32(sumDst, diffDst, a, b []float32) {
+	if hasNEON && len(sumDst) >= 4 {
+		addSubNEON(sumDst, diffDst, a, b)
+		return
+	}
+	addSub32Go(sumDst, diffDst, a, b)
+}
+
+//go:noescape
+func reverseNEON(dst, src []float32)
+
+//go:noescape
+func addSubNEON(sumDst, diffDst, a, b []float32)

--- a/f32/f32_go.go
+++ b/f32/f32_go.go
@@ -478,3 +478,56 @@ func realFFTUnpack32Go(outRe, outIm, zRe, zIm, twRe, twIm []float32, n int) {
 		outIm[k] = evenIm + oddIm
 	}
 }
+
+// reverse32Go reverses a slice in pure Go.
+// dst[i] = src[n-1-i] for i in [0, n)
+func reverse32Go(dst, src []float32) {
+	n := len(src)
+	// Check for in-place operation
+	if &dst[0] == &src[0] {
+		// In-place reversal: swap elements from both ends
+		for i, j := 0, n-1; i < j; i, j = i+1, j-1 {
+			dst[i], dst[j] = dst[j], dst[i]
+		}
+		return
+	}
+	// Out-of-place: copy in reverse order
+	// Process 4 elements at a time for better performance
+	i := 0
+	for ; i+3 < n; i += 4 {
+		j := n - 1 - i
+		dst[i] = src[j]
+		dst[i+1] = src[j-1]
+		dst[i+2] = src[j-2]
+		dst[i+3] = src[j-3]
+	}
+	// Handle remainder
+	for ; i < n; i++ {
+		dst[i] = src[n-1-i]
+	}
+}
+
+// addSub32Go computes element-wise sum and difference in pure Go.
+// sumDst[i] = a[i] + b[i], diffDst[i] = a[i] - b[i]
+func addSub32Go(sumDst, diffDst, a, b []float32) {
+	n := len(a)
+	// Process 4 elements at a time for better performance
+	i := 0
+	for ; i+3 < n; i += 4 {
+		a0, a1, a2, a3 := a[i], a[i+1], a[i+2], a[i+3]
+		b0, b1, b2, b3 := b[i], b[i+1], b[i+2], b[i+3]
+		sumDst[i] = a0 + b0
+		sumDst[i+1] = a1 + b1
+		sumDst[i+2] = a2 + b2
+		sumDst[i+3] = a3 + b3
+		diffDst[i] = a0 - b0
+		diffDst[i+1] = a1 - b1
+		diffDst[i+2] = a2 - b2
+		diffDst[i+3] = a3 - b3
+	}
+	// Handle remainder
+	for ; i < n; i++ {
+		sumDst[i] = a[i] + b[i]
+		diffDst[i] = a[i] - b[i]
+	}
+}

--- a/f32/f32_other.go
+++ b/f32/f32_other.go
@@ -60,3 +60,5 @@ func butterflyComplex32(upperRe, upperIm, lowerRe, lowerIm, twRe, twIm []float32
 func realFFTUnpack32(outRe, outIm, zRe, zIm, twRe, twIm []float32, n int) {
 	realFFTUnpack32Go(outRe, outIm, zRe, zIm, twRe, twIm, n)
 }
+func reverse32(dst, src []float32)             { reverse32Go(dst, src) }
+func addSub32(sumDst, diffDst, a, b []float32) { addSub32Go(sumDst, diffDst, a, b) }


### PR DESCRIPTION
## Summary

Add two new SIMD primitives for FFT optimization:

- **`Reverse(dst, src)`**: Reverses slice order with AVX (8x) and NEON (4x) SIMD, supporting both in-place and out-of-place operation
- **`AddSub(sumDst, diffDst, a, b)`**: Computes sum and difference simultaneously, loading a and b only once for better cache efficiency

These primitives enable pair-processing optimization in Real FFT unpacking where k and N/2-k share the same Z values, potentially halving loop iterations.

## Performance (AMD64 AVX, 12th Gen i7)

| Operation | Size | SIMD | Go | Speedup |
|-----------|------|------|-----|---------|
| Reverse | 1024 | 55ns | 286ns | **5.2x** |
| Reverse | 4096 | 225ns | 1118ns | **5.0x** |
| AddSub | 1024 | 63ns | 507ns | **8.1x** |
| AddSub | 4096 | 794ns | 2027ns | **2.6x** |

## Test plan

- [x] All tests pass on AMD64 (`go test ./f32/...`)
- [ ] ARM64 tests pass in CI
- [x] Benchmarks show expected speedup
- [x] Go vet passes for AMD64 and ARM64