### PR TITLE
Fix misleading DotProductUnsafe documentation

### DIFF
--- a/f32/f32.go
+++ b/f32/f32.go
@@ -23,7 +23,7 @@ func DotProduct(a, b []float32) float32 {
 
 // DotProductUnsafe computes the dot product without empty-slice checks.
 // It skips the len==0 guard in [DotProduct] but is otherwise identical:
-// the underlying SIMD kernels clamp to min(len(a), len(b)) internally,
+// the underlying SIMD kernels and Go fallback clamp to min(len(a), len(b)) internally,
 // so mismatched lengths do not cause out-of-bounds access.
 //
 // PRECONDITIONS (caller must ensure):

--- a/f32/f32.go
+++ b/f32/f32.go
@@ -21,15 +21,13 @@ func DotProduct(a, b []float32) float32 {
 	return dotProduct(a, b)
 }
 
-// DotProductUnsafe computes the dot product without length validation.
-// This is a low-overhead variant for performance-critical code paths.
+// DotProductUnsafe computes the dot product without empty-slice checks.
+// It skips the len==0 guard in [DotProduct] but is otherwise identical:
+// the underlying SIMD kernels clamp to min(len(a), len(b)) internally,
+// so mismatched lengths do not cause out-of-bounds access.
 //
 // PRECONDITIONS (caller must ensure):
-//   - len(a) == len(b)
-//   - len(a) > 0
-//
-// Violating these preconditions results in undefined behavior (panic or incorrect results).
-// Use DotProduct for safe operation with automatic length handling.
+//   - len(a) > 0 && len(b) > 0
 func DotProductUnsafe(a, b []float32) float32 {
 	return dotProduct(a, b)
 }

--- a/f64/f64.go
+++ b/f64/f64.go
@@ -23,7 +23,7 @@ func DotProduct(a, b []float64) float64 {
 
 // DotProductUnsafe computes the dot product without empty-slice checks.
 // It skips the len==0 guard in [DotProduct] but is otherwise identical:
-// the underlying SIMD kernels clamp to min(len(a), len(b)) internally,
+// the underlying SIMD kernels and Go fallback clamp to min(len(a), len(b)) internally,
 // so mismatched lengths do not cause out-of-bounds access.
 //
 // PRECONDITIONS (caller must ensure):

--- a/f64/f64.go
+++ b/f64/f64.go
@@ -21,15 +21,13 @@ func DotProduct(a, b []float64) float64 {
 	return dotProduct(a, b)
 }
 
-// DotProductUnsafe computes the dot product without length validation.
-// This is a low-overhead variant for performance-critical code paths.
+// DotProductUnsafe computes the dot product without empty-slice checks.
+// It skips the len==0 guard in [DotProduct] but is otherwise identical:
+// the underlying SIMD kernels clamp to min(len(a), len(b)) internally,
+// so mismatched lengths do not cause out-of-bounds access.
 //
 // PRECONDITIONS (caller must ensure):
-//   - len(a) == len(b)
-//   - len(a) > 0
-//
-// Violating these preconditions results in undefined behavior (panic or incorrect results).
-// Use DotProduct for safe operation with automatic length handling.
+//   - len(a) > 0 && len(b) > 0
 func DotProductUnsafe(a, b []float64) float64 {
 	return dotProduct(a, b)
 }


### PR DESCRIPTION
## Summary

- Update `DotProductUnsafe` docs in both f32 and f64 to accurately reflect that the SIMD kernels (`CMOVQLT` on AMD64, `CSEL` on ARM64) and pure-Go fallback all clamp to `min(len(a), len(b))` internally
- Remove the incorrect claim that mismatched lengths cause "undefined behavior (panic or incorrect results)"
- Simplify preconditions to the only real requirement: both slices must be non-empty

## Test plan

- [x] `go test ./f32/ ./f64/` passes
- Doc-only change, no behavioral impact

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Clarified preconditions for the unsafe dot-product operation: inputs must be non-empty (no longer requiring equal lengths).
  * Noted that mismatched non-empty input lengths are handled safely to avoid out-of-bounds processing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->