### PR TITLE
Add IEEE 754 special-value tests for Abs

### DIFF
--- a/f32/f32_test.go
+++ b/f32/f32_test.go
@@ -101,6 +101,60 @@ func TestAbs(t *testing.T) {
 	}
 }
 
+func TestAbs_SpecialValues(t *testing.T) {
+	posInf := float32(math.Inf(1))
+	negInf := float32(math.Inf(-1))
+	nan := float32(math.NaN())
+	negZero := float32(math.Float64frombits(1 << 63)) // -0
+
+	tests := []struct {
+		name string
+		in   float32
+		want float32
+	}{
+		{"positive_inf", posInf, posInf},
+		{"negative_inf", negInf, posInf},
+		{"negative_zero", negZero, 0},
+		{"positive_zero", 0, 0},
+		{"smallest_normal", math.SmallestNonzeroFloat32, math.SmallestNonzeroFloat32},
+		{"neg_smallest_normal", -math.SmallestNonzeroFloat32, math.SmallestNonzeroFloat32},
+		{"max_float32", math.MaxFloat32, math.MaxFloat32},
+		{"neg_max_float32", -math.MaxFloat32, math.MaxFloat32},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			dst := make([]float32, 1)
+			Abs(dst, []float32{tt.in})
+			if dst[0] != tt.want {
+				t.Errorf("Abs(%v) = %v, want %v", tt.in, dst[0], tt.want)
+			}
+		})
+	}
+
+	// NaN: abs(NaN) should be NaN (sign bit cleared, but still NaN)
+	t.Run("nan", func(t *testing.T) {
+		dst := make([]float32, 1)
+		Abs(dst, []float32{nan})
+		if !math.IsNaN(float64(dst[0])) {
+			t.Errorf("Abs(NaN) = %v, want NaN", dst[0])
+		}
+	})
+
+	// Negative NaN: abs(-NaN) should be NaN
+	t.Run("negative_nan", func(t *testing.T) {
+		negNaN := math.Float32frombits(math.Float32bits(nan) | (1 << 31))
+		dst := make([]float32, 1)
+		Abs(dst, []float32{negNaN})
+		if !math.IsNaN(float64(dst[0])) {
+			t.Errorf("Abs(-NaN) = %v, want NaN", dst[0])
+		}
+		if math.Signbit(float64(dst[0])) {
+			t.Errorf("Abs(-NaN) has sign bit set, want positive NaN")
+		}
+	})
+}
+
 func TestFMA(t *testing.T) {
 	a := []float32{1, 2, 3, 4, 5, 6, 7, 8}
 	b := []float32{2, 2, 2, 2, 2, 2, 2, 2}

--- a/f32/f32_test.go
+++ b/f32/f32_test.go
@@ -105,7 +105,7 @@ func TestAbs_SpecialValues(t *testing.T) {
 	posInf := float32(math.Inf(1))
 	negInf := float32(math.Inf(-1))
 	nan := float32(math.NaN())
-	negZero := float32(math.Float64frombits(1 << 63)) // -0
+	negZero := math.Float32frombits(1 << 31) // -0
 
 	tests := []struct {
 		name string
@@ -126,8 +126,9 @@ func TestAbs_SpecialValues(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			dst := make([]float32, 1)
 			Abs(dst, []float32{tt.in})
-			if dst[0] != tt.want {
-				t.Errorf("Abs(%v) = %v, want %v", tt.in, dst[0], tt.want)
+			if math.Float32bits(dst[0]) != math.Float32bits(tt.want) {
+				t.Errorf("Abs(%v) = %v (bits: %08x), want %v (bits: %08x)",
+					tt.in, dst[0], math.Float32bits(dst[0]), tt.want, math.Float32bits(tt.want))
 			}
 		})
 	}

--- a/f64/f64_test.go
+++ b/f64/f64_test.go
@@ -204,8 +204,9 @@ func TestAbs_SpecialValues(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			dst := make([]float64, 1)
 			Abs(dst, []float64{tt.in})
-			if dst[0] != tt.want {
-				t.Errorf("Abs(%v) = %v, want %v", tt.in, dst[0], tt.want)
+			if math.Float64bits(dst[0]) != math.Float64bits(tt.want) {
+				t.Errorf("Abs(%v) = %v (bits: %016x), want %v (bits: %016x)",
+					tt.in, dst[0], math.Float64bits(dst[0]), tt.want, math.Float64bits(tt.want))
 			}
 		})
 	}

--- a/f64/f64_test.go
+++ b/f64/f64_test.go
@@ -179,6 +179,60 @@ func TestAbs(t *testing.T) {
 	}
 }
 
+func TestAbs_SpecialValues(t *testing.T) {
+	posInf := math.Inf(1)
+	negInf := math.Inf(-1)
+	nan := math.NaN()
+	negZero := math.Float64frombits(1 << 63)
+
+	tests := []struct {
+		name string
+		in   float64
+		want float64
+	}{
+		{"positive_inf", posInf, posInf},
+		{"negative_inf", negInf, posInf},
+		{"negative_zero", negZero, 0},
+		{"positive_zero", 0, 0},
+		{"smallest_normal", math.SmallestNonzeroFloat64, math.SmallestNonzeroFloat64},
+		{"neg_smallest_normal", -math.SmallestNonzeroFloat64, math.SmallestNonzeroFloat64},
+		{"max_float64", math.MaxFloat64, math.MaxFloat64},
+		{"neg_max_float64", -math.MaxFloat64, math.MaxFloat64},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			dst := make([]float64, 1)
+			Abs(dst, []float64{tt.in})
+			if dst[0] != tt.want {
+				t.Errorf("Abs(%v) = %v, want %v", tt.in, dst[0], tt.want)
+			}
+		})
+	}
+
+	// NaN: abs(NaN) should be NaN (sign bit cleared, but still NaN)
+	t.Run("nan", func(t *testing.T) {
+		dst := make([]float64, 1)
+		Abs(dst, []float64{nan})
+		if !math.IsNaN(dst[0]) {
+			t.Errorf("Abs(NaN) = %v, want NaN", dst[0])
+		}
+	})
+
+	// Negative NaN: abs(-NaN) should be NaN
+	t.Run("negative_nan", func(t *testing.T) {
+		negNaN := math.Float64frombits(math.Float64bits(nan) | (1 << 63))
+		dst := make([]float64, 1)
+		Abs(dst, []float64{negNaN})
+		if !math.IsNaN(dst[0]) {
+			t.Errorf("Abs(-NaN) = %v, want NaN", dst[0])
+		}
+		if math.Signbit(dst[0]) {
+			t.Errorf("Abs(-NaN) has sign bit set, want positive NaN")
+		}
+	})
+}
+
 func TestNeg(t *testing.T) {
 	a := []float64{1, -2, 3, -4, 5}
 	dst := make([]float64, len(a))


### PR DESCRIPTION
## Summary

- Add `TestAbs_SpecialValues` to both f32 and f64 packages
- Tests NaN, -NaN, +Inf, -Inf, -0, denormals, and max float values
- Verifies sign bit is cleared correctly for all IEEE 754 edge cases
- Follow-up from review feedback on PR #17

## Test plan

- [x] `go test ./f32/ ./f64/ -count=1` passes
- [x] `golangci-lint run ./f32/ ./f64/` — 0 issues

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Enhanced test coverage for the floating-point absolute value function to thoroughly validate behavior on IEEE-754 special cases, including infinity, zero variants, subnormal values, and NaN handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->