### PR TITLE
Document architecture-dependent NaN behavior in Min/Max

### DIFF
--- a/f32/f32.go
+++ b/f32/f32.go
@@ -96,7 +96,12 @@ func Sum(a []float32) float32 {
 	return sum(a)
 }
 
-// Min returns the minimum value.
+// Min returns the minimum value in the slice.
+// Returns +Inf for empty slices.
+//
+// NaN handling: unlike [math.Min], this function does not propagate NaN.
+// If the input contains NaN values, the result is architecture-dependent.
+// Callers that require strict NaN semantics should filter NaN values first.
 func Min(a []float32) float32 {
 	if len(a) == 0 {
 		return posInf
@@ -104,7 +109,12 @@ func Min(a []float32) float32 {
 	return min32(a)
 }
 
-// Max returns the maximum value.
+// Max returns the maximum value in the slice.
+// Returns -Inf for empty slices.
+//
+// NaN handling: unlike [math.Max], this function does not propagate NaN.
+// If the input contains NaN values, the result is architecture-dependent.
+// Callers that require strict NaN semantics should filter NaN values first.
 func Max(a []float32) float32 {
 	if len(a) == 0 {
 		return negInf

--- a/f64/f64.go
+++ b/f64/f64.go
@@ -105,6 +105,10 @@ func Sum(a []float64) float64 {
 
 // Min returns the minimum value in the slice.
 // Returns +Inf for empty slices.
+//
+// NaN handling: unlike [math.Min], this function does not propagate NaN.
+// If the input contains NaN values, the result is architecture-dependent.
+// Callers that require strict NaN semantics should filter NaN values first.
 func Min(a []float64) float64 {
 	if len(a) == 0 {
 		return posInf
@@ -114,6 +118,10 @@ func Min(a []float64) float64 {
 
 // Max returns the maximum value in the slice.
 // Returns -Inf for empty slices.
+//
+// NaN handling: unlike [math.Max], this function does not propagate NaN.
+// If the input contains NaN values, the result is architecture-dependent.
+// Callers that require strict NaN semantics should filter NaN values first.
 func Max(a []float64) float64 {
 	if len(a) == 0 {
 		return negInf


### PR DESCRIPTION
## Summary

- Add NaN handling caveats to `Min` and `Max` godoc in both f32 and f64 packages
- Clarifies that unlike `math.Min`/`math.Max`, NaN propagation is not guaranteed
- Documents that behavior varies across x86 (VMINPS/VMAXPS), ARM (FMIN/FMAX), and pure Go backends

## Test plan

- [x] `go test ./f32/ ./f64/` passes
- Doc-only change, no behavioral impact