### PR TITLE
Implementing Sin/Cos, Gather/Scatter, and some proposed updates

### DIFF
--- a/README.md
+++ b/README.md
@@ -126,6 +126,7 @@ fmt.Println(cpu.HasFP16())   // true/false (ARM64 half-precision SIMD)
 |                 | `ConvolveValidMulti(dsts, sig, ks)` | Multi-kernel convolution      | 8x / 4x / 2x                        |
 |                 | `AccumulateAdd(dst, src, off)`      | Overlap-add: dst[off:] += src | 8x / 4x / 2x                        |
 | **Data Movement**| `Gather(dst, src, indices)`         | Indexed gather                | 4x hardware gather (AVX2) / 2x pack (NEON) / Go fallback |
+|                 | `Scatter(dst, src, indices)`        | Indexed scatter               | Go fallback                          |
 | **Audio**       | `Interleave2(dst, a, b)`            | Pack stereo: [L,R,L,R,...]    | 4x / 2x                             |
 |                 | `Deinterleave2(a, b, src)`          | Unpack stereo to channels     | 4x / 2x                             |
 |                 | `CubicInterpDot(hist,a,b,c,d,x)`    | Fused cubic interp dot product| 4x / 2x                             |

--- a/README.md
+++ b/README.md
@@ -90,13 +90,20 @@ fmt.Println(cpu.HasFP16())   // true/false (ARM64 half-precision SIMD)
 |                 | `Div(dst, a, b)`                    | Element-wise division         | 8x / 4x / 2x                        |
 |                 | `Scale(dst, a, s)`                  | Multiply by scalar            | 8x / 4x / 2x                        |
 |                 | `AddScalar(dst, a, s)`              | Add scalar                    | 8x / 4x / 2x                        |
+|                 | `SubFromScalar(dst, a, s)`          | Scalar minus vector           | 8x / 4x / 2x (composed SIMD)        |
 |                 | `FMA(dst, a, b, c)`                 | Fused multiply-add: a\*b+c    | 8x / 4x / 2x                        |
 |                 | `AddScaled(dst, alpha, s)`          | dst += alpha\*s (axpy)        | 8x / 4x / 2x                        |
 | **Unary**       | `Abs(dst, a)`                       | Absolute value                | 8x / 4x / 2x                        |
 |                 | `Neg(dst, a)`                       | Negation                      | 8x / 4x / 2x                        |
 |                 | `Sqrt(dst, a)`                      | Square root                   | 8x / 4x / 2x                        |
 |                 | `Reciprocal(dst, a)`                | Reciprocal (1/x)              | 8x / 4x / 2x                        |
+|                 | `Round(dst, src)`                   | Round half away from zero     | 4x (AVX) / 2x (NEON) / Go fallback  |
+| **Trigonometric**| `Sin(dst, src)`                     | Element-wise sine             | Accelerate (darwin/arm64/cgo), SIMD poly (amd64/arm64), Go fallback |
+|                 | `Cos(dst, src)`                     | Element-wise cosine           | Accelerate (darwin/arm64/cgo), SIMD poly (amd64/arm64), Go fallback |
+|                 | `SinCos(sinDst, cosDst, src)`       | Combined sine and cosine      | Accelerate (darwin/arm64/cgo), fused asm (amd64 finite-range), SIMD poly fallback |
 | **Reduction**   | `DotProduct(a, b)`                  | Dot product                   | 8x / 4x / 2x                        |
+|                 | `WeightedSum(w, src)`               | Weighted sum Σ(wᵢ·srcᵢ)       | 8x / 4x / 2x                        |
+|                 | `SumOfSquares(src)`                 | Sum of squares Σ(srcᵢ²)       | 8x / 4x / 2x                        |
 |                 | `Sum(a)`                            | Sum of elements               | 8x / 4x / 2x                        |
 |                 | `Min(a)`                            | Minimum value                 | 8x / 4x / 2x                        |
 |                 | `Max(a)`                            | Maximum value                 | 8x / 4x / 2x                        |
@@ -118,6 +125,7 @@ fmt.Println(cpu.HasFP16())   // true/false (ARM64 half-precision SIMD)
 | **Signal**      | `ConvolveValid(dst, sig, k)`        | FIR filter / convolution      | 8x / 4x / 2x                        |
 |                 | `ConvolveValidMulti(dsts, sig, ks)` | Multi-kernel convolution      | 8x / 4x / 2x                        |
 |                 | `AccumulateAdd(dst, src, off)`      | Overlap-add: dst[off:] += src | 8x / 4x / 2x                        |
+| **Data Movement**| `Gather(dst, src, indices)`         | Indexed gather                | 4x hardware gather (AVX2) / 2x pack (NEON) / Go fallback |
 | **Audio**       | `Interleave2(dst, a, b)`            | Pack stereo: [L,R,L,R,...]    | 4x / 2x                             |
 |                 | `Deinterleave2(a, b, src)`          | Unpack stereo to channels     | 4x / 2x                             |
 |                 | `CubicInterpDot(hist,a,b,c,d,x)`    | Fused cubic interp dot product| 4x / 2x                             |

--- a/README.md
+++ b/README.md
@@ -100,7 +100,7 @@ fmt.Println(cpu.HasFP16())   // true/false (ARM64 half-precision SIMD)
 |                 | `Round(dst, src)`                   | Round half away from zero     | 4x (AVX) / 2x (NEON) / Go fallback  |
 | **Trigonometric**| `Sin(dst, src)`                     | Element-wise sine             | Accelerate (darwin/arm64/cgo), SIMD poly (amd64/arm64), Go fallback |
 |                 | `Cos(dst, src)`                     | Element-wise cosine           | Accelerate (darwin/arm64/cgo), SIMD poly (amd64/arm64), Go fallback |
-|                 | `SinCos(sinDst, cosDst, src)`       | Combined sine and cosine      | Accelerate (darwin/arm64/cgo), fused asm (amd64 finite-range), SIMD poly fallback |
+|                 | `SinCos(sinDst, cosDst, src)`       | Combined sine and cosine      | Accelerate (darwin/arm64/cgo), SIMD poly with per-element fallback |
 | **Reduction**   | `DotProduct(a, b)`                  | Dot product                   | 8x / 4x / 2x                        |
 |                 | `WeightedSum(w, src)`               | Weighted sum Σ(wᵢ·srcᵢ)       | 8x / 4x / 2x                        |
 |                 | `SumOfSquares(src)`                 | Sum of squares Σ(srcᵢ²)       | 8x / 4x / 2x                        |
@@ -116,9 +116,9 @@ fmt.Println(cpu.HasFP16())   // true/false (ARM64 half-precision SIMD)
 |                 | `Normalize(dst, a)`                 | Unit vector normalization     | 8x / 4x / 2x                        |
 |                 | `CumulativeSum(dst, a)`             | Running sum                   | Sequential                          |
 | **Range**       | `Clamp(dst, a, min, max)`           | Clamp to range                | 8x / 4x / 2x                        |
-| **Activation**  | `Sigmoid(dst, src)`                 | Sigmoid: 1/(1+e^-x)           | 4x (AVX) / 2x (NEON)                |
+| **Activation**  | `Sigmoid(dst, src)`                 | Sigmoid activation            | 4x (AVX) / 2x (NEON), fast approx on SIMD paths |
 |                 | `ReLU(dst, src)`                    | Rectified Linear Unit         | 8x / 4x / 2x                        |
-|                 | `Tanh(dst, src)`                    | Hyperbolic tangent            | 8x / 4x / 2x                        |
+|                 | `Tanh(dst, src)`                    | Hyperbolic tangent            | 8x / 4x / 2x, fast approx on SIMD paths |
 |                 | `Exp(dst, src)`                     | Exponential e^x               | Pure Go                             |
 |                 | `ClampScale(dst, src, min, max, s)` | Fused clamp and scale         | 8x / 4x / 2x                        |
 | **Batch**       | `DotProductBatch(r, rows, v)`       | Multiple dot products         | 8x / 4x / 2x                        |

--- a/c128/c128_amd64.s
+++ b/c128/c128_amd64.s
@@ -767,49 +767,63 @@ TEXT ·absAVX512(SB), NOSPLIT, $0-48
     MOVQ a_base+24(FP), SI
 
     MOVQ CX, AX
-    SHRQ $1, AX            // Process 2 elements per iteration
-    JZ   abs_avx512_remainder
+    SHRQ $2, AX            // Process 4 elements per iteration
+    JZ   abs_avx512_loop2_check
+
+abs_avx512_loop4:
+    // Load 4 complex128 = 8 float64: [r0, i0, r1, i1, r2, i2, r3, i3]
+    VMOVUPD (SI), Z0
+
+    // Compute [r²+i²] with shuffle+add (no horizontal add dependency).
+    VMULPD Z0, Z0, Z0
+    VSHUFPD $0x55, Z0, Z0, Z1
+    VADDPD Z0, Z1, Z2      // [s0, s0, s1, s1, s2, s2, s3, s3]
+
+    // Pack duplicated sums into contiguous lanes: [s0, s1, s2, s3].
+    VEXTRACTF64X4 $1, Z2, Y3
+    VEXTRACTF128 $1, Y2, X4
+    VUNPCKLPD X4, X2, X2
+    VEXTRACTF128 $1, Y3, X5
+    VUNPCKLPD X5, X3, X3
+    VINSERTF128 $1, X3, Y2, Y2
+
+    VSQRTPD Y2, Y2
+    VMOVUPD Y2, (DX)
+
+    ADDQ $64, SI           // 4 complex128 = 64 bytes
+    ADDQ $32, DX           // 4 float64 = 32 bytes
+    DECQ AX
+    JNZ  abs_avx512_loop4
+
+abs_avx512_loop2_check:
+    ANDQ $3, CX
+    MOVQ CX, AX
+    SHRQ $1, AX
+    JZ   abs_avx512_remainder1
 
 abs_avx512_loop2:
     // Load 2 complex128 = 4 float64: [r0, i0, r1, i1]
     VMOVUPD (SI), Y0
-
-    // Square all elements: [r0², i0², r1², i1²]
     VMULPD Y0, Y0, Y0
+    VSHUFPD $0x55, Y0, Y0, Y1
+    VADDPD Y0, Y1, Y0      // [s0, s0, s1, s1]
 
-    // Horizontal add pairs within each 128-bit lane
-    // VHADDPD Y0, Y0, Y0 produces:
-    //   Lane 0: [r0²+i0², r0²+i0²]
-    //   Lane 1: [r1²+i1², r1²+i1²]
-    // Result: [r0²+i0², r0²+i0², r1²+i1², r1²+i1²]
-    VHADDPD Y0, Y0, Y0
-
-    // Pack results: elements 0 and 2 contain the sums we need
-    // Extract upper 128 bits: X1 = [r1²+i1², r1²+i1²]
     VEXTRACTF128 $1, Y0, X1
-    // Unpack low elements: X0 = [r0²+i0², r1²+i1²]
-    VUNPCKLPD X1, X0, X0
-
-    // Take sqrt: X0 = [|z0|, |z1|]
+    VUNPCKLPD X1, X0, X0   // [s0, s1]
     VSQRTPD X0, X0
-
-    // Store 2 results
     VMOVUPD X0, (DX)
 
-    ADDQ $32, SI           // 2 complex128 = 32 bytes
-    ADDQ $16, DX           // 2 float64 = 16 bytes
+    ADDQ $32, SI
+    ADDQ $16, DX
     DECQ AX
     JNZ  abs_avx512_loop2
 
-abs_avx512_remainder:
+abs_avx512_remainder1:
     ANDQ $1, CX
     JZ   abs_avx512_done
 
     // Handle 1 remaining element using XMM
-abs_avx512_remainder_loop:
     MOVUPD (SI), X0        // Load one complex128
-
-    // X0 = [real, imag]
     VMOVDDUP X0, X1        // X1 = [real, real]
     VSHUFPD $1, X0, X0, X2 // X2 = [imag, imag]
 
@@ -817,13 +831,7 @@ abs_avx512_remainder_loop:
     VMULPD X2, X2, X2      // imag²
     VADDPD X2, X1, X1      // r² + i²
     VSQRTPD X1, X1
-
     VMOVSD X1, (DX)
-
-    ADDQ $16, SI
-    ADDQ $8, DX
-    DECQ CX
-    JNZ  abs_avx512_remainder_loop
 
 abs_avx512_done:
     VZEROUPPER
@@ -835,27 +843,40 @@ TEXT ·absAVX(SB), NOSPLIT, $0-48
     MOVQ dst_len+8(FP), CX
     MOVQ a_base+24(FP), SI
 
-    TESTQ CX, CX
+    MOVQ CX, AX
+    SHRQ $1, AX
+    JZ   abs_avx_remainder
+
+abs_avx_loop2:
+    // Load 2 complex128 = 4 float64: [r0, i0, r1, i1]
+    VMOVUPD (SI), Y0
+    VMULPD Y0, Y0, Y0
+    VSHUFPD $0x55, Y0, Y0, Y1
+    VADDPD Y0, Y1, Y0      // [s0, s0, s1, s1]
+
+    VEXTRACTF128 $1, Y0, X1
+    VUNPCKLPD X1, X0, X0   // [s0, s1]
+    VSQRTPD X0, X0
+    VMOVUPD X0, (DX)
+
+    ADDQ $32, SI
+    ADDQ $16, DX
+    DECQ AX
+    JNZ  abs_avx_loop2
+
+abs_avx_remainder:
+    ANDQ $1, CX
     JZ   abs_avx_done
 
-abs_avx_loop:
-    VMOVUPD (SI), X0       // Load one complex128
-
-    // X0 = [real, imag]
-    VMOVDDUP X0, X1        // X1 = [real, real]
-    VSHUFPD $1, X0, X0, X2 // X2 = [imag, imag]
-
-    VMULPD X1, X1, X1      // real²
-    VMULPD X2, X2, X2      // imag²
-    VADDPD X2, X1, X1      // r² + i²
+    // Handle 1 remaining element
+    MOVUPD (SI), X0
+    VMOVDDUP X0, X1
+    VSHUFPD $1, X0, X0, X2
+    VMULPD X1, X1, X1
+    VMULPD X2, X2, X2
+    VADDPD X2, X1, X1
     VSQRTPD X1, X1
-
     VMOVSD X1, (DX)
-
-    ADDQ $16, SI
-    ADDQ $8, DX
-    DECQ CX
-    JNZ  abs_avx_loop
 
 abs_avx_done:
     VZEROUPPER

