### PR TITLE
Use bitwise sign-clear for f32 absGo fallback

### DIFF
--- a/f32/f32_go.go
+++ b/f32/f32_go.go
@@ -105,7 +105,7 @@ func maxGo(a []float32) float32 {
 
 func absGo(dst, a []float32) {
 	for i := range dst {
-		dst[i] = float32(math.Abs(float64(a[i])))
+		dst[i] = math.Float32frombits(math.Float32bits(a[i]) &^ (1 << 31))
 	}
 }
 

--- a/f32/f32_go.go
+++ b/f32/f32_go.go
@@ -4,8 +4,9 @@ import "math"
 
 // Loop unroll factors for SIMD-width matching
 const (
-	unrollFactor = 8 // Match AVX 256-bit = 8 x float32
-	unrollMask   = unrollFactor - 1
+	unrollFactor      = 8 // Match AVX 256-bit = 8 x float32
+	unrollMask        = unrollFactor - 1
+	float32SignBitPos = 31 // IEEE 754 float32 sign bit position
 )
 
 // Numerical stability thresholds
@@ -105,7 +106,7 @@ func maxGo(a []float32) float32 {
 
 func absGo(dst, a []float32) {
 	for i := range dst {
-		dst[i] = math.Float32frombits(math.Float32bits(a[i]) &^ (1 << 31))
+		dst[i] = math.Float32frombits(math.Float32bits(a[i]) &^ (1 << float32SignBitPos))
 	}
 }
 


### PR DESCRIPTION
## Summary

- Replace `float32(math.Abs(float64(a[i])))` with `math.Float32frombits(math.Float32bits(a[i]) &^ (1 << 31))` in the pure Go fallback
- Eliminates unnecessary float32→float64→float32 type conversion round-trip
- Matches the bitwise approach already used in the f16 package

Only affects the Go fallback path (platforms without AVX/NEON). On amd64/arm64 the SIMD assembly path is used.

## Test plan

- [x] `go test ./f32/ -count=1` passes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Optimized absolute-value computation for 32-bit floating-point values using a more efficient internal method.
  * No changes to public APIs or observable behavior; results remain the same while improving internal performance.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->