--- a/c128/c128_go.go
+++ b/c128/c128_go.go
@@ -7,6 +7,11 @@ import "math"
 // mulGo computes element-wise complex multiplication.
 // (a + bi)(c + di) = (ac - bd) + (ad + bc)i
 func mulGo(dst, a, b []complex128) {
+	if len(dst) == 0 {
+		return
+	}
+	_ = a[len(dst)-1]
+	_ = b[len(dst)-1]
 	for i := range dst {
 		dst[i] = a[i] * b[i]
 	}
@@ -15,6 +20,11 @@ func mulGo(dst, a, b []complex128) {
 // mulConjGo computes element-wise multiplication by conjugate.
 // (a + bi)(c - di) = (ac + bd) + (bc - ad)i
 func mulConjGo(dst, a, b []complex128) {
+	if len(dst) == 0 {
+		return
+	}
+	_ = a[len(dst)-1]
+	_ = b[len(dst)-1]
 	for i := range dst {
 		ar, ai := real(a[i]), imag(a[i])
 		br, bi := real(b[i]), imag(b[i])
@@ -27,6 +37,10 @@ func mulConjGo(dst, a, b []complex128) {
 
 // scaleGo multiplies each element by a complex scalar.
 func scaleGo(dst, a []complex128, s complex128) {
+	if len(dst) == 0 {
+		return
+	}
+	_ = a[len(dst)-1]
 	for i := range dst {
 		dst[i] = a[i] * s
 	}
@@ -34,6 +48,11 @@ func scaleGo(dst, a []complex128, s complex128) {
 
 // addGo computes element-wise complex addition.
 func addGo(dst, a, b []complex128) {
+	if len(dst) == 0 {
+		return
+	}
+	_ = a[len(dst)-1]
+	_ = b[len(dst)-1]
 	for i := range dst {
 		dst[i] = a[i] + b[i]
 	}
@@ -41,6 +60,11 @@ func addGo(dst, a, b []complex128) {
 
 // subGo computes element-wise complex subtraction.
 func subGo(dst, a, b []complex128) {
+	if len(dst) == 0 {
+		return
+	}
+	_ = a[len(dst)-1]
+	_ = b[len(dst)-1]
 	for i := range dst {
 		dst[i] = a[i] - b[i]
 	}
@@ -48,6 +72,10 @@ func subGo(dst, a, b []complex128) {
 
 // absGo computes element-wise complex magnitude: |a + bi| = sqrt(a² + b²).
 func absGo(dst []float64, a []complex128) {
+	if len(dst) == 0 {
+		return
+	}
+	_ = a[len(dst)-1]
 	for i := range dst {
 		r := real(a[i])
 		im := imag(a[i])
@@ -57,6 +85,10 @@ func absGo(dst []float64, a []complex128) {
 
 // absSqGo computes element-wise magnitude squared: |a + bi|² = a² + b².
 func absSqGo(dst []float64, a []complex128) {
+	if len(dst) == 0 {
+		return
+	}
+	_ = a[len(dst)-1]
 	for i := range dst {
 		r := real(a[i])
 		im := imag(a[i])
@@ -66,6 +98,10 @@ func absSqGo(dst []float64, a []complex128) {
 
 // conjGo computes element-wise complex conjugate: conj(a + bi) = a - bi.
 func conjGo(dst, a []complex128) {
+	if len(dst) == 0 {
+		return
+	}
+	_ = a[len(dst)-1]
 	for i := range dst {
 		dst[i] = complex(real(a[i]), -imag(a[i]))
 	}

--- a/c64/c64_go.go
+++ b/c64/c64_go.go
@@ -7,6 +7,11 @@ import "math"
 // mulGo computes element-wise complex multiplication.
 // (a + bi)(c + di) = (ac - bd) + (ad + bc)i
 func mulGo(dst, a, b []complex64) {
+	if len(dst) == 0 {
+		return
+	}
+	_ = a[len(dst)-1]
+	_ = b[len(dst)-1]
 	for i := range dst {
 		dst[i] = a[i] * b[i]
 	}
@@ -15,6 +20,11 @@ func mulGo(dst, a, b []complex64) {
 // mulConjGo computes element-wise multiplication by conjugate.
 // (a + bi)(c - di) = (ac + bd) + (bc - ad)i
 func mulConjGo(dst, a, b []complex64) {
+	if len(dst) == 0 {
+		return
+	}
+	_ = a[len(dst)-1]
+	_ = b[len(dst)-1]
 	for i := range dst {
 		ar, ai := real(a[i]), imag(a[i])
 		br, bi := real(b[i]), imag(b[i])
@@ -27,6 +37,10 @@ func mulConjGo(dst, a, b []complex64) {
 
 // scaleGo multiplies each element by a complex scalar.
 func scaleGo(dst, a []complex64, s complex64) {
+	if len(dst) == 0 {
+		return
+	}
+	_ = a[len(dst)-1]
 	for i := range dst {
 		dst[i] = a[i] * s
 	}
@@ -34,6 +48,11 @@ func scaleGo(dst, a []complex64, s complex64) {
 
 // addGo computes element-wise complex addition.
 func addGo(dst, a, b []complex64) {
+	if len(dst) == 0 {
+		return
+	}
+	_ = a[len(dst)-1]
+	_ = b[len(dst)-1]
 	for i := range dst {
 		dst[i] = a[i] + b[i]
 	}
@@ -41,6 +60,11 @@ func addGo(dst, a, b []complex64) {
 
 // subGo computes element-wise complex subtraction.
 func subGo(dst, a, b []complex64) {
+	if len(dst) == 0 {
+		return
+	}
+	_ = a[len(dst)-1]
+	_ = b[len(dst)-1]
 	for i := range dst {
 		dst[i] = a[i] - b[i]
 	}
@@ -48,6 +72,10 @@ func subGo(dst, a, b []complex64) {
 
 // absGo computes element-wise complex magnitude: |a + bi| = sqrt(a^2 + b^2).
 func absGo(dst []float32, a []complex64) {
+	if len(dst) == 0 {
+		return
+	}
+	_ = a[len(dst)-1]
 	for i := range dst {
 		r := float64(real(a[i]))
 		im := float64(imag(a[i]))
@@ -57,6 +85,10 @@ func absGo(dst []float32, a []complex64) {
 
 // absSqGo computes element-wise magnitude squared: |a + bi|^2 = a^2 + b^2.
 func absSqGo(dst []float32, a []complex64) {
+	if len(dst) == 0 {
+		return
+	}
+	_ = a[len(dst)-1]
 	for i := range dst {
 		r := real(a[i])
 		im := imag(a[i])
@@ -66,6 +98,10 @@ func absSqGo(dst []float32, a []complex64) {
 
 // conjGo computes element-wise complex conjugate: conj(a + bi) = a - bi.
 func conjGo(dst, a []complex64) {
+	if len(dst) == 0 {
+		return
+	}
+	_ = a[len(dst)-1]
 	for i := range dst {
 		dst[i] = complex(real(a[i]), -imag(a[i]))
 	}
@@ -73,6 +109,10 @@ func conjGo(dst, a []complex64) {
 
 // fromRealGo converts real float32 values to complex64.
 func fromRealGo(dst []complex64, src []float32) {
+	if len(dst) == 0 {
+		return
+	}
+	_ = src[len(dst)-1]
 	for i := range dst {
 		dst[i] = complex(src[i], 0)
 	}

--- a/f16/f16_arm64.s
+++ b/f16/f16_arm64.s
@@ -97,8 +97,8 @@ TEXT ·dotProductNEON(SB), NOSPLIT, $0-52
     MOVD b_base+24(FP), R1
 
     // Zero accumulators (4 FP32 each)
-    VEOR V4.B16, V4.B16, V4.B16
-    VEOR V5.B16, V5.B16, V5.B16
+    VEOR V6.B16, V6.B16, V6.B16
+    VEOR V7.B16, V7.B16, V7.B16
 
     LSR $3, R2, R3
     CBZ R3, dot16_reduce
@@ -109,28 +109,27 @@ dot16_loop8:
     VLD1 (R1), [V1.H8]          // Load 8 FP16 from b
     ADD $16, R1
 
-    // Multiply in FP16: V2 = V0 * V1
-    WORD $0x6E411C02            // FMUL V2.8H, V0.8H, V1.8H
+    // Widen to FP32 first to avoid FP16 overflow in products.
+    WORD $0x0E217802            // FCVTL V2.4S, V0.4H
+    WORD $0x4E217803            // FCVTL2 V3.4S, V0.8H
+    WORD $0x0E217824            // FCVTL V4.4S, V1.4H
+    WORD $0x4E217825            // FCVTL2 V5.4S, V1.8H
 
-    // Convert products to FP32 and accumulate
-    WORD $0x0E217843            // FCVTL V3.4S, V2.4H (lower 4)
-    WORD $0x4E217842            // FCVTL2 V2.4S, V2.8H (upper 4, reuse V2)
-
-    // Accumulate in FP32
-    WORD $0x4E23D484            // FADD V4.4S, V4.4S, V3.4S
-    WORD $0x4E22D4A5            // FADD V5.4S, V5.4S, V2.4S
+    // Accumulate products in FP32.
+    WORD $0x4E24CC46            // FMLA V6.4S, V2.4S, V4.4S
+    WORD $0x4E25CC67            // FMLA V7.4S, V3.4S, V5.4S
 
     SUB $1, R3
     CBNZ R3, dot16_loop8
 
     // Combine accumulators
-    WORD $0x4E25D484            // FADD V4.4S, V4.4S, V5.4S
+    WORD $0x4E27D4C6            // FADD V6.4S, V6.4S, V7.4S
 
 dot16_reduce:
-    // Horizontal sum of V4.4S -> S4
-    WORD $0x6E24D484            // FADDP V4.4S, V4.4S, V4.4S
-    WORD $0x7E30D884            // FADDP S4, V4.2S
-    FMOVS F4, ret+48(FP)
+    // Horizontal sum of V6.4S -> S6
+    WORD $0x6E26D4C6            // FADDP V6.4S, V6.4S, V6.4S
+    WORD $0x7E30D8C6            // FADDP S6, V6.2S
+    FMOVS F6, ret+48(FP)
     RET
 
 // func addNEON(dst, a, b []Float16)

--- a/f16/f16_go.go
+++ b/f16/f16_go.go
@@ -5,38 +5,38 @@ import "math"
 // IEEE 754 half-precision format constants.
 const (
 	// FP16 bit layout
-	fp16SignShift     = 15
-	fp16ExpShift      = 10
-	fp16ExpMask       = 0x1F
-	fp16MantMask      = 0x3FF
-	fp16MantHighBit   = 0x400
-	fp16ExpMax        = 31
-	fp16ExpBias       = 15
-	fp16Infinity      = 0x7C00
-	fp16SignMask      = 0x8000
-	fp16AbsMask       = 0x7FFF
-	fp16NormExpMax    = 30
+	fp16SignShift   = 15
+	fp16ExpShift    = 10
+	fp16ExpMask     = 0x1F
+	fp16MantMask    = 0x3FF
+	fp16MantHighBit = 0x400
+	fp16ExpMax      = 31
+	fp16ExpBias     = 15
+	fp16Infinity    = 0x7C00
+	fp16SignMask    = 0x8000
+	fp16AbsMask     = 0x7FFF
+	fp16NormExpMax  = 30
 
 	// FP32 bit layout
-	fp32SignShift     = 31
-	fp32ExpShift      = 23
-	fp32ExpMask       = 0xFF
-	fp32MantMask      = 0x7FFFFF
-	fp32Infinity      = 0x7F800000
-	fp32ExpBias       = 127
-	fp32SignMask      = 0x8000
-	fp32MantHighBit   = 0x800000
+	fp32SignShift   = 31
+	fp32ExpShift    = 23
+	fp32ExpMask     = 0xFF
+	fp32MantMask    = 0x7FFFFF
+	fp32Infinity    = 0x7F800000
+	fp32ExpBias     = 127
+	fp32SignMask    = 0x8000
+	fp32MantHighBit = 0x800000
 
 	// Conversion constants
-	fp32MantShift     = 13                             // FP32 mantissa bits to shift for FP16
-	fp32SignExtract   = 16                             // Shift to extract sign from FP32 to FP16 position
-	fp32RoundBit      = 0x1000                         // Bit 12 for rounding
-	fp32RoundMask     = 0xFFF                          // Bits below round bit
-	fp32RoundCheck    = 0x2000                         // Bit 13 for round-to-even check
-	expBiasDiff       = fp32ExpBias - fp16ExpBias      // 112
-	expOverflow       = fp32ExpBias + fp16ExpBias      // 142 - overflow threshold
-	expUnderflow      = fp32ExpBias - 24               // 103 - underflow threshold
-	expDenormThresh   = fp32ExpBias - fp16ExpBias + 1  // 113 - denormalized threshold
+	fp32MantShift   = 13                            // FP32 mantissa bits to shift for FP16
+	fp32SignExtract = 16                            // Shift to extract sign from FP32 to FP16 position
+	fp32RoundBit    = 0x1000                        // Bit 12 for rounding
+	fp32RoundMask   = 0xFFF                         // Bits below round bit
+	fp32RoundCheck  = 0x2000                        // Bit 13 for round-to-even check
+	expBiasDiff     = fp32ExpBias - fp16ExpBias     // 112
+	expOverflow     = fp32ExpBias + fp16ExpBias     // 142 - overflow threshold
+	expUnderflow    = fp32ExpBias - 24              // 103 - underflow threshold
+	expDenormThresh = fp32ExpBias - fp16ExpBias + 1 // 113 - denormalized threshold
 )
 
 // toFloat32Go converts Float16 to float32 using pure Go.
@@ -144,6 +144,10 @@ func fromFloat32Go(f float32) Float16 {
 
 // toFloat32SliceGo converts a slice of Float16 to float32.
 func toFloat32SliceGo(dst []float32, src []Float16) {
+	if len(dst) == 0 {
+		return
+	}
+	_ = src[len(dst)-1]
 	for i := range dst {
 		dst[i] = toFloat32Go(src[i])
 	}
@@ -151,6 +155,10 @@ func toFloat32SliceGo(dst []float32, src []Float16) {
 
 // fromFloat32SliceGo converts a slice of float32 to Float16.
 func fromFloat32SliceGo(dst []Float16, src []float32) {
+	if len(dst) == 0 {
+		return
+	}
+	_ = src[len(dst)-1]
 	for i := range dst {
 		dst[i] = fromFloat32Go(src[i])
 	}
@@ -159,6 +167,11 @@ func fromFloat32SliceGo(dst []Float16, src []float32) {
 // dotProductGo computes dot product using pure Go (converts to float32).
 func dotProductGo(a, b []Float16) float32 {
 	n := min(len(a), len(b))
+	if n == 0 {
+		return 0
+	}
+	_ = a[n-1]
+	_ = b[n-1]
 	var sum float32
 	for i := range n {
 		sum += toFloat32Go(a[i]) * toFloat32Go(b[i])
@@ -168,6 +181,11 @@ func dotProductGo(a, b []Float16) float32 {
 
 // addGo computes element-wise addition.
 func addGo(dst, a, b []Float16) {
+	if len(dst) == 0 {
+		return
+	}
+	_ = a[len(dst)-1]
+	_ = b[len(dst)-1]
 	for i := range dst {
 		dst[i] = fromFloat32Go(toFloat32Go(a[i]) + toFloat32Go(b[i]))
 	}
@@ -175,6 +193,11 @@ func addGo(dst, a, b []Float16) {
 
 // subGo computes element-wise subtraction.
 func subGo(dst, a, b []Float16) {
+	if len(dst) == 0 {
+		return
+	}
+	_ = a[len(dst)-1]
+	_ = b[len(dst)-1]
 	for i := range dst {
 		dst[i] = fromFloat32Go(toFloat32Go(a[i]) - toFloat32Go(b[i]))
 	}
@@ -182,6 +205,11 @@ func subGo(dst, a, b []Float16) {
 
 // mulGo computes element-wise multiplication.
 func mulGo(dst, a, b []Float16) {
+	if len(dst) == 0 {
+		return
+	}
+	_ = a[len(dst)-1]
+	_ = b[len(dst)-1]
 	for i := range dst {
 		dst[i] = fromFloat32Go(toFloat32Go(a[i]) * toFloat32Go(b[i]))
 	}
@@ -189,6 +217,10 @@ func mulGo(dst, a, b []Float16) {
 
 // scaleGo multiplies each element by a scalar.
 func scaleGo(dst, a []Float16, s Float16) {
+	if len(dst) == 0 {
+		return
+	}
+	_ = a[len(dst)-1]
 	sf := toFloat32Go(s)
 	for i := range dst {
 		dst[i] = fromFloat32Go(toFloat32Go(a[i]) * sf)
@@ -197,6 +229,12 @@ func scaleGo(dst, a []Float16, s Float16) {
 
 // fmaGo computes fused multiply-add.
 func fmaGo(dst, a, b, c []Float16) {
+	if len(dst) == 0 {
+		return
+	}
+	_ = a[len(dst)-1]
+	_ = b[len(dst)-1]
+	_ = c[len(dst)-1]
 	for i := range dst {
 		dst[i] = fromFloat32Go(toFloat32Go(a[i])*toFloat32Go(b[i]) + toFloat32Go(c[i]))
 	}
@@ -213,6 +251,10 @@ func sumGo(a []Float16) float32 {
 
 // absGo computes element-wise absolute value.
 func absGo(dst, a []Float16) {
+	if len(dst) == 0 {
+		return
+	}
+	_ = a[len(dst)-1]
 	for i := range dst {
 		// Clear sign bit
 		dst[i] = a[i] & fp16AbsMask
@@ -221,6 +263,10 @@ func absGo(dst, a []Float16) {
 
 // negGo computes element-wise negation.
 func negGo(dst, a []Float16) {
+	if len(dst) == 0 {
+		return
+	}
+	_ = a[len(dst)-1]
 	for i := range dst {
 		// Flip sign bit
 		dst[i] = a[i] ^ fp16SignMask
@@ -229,6 +275,10 @@ func negGo(dst, a []Float16) {
 
 // reluGo computes ReLU activation.
 func reluGo(dst, src []Float16) {
+	if len(dst) == 0 {
+		return
+	}
+	_ = src[len(dst)-1]
 	for i := range dst {
 		if src[i]&0x8000 != 0 { // negative (sign bit set)
 			dst[i] = 0
@@ -240,6 +290,10 @@ func reluGo(dst, src []Float16) {
 
 // sigmoidGo computes sigmoid activation.
 func sigmoidGo(dst, src []Float16) {
+	if len(dst) == 0 {
+		return
+	}
+	_ = src[len(dst)-1]
 	for i := range dst {
 		x := toFloat32Go(src[i])
 		// sigmoid(x) = 1 / (1 + exp(-x))
@@ -277,6 +331,11 @@ func maxGo(a []Float16) Float16 {
 
 // divGo computes element-wise division.
 func divGo(dst, a, b []Float16) {
+	if len(dst) == 0 {
+		return
+	}
+	_ = a[len(dst)-1]
+	_ = b[len(dst)-1]
 	for i := range dst {
 		dst[i] = fromFloat32Go(toFloat32Go(a[i]) / toFloat32Go(b[i]))
 	}
@@ -284,6 +343,10 @@ func divGo(dst, a, b []Float16) {
 
 // addScalarGo adds a scalar to each element.
 func addScalarGo(dst, a []Float16, s Float16) {
+	if len(dst) == 0 {
+		return
+	}
+	_ = a[len(dst)-1]
 	sf := toFloat32Go(s)
 	for i := range dst {
 		dst[i] = fromFloat32Go(toFloat32Go(a[i]) + sf)
@@ -292,6 +355,10 @@ func addScalarGo(dst, a []Float16, s Float16) {
 
 // clampGo clamps each element to [minVal, maxVal].
 func clampGo(dst, a []Float16, minVal, maxVal Float16) {
+	if len(dst) == 0 {
+		return
+	}
+	_ = a[len(dst)-1]
 	minF := toFloat32Go(minVal)
 	maxF := toFloat32Go(maxVal)
 	for i := range dst {
@@ -307,6 +374,10 @@ func clampGo(dst, a []Float16, minVal, maxVal Float16) {
 
 // sqrtGo computes element-wise square root.
 func sqrtGo(dst, a []Float16) {
+	if len(dst) == 0 {
+		return
+	}
+	_ = a[len(dst)-1]
 	for i := range dst {
 		dst[i] = fromFloat32Go(float32(math.Sqrt(float64(toFloat32Go(a[i])))))
 	}
@@ -314,6 +385,10 @@ func sqrtGo(dst, a []Float16) {
 
 // reciprocalGo computes element-wise reciprocal.
 func reciprocalGo(dst, a []Float16) {
+	if len(dst) == 0 {
+		return
+	}
+	_ = a[len(dst)-1]
 	for i := range dst {
 		dst[i] = fromFloat32Go(1.0 / toFloat32Go(a[i]))
 	}
@@ -321,6 +396,10 @@ func reciprocalGo(dst, a []Float16) {
 
 // expGo computes element-wise exponential.
 func expGo(dst, src []Float16) {
+	if len(dst) == 0 {
+		return
+	}
+	_ = src[len(dst)-1]
 	for i := range dst {
 		dst[i] = fromFloat32Go(float32(math.Exp(float64(toFloat32Go(src[i])))))
 	}
@@ -328,6 +407,10 @@ func expGo(dst, src []Float16) {
 
 // tanhGo computes element-wise hyperbolic tangent.
 func tanhGo(dst, src []Float16) {
+	if len(dst) == 0 {
+		return
+	}
+	_ = src[len(dst)-1]
 	for i := range dst {
 		dst[i] = fromFloat32Go(float32(math.Tanh(float64(toFloat32Go(src[i])))))
 	}
@@ -363,6 +446,10 @@ func maxIdxGo(a []Float16) int {
 
 // addScaledGo computes dst[i] += alpha * s[i].
 func addScaledGo(dst []Float16, alpha Float16, s []Float16) {
+	if len(dst) == 0 {
+		return
+	}
+	_ = s[len(dst)-1]
 	alphaF := toFloat32Go(alpha)
 	for i := range dst {
 		dst[i] = fromFloat32Go(toFloat32Go(dst[i]) + alphaF*toFloat32Go(s[i]))
@@ -372,6 +459,10 @@ func addScaledGo(dst []Float16, alpha Float16, s []Float16) {
 // euclideanDistanceGo computes Euclidean distance.
 func euclideanDistanceGo(a, b []Float16) float32 {
 	var sum float32
+	if len(a) == 0 {
+		return 0
+	}
+	_ = b[len(a)-1]
 	for i := range a {
 		d := toFloat32Go(a[i]) - toFloat32Go(b[i])
 		sum += d * d
@@ -391,6 +482,10 @@ func varianceGo(a []Float16, mean float32) float32 {
 
 // cumulativeSumGo computes cumulative sum.
 func cumulativeSumGo(dst, a []Float16) {
+	if len(dst) == 0 {
+		return
+	}
+	_ = a[len(dst)-1]
 	var sum float32
 	for i := range dst {
 		sum += toFloat32Go(a[i])
@@ -400,6 +495,10 @@ func cumulativeSumGo(dst, a []Float16) {
 
 // dotProductBatchGo computes batch dot products.
 func dotProductBatchGo(results []float32, rows [][]Float16, vec []Float16) {
+	if len(rows) == 0 {
+		return
+	}
+	_ = results[len(rows)-1]
 	for i, row := range rows {
 		results[i] = dotProductGo(row, vec)
 	}
@@ -407,6 +506,10 @@ func dotProductBatchGo(results []float32, rows [][]Float16, vec []Float16) {
 
 // accumulateAddGo adds src to dst[offset:].
 func accumulateAddGo(dst, src []Float16) {
+	if len(src) == 0 {
+		return
+	}
+	_ = dst[len(src)-1]
 	for i := range src {
 		dst[i] = fromFloat32Go(toFloat32Go(dst[i]) + toFloat32Go(src[i]))
 	}
@@ -414,7 +517,15 @@ func accumulateAddGo(dst, src []Float16) {
 
 // convolveValidGo computes valid convolution.
 func convolveValidGo(dst, signal, kernel []Float16) {
+	if len(dst) == 0 {
+		return
+	}
 	kernelLen := len(kernel)
+	if kernelLen == 0 {
+		return
+	}
+	_ = signal[len(dst)+kernelLen-2]
+	_ = kernel[kernelLen-1]
 	for i := range dst {
 		var sum float32
 		for j := range kernelLen {
@@ -426,6 +537,11 @@ func convolveValidGo(dst, signal, kernel []Float16) {
 
 // interleave2Go interleaves two slices.
 func interleave2Go(dst, a, b []Float16) {
+	if len(a) == 0 {
+		return
+	}
+	_ = b[len(a)-1]
+	_ = dst[2*len(a)-1]
 	for i := range a {
 		dst[i*2] = a[i]
 		dst[i*2+1] = b[i]
@@ -434,6 +550,11 @@ func interleave2Go(dst, a, b []Float16) {
 
 // deinterleave2Go deinterleaves a slice.
 func deinterleave2Go(a, b, src []Float16) {
+	if len(a) == 0 {
+		return
+	}
+	_ = b[len(a)-1]
+	_ = src[2*len(a)-1]
 	for i := range a {
 		a[i] = src[i*2]
 		b[i] = src[i*2+1]
@@ -442,6 +563,10 @@ func deinterleave2Go(a, b, src []Float16) {
 
 // clampScaleGo performs fused clamp and scale.
 func clampScaleGo(dst, src []Float16, minVal, maxVal, scale Float16) {
+	if len(dst) == 0 {
+		return
+	}
+	_ = src[len(dst)-1]
 	minF := toFloat32Go(minVal)
 	maxF := toFloat32Go(maxVal)
 	scaleF := toFloat32Go(scale)

--- a/f16/f16_test.go
+++ b/f16/f16_test.go
@@ -34,7 +34,7 @@ func TestToFloat32(t *testing.T) {
 		{"neg_one", 0xBC00, -1.0},
 		{"two", 0x4000, 2.0},
 		{"half", 0x3800, 0.5},
-		{"max_normal", 0x7BFF, 65504.0},  // Largest FP16 normal
+		{"max_normal", 0x7BFF, 65504.0},          // Largest FP16 normal
 		{"min_normal", 0x0400, 0.00006103515625}, // Smallest positive normal
 		{"inf", 0x7C00, float32(math.Inf(1))},
 		{"neg_inf", 0xFC00, float32(math.Inf(-1))},
@@ -206,6 +206,25 @@ func TestDotProduct_Large(t *testing.T) {
 		if !almostEqual32(got, want, tol) {
 			t.Errorf("DotProduct(n=%d) = %v, want %v", n, got, want)
 		}
+	}
+}
+
+func TestDotProduct_WidenBeforeMultiply(t *testing.T) {
+	// 300*300 = 90000, which overflows FP16 but is finite in FP32.
+	a := make([]Float16, 8)
+	b := make([]Float16, 8)
+	for i := range a {
+		a[i] = FromFloat32(300)
+		b[i] = FromFloat32(300)
+	}
+
+	got := DotProduct(a, b)
+	want := float32(8 * 300 * 300)
+	if math.IsInf(float64(got), 0) || math.IsNaN(float64(got)) {
+		t.Fatalf("DotProduct() produced non-finite result: %v", got)
+	}
+	if !almostEqual32(got, want, want*0.01) {
+		t.Fatalf("DotProduct() = %v, want %v", got, want)
 	}
 }
 

--- a/f32/f32_amd64.s
+++ b/f32/f32_amd64.s
@@ -2674,30 +2674,31 @@ TEXT ·cubicInterpDotAVX(SB), NOSPLIT, $0-132
     JZ   cubic32_avx_loop8_check
 
 cubic32_avx_loop16:
-    // First vector (8 elements)
-    VMOVUPS (R10), Y1          // Y1 = d[i:i+8]
-    VMOVUPS (R9), Y2           // Y2 = c[i:i+8]
-    VMOVUPS (R8), Y3           // Y3 = b[i:i+8]
-    VMOVUPS (DI), Y4           // Y4 = a[i:i+8]
-    VMOVUPS (SI), Y5           // Y5 = hist[i:i+8]
+    // Stage 1: p = c + x*d (2 independent vectors)
+    VMOVUPS 0(R9), Y1
+    VMOVUPS 32(R9), Y2
+    VMOVUPS 0(R10), Y5
+    VFMADD231PS Y5, Y7, Y1
+    VMOVUPS 32(R10), Y5
+    VFMADD231PS Y5, Y7, Y2
 
-    // Horner's method: coef = a + x*(b + x*(c + x*d))
-    VFMADD231PS Y1, Y7, Y2     // Y2 = d*x + c
-    VFMADD231PS Y2, Y7, Y3     // Y3 = (d*x+c)*x + b
-    VFMADD231PS Y3, Y7, Y4     // Y4 = coef
-    VFMADD231PS Y5, Y4, Y0     // acc0 += hist * coef
+    // Stage 2: p = b + x*p
+    VMOVUPS 0(R8), Y5
+    VFMADD213PS Y7, Y5, Y1
+    VMOVUPS 32(R8), Y5
+    VFMADD213PS Y7, Y5, Y2
 
-    // Second vector (8 elements)
-    VMOVUPS 32(R10), Y1        // Y1 = d[i+8:i+16]
-    VMOVUPS 32(R9), Y2         // Y2 = c[i+8:i+16]
-    VMOVUPS 32(R8), Y3         // Y3 = b[i+8:i+16]
-    VMOVUPS 32(DI), Y4         // Y4 = a[i+8:i+16]
-    VMOVUPS 32(SI), Y5         // Y5 = hist[i+8:i+16]
+    // Stage 3: coef = a + x*p
+    VMOVUPS 0(DI), Y3
+    VFMADD213PS Y7, Y3, Y1
+    VMOVUPS 32(DI), Y4
+    VFMADD213PS Y7, Y4, Y2
 
-    VFMADD231PS Y1, Y7, Y2     // Y2 = d*x + c
-    VFMADD231PS Y2, Y7, Y3     // Y3 = (d*x+c)*x + b
-    VFMADD231PS Y3, Y7, Y4     // Y4 = coef
-    VFMADD231PS Y5, Y4, Y6     // acc1 += hist * coef
+    // Accumulate with independent accumulators.
+    VMOVUPS 0(SI), Y5
+    VFMADD231PS Y5, Y1, Y0
+    VMOVUPS 32(SI), Y5
+    VFMADD231PS Y5, Y2, Y6
 
     // Advance pointers
     ADDQ $64, SI

--- a/f32/f32_go.go
+++ b/f32/f32_go.go
@@ -20,6 +20,11 @@ const (
 func dotProductGo(a, b []float32) float32 {
 	var sum float32
 	n := min(len(a), len(b))
+	if n == 0 {
+		return 0
+	}
+	_ = a[n-1]
+	_ = b[n-1]
 	n8 := n &^ unrollMask
 
 	for i := 0; i < n8; i += 8 {
@@ -40,36 +45,64 @@ func dotProductGo(a, b []float32) float32 {
 }
 
 func addGo(dst, a, b []float32) {
+	if len(dst) == 0 {
+		return
+	}
+	_ = a[len(dst)-1]
+	_ = b[len(dst)-1]
 	for i := range dst {
 		dst[i] = a[i] + b[i]
 	}
 }
 
 func subGo(dst, a, b []float32) {
+	if len(dst) == 0 {
+		return
+	}
+	_ = a[len(dst)-1]
+	_ = b[len(dst)-1]
 	for i := range dst {
 		dst[i] = a[i] - b[i]
 	}
 }
 
 func mulGo(dst, a, b []float32) {
+	if len(dst) == 0 {
+		return
+	}
+	_ = a[len(dst)-1]
+	_ = b[len(dst)-1]
 	for i := range dst {
 		dst[i] = a[i] * b[i]
 	}
 }
 
 func divGo(dst, a, b []float32) {
+	if len(dst) == 0 {
+		return
+	}
+	_ = a[len(dst)-1]
+	_ = b[len(dst)-1]
 	for i := range dst {
 		dst[i] = a[i] / b[i]
 	}
 }
 
 func scaleGo(dst, a []float32, s float32) {
+	if len(dst) == 0 {
+		return
+	}
+	_ = a[len(dst)-1]
 	for i := range dst {
 		dst[i] = a[i] * s
 	}
 }
 
 func addScalarGo(dst, a []float32, s float32) {
+	if len(dst) == 0 {
+		return
+	}
+	_ = a[len(dst)-1]
 	for i := range dst {
 		dst[i] = a[i] + s
 	}
@@ -104,24 +137,42 @@ func maxGo(a []float32) float32 {
 }
 
 func absGo(dst, a []float32) {
+	if len(dst) == 0 {
+		return
+	}
+	_ = a[len(dst)-1]
 	for i := range dst {
 		dst[i] = float32(math.Abs(float64(a[i])))
 	}
 }
 
 func negGo(dst, a []float32) {
+	if len(dst) == 0 {
+		return
+	}
+	_ = a[len(dst)-1]
 	for i := range dst {
 		dst[i] = -a[i]
 	}
 }
 
 func fmaGo(dst, a, b, c []float32) {
+	if len(dst) == 0 {
+		return
+	}
+	_ = a[len(dst)-1]
+	_ = b[len(dst)-1]
+	_ = c[len(dst)-1]
 	for i := range dst {
 		dst[i] = a[i]*b[i] + c[i]
 	}
 }
 
 func clampGo(dst, a []float32, minVal, maxVal float32) {
+	if len(dst) == 0 {
+		return
+	}
+	_ = a[len(dst)-1]
 	for i := range dst {
 		v := a[i]
 		if v < minVal {
@@ -135,6 +186,10 @@ func clampGo(dst, a []float32, minVal, maxVal float32) {
 
 func dotProductBatch32Go(results []float32, rows [][]float32, vec []float32) {
 	vecLen := len(vec)
+	if len(rows) == 0 {
+		return
+	}
+	_ = results[len(rows)-1]
 	for i, row := range rows {
 		n := min(len(row), vecLen)
 		if n == 0 {
@@ -146,19 +201,36 @@ func dotProductBatch32Go(results []float32, rows [][]float32, vec []float32) {
 }
 
 func convolveValid32Go(dst, signal, kernel []float32) {
+	if len(dst) == 0 {
+		return
+	}
 	kLen := len(kernel)
+	if kLen == 0 {
+		return
+	}
+	_ = signal[len(dst)+kLen-2]
+	_ = kernel[kLen-1]
 	for i := range dst {
 		dst[i] = dotProductGo(signal[i:i+kLen], kernel)
 	}
 }
 
 func accumulateAdd32Go(dst, src []float32) {
+	if len(dst) == 0 {
+		return
+	}
+	_ = src[len(dst)-1]
 	for i := range dst {
 		dst[i] += src[i]
 	}
 }
 
 func interleave2Go(dst, a, b []float32) {
+	if len(a) == 0 {
+		return
+	}
+	_ = b[len(a)-1]
+	_ = dst[2*len(a)-1]
 	for i := range a {
 		dst[i*2] = a[i]
 		dst[i*2+1] = b[i]
@@ -166,6 +238,11 @@ func interleave2Go(dst, a, b []float32) {
 }
 
 func deinterleave2Go(a, b, src []float32) {
+	if len(a) == 0 {
+		return
+	}
+	_ = b[len(a)-1]
+	_ = src[2*len(a)-1]
 	for i := range a {
 		a[i] = src[i*2]
 		b[i] = src[i*2+1]
@@ -180,12 +257,20 @@ func convolveValidMultiGo(dsts [][]float32, signal []float32, kernels [][]float3
 }
 
 func sqrt32Go(dst, a []float32) {
+	if len(dst) == 0 {
+		return
+	}
+	_ = a[len(dst)-1]
 	for i := range dst {
 		dst[i] = float32(math.Sqrt(float64(a[i])))
 	}
 }
 
 func reciprocal32Go(dst, a []float32) {
+	if len(dst) == 0 {
+		return
+	}
+	_ = a[len(dst)-1]
 	for i := range dst {
 		dst[i] = 1.0 / a[i]
 	}
@@ -222,6 +307,10 @@ func maxIdxGo(a []float32) int {
 }
 
 func addScaledGo(dst []float32, alpha float32, s []float32) {
+	if len(dst) == 0 {
+		return
+	}
+	_ = s[len(dst)-1]
 	for i := range dst {
 		dst[i] += alpha * s[i]
 	}
@@ -231,6 +320,7 @@ func cumulativeSum32Go(dst, a []float32) {
 	if len(dst) == 0 {
 		return
 	}
+	_ = a[len(dst)-1]
 	sum := float32(0)
 	for i := range dst {
 		sum += a[i]
@@ -249,6 +339,10 @@ func variance32Go(a []float32, mean float32) float32 {
 
 func euclideanDistance32Go(a, b []float32) float32 {
 	var sum float32
+	if len(a) == 0 {
+		return 0
+	}
+	_ = b[len(a)-1]
 	for i := range a {
 		diff := a[i] - b[i]
 		sum += diff * diff
@@ -261,6 +355,13 @@ func euclideanDistance32Go(a, b []float32) float32 {
 func cubicInterpDotGo(hist, a, b, c, d []float32, x float32) float32 {
 	var sum float32
 	n := len(hist)
+	if n == 0 {
+		return 0
+	}
+	_ = a[n-1]
+	_ = b[n-1]
+	_ = c[n-1]
+	_ = d[n-1]
 	n8 := n &^ unrollMask // Round down to multiple of 8
 
 	// Unrolled loop: 8 elements per iteration (match AVX width)
@@ -291,6 +392,10 @@ func cubicInterpDotGo(hist, a, b, c, d []float32, x float32) float32 {
 // sigmoid32Go computes sigmoid(x) = 1 / (1 + e^(-x)) using math.Exp.
 // This is accurate but slower than SIMD approximations.
 func sigmoid32Go(dst, src []float32) {
+	if len(dst) == 0 {
+		return
+	}
+	_ = src[len(dst)-1]
 	for i := range dst {
 		x := src[i]
 		// Clamp extreme values for numerical stability
@@ -307,6 +412,10 @@ func sigmoid32Go(dst, src []float32) {
 
 // relu32Go computes ReLU(x) = max(0, x).
 func relu32Go(dst, src []float32) {
+	if len(dst) == 0 {
+		return
+	}
+	_ = src[len(dst)-1]
 	for i := range dst {
 		if src[i] > 0 {
 			dst[i] = src[i]
@@ -318,6 +427,10 @@ func relu32Go(dst, src []float32) {
 
 // clampScale32Go performs fused clamp and scale operation.
 func clampScale32Go(dst, src []float32, minVal, maxVal, scale float32) {
+	if len(dst) == 0 {
+		return
+	}
+	_ = src[len(dst)-1]
 	for i := range dst {
 		v := src[i]
 		if v < minVal {
@@ -332,6 +445,10 @@ func clampScale32Go(dst, src []float32, minVal, maxVal, scale float32) {
 // tanh32Go computes hyperbolic tangent using math.Tanh for accuracy.
 // This is the accurate implementation used as a fallback when SIMD is unavailable.
 func tanh32Go(dst, src []float32) {
+	if len(dst) == 0 {
+		return
+	}
+	_ = src[len(dst)-1]
 	for i := range dst {
 		dst[i] = float32(math.Tanh(float64(src[i])))
 	}
@@ -339,6 +456,10 @@ func tanh32Go(dst, src []float32) {
 
 // exp32Go computes e^x using math.Exp.
 func exp32Go(dst, src []float32) {
+	if len(dst) == 0 {
+		return
+	}
+	_ = src[len(dst)-1]
 	for i := range dst {
 		x := src[i]
 		// Clamp extreme values
@@ -358,6 +479,11 @@ func exp32Go(dst, src []float32) {
 // Uses loop unrolling for better performance.
 func int32ToFloat32ScaleGo(dst []float32, src []int32, scale float32) {
 	n := len(src)
+	if n == 0 {
+		return
+	}
+	_ = dst[n-1]
+	_ = src[n-1]
 	n8 := n &^ unrollMask // Round down to multiple of 8
 
 	// Unrolled loop: 8 elements per iteration
@@ -387,6 +513,14 @@ func int32ToFloat32ScaleGo(dst []float32, src []int32, scale float32) {
 //	dstRe[i] = aRe[i]*bRe[i] - aIm[i]*bIm[i]
 //	dstIm[i] = aRe[i]*bIm[i] + aIm[i]*bRe[i]
 func mulComplex32Go(dstRe, dstIm, aRe, aIm, bRe, bIm []float32) {
+	if len(dstRe) == 0 {
+		return
+	}
+	_ = dstIm[len(dstRe)-1]
+	_ = aRe[len(dstRe)-1]
+	_ = aIm[len(dstRe)-1]
+	_ = bRe[len(dstRe)-1]
+	_ = bIm[len(dstRe)-1]
 	for i := range dstRe {
 		ar, ai := aRe[i], aIm[i]
 		br, bi := bRe[i], bIm[i]
@@ -400,6 +534,14 @@ func mulComplex32Go(dstRe, dstIm, aRe, aIm, bRe, bIm []float32) {
 //	dstRe[i] = aRe[i]*bRe[i] + aIm[i]*bIm[i]
 //	dstIm[i] = aIm[i]*bRe[i] - aRe[i]*bIm[i]
 func mulConjComplex32Go(dstRe, dstIm, aRe, aIm, bRe, bIm []float32) {
+	if len(dstRe) == 0 {
+		return
+	}
+	_ = dstIm[len(dstRe)-1]
+	_ = aRe[len(dstRe)-1]
+	_ = aIm[len(dstRe)-1]
+	_ = bRe[len(dstRe)-1]
+	_ = bIm[len(dstRe)-1]
 	for i := range dstRe {
 		ar, ai := aRe[i], aIm[i]
 		br, bi := bRe[i], bIm[i]
@@ -412,6 +554,11 @@ func mulConjComplex32Go(dstRe, dstIm, aRe, aIm, bRe, bIm []float32) {
 //
 //	dst[i] = aRe[i]^2 + aIm[i]^2
 func absSqComplex32Go(dst, aRe, aIm []float32) {
+	if len(dst) == 0 {
+		return
+	}
+	_ = aRe[len(dst)-1]
+	_ = aIm[len(dst)-1]
 	for i := range dst {
 		r, im := aRe[i], aIm[i]
 		dst[i] = r*r + im*im
@@ -423,6 +570,14 @@ func absSqComplex32Go(dst, aRe, aIm []float32) {
 //	temp = lower * twiddle (complex multiply)
 //	upper, lower = upper + temp, upper - temp
 func butterflyComplex32Go(upperRe, upperIm, lowerRe, lowerIm, twRe, twIm []float32) {
+	if len(upperRe) == 0 {
+		return
+	}
+	_ = upperIm[len(upperRe)-1]
+	_ = lowerRe[len(upperRe)-1]
+	_ = lowerIm[len(upperRe)-1]
+	_ = twRe[len(upperRe)-1]
+	_ = twIm[len(upperRe)-1]
 	for i := range upperRe {
 		// Complex multiply: temp = lower * twiddle
 		lr, li := lowerRe[i], lowerIm[i]
@@ -447,6 +602,15 @@ const realFFTUnpackHalf = 0.5
 //
 //	X[k] = 0.5*(Z[k] + conj(Z[n-k])) + W[k]*(-0.5i)*(Z[k] - conj(Z[n-k]))
 func realFFTUnpack32Go(outRe, outIm, zRe, zIm, twRe, twIm []float32, n int) {
+	if n <= 1 {
+		return
+	}
+	_ = outRe[n-1]
+	_ = outIm[n-1]
+	_ = zRe[n-1]
+	_ = zIm[n-1]
+	_ = twRe[n-2]
+	_ = twIm[n-2]
 	// Process k from 1 to n-1
 	// For each k, we need Z[k] and Z[n-k] (mirrored)
 	for k := 1; k < n; k++ {
@@ -483,6 +647,11 @@ func realFFTUnpack32Go(outRe, outIm, zRe, zIm, twRe, twIm []float32, n int) {
 // dst[i] = src[n-1-i] for i in [0, n)
 func reverse32Go(dst, src []float32) {
 	n := len(src)
+	if n == 0 {
+		return
+	}
+	_ = dst[n-1]
+	_ = src[n-1]
 	// Check for in-place operation
 	if &dst[0] == &src[0] {
 		// In-place reversal: swap elements from both ends
@@ -511,6 +680,12 @@ func reverse32Go(dst, src []float32) {
 // sumDst[i] = a[i] + b[i], diffDst[i] = a[i] - b[i]
 func addSub32Go(sumDst, diffDst, a, b []float32) {
 	n := len(a)
+	if n == 0 {
+		return
+	}
+	_ = b[n-1]
+	_ = sumDst[n-1]
+	_ = diffDst[n-1]
 	// Process 4 elements at a time for better performance
 	i := 0
 	for ; i+3 < n; i += 4 {

--- a/f64/cubic_avx_amd64_test.go
+++ b/f64/cubic_avx_amd64_test.go
@@ -1,0 +1,79 @@
+//go:build amd64
+
+package f64
+
+import (
+	"fmt"
+	"math"
+	"testing"
+
+	"github.com/tphakala/simd/cpu"
+)
+
+func TestCubicInterpDotAVX_Direct(t *testing.T) {
+	if !cpu.X86.AVX || !cpu.X86.FMA {
+		t.Skip("AVX+FMA not supported on this CPU")
+	}
+
+	sizes := []int{4, 5, 7, 8, 15, 16, 17, 31, 32, 33, 64, 241, 1000}
+	for _, n := range sizes {
+		hist := make([]float64, n)
+		a := make([]float64, n)
+		b := make([]float64, n)
+		c := make([]float64, n)
+		d := make([]float64, n)
+
+		for i := range n {
+			fi := float64(i)
+			hist[i] = math.Sin(fi*0.17) + 0.01*fi
+			a[i] = math.Cos(fi*0.11) * 0.7
+			b[i] = math.Sin(fi*0.07) * 0.5
+			c[i] = math.Cos(fi*0.03) * 0.25
+			d[i] = math.Sin(fi*0.19) * 0.125
+		}
+
+		x := 0.73125
+		got := cubicInterpDotAVX(hist, a, b, c, d, x)
+		want := cubicInterpDotRef64(hist, a, b, c, d, x)
+
+		tol := math.Abs(want)*1e-10 + 1e-12
+		if math.Abs(got-want) > tol {
+			t.Fatalf("n=%d: cubicInterpDotAVX=%v, want=%v, diff=%v", n, got, want, got-want)
+		}
+	}
+}
+
+func BenchmarkCubicInterpDotAVX_Direct(b *testing.B) {
+	if !cpu.X86.AVX || !cpu.X86.FMA {
+		b.Skip("AVX+FMA not supported on this CPU")
+	}
+
+	for _, n := range []int{64, 241, 1000} {
+		b.Run(fmt.Sprintf("n=%d", n), func(b *testing.B) {
+			hist := make([]float64, n)
+			a := make([]float64, n)
+			bb := make([]float64, n)
+			c := make([]float64, n)
+			d := make([]float64, n)
+
+			for i := range n {
+				fi := float64(i)
+				hist[i] = math.Sin(fi*0.17) + 0.01*fi
+				a[i] = math.Cos(fi*0.11) * 0.7
+				bb[i] = math.Sin(fi*0.07) * 0.5
+				c[i] = math.Cos(fi*0.03) * 0.25
+				d[i] = math.Sin(fi*0.19) * 0.125
+			}
+
+			x := 0.73125
+			b.SetBytes(int64(n * 8 * 5))
+			b.ResetTimer()
+
+			var result float64
+			for i := 0; i < b.N; i++ {
+				result = cubicInterpDotAVX(hist, a, bb, c, d, x)
+			}
+			sink64 = result
+		})
+	}
+}

--- a/f64/f64.go
+++ b/f64/f64.go
@@ -129,6 +129,8 @@ func Sum(a []float64) float64 {
 
 // Min returns the minimum value in the slice.
 // Returns +Inf for empty slices.
+// If any element is NaN, Min returns NaN.
+// Signed zeros follow IEEE-754 rules: Min(+0, -0) = -0.
 func Min(a []float64) float64 {
 	if len(a) == 0 {
 		return posInf
@@ -138,6 +140,8 @@ func Min(a []float64) float64 {
 
 // Max returns the maximum value in the slice.
 // Returns -Inf for empty slices.
+// If any element is NaN, Max returns NaN.
+// Signed zeros follow IEEE-754 rules: Max(+0, -0) = +0.
 func Max(a []float64) float64 {
 	if len(a) == 0 {
 		return negInf
@@ -542,11 +546,11 @@ func ConvolveValidMulti(dsts [][]float64, signal []float64, kernels [][]float64)
 	convolveValidMulti64(dsts, signal, kernels, n, kLen)
 }
 
-// Sigmoid computes the sigmoid activation function: dst[i] = 1 / (1 + e^(-src[i])).
-// This is commonly used as an activation function in neural networks.
+// Sigmoid computes the sigmoid activation function for each element.
+// SIMD paths may use a fast approximation; Go fallback uses math.Exp-based evaluation.
 // Processes min(len(dst), len(src)) elements.
 //
-// Uses AVX+FMA on AMD64 (4x float64), NEON on ARM64 (2x float64).
+// Uses AVX on AMD64 (4x float64), NEON on ARM64 (2x float64).
 func Sigmoid(dst, src []float64) {
 	n := min(len(dst), len(src))
 	if n == 0 {
@@ -555,10 +559,9 @@ func Sigmoid(dst, src []float64) {
 	sigmoid64(dst[:n], src[:n])
 }
 
-// SigmoidInPlace computes the sigmoid activation function in-place: a[i] = 1 / (1 + e^(-a[i])).
-// This is commonly used as an activation function in neural networks.
+// SigmoidInPlace computes sigmoid in-place.
 //
-// Uses AVX+FMA on AMD64 (4x float64), NEON on ARM64 (2x float64).
+// Uses AVX on AMD64 (4x float64), NEON on ARM64 (2x float64).
 func SigmoidInPlace(a []float64) {
 	if len(a) == 0 {
 		return
@@ -601,7 +604,7 @@ func ClampScale(dst, src []float64, minVal, maxVal, scale float64) {
 }
 
 // Tanh computes the hyperbolic tangent: dst[i] = tanh(src[i]).
-// Uses fast approximation: tanh(x) ≈ x / (1 + |x|) for |x| < 1, sign(x) for |x| >= 2.5, polynomial otherwise.
+// SIMD paths use a fast approximation with relaxed precision compared to math.Tanh.
 // Processes min(len(dst), len(src)) elements.
 //
 // Uses AVX on AMD64 (4x float64), NEON on ARM64 (2x float64).
@@ -622,10 +625,10 @@ func TanhInPlace(a []float64) {
 }
 
 // Exp computes the exponential function: dst[i] = e^src[i].
-// Uses polynomial approximation for reasonable accuracy and performance.
+// Uses math.Exp with overflow/underflow clamping for numerical stability.
 // Processes min(len(dst), len(src)) elements.
 //
-// Uses AVX+FMA on AMD64 (4x float64), NEON on ARM64 (2x float64).
+// Uses pure Go implementation on all architectures.
 func Exp(dst, src []float64) {
 	n := min(len(dst), len(src))
 	if n == 0 {

--- a/f64/f64.go
+++ b/f64/f64.go
@@ -21,6 +21,20 @@ func DotProduct(a, b []float64) float64 {
 	return dotProduct(a, b)
 }
 
+// WeightedSum computes the weighted sum Σ(weights[i] * src[i]).
+// This is equivalent to DotProduct(weights, src).
+func WeightedSum(weights, src []float64) float64 {
+	return DotProduct(weights, src)
+}
+
+// SumOfSquares computes Σ(src[i] * src[i]).
+func SumOfSquares(src []float64) float64 {
+	if len(src) == 0 {
+		return 0
+	}
+	return dotProduct(src, src)
+}
+
 // DotProductUnsafe computes the dot product without length validation.
 // This is a low-overhead variant for performance-critical code paths.
 //
@@ -95,6 +109,16 @@ func AddScalar(dst, a []float64, s float64) {
 	addScalar(dst[:n], a[:n], s)
 }
 
+// SubFromScalar subtracts each element from a scalar: dst[i] = s - a[i].
+// Processes min(len(dst), len(a)) elements.
+func SubFromScalar(dst, a []float64, s float64) {
+	n := min(len(a), len(dst))
+	if n == 0 {
+		return
+	}
+	subFromScalar64(dst[:n], a[:n], s)
+}
+
 // Sum returns the sum of all elements in the slice.
 func Sum(a []float64) float64 {
 	if len(a) == 0 {
@@ -158,6 +182,48 @@ func Clamp(dst, a []float64, minVal, maxVal float64) {
 		return
 	}
 	clamp64(dst[:n], a[:n], minVal, maxVal)
+}
+
+// Sin computes element-wise sine: dst[i] = sin(src[i]).
+// Processes min(len(dst), len(src)) elements.
+func Sin(dst, src []float64) {
+	n := min(len(dst), len(src))
+	if n == 0 {
+		return
+	}
+	sin64(dst[:n], src[:n])
+}
+
+// Cos computes element-wise cosine: dst[i] = cos(src[i]).
+// Processes min(len(dst), len(src)) elements.
+func Cos(dst, src []float64) {
+	n := min(len(dst), len(src))
+	if n == 0 {
+		return
+	}
+	cos64(dst[:n], src[:n])
+}
+
+// SinCos computes sine and cosine for each input element:
+// sinDst[i] = sin(src[i]), cosDst[i] = cos(src[i]).
+// Processes min(len(sinDst), len(cosDst), len(src)) elements.
+func SinCos(sinDst, cosDst, src []float64) {
+	n := min(len(src), len(sinDst), len(cosDst))
+	if n == 0 {
+		return
+	}
+	sinCos64(sinDst[:n], cosDst[:n], src[:n])
+}
+
+// Round computes element-wise rounding to nearest integer, half away from zero:
+// dst[i] = round(src[i]).
+// Processes min(len(dst), len(src)) elements.
+func Round(dst, src []float64) {
+	n := min(len(dst), len(src))
+	if n == 0 {
+		return
+	}
+	round64(dst[:n], src[:n])
 }
 
 func minLen(a, b, c int) int {
@@ -311,6 +377,19 @@ func AccumulateAdd(dst, src []float64, offset int) {
 		panic("simd: offset+len(src) exceeds len(dst)")
 	}
 	accumulateAdd64(dst[offset:offset+n], src)
+}
+
+// Gather collects elements from src by index:
+// dst[i] = src[indices[i]].
+//
+// Processes min(len(dst), len(indices)) elements.
+// Panics if any selected index is out of range for src.
+func Gather(dst, src []float64, indices []int) {
+	n := min(len(dst), len(indices))
+	if n == 0 {
+		return
+	}
+	gather64(dst[:n], src, indices[:n])
 }
 
 const (

--- a/f64/f64.go
+++ b/f64/f64.go
@@ -396,6 +396,19 @@ func Gather(dst, src []float64, indices []int) {
 	gather64(dst[:n], src, indices[:n])
 }
 
+// Scatter writes elements from src to indexed positions in dst:
+// dst[indices[i]] = src[i].
+//
+// Processes min(len(src), len(indices)) elements.
+// Panics if any selected index is out of range for dst.
+func Scatter(dst, src []float64, indices []int) {
+	n := min(len(src), len(indices))
+	if n == 0 {
+		return
+	}
+	scatter64(dst, src[:n], indices[:n])
+}
+
 const (
 	// normalizeMagnitudeThreshold is the minimum magnitude for normalization.
 	// Vectors with magnitude below this are left unchanged to avoid division by zero.

--- a/f64/f64_amd64.go
+++ b/f64/f64_amd64.go
@@ -48,6 +48,7 @@ var (
 	negImpl               unaryOpFunc
 	sqrtImpl              unaryOpFunc
 	reciprocalImpl        unaryOpFunc
+	roundImpl             unaryOpFunc
 	fmaImpl               fmaFunc
 	clampImpl             clampFunc
 	varianceImpl          varianceFunc
@@ -88,6 +89,7 @@ func initAVX512() {
 	negImpl = negAVX512
 	sqrtImpl = sqrtAVX512
 	reciprocalImpl = reciprocalAVX512
+	roundImpl = roundAVX
 	fmaImpl = fmaAVX512
 	clampImpl = clampAVX512
 	varianceImpl = varianceAVX512
@@ -112,6 +114,7 @@ func initAVX() {
 	negImpl = negAVX
 	sqrtImpl = sqrtAVX
 	reciprocalImpl = reciprocalAVX
+	roundImpl = roundAVX
 	fmaImpl = fmaAVX
 	clampImpl = clampAVX
 	varianceImpl = varianceAVX
@@ -136,6 +139,7 @@ func initSSE2() {
 	negImpl = negSSE2
 	sqrtImpl = sqrtSSE2
 	reciprocalImpl = reciprocalSSE2
+	roundImpl = round64Go
 	fmaImpl = fmaSSE2
 	clampImpl = clampSSE2
 	varianceImpl = varianceSSE2
@@ -160,6 +164,7 @@ func initGo() {
 	negImpl = negGo
 	sqrtImpl = sqrt64Go
 	reciprocalImpl = reciprocal64Go
+	roundImpl = round64Go
 	fmaImpl = fmaGo
 	clampImpl = clampGo
 	varianceImpl = variance64Go
@@ -199,6 +204,16 @@ func addScalar(dst, a []float64, s float64) {
 	addScalarImpl(dst, a, s)
 }
 
+func subFromScalar64(dst, a []float64, s float64) {
+	if cpu.X86.AVX || cpu.X86.SSE2 {
+		// SIMD composition: (s - a) == (-(a)) + s
+		neg64(dst, a)
+		addScalar(dst, dst, s)
+		return
+	}
+	subFromScalarGo(dst, a, s)
+}
+
 func sum(a []float64) float64 {
 	return sumImpl(a)
 }
@@ -235,6 +250,41 @@ func fma64(dst, a, b, c []float64) {
 
 func clamp64(dst, a []float64, minVal, maxVal float64) {
 	clampImpl(dst, a, minVal, maxVal)
+}
+
+func sin64(dst, src []float64) {
+	sin64SIMD(dst, src)
+}
+
+func cos64(dst, src []float64) {
+	cos64SIMD(dst, src)
+}
+
+func sinCos64(sinDst, cosDst, src []float64) {
+	if cpu.X86.AVX && len(src) >= 2 && trigAllFiniteInRange(src) {
+		sinCosAVX(sinDst, cosDst, src)
+		return
+	}
+	sinCos64SIMD(sinDst, cosDst, src)
+}
+
+func round64(dst, src []float64) {
+	roundImpl(dst, src)
+}
+
+func gather64(dst, src []float64, indices []int) {
+	for _, idx := range indices {
+		if idx < 0 || idx >= len(src) {
+			panic("simd: gather index out of range")
+		}
+	}
+
+	if cpu.X86.AVX2 && len(dst) >= minAVXElements {
+		gatherAVX(dst, src, indices)
+		return
+	}
+
+	gatherUncheckedGo(dst, src, indices)
 }
 
 func sqrt64(dst, a []float64) {
@@ -427,6 +477,15 @@ func sqrtAVX(dst, a []float64)
 
 //go:noescape
 func reciprocalAVX(dst, a []float64)
+
+//go:noescape
+func roundAVX(dst, src []float64)
+
+//go:noescape
+func gatherAVX(dst, src []float64, indices []int)
+
+//go:noescape
+func sinCosAVX(sinDst, cosDst, src []float64)
 
 //go:noescape
 func varianceAVX(a []float64, mean float64) float64

--- a/f64/f64_amd64.go
+++ b/f64/f64_amd64.go
@@ -60,12 +60,14 @@ var (
 
 func init() {
 	// Select optimal implementation based on CPU features
-	// Priority: AVX-512 > AVX+FMA > SSE2 > Go
+	// Priority: AVX-512 > AVX+FMA > AVX > SSE2 > Go
 	switch {
 	case cpu.X86.AVX512F && cpu.X86.AVX512VL:
 		initAVX512()
 	case cpu.X86.AVX && cpu.X86.FMA:
 		initAVX()
+	case cpu.X86.AVX:
+		initAVXNoFMA()
 	case cpu.X86.SSE2:
 		initSSE2()
 	default:
@@ -100,6 +102,7 @@ func initAVX512() {
 }
 
 func initAVX() {
+	minSIMDElements = minAVXElements
 	dotProductImpl = dotProductAVX
 	addImpl = addAVX
 	subImpl = subAVX
@@ -124,7 +127,34 @@ func initAVX() {
 	addScaledImpl = addScaledAVX
 }
 
+func initAVXNoFMA() {
+	minSIMDElements = minAVXElements
+	dotProductImpl = dotProductSSE2
+	addImpl = addAVX
+	subImpl = subAVX
+	mulImpl = mulAVX
+	divImpl = divAVX
+	scaleImpl = scaleAVX
+	addScalarImpl = addScalarAVX
+	sumImpl = sumAVX
+	minImpl = minAVX
+	maxImpl = maxAVX
+	absImpl = absAVX
+	negImpl = negAVX
+	sqrtImpl = sqrtAVX
+	reciprocalImpl = reciprocalAVX
+	roundImpl = roundAVX
+	fmaImpl = fmaSSE2
+	clampImpl = clampAVX
+	varianceImpl = varianceSSE2
+	euclideanDistanceImpl = euclideanDistanceSSE2
+	interleave2Impl = interleave2AVX
+	deinterleave2Impl = deinterleave2AVX
+	addScaledImpl = addScaledSSE2
+}
+
 func initSSE2() {
+	minSIMDElements = minAVXElements
 	dotProductImpl = dotProductSSE2
 	addImpl = addSSE2
 	subImpl = subSSE2
@@ -261,10 +291,8 @@ func cos64(dst, src []float64) {
 }
 
 func sinCos64(sinDst, cosDst, src []float64) {
-	if cpu.X86.AVX && len(src) >= 2 && trigAllFiniteInRange(src) {
-		sinCosAVX(sinDst, cosDst, src)
-		return
-	}
+	// Avoid a full pre-validation pass over src; SIMD core handles fast-path
+	// and per-element fallback for NaN/Inf/large magnitudes.
 	sinCos64SIMD(sinDst, cosDst, src)
 }
 
@@ -378,8 +406,7 @@ func cubicInterpDot64(hist, a, b, c, d []float64, x float64) float64 {
 }
 
 func sigmoid64(dst, src []float64) {
-	// Use AVX+FMA if available and have enough elements
-	if cpu.X86.AVX && cpu.X86.FMA && len(dst) >= minAVXElements {
+	if cpu.X86.AVX && len(dst) >= minAVXElements {
 		sigmoidAVX(dst, src)
 		return
 	}

--- a/f64/f64_amd64.go
+++ b/f64/f64_amd64.go
@@ -315,6 +315,16 @@ func gather64(dst, src []float64, indices []int) {
 	gatherUncheckedGo(dst, src, indices)
 }
 
+func scatter64(dst, src []float64, indices []int) {
+	for _, idx := range indices {
+		if idx < 0 || idx >= len(dst) {
+			panic("simd: scatter index out of range")
+		}
+	}
+
+	scatterUncheckedGo(dst, src, indices)
+}
+
 func sqrt64(dst, a []float64) {
 	sqrtImpl(dst, a)
 }

--- a/f64/f64_amd64.s
+++ b/f64/f64_amd64.s
@@ -13,6 +13,90 @@ DATA absf64mask<>+0x30(SB)/8, $0x7fffffffffffffff
 DATA absf64mask<>+0x38(SB)/8, $0x7fffffffffffffff
 GLOBL absf64mask<>(SB), RODATA|NOPTR, $64
 
+// Constants for Round (half away from zero): trunc(abs(x)+0.5) with sign restore.
+DATA roundf64_signmask<>+0x00(SB)/8, $0x8000000000000000
+DATA roundf64_signmask<>+0x08(SB)/8, $0x8000000000000000
+DATA roundf64_signmask<>+0x10(SB)/8, $0x8000000000000000
+DATA roundf64_signmask<>+0x18(SB)/8, $0x8000000000000000
+GLOBL roundf64_signmask<>(SB), RODATA|NOPTR, $32
+
+DATA roundf64_absmask<>+0x00(SB)/8, $0x7fffffffffffffff
+DATA roundf64_absmask<>+0x08(SB)/8, $0x7fffffffffffffff
+DATA roundf64_absmask<>+0x10(SB)/8, $0x7fffffffffffffff
+DATA roundf64_absmask<>+0x18(SB)/8, $0x7fffffffffffffff
+GLOBL roundf64_absmask<>(SB), RODATA|NOPTR, $32
+
+DATA roundf64_half<>+0x00(SB)/8, $0x3fe0000000000000
+DATA roundf64_half<>+0x08(SB)/8, $0x3fe0000000000000
+DATA roundf64_half<>+0x10(SB)/8, $0x3fe0000000000000
+DATA roundf64_half<>+0x18(SB)/8, $0x3fe0000000000000
+GLOBL roundf64_half<>(SB), RODATA|NOPTR, $32
+
+// Constants for sin/cos AVX polynomial path (two float64 lanes).
+DATA trig_invpio2_avx<>+0x00(SB)/8, $0x3fe45f306dc9c883
+DATA trig_invpio2_avx<>+0x08(SB)/8, $0x3fe45f306dc9c883
+GLOBL trig_invpio2_avx<>(SB), RODATA|NOPTR, $16
+
+DATA trig_pio2_hi_avx<>+0x00(SB)/8, $0x3ff921fb54442d18
+DATA trig_pio2_hi_avx<>+0x08(SB)/8, $0x3ff921fb54442d18
+GLOBL trig_pio2_hi_avx<>(SB), RODATA|NOPTR, $16
+
+DATA trig_pio2_lo_avx<>+0x00(SB)/8, $0x3c91a62633145c07
+DATA trig_pio2_lo_avx<>+0x08(SB)/8, $0x3c91a62633145c07
+GLOBL trig_pio2_lo_avx<>(SB), RODATA|NOPTR, $16
+
+DATA trig_sin_c3_avx<>+0x00(SB)/8, $0xbfc5555555555555
+DATA trig_sin_c3_avx<>+0x08(SB)/8, $0xbfc5555555555555
+GLOBL trig_sin_c3_avx<>(SB), RODATA|NOPTR, $16
+
+DATA trig_sin_c5_avx<>+0x00(SB)/8, $0x3f81111111111111
+DATA trig_sin_c5_avx<>+0x08(SB)/8, $0x3f81111111111111
+GLOBL trig_sin_c5_avx<>(SB), RODATA|NOPTR, $16
+
+DATA trig_sin_c7_avx<>+0x00(SB)/8, $0xbf2a01a01a01a01a
+DATA trig_sin_c7_avx<>+0x08(SB)/8, $0xbf2a01a01a01a01a
+GLOBL trig_sin_c7_avx<>(SB), RODATA|NOPTR, $16
+
+DATA trig_sin_c9_avx<>+0x00(SB)/8, $0x3ec71de3a556c734
+DATA trig_sin_c9_avx<>+0x08(SB)/8, $0x3ec71de3a556c734
+GLOBL trig_sin_c9_avx<>(SB), RODATA|NOPTR, $16
+
+DATA trig_sin_c11_avx<>+0x00(SB)/8, $0xbe5ae64567f544e4
+DATA trig_sin_c11_avx<>+0x08(SB)/8, $0xbe5ae64567f544e4
+GLOBL trig_sin_c11_avx<>(SB), RODATA|NOPTR, $16
+
+DATA trig_sin_c13_avx<>+0x00(SB)/8, $0x3de6124613a86d09
+DATA trig_sin_c13_avx<>+0x08(SB)/8, $0x3de6124613a86d09
+GLOBL trig_sin_c13_avx<>(SB), RODATA|NOPTR, $16
+
+DATA trig_cos_c2_avx<>+0x00(SB)/8, $0xbfe0000000000000
+DATA trig_cos_c2_avx<>+0x08(SB)/8, $0xbfe0000000000000
+GLOBL trig_cos_c2_avx<>(SB), RODATA|NOPTR, $16
+
+DATA trig_cos_c4_avx<>+0x00(SB)/8, $0x3fa555555555554b
+DATA trig_cos_c4_avx<>+0x08(SB)/8, $0x3fa555555555554b
+GLOBL trig_cos_c4_avx<>(SB), RODATA|NOPTR, $16
+
+DATA trig_cos_c6_avx<>+0x00(SB)/8, $0xbf56c16c16c14f91
+DATA trig_cos_c6_avx<>+0x08(SB)/8, $0xbf56c16c16c14f91
+GLOBL trig_cos_c6_avx<>(SB), RODATA|NOPTR, $16
+
+DATA trig_cos_c8_avx<>+0x00(SB)/8, $0x3efa01a019cb1590
+DATA trig_cos_c8_avx<>+0x08(SB)/8, $0x3efa01a019cb1590
+GLOBL trig_cos_c8_avx<>(SB), RODATA|NOPTR, $16
+
+DATA trig_cos_c10_avx<>+0x00(SB)/8, $0xbe927e4f809c52ad
+DATA trig_cos_c10_avx<>+0x08(SB)/8, $0xbe927e4f809c52ad
+GLOBL trig_cos_c10_avx<>(SB), RODATA|NOPTR, $16
+
+DATA trig_cos_c12_avx<>+0x00(SB)/8, $0x3e21ee9ebdb4b1c4
+DATA trig_cos_c12_avx<>+0x08(SB)/8, $0x3e21ee9ebdb4b1c4
+GLOBL trig_cos_c12_avx<>(SB), RODATA|NOPTR, $16
+
+DATA trig_one_avx<>+0x00(SB)/8, $0x3ff0000000000000
+DATA trig_one_avx<>+0x08(SB)/8, $0x3ff0000000000000
+GLOBL trig_one_avx<>(SB), RODATA|NOPTR, $16
+
 // ============================================================================
 // AVX+FMA IMPLEMENTATIONS (256-bit, 4x float64 per iteration)
 // ============================================================================
@@ -397,6 +481,345 @@ addsc_avx_scalar:
     JNZ  addsc_avx_scalar
 
 addsc_avx_done:
+    VZEROUPPER
+    RET
+
+// func roundAVX(dst, src []float64)
+// Round half away from zero:
+//   round(x) = copysign(trunc(abs(x)+0.5), x)
+TEXT ·roundAVX(SB), NOSPLIT, $0-48
+    MOVQ dst_base+0(FP), DX
+    MOVQ dst_len+8(FP), CX
+    MOVQ src_base+24(FP), SI
+
+    VMOVUPD roundf64_absmask<>(SB), Y3
+    VMOVUPD roundf64_signmask<>(SB), Y4
+    VMOVUPD roundf64_half<>(SB), Y5
+
+    MOVQ CX, AX
+    SHRQ $2, AX
+    JZ   round_avx_remainder
+
+round_avx_loop4:
+    VMOVUPD (SI), Y0                  // Y0 = x
+    VANDPD Y3, Y0, Y1                 // Y1 = abs(x)
+    VADDPD Y5, Y1, Y1                 // Y1 = abs(x) + 0.5
+    VROUNDPD $3, Y1, Y1               // Y1 = trunc(abs(x)+0.5)
+    VANDPD Y4, Y0, Y2                 // Y2 = signbit(x)
+    VORPD Y2, Y1, Y1                  // Y1 = apply sign
+    VMOVUPD Y1, (DX)
+    ADDQ $32, SI
+    ADDQ $32, DX
+    DECQ AX
+    JNZ  round_avx_loop4
+
+round_avx_remainder:
+    ANDQ $3, CX
+    JZ   round_avx_done
+
+    VMOVSD roundf64_absmask<>(SB), X3
+    VMOVSD roundf64_signmask<>(SB), X4
+    VMOVSD roundf64_half<>(SB), X5
+
+round_avx_scalar:
+    VMOVSD (SI), X0                   // X0 = x
+    VANDPD X3, X0, X1                 // X1 = abs(x)
+    VADDSD X5, X1, X1                 // X1 = abs(x)+0.5
+    VROUNDSD $3, X1, X1, X1           // X1 = trunc(abs(x)+0.5)
+    VANDPD X4, X0, X2                 // X2 = signbit(x)
+    VORPD X2, X1, X1                  // X1 = apply sign
+    VMOVSD X1, (DX)
+    ADDQ $8, SI
+    ADDQ $8, DX
+    DECQ CX
+    JNZ  round_avx_scalar
+
+round_avx_done:
+    VZEROUPPER
+    RET
+
+// func gatherAVX(dst, src []float64, indices []int)
+// Gathers scattered values into contiguous dst. Indices are pre-validated.
+TEXT ·gatherAVX(SB), NOSPLIT, $0-72
+    MOVQ dst_base+0(FP), DX
+    MOVQ dst_len+8(FP), CX
+    MOVQ src_base+24(FP), SI
+    MOVQ indices_base+48(FP), DI
+
+    MOVQ CX, AX
+    SHRQ $2, AX
+    JZ   gather_avx_remainder
+
+gather_avx_loop4:
+    VMOVDQU (DI), Y2                  // Y2 = 4x int64 indices
+    VPCMPEQQ Y3, Y3, Y3               // Y3 = all-ones gather mask
+    VXORPD Y0, Y0, Y0
+    VGATHERQPD Y3, (SI)(Y2*8), Y0     // Y0 = src[indices[*]]
+    VMOVUPD Y0, (DX)
+
+    ADDQ $32, DX
+    ADDQ $32, DI
+    DECQ AX
+    JNZ  gather_avx_loop4
+
+gather_avx_remainder:
+    ANDQ $3, CX
+    JZ   gather_avx_done
+
+gather_avx_scalar:
+    MOVQ (DI), AX
+    VMOVSD (SI)(AX*8), X0
+    VMOVSD X0, (DX)
+    ADDQ $8, DI
+    ADDQ $8, DX
+    DECQ CX
+    JNZ  gather_avx_scalar
+
+gather_avx_done:
+    VZEROUPPER
+    RET
+
+// func sinCosAVX(sinDst, cosDst, src []float64)
+// Fused sin/cos kernel using shared range reduction + polynomial approximation.
+// Preconditions (validated by Go caller):
+//   - len(src) == len(sinDst) == len(cosDst)
+//   - src values are finite and |src[i]| <= trigFallbackAbsLimit
+TEXT ·sinCosAVX(SB), NOSPLIT, $0-72
+    MOVQ sinDst_base+0(FP), R8
+    MOVQ cosDst_base+24(FP), R9
+    MOVQ src_base+48(FP), SI
+    MOVQ src_len+56(FP), CX
+    MOVQ $0x8000000000000000, R15     // sign-bit mask for negation
+
+    MOVQ CX, AX
+    SHRQ $1, AX                        // pairs
+    JZ   sincos_avx_remainder
+
+sincos_avx_loop2:
+    VMOVUPD (SI), X0                   // x
+
+    // q = round(x * 2/pi), r = x - q*(pi/2_hi) - q*(pi/2_lo)
+    VMULPD trig_invpio2_avx<>(SB), X0, X1
+    VROUNDPD $0, X1, X2                // nearest integer
+    VMULPD trig_pio2_hi_avx<>(SB), X2, X3
+    VSUBPD X3, X0, X3
+    VMULPD trig_pio2_lo_avx<>(SB), X2, X4
+    VSUBPD X4, X3, X3                  // r
+    VMULPD X3, X3, X4                  // r2
+
+    // sin(r) = r * P(r^2)
+    VMOVUPD trig_sin_c13_avx<>(SB), X5
+    VMULPD X4, X5, X5
+    VADDPD trig_sin_c11_avx<>(SB), X5, X5
+    VMULPD X4, X5, X5
+    VADDPD trig_sin_c9_avx<>(SB), X5, X5
+    VMULPD X4, X5, X5
+    VADDPD trig_sin_c7_avx<>(SB), X5, X5
+    VMULPD X4, X5, X5
+    VADDPD trig_sin_c5_avx<>(SB), X5, X5
+    VMULPD X4, X5, X5
+    VADDPD trig_sin_c3_avx<>(SB), X5, X5
+    VMULPD X4, X5, X5
+    VADDPD trig_one_avx<>(SB), X5, X5
+    VMULPD X3, X5, X6                  // X6 = sin(r)
+
+    // cos(r) = Q(r^2)
+    VMOVUPD trig_cos_c12_avx<>(SB), X7
+    VMULPD X4, X7, X7
+    VADDPD trig_cos_c10_avx<>(SB), X7, X7
+    VMULPD X4, X7, X7
+    VADDPD trig_cos_c8_avx<>(SB), X7, X7
+    VMULPD X4, X7, X7
+    VADDPD trig_cos_c6_avx<>(SB), X7, X7
+    VMULPD X4, X7, X7
+    VADDPD trig_cos_c4_avx<>(SB), X7, X7
+    VMULPD X4, X7, X7
+    VADDPD trig_cos_c2_avx<>(SB), X7, X7
+    VMULPD X4, X7, X7
+    VADDPD trig_one_avx<>(SB), X7, X7  // X7 = cos(r)
+
+    // Lane 0 quadrant mapping
+    VCVTTSD2SI X2, R10
+    MOVQ R10, R11
+    ANDQ $3, R11
+    VMOVQ X6, R12                       // sin lane 0 bits
+    VMOVQ X7, R13                       // cos lane 0 bits
+
+    CMPQ R11, $0
+    JE   sincos_avx_lane0_q0
+    CMPQ R11, $1
+    JE   sincos_avx_lane0_q1
+    CMPQ R11, $2
+    JE   sincos_avx_lane0_q2
+    // q=3: sin=-c, cos=s
+    MOVQ R13, R14
+    XORQ R15, R14
+    MOVQ R12, BX
+    JMP  sincos_avx_lane0_store
+
+sincos_avx_lane0_q2:
+    // q=2: sin=-s, cos=-c
+    MOVQ R12, R14
+    XORQ R15, R14
+    MOVQ R13, BX
+    XORQ R15, BX
+    JMP  sincos_avx_lane0_store
+
+sincos_avx_lane0_q1:
+    // q=1: sin=c, cos=-s
+    MOVQ R13, R14
+    MOVQ R12, BX
+    XORQ R15, BX
+    JMP  sincos_avx_lane0_store
+
+sincos_avx_lane0_q0:
+    // q=0: sin=s, cos=c
+    MOVQ R12, R14
+    MOVQ R13, BX
+
+sincos_avx_lane0_store:
+    MOVQ R14, (R8)
+    MOVQ BX, (R9)
+
+    // Lane 1 quadrant mapping
+    VPSRLDQ $8, X2, X1
+    VCVTTSD2SI X1, R10
+    MOVQ R10, R11
+    ANDQ $3, R11
+    VPSRLDQ $8, X6, X1
+    VMOVQ X1, R12                       // sin lane 1 bits
+    VPSRLDQ $8, X7, X1
+    VMOVQ X1, R13                       // cos lane 1 bits
+
+    CMPQ R11, $0
+    JE   sincos_avx_lane1_q0
+    CMPQ R11, $1
+    JE   sincos_avx_lane1_q1
+    CMPQ R11, $2
+    JE   sincos_avx_lane1_q2
+    // q=3: sin=-c, cos=s
+    MOVQ R13, R14
+    XORQ R15, R14
+    MOVQ R12, BX
+    JMP  sincos_avx_lane1_store
+
+sincos_avx_lane1_q2:
+    // q=2: sin=-s, cos=-c
+    MOVQ R12, R14
+    XORQ R15, R14
+    MOVQ R13, BX
+    XORQ R15, BX
+    JMP  sincos_avx_lane1_store
+
+sincos_avx_lane1_q1:
+    // q=1: sin=c, cos=-s
+    MOVQ R13, R14
+    MOVQ R12, BX
+    XORQ R15, BX
+    JMP  sincos_avx_lane1_store
+
+sincos_avx_lane1_q0:
+    // q=0: sin=s, cos=c
+    MOVQ R12, R14
+    MOVQ R13, BX
+
+sincos_avx_lane1_store:
+    MOVQ R14, 8(R8)
+    MOVQ BX, 8(R9)
+
+    ADDQ $16, SI
+    ADDQ $16, R8
+    ADDQ $16, R9
+    DECQ AX
+    JNZ  sincos_avx_loop2
+
+sincos_avx_remainder:
+    ANDQ $1, CX
+    JZ   sincos_avx_done
+
+    // Scalar remainder: same range reduction + polynomial path.
+    VMOVSD (SI), X0
+    VMULSD trig_invpio2_avx<>(SB), X0, X1
+    VROUNDSD $0, X1, X1, X2
+    VMULSD trig_pio2_hi_avx<>(SB), X2, X3
+    VSUBSD X3, X0, X3
+    VMULSD trig_pio2_lo_avx<>(SB), X2, X4
+    VSUBSD X4, X3, X3
+    VMULSD X3, X3, X4                    // r2
+
+    // sin(r)
+    VMOVSD trig_sin_c13_avx<>(SB), X5
+    VMULSD X4, X5, X5
+    VADDSD trig_sin_c11_avx<>(SB), X5, X5
+    VMULSD X4, X5, X5
+    VADDSD trig_sin_c9_avx<>(SB), X5, X5
+    VMULSD X4, X5, X5
+    VADDSD trig_sin_c7_avx<>(SB), X5, X5
+    VMULSD X4, X5, X5
+    VADDSD trig_sin_c5_avx<>(SB), X5, X5
+    VMULSD X4, X5, X5
+    VADDSD trig_sin_c3_avx<>(SB), X5, X5
+    VMULSD X4, X5, X5
+    VADDSD trig_one_avx<>(SB), X5, X5
+    VMULSD X3, X5, X6
+
+    // cos(r)
+    VMOVSD trig_cos_c12_avx<>(SB), X7
+    VMULSD X4, X7, X7
+    VADDSD trig_cos_c10_avx<>(SB), X7, X7
+    VMULSD X4, X7, X7
+    VADDSD trig_cos_c8_avx<>(SB), X7, X7
+    VMULSD X4, X7, X7
+    VADDSD trig_cos_c6_avx<>(SB), X7, X7
+    VMULSD X4, X7, X7
+    VADDSD trig_cos_c4_avx<>(SB), X7, X7
+    VMULSD X4, X7, X7
+    VADDSD trig_cos_c2_avx<>(SB), X7, X7
+    VMULSD X4, X7, X7
+    VADDSD trig_one_avx<>(SB), X7, X7
+
+    VCVTTSD2SI X2, R10
+    ANDQ $3, R10
+    VMOVQ X6, R12
+    VMOVQ X7, R13
+
+    CMPQ R10, $0
+    JE   sincos_avx_scalar_q0
+    CMPQ R10, $1
+    JE   sincos_avx_scalar_q1
+    CMPQ R10, $2
+    JE   sincos_avx_scalar_q2
+    // q=3: sin=-c, cos=s
+    MOVQ R13, R14
+    XORQ R15, R14
+    MOVQ R12, BX
+    JMP  sincos_avx_scalar_store
+
+sincos_avx_scalar_q2:
+    // q=2: sin=-s, cos=-c
+    MOVQ R12, R14
+    XORQ R15, R14
+    MOVQ R13, BX
+    XORQ R15, BX
+    JMP  sincos_avx_scalar_store
+
+sincos_avx_scalar_q1:
+    // q=1: sin=c, cos=-s
+    MOVQ R13, R14
+    MOVQ R12, BX
+    XORQ R15, BX
+    JMP  sincos_avx_scalar_store
+
+sincos_avx_scalar_q0:
+    // q=0: sin=s, cos=c
+    MOVQ R12, R14
+    MOVQ R13, BX
+
+sincos_avx_scalar_store:
+    MOVQ R14, (R8)
+    MOVQ BX, (R9)
+
+sincos_avx_done:
     VZEROUPPER
     RET
 

--- a/f64/f64_amd64.s
+++ b/f64/f64_amd64.s
@@ -3520,34 +3520,101 @@ TEXT ·cubicInterpDotAVX(SB), NOSPLIT, $0-136
     // Broadcast x to all lanes of Y7
     VBROADCASTSD x+120(FP), Y7
 
-    // Initialize accumulator to zero
-    VXORPD Y0, Y0, Y0          // Y0 = accumulator
+    // Initialize 4 independent accumulators to hide FMA latency.
+    VXORPD Y0, Y0, Y0          // acc0
+    VXORPD Y11, Y11, Y11       // acc1
+    VXORPD Y12, Y12, Y12       // acc2
+    VXORPD Y13, Y13, Y13       // acc3
 
-    // Process 4 elements per iteration (one YMM register)
+    // Process 16 elements per iteration (4 vectors) with independent chains.
     MOVQ CX, AX
-    SHRQ $2, AX                // AX = len / 4
+    SHRQ $4, AX                // AX = len / 16
+    JZ   cubic_avx_loop4_check
+
+cubic_avx_loop16:
+    // Stage 1: p = c + x*d (4 independent vectors)
+    VMOVUPD 0(R9), Y1
+    VMOVUPD 0(R10), Y5
+    VFMADD231PD Y5, Y7, Y1
+
+    VMOVUPD 32(R9), Y2
+    VMOVUPD 32(R10), Y5
+    VFMADD231PD Y5, Y7, Y2
+
+    VMOVUPD 64(R9), Y3
+    VMOVUPD 64(R10), Y5
+    VFMADD231PD Y5, Y7, Y3
+
+    VMOVUPD 96(R9), Y4
+    VMOVUPD 96(R10), Y5
+    VFMADD231PD Y5, Y7, Y4
+
+    // Stage 2: p = b + x*p
+    VMOVUPD 0(R8), Y5
+    VFMADD213PD Y7, Y5, Y1
+    VMOVUPD 32(R8), Y5
+    VFMADD213PD Y7, Y5, Y2
+    VMOVUPD 64(R8), Y5
+    VFMADD213PD Y7, Y5, Y3
+    VMOVUPD 96(R8), Y5
+    VFMADD213PD Y7, Y5, Y4
+
+    // Stage 3: coef = a + x*p
+    VMOVUPD 0(DI), Y5
+    VFMADD213PD Y7, Y5, Y1
+    VMOVUPD 32(DI), Y5
+    VFMADD213PD Y7, Y5, Y2
+    VMOVUPD 64(DI), Y5
+    VFMADD213PD Y7, Y5, Y3
+    VMOVUPD 96(DI), Y5
+    VFMADD213PD Y7, Y5, Y4
+
+    // Accumulate: Σ hist * coef with independent accumulators.
+    VMOVUPD 0(SI), Y5
+    VFMADD231PD Y5, Y1, Y0
+    VMOVUPD 32(SI), Y5
+    VFMADD231PD Y5, Y2, Y11
+    VMOVUPD 64(SI), Y5
+    VFMADD231PD Y5, Y3, Y12
+    VMOVUPD 96(SI), Y5
+    VFMADD231PD Y5, Y4, Y13
+
+    // Advance pointers by 16 elements.
+    ADDQ $128, SI
+    ADDQ $128, DI
+    ADDQ $128, R8
+    ADDQ $128, R9
+    ADDQ $128, R10
+    DECQ AX
+    JNZ  cubic_avx_loop16
+
+    // Combine accumulators.
+    VADDPD Y11, Y0, Y0
+    VADDPD Y12, Y0, Y0
+    VADDPD Y13, Y0, Y0
+
+cubic_avx_loop4_check:
+    // Handle remaining 4-element vectors.
+    ANDQ $15, CX
+    MOVQ CX, AX
+    SHRQ $2, AX
     JZ   cubic_avx_remainder
 
 cubic_avx_loop4:
-    // Load coefficient vectors
-    VMOVUPD (R10), Y1          // Y1 = d[i:i+4]
-    VMOVUPD (R9), Y2           // Y2 = c[i:i+4]
-    VMOVUPD (R8), Y3           // Y3 = b[i:i+4]
-    VMOVUPD (DI), Y4           // Y4 = a[i:i+4]
-    VMOVUPD (SI), Y5           // Y5 = hist[i:i+4]
+    VMOVUPD (R10), Y1          // d
+    VMOVUPD (R9), Y2           // c
+    VMOVUPD (R8), Y3           // b
+    VMOVUPD (DI), Y4           // a
+    VMOVUPD (SI), Y5           // hist
 
     // Horner's method: coef = a + x*(b + x*(c + x*d))
-    // Step 1: Y2 = c + x*d (using VFMADD231: dst = src1*src2 + dst)
-    VFMADD231PD Y1, Y7, Y2     // Y2 = d*x + c
-    // Step 2: Y3 = b + x*(c + x*d)
-    VFMADD231PD Y2, Y7, Y3     // Y3 = (d*x+c)*x + b
-    // Step 3: Y4 = a + x*(b + x*(c + x*d))
-    VFMADD231PD Y3, Y7, Y4     // Y4 = ((d*x+c)*x+b)*x + a = coef
+    VFMADD231PD Y1, Y7, Y2
+    VFMADD231PD Y2, Y7, Y3
+    VFMADD231PD Y3, Y7, Y4
 
     // Accumulate: acc += hist * coef
-    VFMADD231PD Y5, Y4, Y0     // Y0 = hist * coef + Y0
+    VFMADD231PD Y5, Y4, Y0
 
-    // Advance pointers
     ADDQ $32, SI
     ADDQ $32, DI
     ADDQ $32, R8
@@ -3565,6 +3632,7 @@ cubic_avx_remainder:
     // Handle remaining 1-3 elements
     ANDQ $3, CX
     JZ   cubic_avx_done
+    VMOVSD x+120(FP), X6       // X6 = x
 
 cubic_avx_scalar:
     // Load single elements
@@ -3573,7 +3641,6 @@ cubic_avx_scalar:
     VMOVSD (R8), X3            // X3 = b[i]
     VMOVSD (DI), X4            // X4 = a[i]
     VMOVSD (SI), X5            // X5 = hist[i]
-    VMOVSD x+120(FP), X6       // X6 = x
 
     // Horner's method for scalar
     VFMADD231SD X1, X6, X2     // X2 = d*x + c

--- a/f64/f64_arm64.go
+++ b/f64/f64_arm64.go
@@ -147,10 +147,8 @@ func sinCos64(sinDst, cosDst, src []float64) {
 	if accelerate.SinCos64(sinDst, cosDst, src) {
 		return
 	}
-	if hasNEON && len(src) > 0 && trigAllFiniteInRange(src) {
-		sinCosNEON(sinDst, cosDst, src)
-		return
-	}
+	// Avoid a full pre-validation pass over src; SIMD core handles fast-path
+	// and per-element fallback for NaN/Inf/large magnitudes.
 	sinCos64SIMD(sinDst, cosDst, src)
 }
 

--- a/f64/f64_arm64.go
+++ b/f64/f64_arm64.go
@@ -2,7 +2,10 @@
 
 package f64
 
-import "github.com/tphakala/simd/cpu"
+import (
+	"github.com/tphakala/simd/cpu"
+	"github.com/tphakala/simd/internal/accelerate"
+)
 
 var (
 	hasNEON = cpu.ARM64.NEON
@@ -63,6 +66,16 @@ func addScalar(dst, a []float64, s float64) {
 	addScalarGo(dst, a, s)
 }
 
+func subFromScalar64(dst, a []float64, s float64) {
+	if hasNEON && len(dst) >= 2 {
+		// SIMD composition: (s - a) == (-(a)) + s
+		neg64(dst, a)
+		addScalar(dst, dst, s)
+		return
+	}
+	subFromScalarGo(dst, a, s)
+}
+
 func sum(a []float64) float64 {
 	if hasNEON && len(a) >= 2 {
 		return sumNEON(a)
@@ -114,6 +127,54 @@ func clamp64(dst, a []float64, minVal, maxVal float64) {
 		return
 	}
 	clampGo(dst, a, minVal, maxVal)
+}
+
+func sin64(dst, src []float64) {
+	if accelerate.Sin64(dst, src) {
+		return
+	}
+	sin64SIMD(dst, src)
+}
+
+func cos64(dst, src []float64) {
+	if accelerate.Cos64(dst, src) {
+		return
+	}
+	cos64SIMD(dst, src)
+}
+
+func sinCos64(sinDst, cosDst, src []float64) {
+	if accelerate.SinCos64(sinDst, cosDst, src) {
+		return
+	}
+	if hasNEON && len(src) > 0 && trigAllFiniteInRange(src) {
+		sinCosNEON(sinDst, cosDst, src)
+		return
+	}
+	sinCos64SIMD(sinDst, cosDst, src)
+}
+
+func round64(dst, src []float64) {
+	if hasNEON && len(dst) >= 2 {
+		roundNEON(dst, src)
+		return
+	}
+	round64Go(dst, src)
+}
+
+func gather64(dst, src []float64, indices []int) {
+	for _, idx := range indices {
+		if idx < 0 || idx >= len(src) {
+			panic("simd: gather index out of range")
+		}
+	}
+
+	if hasNEON && len(dst) >= 2 {
+		gatherNEON(dst, src, indices)
+		return
+	}
+
+	gatherUncheckedGo(dst, src, indices)
 }
 
 func sqrt64(dst, a []float64) {
@@ -228,6 +289,15 @@ func sqrtNEON(dst, a []float64)
 
 //go:noescape
 func reciprocalNEON(dst, a []float64)
+
+//go:noescape
+func roundNEON(dst, src []float64)
+
+//go:noescape
+func gatherNEON(dst, src []float64, indices []int)
+
+//go:noescape
+func sinCosNEON(sinDst, cosDst, src []float64)
 
 //go:noescape
 func varianceNEON(a []float64, mean float64) float64

--- a/f64/f64_arm64.go
+++ b/f64/f64_arm64.go
@@ -175,6 +175,16 @@ func gather64(dst, src []float64, indices []int) {
 	gatherUncheckedGo(dst, src, indices)
 }
 
+func scatter64(dst, src []float64, indices []int) {
+	for _, idx := range indices {
+		if idx < 0 || idx >= len(dst) {
+			panic("simd: scatter index out of range")
+		}
+	}
+
+	scatterUncheckedGo(dst, src, indices)
+}
+
 func sqrt64(dst, a []float64) {
 	if hasNEON && len(dst) >= 2 {
 		sqrtNEON(dst, a)

--- a/f64/f64_arm64.s
+++ b/f64/f64_arm64.s
@@ -256,6 +256,203 @@ addsc_scalar:
 addsc_done:
     RET
 
+// func roundNEON(dst, src []float64)
+// Round half away from zero using FRINTA.
+TEXT ·roundNEON(SB), NOSPLIT, $0-48
+    MOVD dst_base+0(FP), R0
+    MOVD dst_len+8(FP), R2
+    MOVD src_base+24(FP), R1
+
+    LSR $1, R2, R3
+    CBZ R3, round_scalar
+
+round_loop2:
+    VLD1.P 16(R1), [V0.D2]
+    WORD $0x6E618800           // FRINTA V0.2D, V0.2D
+    VST1.P [V0.D2], 16(R0)
+    SUB $1, R3
+    CBNZ R3, round_loop2
+
+round_scalar:
+    AND $1, R2
+    CBZ R2, round_done
+    FMOVD (R1), F0
+    WORD $0x1E664000           // FRINTA D0, D0
+    FMOVD F0, (R0)
+
+round_done:
+    RET
+
+// func gatherNEON(dst, src []float64, indices []int)
+// Indices are pre-validated in Go before this function is called.
+TEXT ·gatherNEON(SB), NOSPLIT, $0-72
+    MOVD dst_base+0(FP), R0
+    MOVD dst_len+8(FP), R3
+    MOVD src_base+24(FP), R1
+    MOVD indices_base+48(FP), R2
+
+    LSR $1, R3, R4
+    CBZ R4, gather_scalar
+
+gather_loop2:
+    MOVD (R2), R5
+    MOVD 8(R2), R6
+    MOVD (R1)(R5<<3), R7
+    MOVD (R1)(R6<<3), R8
+    WORD $0x4E081CE0           // INS V0.D[0], R7
+    WORD $0x4E181D00           // INS V0.D[1], R8
+    VST1.P [V0.D2], 16(R0)
+    ADD $16, R2
+    SUB $1, R4
+    CBNZ R4, gather_loop2
+
+gather_scalar:
+    AND $1, R3
+    CBZ R3, gather_done
+    MOVD (R2), R5
+    FMOVD (R1)(R5<<3), F0
+    FMOVD F0, (R0)
+
+gather_done:
+    RET
+
+// func sinCosNEON(sinDst, cosDst, src []float64)
+// Fused scalar-assembly sin/cos kernel with shared range reduction.
+// Preconditions (validated by Go caller):
+//   - len(src) == len(sinDst) == len(cosDst)
+//   - src values are finite and |src[i]| <= trigFallbackAbsLimit
+TEXT ·sinCosNEON(SB), NOSPLIT, $0-72
+    MOVD sinDst_base+0(FP), R0
+    MOVD cosDst_base+24(FP), R1
+    MOVD src_base+48(FP), R2
+    MOVD src_len+56(FP), R3
+
+    // Load constants into FP registers
+    MOVD $0x3fe45f306dc9c883, R10      // 2/pi
+    FMOVD R10, F16
+    MOVD $0x3ff921fb54442d18, R10      // pi/2 high
+    FMOVD R10, F17
+    MOVD $0x3c91a62633145c07, R10      // pi/2 low
+    FMOVD R10, F18
+    MOVD $0x3ff0000000000000, R10      // 1.0
+    FMOVD R10, F19
+
+    MOVD $0x3de6124613a86d09, R10      // sin c13
+    FMOVD R10, F20
+    MOVD $0xbe5ae64567f544e4, R10      // sin c11
+    FMOVD R10, F21
+    MOVD $0x3ec71de3a556c734, R10      // sin c9
+    FMOVD R10, F22
+    MOVD $0xbf2a01a01a01a01a, R10      // sin c7
+    FMOVD R10, F23
+    MOVD $0x3f81111111111111, R10      // sin c5
+    FMOVD R10, F24
+    MOVD $0xbfc5555555555555, R10      // sin c3
+    FMOVD R10, F25
+
+    MOVD $0x3e21ee9ebdb4b1c4, R10      // cos c12
+    FMOVD R10, F26
+    MOVD $0xbe927e4f809c52ad, R10      // cos c10
+    FMOVD R10, F27
+    MOVD $0x3efa01a019cb1590, R10      // cos c8
+    FMOVD R10, F28
+    MOVD $0xbf56c16c16c14f91, R10      // cos c6
+    FMOVD R10, F29
+    MOVD $0x3fa555555555554b, R10      // cos c4
+    FMOVD R10, F30
+    MOVD $0xbfe0000000000000, R10      // cos c2
+    FMOVD R10, F31
+
+sincos_neon_loop:
+    CBZ R3, sincos_neon_done
+
+    FMOVD (R2), F0                     // x
+
+    // q = round(x * 2/pi)
+    FMULD F0, F16, F1
+    FRINTAD F1, F1
+
+    // r = x - q*(pi/2_hi) - q*(pi/2_lo)
+    FMULD F1, F17, F2
+    FSUBD F2, F0, F3
+    FMULD F1, F18, F2
+    FSUBD F2, F3, F3
+    FMULD F3, F3, F4                   // r2
+
+    // sin(r) = r * P(r^2)
+    FMULD F4, F20, F5
+    FADDD F21, F5, F5
+    FMULD F4, F5, F5
+    FADDD F22, F5, F5
+    FMULD F4, F5, F5
+    FADDD F23, F5, F5
+    FMULD F4, F5, F5
+    FADDD F24, F5, F5
+    FMULD F4, F5, F5
+    FADDD F25, F5, F5
+    FMULD F4, F5, F5
+    FADDD F19, F5, F5
+    FMULD F3, F5, F6                   // sinr
+
+    // cos(r) = Q(r^2)
+    FMULD F4, F26, F7
+    FADDD F27, F7, F7
+    FMULD F4, F7, F7
+    FADDD F28, F7, F7
+    FMULD F4, F7, F7
+    FADDD F29, F7, F7
+    FMULD F4, F7, F7
+    FADDD F30, F7, F7
+    FMULD F4, F7, F7
+    FADDD F31, F7, F7
+    FMULD F4, F7, F7
+    FADDD F19, F7, F7                  // cosr
+
+    FCVTZSD F1, R4                     // integer quadrant source
+    AND $3, R4, R5
+
+    // Default q=0: sin=s, cos=c
+    FMOVD F6, F10
+    FMOVD F7, F11
+
+    CMP $1, R5
+    BEQ sincos_neon_q1
+    CMP $2, R5
+    BEQ sincos_neon_q2
+    CMP $3, R5
+    BEQ sincos_neon_q3
+    B sincos_neon_store
+
+sincos_neon_q1:
+    // q=1: sin=c, cos=-s
+    FMOVD F7, F10
+    FNEGD F6, F11
+    B sincos_neon_store
+
+sincos_neon_q2:
+    // q=2: sin=-s, cos=-c
+    FNEGD F6, F10
+    FNEGD F7, F11
+    B sincos_neon_store
+
+sincos_neon_q3:
+    // q=3: sin=-c, cos=s
+    FNEGD F7, F10
+    FMOVD F6, F11
+
+sincos_neon_store:
+    FMOVD F10, (R0)
+    FMOVD F11, (R1)
+
+    ADD $8, R2
+    ADD $8, R0
+    ADD $8, R1
+    SUB $1, R3
+    B sincos_neon_loop
+
+sincos_neon_done:
+    RET
+
 // func sumNEON(a []float64) float64
 TEXT ·sumNEON(SB), NOSPLIT, $0-32
     MOVD a_base+0(FP), R0

--- a/f64/f64_arm64.s
+++ b/f64/f64_arm64.s
@@ -974,22 +974,20 @@ cubic_neon_loop4:
     VLD1.P 16(R1), [V13.D2]    // V13 = a[i+2:i+4]
     VLD1.P 16(R0), [V14.D2]    // V14 = hist[i+2:i+4]
 
-    // Horner's method for first pair: coef = a + x*(b + x*(c + x*d))
-    // FMLA Vd.2D, Vn.2D, Vm.2D: Vd = Vd + Vn * Vm
-    // Step 1: V3 = c + d*x
+    // Horner stage 1 for both vectors: p = c + x*d
     WORD $0x4E7FCC43           // FMLA V3.2D, V2.2D, V31.2D
-    // Step 2: V4 = b + (c + d*x)*x
-    WORD $0x4E7FCC64           // FMLA V4.2D, V3.2D, V31.2D
-    // Step 3: V5 = a + (b + (c + d*x)*x)*x = coef
-    WORD $0x4E7FCC85           // FMLA V5.2D, V4.2D, V31.2D
-    // Accumulate: acc0 += hist * coef
-    WORD $0x4E65CCC0           // FMLA V0.2D, V6.2D, V5.2D
-
-    // Horner's method for second pair
     WORD $0x4E7FCD4B           // FMLA V11.2D, V10.2D, V31.2D
+
+    // Horner stage 2 for both vectors: p = b + x*p
+    WORD $0x4E7FCC64           // FMLA V4.2D, V3.2D, V31.2D
     WORD $0x4E7FCD6C           // FMLA V12.2D, V11.2D, V31.2D
+
+    // Horner stage 3 for both vectors: coef = a + x*p
+    WORD $0x4E7FCC85           // FMLA V5.2D, V4.2D, V31.2D
     WORD $0x4E7FCD8D           // FMLA V13.2D, V12.2D, V31.2D
-    // Accumulate: acc1 += hist * coef
+
+    // Accumulate: acc += hist * coef
+    WORD $0x4E65CCC0           // FMLA V0.2D, V6.2D, V5.2D
     WORD $0x4E6DCDC1           // FMLA V1.2D, V14.2D, V13.2D
 
     SUB $1, R5

--- a/f64/f64_go.go
+++ b/f64/f64_go.go
@@ -11,7 +11,6 @@ const (
 // Numerical stability thresholds
 const (
 	sigmoidClampThreshold = 20.0  // sigmoid(±20) ≈ 1.0 - 2e-9 (float64 precision limit)
-	tanhClampThreshold    = 2.5   // fast approximation threshold: tanh(±2.5) saturates to ±1
 	expOverflowThreshold  = 709.0 // exp(709.78) = max float64; clamp to prevent overflow
 )
 
@@ -20,6 +19,11 @@ const (
 func dotProductGo(a, b []float64) float64 {
 	var sum float64
 	n := min(len(a), len(b))
+	if n == 0 {
+		return 0
+	}
+	_ = a[n-1]
+	_ = b[n-1]
 	n4 := n &^ unrollMask // Round down to multiple of 4
 
 	// Unrolled loop: 4 FMAs per iteration
@@ -38,42 +42,74 @@ func dotProductGo(a, b []float64) float64 {
 }
 
 func addGo(dst, a, b []float64) {
+	if len(dst) == 0 {
+		return
+	}
+	_ = a[len(dst)-1]
+	_ = b[len(dst)-1]
 	for i := range dst {
 		dst[i] = a[i] + b[i]
 	}
 }
 
 func subGo(dst, a, b []float64) {
+	if len(dst) == 0 {
+		return
+	}
+	_ = a[len(dst)-1]
+	_ = b[len(dst)-1]
 	for i := range dst {
 		dst[i] = a[i] - b[i]
 	}
 }
 
 func mulGo(dst, a, b []float64) {
+	if len(dst) == 0 {
+		return
+	}
+	_ = a[len(dst)-1]
+	_ = b[len(dst)-1]
 	for i := range dst {
 		dst[i] = a[i] * b[i]
 	}
 }
 
 func divGo(dst, a, b []float64) {
+	if len(dst) == 0 {
+		return
+	}
+	_ = a[len(dst)-1]
+	_ = b[len(dst)-1]
 	for i := range dst {
 		dst[i] = a[i] / b[i]
 	}
 }
 
 func scaleGo(dst, a []float64, s float64) {
+	if len(dst) == 0 {
+		return
+	}
+	_ = a[len(dst)-1]
 	for i := range dst {
 		dst[i] = a[i] * s
 	}
 }
 
 func addScalarGo(dst, a []float64, s float64) {
+	if len(dst) == 0 {
+		return
+	}
+	_ = a[len(dst)-1]
 	for i := range dst {
 		dst[i] = a[i] + s
 	}
 }
 
 func subFromScalarGo(dst, a []float64, s float64) {
+	if len(dst) == 0 {
+		return
+	}
+	_ = a[len(dst)-1]
 	for i := range dst {
 		dst[i] = s - a[i]
 	}
@@ -90,9 +126,7 @@ func sumGo(a []float64) float64 {
 func minGo(a []float64) float64 {
 	m := a[0]
 	for _, v := range a[1:] {
-		if v < m {
-			m = v
-		}
+		m = math.Min(m, v)
 	}
 	return m
 }
@@ -100,32 +134,48 @@ func minGo(a []float64) float64 {
 func maxGo(a []float64) float64 {
 	m := a[0]
 	for _, v := range a[1:] {
-		if v > m {
-			m = v
-		}
+		m = math.Max(m, v)
 	}
 	return m
 }
 
 func absGo(dst, a []float64) {
+	if len(dst) == 0 {
+		return
+	}
+	_ = a[len(dst)-1]
 	for i := range dst {
 		dst[i] = math.Abs(a[i])
 	}
 }
 
 func negGo(dst, a []float64) {
+	if len(dst) == 0 {
+		return
+	}
+	_ = a[len(dst)-1]
 	for i := range dst {
 		dst[i] = -a[i]
 	}
 }
 
 func fmaGo(dst, a, b, c []float64) {
+	if len(dst) == 0 {
+		return
+	}
+	_ = a[len(dst)-1]
+	_ = b[len(dst)-1]
+	_ = c[len(dst)-1]
 	for i := range dst {
 		dst[i] = math.FMA(a[i], b[i], c[i])
 	}
 }
 
 func clampGo(dst, a []float64, minVal, maxVal float64) {
+	if len(dst) == 0 {
+		return
+	}
+	_ = a[len(dst)-1]
 	for i := range dst {
 		v := a[i]
 		if v < minVal {

--- a/f64/f64_go.go
+++ b/f64/f64_go.go
@@ -228,6 +228,22 @@ func gatherUncheckedGo(dst, src []float64, indices []int) {
 	}
 }
 
+func scatterGo(dst, src []float64, indices []int) {
+	for i := range src {
+		idx := indices[i]
+		if idx < 0 || idx >= len(dst) {
+			panic("simd: scatter index out of range")
+		}
+	}
+	scatterUncheckedGo(dst, src, indices)
+}
+
+func scatterUncheckedGo(dst, src []float64, indices []int) {
+	for i := range src {
+		dst[indices[i]] = src[i]
+	}
+}
+
 func sqrt64Go(dst, a []float64) {
 	for i := range dst {
 		dst[i] = math.Sqrt(a[i])

--- a/f64/f64_go.go
+++ b/f64/f64_go.go
@@ -73,6 +73,12 @@ func addScalarGo(dst, a []float64, s float64) {
 	}
 }
 
+func subFromScalarGo(dst, a []float64, s float64) {
+	for i := range dst {
+		dst[i] = s - a[i]
+	}
+}
+
 func sumGo(a []float64) float64 {
 	var sum float64
 	for _, v := range a {
@@ -128,6 +134,47 @@ func clampGo(dst, a []float64, minVal, maxVal float64) {
 			v = maxVal
 		}
 		dst[i] = v
+	}
+}
+
+func sin64Go(dst, src []float64) {
+	for i := range dst {
+		dst[i] = math.Sin(src[i])
+	}
+}
+
+func cos64Go(dst, src []float64) {
+	for i := range dst {
+		dst[i] = math.Cos(src[i])
+	}
+}
+
+func sinCos64Go(sinDst, cosDst, src []float64) {
+	for i := range src {
+		sinDst[i], cosDst[i] = math.Sincos(src[i])
+	}
+}
+
+func round64Go(dst, src []float64) {
+	for i := range dst {
+		dst[i] = math.Round(src[i])
+	}
+}
+
+func gatherGo(dst, src []float64, indices []int) {
+	for i := range dst {
+		idx := indices[i]
+		if idx < 0 || idx >= len(src) {
+			panic("simd: gather index out of range")
+		}
+	}
+	gatherUncheckedGo(dst, src, indices)
+}
+
+func gatherUncheckedGo(dst, src []float64, indices []int) {
+	for i := range dst {
+		idx := indices[i]
+		dst[i] = src[idx]
 	}
 }
 

--- a/f64/f64_newops_test.go
+++ b/f64/f64_newops_test.go
@@ -1,0 +1,190 @@
+package f64
+
+import (
+	"math"
+	"testing"
+)
+
+const trigApproxTol = 1e-12
+
+func TestSin(t *testing.T) {
+	src := []float64{0, math.Pi / 6, math.Pi / 2, math.Pi}
+	dst := make([]float64, len(src))
+
+	Sin(dst, src)
+
+	for i := range src {
+		want := math.Sin(src[i])
+		if math.Abs(dst[i]-want) > trigApproxTol {
+			t.Errorf("Sin()[%d] = %v, want %v", i, dst[i], want)
+		}
+	}
+}
+
+func TestCos(t *testing.T) {
+	src := []float64{0, math.Pi / 3, math.Pi / 2, math.Pi}
+	dst := make([]float64, len(src))
+
+	Cos(dst, src)
+
+	for i := range src {
+		want := math.Cos(src[i])
+		if math.Abs(dst[i]-want) > trigApproxTol {
+			t.Errorf("Cos()[%d] = %v, want %v", i, dst[i], want)
+		}
+	}
+}
+
+func TestSinCos(t *testing.T) {
+	src := []float64{0, math.Pi / 4, math.Pi / 2, math.Pi}
+	sinDst := make([]float64, len(src))
+	cosDst := make([]float64, len(src))
+
+	SinCos(sinDst, cosDst, src)
+
+	for i := range src {
+		wantSin, wantCos := math.Sincos(src[i])
+		if math.Abs(sinDst[i]-wantSin) > trigApproxTol {
+			t.Errorf("SinCos() sin[%d] = %v, want %v", i, sinDst[i], wantSin)
+		}
+		if math.Abs(cosDst[i]-wantCos) > trigApproxTol {
+			t.Errorf("SinCos() cos[%d] = %v, want %v", i, cosDst[i], wantCos)
+		}
+	}
+}
+
+func TestSinCos_DifferentLengths(t *testing.T) {
+	src := []float64{0, math.Pi / 4, math.Pi / 2, math.Pi}
+	sinDst := make([]float64, 2)
+	cosDst := make([]float64, 3)
+
+	SinCos(sinDst, cosDst, src)
+
+	for i := range sinDst {
+		wantSin, wantCos := math.Sincos(src[i])
+		if math.Abs(sinDst[i]-wantSin) > trigApproxTol {
+			t.Errorf("SinCos() sin[%d] = %v, want %v", i, sinDst[i], wantSin)
+		}
+		if math.Abs(cosDst[i]-wantCos) > trigApproxTol {
+			t.Errorf("SinCos() cos[%d] = %v, want %v", i, cosDst[i], wantCos)
+		}
+	}
+}
+
+func TestSubFromScalar(t *testing.T) {
+	src := []float64{1, -2, 3.5, 10}
+	dst := make([]float64, len(src))
+	SubFromScalar(dst, src, 7.0)
+
+	want := []float64{6, 9, 3.5, -3}
+	for i := range dst {
+		if dst[i] != want[i] {
+			t.Errorf("SubFromScalar()[%d] = %v, want %v", i, dst[i], want[i])
+		}
+	}
+}
+
+func TestRound(t *testing.T) {
+	src := []float64{-2.5, -1.5, -0.5, 0.4, 0.5, 1.5, 2.5, 3.49, 3.5}
+	dst := make([]float64, len(src))
+
+	Round(dst, src)
+
+	for i := range src {
+		want := math.Round(src[i])
+		if dst[i] != want {
+			t.Errorf("Round()[%d] = %v, want %v", i, dst[i], want)
+		}
+	}
+}
+
+func TestRound_SpecialValues(t *testing.T) {
+	src := []float64{math.NaN(), math.Inf(1), math.Inf(-1)}
+	dst := make([]float64, len(src))
+
+	Round(dst, src)
+
+	if !math.IsNaN(dst[0]) {
+		t.Errorf("Round(NaN) = %v, want NaN", dst[0])
+	}
+	if !math.IsInf(dst[1], 1) {
+		t.Errorf("Round(+Inf) = %v, want +Inf", dst[1])
+	}
+	if !math.IsInf(dst[2], -1) {
+		t.Errorf("Round(-Inf) = %v, want -Inf", dst[2])
+	}
+}
+
+func TestWeightedSum(t *testing.T) {
+	weights := []float64{0.5, -1, 2, 0.25}
+	src := []float64{8, 3, -2, 4}
+
+	got := WeightedSum(weights, src)
+	want := 0.5*8 + (-1)*3 + 2*(-2) + 0.25*4
+	if got != want {
+		t.Errorf("WeightedSum() = %v, want %v", got, want)
+	}
+}
+
+func TestSumOfSquares(t *testing.T) {
+	src := []float64{3, 4, -12}
+	got := SumOfSquares(src)
+	want := 9.0 + 16.0 + 144.0
+	if got != want {
+		t.Errorf("SumOfSquares() = %v, want %v", got, want)
+	}
+
+	if SumOfSquares(nil) != 0 {
+		t.Errorf("SumOfSquares(nil) should return 0")
+	}
+}
+
+func TestGather(t *testing.T) {
+	src := []float64{10, 20, 30, 40, 50}
+	indices := []int{4, 0, 3, 1}
+	dst := make([]float64, len(indices))
+
+	Gather(dst, src, indices)
+
+	want := []float64{50, 10, 40, 20}
+	for i := range dst {
+		if dst[i] != want[i] {
+			t.Errorf("Gather()[%d] = %v, want %v", i, dst[i], want[i])
+		}
+	}
+}
+
+func TestGather_DifferentLengths(t *testing.T) {
+	src := []float64{1, 2, 3, 4}
+	indices := []int{3, 2, 1}
+	dst := make([]float64, 2)
+
+	Gather(dst, src, indices)
+
+	want := []float64{4, 3}
+	for i := range dst {
+		if dst[i] != want[i] {
+			t.Errorf("Gather()[%d] = %v, want %v", i, dst[i], want[i])
+		}
+	}
+}
+
+func TestGather_PanicsNegativeIndex(t *testing.T) {
+	defer func() {
+		if recover() == nil {
+			t.Error("Gather() did not panic for negative index")
+		}
+	}()
+
+	Gather(make([]float64, 1), []float64{1, 2, 3}, []int{-1})
+}
+
+func TestGather_PanicsOutOfRange(t *testing.T) {
+	defer func() {
+		if recover() == nil {
+			t.Error("Gather() did not panic for out-of-range index")
+		}
+	}()
+
+	Gather(make([]float64, 1), []float64{1, 2, 3}, []int{3})
+}

--- a/f64/f64_newops_test.go
+++ b/f64/f64_newops_test.go
@@ -215,3 +215,65 @@ func TestGather_PanicsOutOfRange(t *testing.T) {
 
 	Gather(make([]float64, 1), []float64{1, 2, 3}, []int{3})
 }
+
+func TestScatter(t *testing.T) {
+	src := []float64{10, 20, 30, 40}
+	indices := []int{4, 0, 3, 1}
+	dst := make([]float64, 5)
+
+	Scatter(dst, src, indices)
+
+	want := []float64{20, 40, 0, 30, 10}
+	for i := range dst {
+		if dst[i] != want[i] {
+			t.Errorf("Scatter()[%d] = %v, want %v", i, dst[i], want[i])
+		}
+	}
+}
+
+func TestScatter_DifferentLengths(t *testing.T) {
+	src := []float64{1, 2, 3, 4}
+	indices := []int{3, 2, 1}
+	dst := make([]float64, 4)
+
+	Scatter(dst, src, indices)
+
+	want := []float64{0, 3, 2, 1}
+	for i := range dst {
+		if dst[i] != want[i] {
+			t.Errorf("Scatter()[%d] = %v, want %v", i, dst[i], want[i])
+		}
+	}
+}
+
+func TestScatter_DuplicateIndices(t *testing.T) {
+	src := []float64{1, 2, 3}
+	indices := []int{1, 1, 1}
+	dst := make([]float64, 2)
+
+	Scatter(dst, src, indices)
+
+	if dst[1] != 3 {
+		t.Errorf("Scatter() last write should win: got %v, want %v", dst[1], 3)
+	}
+}
+
+func TestScatter_PanicsNegativeIndex(t *testing.T) {
+	defer func() {
+		if recover() == nil {
+			t.Error("Scatter() did not panic for negative index")
+		}
+	}()
+
+	Scatter(make([]float64, 3), []float64{1}, []int{-1})
+}
+
+func TestScatter_PanicsOutOfRange(t *testing.T) {
+	defer func() {
+		if recover() == nil {
+			t.Error("Scatter() did not panic for out-of-range index")
+		}
+	}()
+
+	Scatter(make([]float64, 3), []float64{1}, []int{3})
+}

--- a/f64/f64_newops_test.go
+++ b/f64/f64_newops_test.go
@@ -71,6 +71,33 @@ func TestSinCos_DifferentLengths(t *testing.T) {
 	}
 }
 
+func TestSinCos_SpecialValues(t *testing.T) {
+	src := []float64{0, 1e7, -1e7, math.NaN(), math.Inf(1), math.Inf(-1)}
+	sinDst := make([]float64, len(src))
+	cosDst := make([]float64, len(src))
+
+	SinCos(sinDst, cosDst, src)
+
+	for i := range src {
+		wantSin, wantCos := math.Sincos(src[i])
+		if math.IsNaN(wantSin) {
+			if !math.IsNaN(sinDst[i]) {
+				t.Errorf("SinCos() sin[%d] = %v, want NaN", i, sinDst[i])
+			}
+		} else if math.Abs(sinDst[i]-wantSin) > trigApproxTol {
+			t.Errorf("SinCos() sin[%d] = %v, want %v", i, sinDst[i], wantSin)
+		}
+
+		if math.IsNaN(wantCos) {
+			if !math.IsNaN(cosDst[i]) {
+				t.Errorf("SinCos() cos[%d] = %v, want NaN", i, cosDst[i])
+			}
+		} else if math.Abs(cosDst[i]-wantCos) > trigApproxTol {
+			t.Errorf("SinCos() cos[%d] = %v, want %v", i, cosDst[i], wantCos)
+		}
+	}
+}
+
 func TestSubFromScalar(t *testing.T) {
 	src := []float64{1, -2, 3.5, 10}
 	dst := make([]float64, len(src))

--- a/f64/f64_other.go
+++ b/f64/f64_other.go
@@ -11,6 +11,7 @@ func mul(dst, a, b []float64)                          { mulGo(dst, a, b) }
 func div(dst, a, b []float64)                          { divGo(dst, a, b) }
 func scale(dst, a []float64, s float64)                { scaleGo(dst, a, s) }
 func addScalar(dst, a []float64, s float64)            { addScalarGo(dst, a, s) }
+func subFromScalar64(dst, a []float64, s float64)      { subFromScalarGo(dst, a, s) }
 func sum(a []float64) float64                          { return sumGo(a) }
 func min64(a []float64) float64                        { return minGo(a) }
 func max64(a []float64) float64                        { return maxGo(a) }
@@ -18,6 +19,11 @@ func abs64(dst, a []float64)                           { absGo(dst, a) }
 func neg64(dst, a []float64)                           { negGo(dst, a) }
 func fma64(dst, a, b, c []float64)                     { fmaGo(dst, a, b, c) }
 func clamp64(dst, a []float64, minVal, maxVal float64) { clampGo(dst, a, minVal, maxVal) }
+func sin64(dst, src []float64)                         { sin64Go(dst, src) }
+func cos64(dst, src []float64)                         { cos64Go(dst, src) }
+func sinCos64(sinDst, cosDst, src []float64)           { sinCos64Go(sinDst, cosDst, src) }
+func round64(dst, src []float64)                       { round64Go(dst, src) }
+func gather64(dst, src []float64, indices []int)       { gatherGo(dst, src, indices) }
 func sqrt64(dst, a []float64)                          { sqrt64Go(dst, a) }
 func reciprocal64(dst, a []float64)                    { reciprocal64Go(dst, a) }
 func variance64(a []float64, mean float64) float64     { return variance64Go(a, mean) }

--- a/f64/f64_other.go
+++ b/f64/f64_other.go
@@ -24,6 +24,7 @@ func cos64(dst, src []float64)                         { cos64Go(dst, src) }
 func sinCos64(sinDst, cosDst, src []float64)           { sinCos64Go(sinDst, cosDst, src) }
 func round64(dst, src []float64)                       { round64Go(dst, src) }
 func gather64(dst, src []float64, indices []int)       { gatherGo(dst, src, indices) }
+func scatter64(dst, src []float64, indices []int)      { scatterGo(dst, src, indices) }
 func sqrt64(dst, a []float64)                          { sqrt64Go(dst, a) }
 func reciprocal64(dst, a []float64)                    { reciprocal64Go(dst, a) }
 func variance64(a []float64, mean float64) float64     { return variance64Go(a, mean) }

--- a/f64/f64_test.go
+++ b/f64/f64_test.go
@@ -165,6 +165,40 @@ func TestMinMax(t *testing.T) {
 	}
 }
 
+func TestMinMax_SpecialValues(t *testing.T) {
+	// NaN should propagate regardless of position.
+	nanCases := [][]float64{
+		{1, math.NaN()},
+		{math.NaN(), 1},
+		{2, 1, math.NaN(), -5},
+		{2, 1, -5, math.NaN()},
+	}
+	for _, input := range nanCases {
+		if got := Min(input); !math.IsNaN(got) {
+			t.Errorf("Min(%v) = %v, want NaN", input, got)
+		}
+		if got := Max(input); !math.IsNaN(got) {
+			t.Errorf("Max(%v) = %v, want NaN", input, got)
+		}
+	}
+
+	// Signed zero should follow IEEE-754 min/max behavior.
+	zeroCases := [][]float64{
+		{0.0, math.Copysign(0, -1)},
+		{math.Copysign(0, -1), 0.0},
+	}
+	for _, input := range zeroCases {
+		minVal := Min(input)
+		maxVal := Max(input)
+		if minVal != 0 || !math.Signbit(minVal) {
+			t.Errorf("Min(%v) = %v (signbit=%v), want -0", input, minVal, math.Signbit(minVal))
+		}
+		if maxVal != 0 || math.Signbit(maxVal) {
+			t.Errorf("Max(%v) = %v (signbit=%v), want +0", input, maxVal, math.Signbit(maxVal))
+		}
+	}
+}
+
 func TestAbs(t *testing.T) {
 	a := []float64{-1, 2, -3, 4, -5}
 	dst := make([]float64, len(a))

--- a/f64/go_impl_amd64_test.go
+++ b/f64/go_impl_amd64_test.go
@@ -76,3 +76,35 @@ func TestInitAVX512(t *testing.T) {
 	dotProductImpl = savedDotProduct
 	minSIMDElements = savedMinSIMD
 }
+
+func TestInitAVXNoFMA(t *testing.T) {
+	savedDotProduct := dotProductImpl
+	savedMinSIMD := minSIMDElements
+
+	initAVXNoFMA()
+
+	a := []float64{1, 2, 3, 4}
+	b := []float64{4, 3, 2, 1}
+	dst := make([]float64, len(a))
+
+	// dotProduct should remain functional via SSE2 fallback in AVX-without-FMA mode
+	gotDot := dotProductImpl(a, b)
+	if gotDot != 20 {
+		t.Errorf("After initAVXNoFMA, dotProduct = %v, want 20", gotDot)
+	}
+
+	// Non-FMA arithmetic paths should still use AVX implementations
+	addImpl(dst, a, b)
+	for i, want := range []float64{5, 5, 5, 5} {
+		if dst[i] != want {
+			t.Errorf("After initAVXNoFMA, add[%d] = %v, want %v", i, dst[i], want)
+		}
+	}
+
+	if minSIMDElements != minAVXElements {
+		t.Errorf("initAVXNoFMA didn't set minSIMDElements correctly")
+	}
+
+	dotProductImpl = savedDotProduct
+	minSIMDElements = savedMinSIMD
+}

--- a/f64/trig_simd.go
+++ b/f64/trig_simd.go
@@ -28,15 +28,6 @@ const (
 	trigFallbackAbsLimit = 1.0e6
 )
 
-func trigAllFiniteInRange(src []float64) bool {
-	for _, v := range src {
-		if math.IsNaN(v) || math.IsInf(v, 0) || math.Abs(v) > trigFallbackAbsLimit {
-			return false
-		}
-	}
-	return true
-}
-
 func sin64SIMD(dst, src []float64) {
 	sinCos64SIMDCore(dst, nil, src)
 }

--- a/f64/trig_simd.go
+++ b/f64/trig_simd.go
@@ -1,0 +1,178 @@
+package f64
+
+import "math"
+
+const (
+	trigChunkSize = 128
+
+	trigInvPiOver2 = 0.63661977236758134308 // 2 / pi
+	trigPiOver2Hi  = 1.5707963267948966
+	trigPiOver2Lo  = 6.123233995736766e-17 // (pi/2) - trigPiOver2Hi
+
+	// Polynomial coefficients for sin/cos on reduced range.
+	trigSinC3  = -1.6666666666666665741e-1
+	trigSinC5  = 8.333333333333332871e-3
+	trigSinC7  = -1.9841269841269841253e-4
+	trigSinC9  = 2.7557319223985890653e-6
+	trigSinC11 = -2.5052108385441718775e-8
+	trigSinC13 = 1.6059043836821614599e-10
+
+	trigCosC2  = -5.0000000000000000000e-1
+	trigCosC4  = 4.1666666666666592922e-2
+	trigCosC6  = -1.3888888888873056412e-3
+	trigCosC8  = 2.4801587289476729418e-5
+	trigCosC10 = -2.7557314351390663304e-7
+	trigCosC12 = 2.0875723212981748279e-9
+
+	// For very large magnitudes, fall back to scalar libm range reduction.
+	trigFallbackAbsLimit = 1.0e6
+)
+
+func trigAllFiniteInRange(src []float64) bool {
+	for _, v := range src {
+		if math.IsNaN(v) || math.IsInf(v, 0) || math.Abs(v) > trigFallbackAbsLimit {
+			return false
+		}
+	}
+	return true
+}
+
+func sin64SIMD(dst, src []float64) {
+	sinCos64SIMDCore(dst, nil, src)
+}
+
+func cos64SIMD(dst, src []float64) {
+	sinCos64SIMDCore(nil, dst, src)
+}
+
+func sinCos64SIMD(sinDst, cosDst, src []float64) {
+	sinCos64SIMDCore(sinDst, cosDst, src)
+}
+
+// sinCos64SIMDCore computes sin/cos using SIMD arithmetic primitives with
+// polynomial approximation and quadrant mapping.
+func sinCos64SIMDCore(sinDst, cosDst, src []float64) {
+	n := len(src)
+	if n == 0 {
+		return
+	}
+
+	var qBuf [trigChunkSize]float64
+	var rBuf [trigChunkSize]float64
+	var r2Buf [trigChunkSize]float64
+	var pBuf [trigChunkSize]float64
+	var sinBuf [trigChunkSize]float64
+	var cosBuf [trigChunkSize]float64
+
+	for off := 0; off < n; off += trigChunkSize {
+		m := min(trigChunkSize, n-off)
+		x := src[off : off+m]
+
+		q := qBuf[:m]
+		r := rBuf[:m]
+		r2 := r2Buf[:m]
+		p := pBuf[:m]
+		s := sinBuf[:m]
+		c := cosBuf[:m]
+
+		// q = round(x * 2/pi), r = x - q*(pi/2)
+		scale(q, x, trigInvPiOver2)
+		round64(q, q)
+
+		scale(r, q, trigPiOver2Hi)
+		sub(r, x, r)
+		scale(p, q, trigPiOver2Lo)
+		sub(r, r, p)
+
+		mul(r2, r, r)
+
+		// sin(r) = r * P(r^2)
+		scale(p, r2, trigSinC13)
+		addScalar(p, p, trigSinC11)
+		mul(p, p, r2)
+		addScalar(p, p, trigSinC9)
+		mul(p, p, r2)
+		addScalar(p, p, trigSinC7)
+		mul(p, p, r2)
+		addScalar(p, p, trigSinC5)
+		mul(p, p, r2)
+		addScalar(p, p, trigSinC3)
+		mul(p, p, r2)
+		addScalar(p, p, 1.0)
+		mul(s, p, r)
+
+		// cos(r) = Q(r^2)
+		scale(p, r2, trigCosC12)
+		addScalar(p, p, trigCosC10)
+		mul(p, p, r2)
+		addScalar(p, p, trigCosC8)
+		mul(p, p, r2)
+		addScalar(p, p, trigCosC6)
+		mul(p, p, r2)
+		addScalar(p, p, trigCosC4)
+		mul(p, p, r2)
+		addScalar(p, p, trigCosC2)
+		mul(p, p, r2)
+		addScalar(c, p, 1.0)
+
+		needsFallback := false
+		for i := range m {
+			v := x[i]
+			if math.IsNaN(v) || math.IsInf(v, 0) || math.Abs(v) > trigFallbackAbsLimit {
+				needsFallback = true
+				break
+			}
+		}
+
+		if !needsFallback {
+			for i := range m {
+				var sv, cv float64
+				switch int(int64(q[i]) & 3) {
+				case 0:
+					sv, cv = s[i], c[i]
+				case 1:
+					sv, cv = c[i], -s[i]
+				case 2:
+					sv, cv = -s[i], -c[i]
+				default: // 3
+					sv, cv = -c[i], s[i]
+				}
+
+				if sinDst != nil {
+					sinDst[off+i] = sv
+				}
+				if cosDst != nil {
+					cosDst[off+i] = cv
+				}
+			}
+			continue
+		}
+
+		for i := range m {
+			v := x[i]
+			var sv, cv float64
+
+			if math.IsNaN(v) || math.IsInf(v, 0) || math.Abs(v) > trigFallbackAbsLimit {
+				sv, cv = math.Sincos(v)
+			} else {
+				switch int(int64(q[i]) & 3) {
+				case 0:
+					sv, cv = s[i], c[i]
+				case 1:
+					sv, cv = c[i], -s[i]
+				case 2:
+					sv, cv = -s[i], -c[i]
+				default: // 3
+					sv, cv = -c[i], s[i]
+				}
+			}
+
+			if sinDst != nil {
+				sinDst[off+i] = sv
+			}
+			if cosDst != nil {
+				cosDst[off+i] = cv
+			}
+		}
+	}
+}

--- a/internal/accelerate/trig_darwin_arm64_cgo.go
+++ b/internal/accelerate/trig_darwin_arm64_cgo.go
@@ -11,6 +11,7 @@ import "C"
 import "unsafe"
 
 const maxCInt = int(^uint32(0) >> 1)
+const minCgoTrigLen64 = 128
 
 func Enabled() bool {
 	return true
@@ -18,7 +19,7 @@ func Enabled() bool {
 
 func Sin64(dst, src []float64) bool {
 	n := len(dst)
-	if n == 0 || len(src) < n || n > maxCInt {
+	if n == 0 || n < minCgoTrigLen64 || len(src) < n || n > maxCInt {
 		return false
 	}
 	count := C.int(n)
@@ -32,7 +33,7 @@ func Sin64(dst, src []float64) bool {
 
 func Cos64(dst, src []float64) bool {
 	n := len(dst)
-	if n == 0 || len(src) < n || n > maxCInt {
+	if n == 0 || n < minCgoTrigLen64 || len(src) < n || n > maxCInt {
 		return false
 	}
 	count := C.int(n)
@@ -46,7 +47,7 @@ func Cos64(dst, src []float64) bool {
 
 func SinCos64(sinDst, cosDst, src []float64) bool {
 	n := len(src)
-	if n == 0 || len(sinDst) < n || len(cosDst) < n || n > maxCInt {
+	if n == 0 || n < minCgoTrigLen64 || len(sinDst) < n || len(cosDst) < n || n > maxCInt {
 		return false
 	}
 	count := C.int(n)

--- a/internal/accelerate/trig_darwin_arm64_cgo.go
+++ b/internal/accelerate/trig_darwin_arm64_cgo.go
@@ -1,0 +1,60 @@
+//go:build darwin && arm64 && cgo
+
+package accelerate
+
+/*
+#cgo LDFLAGS: -framework Accelerate
+#include <Accelerate/Accelerate.h>
+*/
+import "C"
+
+import "unsafe"
+
+const maxCInt = int(^uint32(0) >> 1)
+
+func Enabled() bool {
+	return true
+}
+
+func Sin64(dst, src []float64) bool {
+	n := len(dst)
+	if n == 0 || len(src) < n || n > maxCInt {
+		return false
+	}
+	count := C.int(n)
+	C.vvsin(
+		(*C.double)(unsafe.Pointer(&dst[0])),
+		(*C.double)(unsafe.Pointer(&src[0])),
+		&count,
+	)
+	return true
+}
+
+func Cos64(dst, src []float64) bool {
+	n := len(dst)
+	if n == 0 || len(src) < n || n > maxCInt {
+		return false
+	}
+	count := C.int(n)
+	C.vvcos(
+		(*C.double)(unsafe.Pointer(&dst[0])),
+		(*C.double)(unsafe.Pointer(&src[0])),
+		&count,
+	)
+	return true
+}
+
+func SinCos64(sinDst, cosDst, src []float64) bool {
+	n := len(src)
+	if n == 0 || len(sinDst) < n || len(cosDst) < n || n > maxCInt {
+		return false
+	}
+	count := C.int(n)
+	C.vvsincos(
+		(*C.double)(unsafe.Pointer(&sinDst[0])),
+		(*C.double)(unsafe.Pointer(&cosDst[0])),
+		(*C.double)(unsafe.Pointer(&src[0])),
+		&count,
+	)
+	return true
+}

--- a/internal/accelerate/trig_stub.go
+++ b/internal/accelerate/trig_stub.go
@@ -1,0 +1,19 @@
+//go:build !darwin || !arm64 || !cgo
+
+package accelerate
+
+func Enabled() bool {
+	return false
+}
+
+func Sin64(_, _ []float64) bool {
+	return false
+}
+
+func Cos64(_, _ []float64) bool {
+	return false
+}
+
+func SinCos64(_, _, _ []float64) bool {
+	return false
+}


### PR DESCRIPTION
* Optimized AVX and AVX-512 assembly routines for computing the magnitude of complex numbers in `c128/c128_amd64.s`, increasing throughput by processing 2 or 4 elements per iteration and reducing instruction dependencies.
* Improved NEON assembly for float16 dot products in `f16/f16_arm64.s` by widening operands to FP32 before multiplication, preventing FP16 overflow and improving numerical stability.
* Added bounds checks and early returns for zero-length slices in all Go vector math routines for `c64`, `c128`, and `f16`, preventing out-of-bounds panics and enabling better compiler optimizations.
* Expanded the `README.md` to document new routines: `SubFromScalar`, `Round`, trigonometric functions (`Sin`, `Cos`, `SinCos`), reduction routines (`WeightedSum`, `SumOfSquares`), and a new data movement routines (`Gather`, `Scatter`). Clarified SIMD acceleration notes for activation functions.

Opening this PR to request your opinion on this, which are mostly some additions I needed for a project. If this is not in line with your direction for this package, please feel free to ignore. Any feedback welcome though :)

Really great package, thank you for making this!

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added trigonometric functions (Sin, Cos, SinCos) and rounding capabilities
  * Introduced Gather and Scatter operations for indexed data access
  * Added WeightedSum and SumOfSquares convenience functions
  * Added SubFromScalar for scalar-minus-vector operations

* **Performance**
  * Optimized vector operations with improved instruction-level parallelism
  * Enhanced ARM64 performance via Accelerate framework integration on Darwin

* **Reliability**
  * Strengthened input validation and bounds checking across all vector operations

<!-- end of auto-generated comment: release notes by coderabbit.ai -->