### PR TITLE
Cherry-pick wins from PR #15: c128 Abs widening, cubic AVX Horner, Round, AVX-no-FMA path

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,13 +90,17 @@ fmt.Println(cpu.HasFP16())   // true/false (ARM64 half-precision SIMD)
 |                 | `Div(dst, a, b)`                    | Element-wise division         | 8x / 4x / 2x                        |
 |                 | `Scale(dst, a, s)`                  | Multiply by scalar            | 8x / 4x / 2x                        |
 |                 | `AddScalar(dst, a, s)`              | Add scalar                    | 8x / 4x / 2x                        |
+|                 | `SubFromScalar(dst, a, s)`          | Scalar minus vector           | 8x / 4x / 2x (composed SIMD)        |
 |                 | `FMA(dst, a, b, c)`                 | Fused multiply-add: a\*b+c    | 8x / 4x / 2x                        |
 |                 | `AddScaled(dst, alpha, s)`          | dst += alpha\*s (axpy)        | 8x / 4x / 2x                        |
 | **Unary**       | `Abs(dst, a)`                       | Absolute value                | 8x / 4x / 2x                        |
 |                 | `Neg(dst, a)`                       | Negation                      | 8x / 4x / 2x                        |
 |                 | `Sqrt(dst, a)`                      | Square root                   | 8x / 4x / 2x                        |
 |                 | `Reciprocal(dst, a)`                | Reciprocal (1/x)              | 8x / 4x / 2x                        |
+|                 | `Round(dst, src)`                   | Round half away from zero     | 4x (AVX) / 2x (NEON) / Go fallback  |
 | **Reduction**   | `DotProduct(a, b)`                  | Dot product                   | 8x / 4x / 2x                        |
+|                 | `WeightedSum(w, src)`               | Weighted sum Σ(wᵢ·srcᵢ)       | 8x / 4x / 2x                        |
+|                 | `SumOfSquares(src)`                 | Sum of squares Σ(srcᵢ²)       | 8x / 4x / 2x                        |
 |                 | `Sum(a)`                            | Sum of elements               | 8x / 4x / 2x                        |
 |                 | `Min(a)`                            | Minimum value                 | 8x / 4x / 2x                        |
 |                 | `Max(a)`                            | Maximum value                 | 8x / 4x / 2x                        |

--- a/c128/c128_amd64.s
+++ b/c128/c128_amd64.s
@@ -705,49 +705,63 @@ TEXT ·absAVX512(SB), NOSPLIT, $0-48
     MOVQ a_base+24(FP), SI
 
     MOVQ CX, AX
-    SHRQ $1, AX            // Process 2 elements per iteration
-    JZ   abs_avx512_remainder
+    SHRQ $2, AX            // Process 4 elements per iteration
+    JZ   abs_avx512_loop2_check
+
+abs_avx512_loop4:
+    // Load 4 complex128 = 8 float64: [r0, i0, r1, i1, r2, i2, r3, i3]
+    VMOVUPD (SI), Z0
+
+    // Compute [r²+i²] with shuffle+add (no horizontal add dependency).
+    VMULPD Z0, Z0, Z0
+    VSHUFPD $0x55, Z0, Z0, Z1
+    VADDPD Z0, Z1, Z2      // [s0, s0, s1, s1, s2, s2, s3, s3]
+
+    // Pack duplicated sums into contiguous lanes: [s0, s1, s2, s3].
+    VEXTRACTF64X4 $1, Z2, Y3
+    VEXTRACTF128 $1, Y2, X4
+    VUNPCKLPD X4, X2, X2
+    VEXTRACTF128 $1, Y3, X5
+    VUNPCKLPD X5, X3, X3
+    VINSERTF128 $1, X3, Y2, Y2
+
+    VSQRTPD Y2, Y2
+    VMOVUPD Y2, (DX)
+
+    ADDQ $64, SI           // 4 complex128 = 64 bytes
+    ADDQ $32, DX           // 4 float64 = 32 bytes
+    DECQ AX
+    JNZ  abs_avx512_loop4
+
+abs_avx512_loop2_check:
+    ANDQ $3, CX
+    MOVQ CX, AX
+    SHRQ $1, AX
+    JZ   abs_avx512_remainder1
 
 abs_avx512_loop2:
     // Load 2 complex128 = 4 float64: [r0, i0, r1, i1]
     VMOVUPD (SI), Y0
-
-    // Square all elements: [r0², i0², r1², i1²]
     VMULPD Y0, Y0, Y0
+    VSHUFPD $0x55, Y0, Y0, Y1
+    VADDPD Y0, Y1, Y0      // [s0, s0, s1, s1]
 
-    // Horizontal add pairs within each 128-bit lane
-    // VHADDPD Y0, Y0, Y0 produces:
-    //   Lane 0: [r0²+i0², r0²+i0²]
-    //   Lane 1: [r1²+i1², r1²+i1²]
-    // Result: [r0²+i0², r0²+i0², r1²+i1², r1²+i1²]
-    VHADDPD Y0, Y0, Y0
-
-    // Pack results: elements 0 and 2 contain the sums we need
-    // Extract upper 128 bits: X1 = [r1²+i1², r1²+i1²]
     VEXTRACTF128 $1, Y0, X1
-    // Unpack low elements: X0 = [r0²+i0², r1²+i1²]
-    VUNPCKLPD X1, X0, X0
-
-    // Take sqrt: X0 = [|z0|, |z1|]
+    VUNPCKLPD X1, X0, X0   // [s0, s1]
     VSQRTPD X0, X0
-
-    // Store 2 results
     VMOVUPD X0, (DX)
 
-    ADDQ $32, SI           // 2 complex128 = 32 bytes
-    ADDQ $16, DX           // 2 float64 = 16 bytes
+    ADDQ $32, SI
+    ADDQ $16, DX
     DECQ AX
     JNZ  abs_avx512_loop2
 
-abs_avx512_remainder:
+abs_avx512_remainder1:
     ANDQ $1, CX
     JZ   abs_avx512_done
 
     // Handle 1 remaining element using XMM
-abs_avx512_remainder_loop:
     MOVUPD (SI), X0        // Load one complex128
-
-    // X0 = [real, imag]
     VMOVDDUP X0, X1        // X1 = [real, real]
     VSHUFPD $1, X0, X0, X2 // X2 = [imag, imag]
 
@@ -755,13 +769,7 @@ abs_avx512_remainder_loop:
     VMULPD X2, X2, X2      // imag²
     VADDPD X2, X1, X1      // r² + i²
     VSQRTPD X1, X1
-
     VMOVSD X1, (DX)
-
-    ADDQ $16, SI
-    ADDQ $8, DX
-    DECQ CX
-    JNZ  abs_avx512_remainder_loop
 
 abs_avx512_done:
     VZEROUPPER
@@ -773,27 +781,40 @@ TEXT ·absAVX(SB), NOSPLIT, $0-48
     MOVQ dst_len+8(FP), CX
     MOVQ a_base+24(FP), SI
 
-    TESTQ CX, CX
+    MOVQ CX, AX
+    SHRQ $1, AX
+    JZ   abs_avx_remainder
+
+abs_avx_loop2:
+    // Load 2 complex128 = 4 float64: [r0, i0, r1, i1]
+    VMOVUPD (SI), Y0
+    VMULPD Y0, Y0, Y0
+    VSHUFPD $0x55, Y0, Y0, Y1
+    VADDPD Y0, Y1, Y0      // [s0, s0, s1, s1]
+
+    VEXTRACTF128 $1, Y0, X1
+    VUNPCKLPD X1, X0, X0   // [s0, s1]
+    VSQRTPD X0, X0
+    VMOVUPD X0, (DX)
+
+    ADDQ $32, SI
+    ADDQ $16, DX
+    DECQ AX
+    JNZ  abs_avx_loop2
+
+abs_avx_remainder:
+    ANDQ $1, CX
     JZ   abs_avx_done
 
-abs_avx_loop:
-    VMOVUPD (SI), X0       // Load one complex128
-
-    // X0 = [real, imag]
-    VMOVDDUP X0, X1        // X1 = [real, real]
-    VSHUFPD $1, X0, X0, X2 // X2 = [imag, imag]
-
-    VMULPD X1, X1, X1      // real²
-    VMULPD X2, X2, X2      // imag²
-    VADDPD X2, X1, X1      // r² + i²
+    // Handle 1 remaining element
+    MOVUPD (SI), X0
+    VMOVDDUP X0, X1
+    VSHUFPD $1, X0, X0, X2
+    VMULPD X1, X1, X1
+    VMULPD X2, X2, X2
+    VADDPD X2, X1, X1
     VSQRTPD X1, X1
-
     VMOVSD X1, (DX)
-
-    ADDQ $16, SI
-    ADDQ $8, DX
-    DECQ CX
-    JNZ  abs_avx_loop
 
 abs_avx_done:
     VZEROUPPER

--- a/c128/c128_go.go
+++ b/c128/c128_go.go
@@ -2,11 +2,18 @@ package c128
 
 import "math"
 
-// Pure Go implementations - used as fallback on all architectures
+// Pure Go implementations - used as fallback on all architectures.
+// Each fallback explicitly bounds-checks input slices once at entry; this lets
+// the compiler hoist per-iteration bounds checks out of the hot loop.
 
 // mulGo computes element-wise complex multiplication.
 // (a + bi)(c + di) = (ac - bd) + (ad + bc)i
 func mulGo(dst, a, b []complex128) {
+	if len(dst) == 0 {
+		return
+	}
+	_ = a[len(dst)-1]
+	_ = b[len(dst)-1]
 	for i := range dst {
 		dst[i] = a[i] * b[i]
 	}
@@ -15,6 +22,11 @@ func mulGo(dst, a, b []complex128) {
 // mulConjGo computes element-wise multiplication by conjugate.
 // (a + bi)(c - di) = (ac + bd) + (bc - ad)i
 func mulConjGo(dst, a, b []complex128) {
+	if len(dst) == 0 {
+		return
+	}
+	_ = a[len(dst)-1]
+	_ = b[len(dst)-1]
 	for i := range dst {
 		ar, ai := real(a[i]), imag(a[i])
 		br, bi := real(b[i]), imag(b[i])
@@ -27,6 +39,10 @@ func mulConjGo(dst, a, b []complex128) {
 
 // scaleGo multiplies each element by a complex scalar.
 func scaleGo(dst, a []complex128, s complex128) {
+	if len(dst) == 0 {
+		return
+	}
+	_ = a[len(dst)-1]
 	for i := range dst {
 		dst[i] = a[i] * s
 	}
@@ -34,6 +50,11 @@ func scaleGo(dst, a []complex128, s complex128) {
 
 // addGo computes element-wise complex addition.
 func addGo(dst, a, b []complex128) {
+	if len(dst) == 0 {
+		return
+	}
+	_ = a[len(dst)-1]
+	_ = b[len(dst)-1]
 	for i := range dst {
 		dst[i] = a[i] + b[i]
 	}
@@ -41,6 +62,11 @@ func addGo(dst, a, b []complex128) {
 
 // subGo computes element-wise complex subtraction.
 func subGo(dst, a, b []complex128) {
+	if len(dst) == 0 {
+		return
+	}
+	_ = a[len(dst)-1]
+	_ = b[len(dst)-1]
 	for i := range dst {
 		dst[i] = a[i] - b[i]
 	}
@@ -48,6 +74,10 @@ func subGo(dst, a, b []complex128) {
 
 // absGo computes element-wise complex magnitude: |a + bi| = sqrt(a² + b²).
 func absGo(dst []float64, a []complex128) {
+	if len(dst) == 0 {
+		return
+	}
+	_ = a[len(dst)-1]
 	for i := range dst {
 		r := real(a[i])
 		im := imag(a[i])
@@ -57,6 +87,10 @@ func absGo(dst []float64, a []complex128) {
 
 // absSqGo computes element-wise magnitude squared: |a + bi|² = a² + b².
 func absSqGo(dst []float64, a []complex128) {
+	if len(dst) == 0 {
+		return
+	}
+	_ = a[len(dst)-1]
 	for i := range dst {
 		r := real(a[i])
 		im := imag(a[i])
@@ -66,6 +100,10 @@ func absSqGo(dst []float64, a []complex128) {
 
 // conjGo computes element-wise complex conjugate: conj(a + bi) = a - bi.
 func conjGo(dst, a []complex128) {
+	if len(dst) == 0 {
+		return
+	}
+	_ = a[len(dst)-1]
 	for i := range dst {
 		dst[i] = complex(real(a[i]), -imag(a[i]))
 	}

--- a/c128/go_impl_bce_test.go
+++ b/c128/go_impl_bce_test.go
@@ -1,0 +1,21 @@
+package c128
+
+import "testing"
+
+// TestGoFallbacks_EmptyDst exercises the `if len(dst) == 0 { return }` BCE
+// guard branches in the Go fallbacks. On AVX-capable hosts those branches
+// are not normally hit because the public API short-circuits before dispatch.
+func TestGoFallbacks_EmptyDst(_ *testing.T) {
+	src := []complex128{1 + 2i, 3 + 4i, 5 + 6i}
+	dst := []complex128{}
+	dstReal := []float64{}
+
+	mulGo(dst, src, src)
+	mulConjGo(dst, src, src)
+	scaleGo(dst, src, 1+1i)
+	addGo(dst, src, src)
+	subGo(dst, src, src)
+	absGo(dstReal, src)
+	absSqGo(dstReal, src)
+	conjGo(dst, src)
+}

--- a/c64/c64_go.go
+++ b/c64/c64_go.go
@@ -2,11 +2,18 @@ package c64
 
 import "math"
 
-// Pure Go implementations - used as fallback on all architectures
+// Pure Go implementations - used as fallback on all architectures.
+// Each fallback bounds-checks input slices once at entry so the compiler can
+// hoist per-iteration bounds checks out of the hot loop.
 
 // mulGo computes element-wise complex multiplication.
 // (a + bi)(c + di) = (ac - bd) + (ad + bc)i
 func mulGo(dst, a, b []complex64) {
+	if len(dst) == 0 {
+		return
+	}
+	_ = a[len(dst)-1]
+	_ = b[len(dst)-1]
 	for i := range dst {
 		dst[i] = a[i] * b[i]
 	}
@@ -15,6 +22,11 @@ func mulGo(dst, a, b []complex64) {
 // mulConjGo computes element-wise multiplication by conjugate.
 // (a + bi)(c - di) = (ac + bd) + (bc - ad)i
 func mulConjGo(dst, a, b []complex64) {
+	if len(dst) == 0 {
+		return
+	}
+	_ = a[len(dst)-1]
+	_ = b[len(dst)-1]
 	for i := range dst {
 		ar, ai := real(a[i]), imag(a[i])
 		br, bi := real(b[i]), imag(b[i])
@@ -27,6 +39,10 @@ func mulConjGo(dst, a, b []complex64) {
 
 // scaleGo multiplies each element by a complex scalar.
 func scaleGo(dst, a []complex64, s complex64) {
+	if len(dst) == 0 {
+		return
+	}
+	_ = a[len(dst)-1]
 	for i := range dst {
 		dst[i] = a[i] * s
 	}
@@ -34,6 +50,11 @@ func scaleGo(dst, a []complex64, s complex64) {
 
 // addGo computes element-wise complex addition.
 func addGo(dst, a, b []complex64) {
+	if len(dst) == 0 {
+		return
+	}
+	_ = a[len(dst)-1]
+	_ = b[len(dst)-1]
 	for i := range dst {
 		dst[i] = a[i] + b[i]
 	}
@@ -41,6 +62,11 @@ func addGo(dst, a, b []complex64) {
 
 // subGo computes element-wise complex subtraction.
 func subGo(dst, a, b []complex64) {
+	if len(dst) == 0 {
+		return
+	}
+	_ = a[len(dst)-1]
+	_ = b[len(dst)-1]
 	for i := range dst {
 		dst[i] = a[i] - b[i]
 	}
@@ -48,6 +74,10 @@ func subGo(dst, a, b []complex64) {
 
 // absGo computes element-wise complex magnitude: |a + bi| = sqrt(a^2 + b^2).
 func absGo(dst []float32, a []complex64) {
+	if len(dst) == 0 {
+		return
+	}
+	_ = a[len(dst)-1]
 	for i := range dst {
 		r := float64(real(a[i]))
 		im := float64(imag(a[i]))
@@ -57,6 +87,10 @@ func absGo(dst []float32, a []complex64) {
 
 // absSqGo computes element-wise magnitude squared: |a + bi|^2 = a^2 + b^2.
 func absSqGo(dst []float32, a []complex64) {
+	if len(dst) == 0 {
+		return
+	}
+	_ = a[len(dst)-1]
 	for i := range dst {
 		r := real(a[i])
 		im := imag(a[i])
@@ -66,6 +100,10 @@ func absSqGo(dst []float32, a []complex64) {
 
 // conjGo computes element-wise complex conjugate: conj(a + bi) = a - bi.
 func conjGo(dst, a []complex64) {
+	if len(dst) == 0 {
+		return
+	}
+	_ = a[len(dst)-1]
 	for i := range dst {
 		dst[i] = complex(real(a[i]), -imag(a[i]))
 	}
@@ -73,6 +111,10 @@ func conjGo(dst, a []complex64) {
 
 // fromRealGo converts real float32 values to complex64.
 func fromRealGo(dst []complex64, src []float32) {
+	if len(dst) == 0 {
+		return
+	}
+	_ = src[len(dst)-1]
 	for i := range dst {
 		dst[i] = complex(src[i], 0)
 	}

--- a/c64/go_impl_bce_test.go
+++ b/c64/go_impl_bce_test.go
@@ -1,0 +1,23 @@
+package c64
+
+import "testing"
+
+// TestGoFallbacks_EmptyDst exercises the `if len(dst) == 0 { return }` BCE
+// guard branches in the Go fallbacks. On AVX-capable hosts those branches
+// are not normally hit because the public API short-circuits before dispatch.
+func TestGoFallbacks_EmptyDst(_ *testing.T) {
+	src := []complex64{1 + 2i, 3 + 4i, 5 + 6i}
+	srcReal := []float32{1, 2, 3}
+	dst := []complex64{}
+	dstReal := []float32{}
+
+	mulGo(dst, src, src)
+	mulConjGo(dst, src, src)
+	scaleGo(dst, src, 1+1i)
+	addGo(dst, src, src)
+	subGo(dst, src, src)
+	absGo(dstReal, src)
+	absSqGo(dstReal, src)
+	conjGo(dst, src)
+	fromRealGo(dst, srcReal)
+}

--- a/f16/f16_go.go
+++ b/f16/f16_go.go
@@ -159,6 +159,11 @@ func fromFloat32SliceGo(dst []Float16, src []float32) {
 // dotProductGo computes dot product using pure Go (converts to float32).
 func dotProductGo(a, b []Float16) float32 {
 	n := min(len(a), len(b))
+	if n == 0 {
+		return 0
+	}
+	_ = a[n-1]
+	_ = b[n-1]
 	var sum float32
 	for i := range n {
 		sum += toFloat32Go(a[i]) * toFloat32Go(b[i])
@@ -168,6 +173,11 @@ func dotProductGo(a, b []Float16) float32 {
 
 // addGo computes element-wise addition.
 func addGo(dst, a, b []Float16) {
+	if len(dst) == 0 {
+		return
+	}
+	_ = a[len(dst)-1]
+	_ = b[len(dst)-1]
 	for i := range dst {
 		dst[i] = fromFloat32Go(toFloat32Go(a[i]) + toFloat32Go(b[i]))
 	}
@@ -175,6 +185,11 @@ func addGo(dst, a, b []Float16) {
 
 // subGo computes element-wise subtraction.
 func subGo(dst, a, b []Float16) {
+	if len(dst) == 0 {
+		return
+	}
+	_ = a[len(dst)-1]
+	_ = b[len(dst)-1]
 	for i := range dst {
 		dst[i] = fromFloat32Go(toFloat32Go(a[i]) - toFloat32Go(b[i]))
 	}
@@ -182,6 +197,11 @@ func subGo(dst, a, b []Float16) {
 
 // mulGo computes element-wise multiplication.
 func mulGo(dst, a, b []Float16) {
+	if len(dst) == 0 {
+		return
+	}
+	_ = a[len(dst)-1]
+	_ = b[len(dst)-1]
 	for i := range dst {
 		dst[i] = fromFloat32Go(toFloat32Go(a[i]) * toFloat32Go(b[i]))
 	}
@@ -189,6 +209,10 @@ func mulGo(dst, a, b []Float16) {
 
 // scaleGo multiplies each element by a scalar.
 func scaleGo(dst, a []Float16, s Float16) {
+	if len(dst) == 0 {
+		return
+	}
+	_ = a[len(dst)-1]
 	sf := toFloat32Go(s)
 	for i := range dst {
 		dst[i] = fromFloat32Go(toFloat32Go(a[i]) * sf)
@@ -197,6 +221,12 @@ func scaleGo(dst, a []Float16, s Float16) {
 
 // fmaGo computes fused multiply-add.
 func fmaGo(dst, a, b, c []Float16) {
+	if len(dst) == 0 {
+		return
+	}
+	_ = a[len(dst)-1]
+	_ = b[len(dst)-1]
+	_ = c[len(dst)-1]
 	for i := range dst {
 		dst[i] = fromFloat32Go(toFloat32Go(a[i])*toFloat32Go(b[i]) + toFloat32Go(c[i]))
 	}
@@ -213,6 +243,10 @@ func sumGo(a []Float16) float32 {
 
 // absGo computes element-wise absolute value.
 func absGo(dst, a []Float16) {
+	if len(dst) == 0 {
+		return
+	}
+	_ = a[len(dst)-1]
 	for i := range dst {
 		// Clear sign bit
 		dst[i] = a[i] & fp16AbsMask
@@ -221,6 +255,10 @@ func absGo(dst, a []Float16) {
 
 // negGo computes element-wise negation.
 func negGo(dst, a []Float16) {
+	if len(dst) == 0 {
+		return
+	}
+	_ = a[len(dst)-1]
 	for i := range dst {
 		// Flip sign bit
 		dst[i] = a[i] ^ fp16SignMask
@@ -229,6 +267,10 @@ func negGo(dst, a []Float16) {
 
 // reluGo computes ReLU activation.
 func reluGo(dst, src []Float16) {
+	if len(dst) == 0 {
+		return
+	}
+	_ = src[len(dst)-1]
 	for i := range dst {
 		if src[i]&0x8000 != 0 { // negative (sign bit set)
 			dst[i] = 0
@@ -240,6 +282,10 @@ func reluGo(dst, src []Float16) {
 
 // sigmoidGo computes sigmoid activation.
 func sigmoidGo(dst, src []Float16) {
+	if len(dst) == 0 {
+		return
+	}
+	_ = src[len(dst)-1]
 	for i := range dst {
 		x := toFloat32Go(src[i])
 		// sigmoid(x) = 1 / (1 + exp(-x))
@@ -277,6 +323,11 @@ func maxGo(a []Float16) Float16 {
 
 // divGo computes element-wise division.
 func divGo(dst, a, b []Float16) {
+	if len(dst) == 0 {
+		return
+	}
+	_ = a[len(dst)-1]
+	_ = b[len(dst)-1]
 	for i := range dst {
 		dst[i] = fromFloat32Go(toFloat32Go(a[i]) / toFloat32Go(b[i]))
 	}
@@ -284,6 +335,10 @@ func divGo(dst, a, b []Float16) {
 
 // addScalarGo adds a scalar to each element.
 func addScalarGo(dst, a []Float16, s Float16) {
+	if len(dst) == 0 {
+		return
+	}
+	_ = a[len(dst)-1]
 	sf := toFloat32Go(s)
 	for i := range dst {
 		dst[i] = fromFloat32Go(toFloat32Go(a[i]) + sf)
@@ -292,6 +347,10 @@ func addScalarGo(dst, a []Float16, s Float16) {
 
 // clampGo clamps each element to [minVal, maxVal].
 func clampGo(dst, a []Float16, minVal, maxVal Float16) {
+	if len(dst) == 0 {
+		return
+	}
+	_ = a[len(dst)-1]
 	minF := toFloat32Go(minVal)
 	maxF := toFloat32Go(maxVal)
 	for i := range dst {
@@ -307,6 +366,10 @@ func clampGo(dst, a []Float16, minVal, maxVal Float16) {
 
 // sqrtGo computes element-wise square root.
 func sqrtGo(dst, a []Float16) {
+	if len(dst) == 0 {
+		return
+	}
+	_ = a[len(dst)-1]
 	for i := range dst {
 		dst[i] = fromFloat32Go(float32(math.Sqrt(float64(toFloat32Go(a[i])))))
 	}

--- a/f16/f16_go.go
+++ b/f16/f16_go.go
@@ -377,6 +377,10 @@ func sqrtGo(dst, a []Float16) {
 
 // reciprocalGo computes element-wise reciprocal.
 func reciprocalGo(dst, a []Float16) {
+	if len(dst) == 0 {
+		return
+	}
+	_ = a[len(dst)-1]
 	for i := range dst {
 		dst[i] = fromFloat32Go(1.0 / toFloat32Go(a[i]))
 	}
@@ -384,6 +388,10 @@ func reciprocalGo(dst, a []Float16) {
 
 // expGo computes element-wise exponential.
 func expGo(dst, src []Float16) {
+	if len(dst) == 0 {
+		return
+	}
+	_ = src[len(dst)-1]
 	for i := range dst {
 		dst[i] = fromFloat32Go(float32(math.Exp(float64(toFloat32Go(src[i])))))
 	}
@@ -391,6 +399,10 @@ func expGo(dst, src []Float16) {
 
 // tanhGo computes element-wise hyperbolic tangent.
 func tanhGo(dst, src []Float16) {
+	if len(dst) == 0 {
+		return
+	}
+	_ = src[len(dst)-1]
 	for i := range dst {
 		dst[i] = fromFloat32Go(float32(math.Tanh(float64(toFloat32Go(src[i])))))
 	}

--- a/f16/go_impl_bce_test.go
+++ b/f16/go_impl_bce_test.go
@@ -1,0 +1,34 @@
+package f16
+
+import "testing"
+
+// TestGoFallbacks_EmptyDst exercises the `if len(dst) == 0 { return }` BCE
+// guard branches in the Go fallbacks. On NEON/AVX hosts those branches are
+// not normally hit because the public API short-circuits before dispatch.
+func TestGoFallbacks_EmptyDst(_ *testing.T) {
+	src := []Float16{FromFloat32(1), FromFloat32(2), FromFloat32(3)}
+	src32 := []float32{1, 2, 3}
+	dst := []Float16{}
+	dst32 := []float32{}
+
+	addGo(dst, src, src)
+	subGo(dst, src, src)
+	mulGo(dst, src, src)
+	divGo(dst, src, src)
+	scaleGo(dst, src, FromFloat32(2))
+	addScalarGo(dst, src, FromFloat32(1))
+	absGo(dst, src)
+	negGo(dst, src)
+	fmaGo(dst, src, src, src)
+	clampGo(dst, src, FromFloat32(0), FromFloat32(1))
+	sqrtGo(dst, src)
+	reciprocalGo(dst, src)
+	reluGo(dst, src)
+	sigmoidGo(dst, src)
+	expGo(dst, src)
+	tanhGo(dst, src)
+	toFloat32SliceGo(dst32, src)
+	fromFloat32SliceGo(dst, src32)
+	dotProductGo(nil, src)
+	dotProductGo(src, nil)
+}

--- a/f32/f32_amd64.s
+++ b/f32/f32_amd64.s
@@ -2674,30 +2674,34 @@ TEXT ·cubicInterpDotAVX(SB), NOSPLIT, $0-132
     JZ   cubic32_avx_loop8_check
 
 cubic32_avx_loop16:
-    // First vector (8 elements)
-    VMOVUPS (R10), Y1          // Y1 = d[i:i+8]
-    VMOVUPS (R9), Y2           // Y2 = c[i:i+8]
-    VMOVUPS (R8), Y3           // Y3 = b[i:i+8]
-    VMOVUPS (DI), Y4           // Y4 = a[i:i+8]
-    VMOVUPS (SI), Y5           // Y5 = hist[i:i+8]
+    // Multi-stage Horner with two independent chains for ILP.
+    // Each VFMADD213PS dst, mul, add computes dst = dst*mul + add.
 
-    // Horner's method: coef = a + x*(b + x*(c + x*d))
-    VFMADD231PS Y1, Y7, Y2     // Y2 = d*x + c
-    VFMADD231PS Y2, Y7, Y3     // Y3 = (d*x+c)*x + b
-    VFMADD231PS Y3, Y7, Y4     // Y4 = coef
-    VFMADD231PS Y5, Y4, Y0     // acc0 += hist * coef
+    // Stage 1: p = c + x*d (two parallel chains)
+    VMOVUPS 0(R9), Y1                       // Y1 = c[0:8]
+    VMOVUPS 32(R9), Y2                      // Y2 = c[8:16]
+    VMOVUPS 0(R10), Y5
+    VFMADD231PS Y5, Y7, Y1                  // Y1 = d*x + c
+    VMOVUPS 32(R10), Y5
+    VFMADD231PS Y5, Y7, Y2                  // Y2 = d*x + c
 
-    // Second vector (8 elements)
-    VMOVUPS 32(R10), Y1        // Y1 = d[i+8:i+16]
-    VMOVUPS 32(R9), Y2         // Y2 = c[i+8:i+16]
-    VMOVUPS 32(R8), Y3         // Y3 = b[i+8:i+16]
-    VMOVUPS 32(DI), Y4         // Y4 = a[i+8:i+16]
-    VMOVUPS 32(SI), Y5         // Y5 = hist[i+8:i+16]
+    // Stage 2: p = b + x*p
+    VMOVUPS 0(R8), Y5
+    VFMADD213PS Y5, Y7, Y1                  // Y1 = Y1*x + b
+    VMOVUPS 32(R8), Y5
+    VFMADD213PS Y5, Y7, Y2                  // Y2 = Y2*x + b
 
-    VFMADD231PS Y1, Y7, Y2     // Y2 = d*x + c
-    VFMADD231PS Y2, Y7, Y3     // Y3 = (d*x+c)*x + b
-    VFMADD231PS Y3, Y7, Y4     // Y4 = coef
-    VFMADD231PS Y5, Y4, Y6     // acc1 += hist * coef
+    // Stage 3: coef = a + x*p
+    VMOVUPS 0(DI), Y3
+    VFMADD213PS Y3, Y7, Y1                  // Y1 = Y1*x + a
+    VMOVUPS 32(DI), Y4
+    VFMADD213PS Y4, Y7, Y2                  // Y2 = Y2*x + a
+
+    // Accumulate with independent accumulators.
+    VMOVUPS 0(SI), Y5
+    VFMADD231PS Y5, Y1, Y0                  // acc0 += hist * coef
+    VMOVUPS 32(SI), Y5
+    VFMADD231PS Y5, Y2, Y6                  // acc1 += hist * coef
 
     // Advance pointers
     ADDQ $64, SI

--- a/f32/f32_go.go
+++ b/f32/f32_go.go
@@ -41,36 +41,64 @@ func dotProductGo(a, b []float32) float32 {
 }
 
 func addGo(dst, a, b []float32) {
+	if len(dst) == 0 {
+		return
+	}
+	_ = a[len(dst)-1]
+	_ = b[len(dst)-1]
 	for i := range dst {
 		dst[i] = a[i] + b[i]
 	}
 }
 
 func subGo(dst, a, b []float32) {
+	if len(dst) == 0 {
+		return
+	}
+	_ = a[len(dst)-1]
+	_ = b[len(dst)-1]
 	for i := range dst {
 		dst[i] = a[i] - b[i]
 	}
 }
 
 func mulGo(dst, a, b []float32) {
+	if len(dst) == 0 {
+		return
+	}
+	_ = a[len(dst)-1]
+	_ = b[len(dst)-1]
 	for i := range dst {
 		dst[i] = a[i] * b[i]
 	}
 }
 
 func divGo(dst, a, b []float32) {
+	if len(dst) == 0 {
+		return
+	}
+	_ = a[len(dst)-1]
+	_ = b[len(dst)-1]
 	for i := range dst {
 		dst[i] = a[i] / b[i]
 	}
 }
 
 func scaleGo(dst, a []float32, s float32) {
+	if len(dst) == 0 {
+		return
+	}
+	_ = a[len(dst)-1]
 	for i := range dst {
 		dst[i] = a[i] * s
 	}
 }
 
 func addScalarGo(dst, a []float32, s float32) {
+	if len(dst) == 0 {
+		return
+	}
+	_ = a[len(dst)-1]
 	for i := range dst {
 		dst[i] = a[i] + s
 	}
@@ -105,24 +133,42 @@ func maxGo(a []float32) float32 {
 }
 
 func absGo(dst, a []float32) {
+	if len(dst) == 0 {
+		return
+	}
+	_ = a[len(dst)-1]
 	for i := range dst {
 		dst[i] = math.Float32frombits(math.Float32bits(a[i]) &^ (1 << float32SignBitPos))
 	}
 }
 
 func negGo(dst, a []float32) {
+	if len(dst) == 0 {
+		return
+	}
+	_ = a[len(dst)-1]
 	for i := range dst {
 		dst[i] = -a[i]
 	}
 }
 
 func fmaGo(dst, a, b, c []float32) {
+	if len(dst) == 0 {
+		return
+	}
+	_ = a[len(dst)-1]
+	_ = b[len(dst)-1]
+	_ = c[len(dst)-1]
 	for i := range dst {
 		dst[i] = a[i]*b[i] + c[i]
 	}
 }
 
 func clampGo(dst, a []float32, minVal, maxVal float32) {
+	if len(dst) == 0 {
+		return
+	}
+	_ = a[len(dst)-1]
 	for i := range dst {
 		v := a[i]
 		if v < minVal {

--- a/f32/f32_go.go
+++ b/f32/f32_go.go
@@ -227,12 +227,20 @@ func convolveValidMultiGo(dsts [][]float32, signal []float32, kernels [][]float3
 }
 
 func sqrt32Go(dst, a []float32) {
+	if len(dst) == 0 {
+		return
+	}
+	_ = a[len(dst)-1]
 	for i := range dst {
 		dst[i] = float32(math.Sqrt(float64(a[i])))
 	}
 }
 
 func reciprocal32Go(dst, a []float32) {
+	if len(dst) == 0 {
+		return
+	}
+	_ = a[len(dst)-1]
 	for i := range dst {
 		dst[i] = 1.0 / a[i]
 	}
@@ -338,6 +346,10 @@ func cubicInterpDotGo(hist, a, b, c, d []float32, x float32) float32 {
 // sigmoid32Go computes sigmoid(x) = 1 / (1 + e^(-x)) using math.Exp.
 // This is accurate but slower than SIMD approximations.
 func sigmoid32Go(dst, src []float32) {
+	if len(dst) == 0 {
+		return
+	}
+	_ = src[len(dst)-1]
 	for i := range dst {
 		x := src[i]
 		// Clamp extreme values for numerical stability
@@ -354,6 +366,10 @@ func sigmoid32Go(dst, src []float32) {
 
 // relu32Go computes ReLU(x) = max(0, x).
 func relu32Go(dst, src []float32) {
+	if len(dst) == 0 {
+		return
+	}
+	_ = src[len(dst)-1]
 	for i := range dst {
 		if src[i] > 0 {
 			dst[i] = src[i]
@@ -365,6 +381,10 @@ func relu32Go(dst, src []float32) {
 
 // clampScale32Go performs fused clamp and scale operation.
 func clampScale32Go(dst, src []float32, minVal, maxVal, scale float32) {
+	if len(dst) == 0 {
+		return
+	}
+	_ = src[len(dst)-1]
 	for i := range dst {
 		v := src[i]
 		if v < minVal {
@@ -379,6 +399,10 @@ func clampScale32Go(dst, src []float32, minVal, maxVal, scale float32) {
 // tanh32Go computes hyperbolic tangent using math.Tanh for accuracy.
 // This is the accurate implementation used as a fallback when SIMD is unavailable.
 func tanh32Go(dst, src []float32) {
+	if len(dst) == 0 {
+		return
+	}
+	_ = src[len(dst)-1]
 	for i := range dst {
 		dst[i] = float32(math.Tanh(float64(src[i])))
 	}
@@ -386,6 +410,10 @@ func tanh32Go(dst, src []float32) {
 
 // exp32Go computes e^x using math.Exp.
 func exp32Go(dst, src []float32) {
+	if len(dst) == 0 {
+		return
+	}
+	_ = src[len(dst)-1]
 	for i := range dst {
 		x := src[i]
 		// Clamp extreme values

--- a/f32/go_impl_bce_test.go
+++ b/f32/go_impl_bce_test.go
@@ -1,0 +1,29 @@
+package f32
+
+import "testing"
+
+// TestGoFallbacks_EmptyDst exercises the `if len(dst) == 0 { return }` BCE
+// guard branches in the Go fallbacks. On AVX/NEON hosts those branches are
+// not normally hit because the public API short-circuits before dispatch.
+func TestGoFallbacks_EmptyDst(_ *testing.T) {
+	src := []float32{1, 2, 3}
+	dst := []float32{}
+
+	addGo(dst, src, src)
+	subGo(dst, src, src)
+	mulGo(dst, src, src)
+	divGo(dst, src, src)
+	scaleGo(dst, src, 2)
+	addScalarGo(dst, src, 1)
+	absGo(dst, src)
+	negGo(dst, src)
+	fmaGo(dst, src, src, src)
+	clampGo(dst, src, 0, 1)
+	sqrt32Go(dst, src)
+	reciprocal32Go(dst, src)
+	sigmoid32Go(dst, src)
+	relu32Go(dst, src)
+	clampScale32Go(dst, src, 0, 1, 1)
+	tanh32Go(dst, src)
+	exp32Go(dst, src)
+}

--- a/f64/f64.go
+++ b/f64/f64.go
@@ -32,6 +32,21 @@ func DotProductUnsafe(a, b []float64) float64 {
 	return dotProduct(a, b)
 }
 
+// WeightedSum returns Σ(weights[i] * src[i]) for i in 0..min(len(weights), len(src)).
+// This is equivalent to [DotProduct]; the alternate name documents intent at the call site
+// when the operands have asymmetric roles (signal vs. weights).
+func WeightedSum(weights, src []float64) float64 {
+	return DotProduct(weights, src)
+}
+
+// SumOfSquares returns Σ(src[i]²).
+func SumOfSquares(src []float64) float64 {
+	if len(src) == 0 {
+		return 0
+	}
+	return dotProduct(src, src)
+}
+
 // Add computes element-wise addition: dst[i] = a[i] + b[i].
 // Processes min(len(dst), len(a), len(b)) elements.
 func Add(dst, a, b []float64) {
@@ -91,6 +106,16 @@ func AddScalar(dst, a []float64, s float64) {
 		return
 	}
 	addScalar(dst[:n], a[:n], s)
+}
+
+// SubFromScalar subtracts each element from a scalar: dst[i] = s - a[i].
+// Processes min(len(dst), len(a)) elements.
+func SubFromScalar(dst, a []float64, s float64) {
+	n := min(len(a), len(dst))
+	if n == 0 {
+		return
+	}
+	subFromScalar64(dst[:n], a[:n], s)
 }
 
 // Sum returns the sum of all elements in the slice.
@@ -164,6 +189,16 @@ func Clamp(dst, a []float64, minVal, maxVal float64) {
 		return
 	}
 	clamp64(dst[:n], a[:n], minVal, maxVal)
+}
+
+// Round rounds each element to the nearest integer, half away from zero:
+// dst[i] = round(src[i]). Processes min(len(dst), len(src)) elements.
+func Round(dst, src []float64) {
+	n := min(len(dst), len(src))
+	if n == 0 {
+		return
+	}
+	round64(dst[:n], src[:n])
 }
 
 func minLen(a, b, c int) int {

--- a/f64/f64.go
+++ b/f64/f64.go
@@ -36,7 +36,10 @@ func DotProductUnsafe(a, b []float64) float64 {
 // This is equivalent to [DotProduct]; the alternate name documents intent at the call site
 // when the operands have asymmetric roles (signal vs. weights).
 func WeightedSum(weights, src []float64) float64 {
-	return DotProduct(weights, src)
+	if len(weights) == 0 || len(src) == 0 {
+		return 0
+	}
+	return dotProduct(weights, src)
 }
 
 // SumOfSquares returns Σ(src[i]²).

--- a/f64/f64_amd64.go
+++ b/f64/f64_amd64.go
@@ -238,14 +238,11 @@ func addScalar(dst, a []float64, s float64) {
 }
 
 func subFromScalar64(dst, a []float64, s float64) {
-	// Compose using existing SIMD primitives: (s - a) == (-a) + s.
-	// Each step uses a SIMD-vectorized kernel; two passes over memory but stays in cache.
-	if cpu.X86.AVX || cpu.X86.SSE2 {
-		neg64(dst, a)
-		addScalar(dst, dst, s)
-		return
-	}
-	subFromScalarGo(dst, a, s)
+	// Compose using already-dispatched primitives: (s - a) == (-a) + s.
+	// Each step is internally vectorized or falls back to Go via the global impl
+	// pointers, so this works on every supported CPU without an extra guard.
+	neg64(dst, a)
+	addScalar(dst, dst, s)
 }
 
 func sum(a []float64) float64 {
@@ -381,8 +378,9 @@ func cubicInterpDot64(hist, a, b, c, d []float64, x float64) float64 {
 }
 
 func sigmoid64(dst, src []float64) {
-	// Use AVX+FMA if available and have enough elements
-	if cpu.X86.AVX && cpu.X86.FMA && len(dst) >= minAVXElements {
+	// sigmoidAVX uses VMULPD/VADDPD/VDIVPD only - no FMA instructions - so it
+	// is safe on AVX-only CPUs.
+	if cpu.X86.AVX && len(dst) >= minAVXElements {
 		sigmoidAVX(dst, src)
 		return
 	}

--- a/f64/f64_amd64.go
+++ b/f64/f64_amd64.go
@@ -48,6 +48,7 @@ var (
 	negImpl               unaryOpFunc
 	sqrtImpl              unaryOpFunc
 	reciprocalImpl        unaryOpFunc
+	roundImpl             unaryOpFunc
 	fmaImpl               fmaFunc
 	clampImpl             clampFunc
 	varianceImpl          varianceFunc
@@ -58,13 +59,15 @@ var (
 )
 
 func init() {
-	// Select optimal implementation based on CPU features
-	// Priority: AVX-512 > AVX+FMA > SSE2 > Go
+	// Select optimal implementation based on CPU features.
+	// Priority: AVX-512 > AVX+FMA > AVX (no FMA) > SSE2 > Go
 	switch {
 	case cpu.X86.AVX512F && cpu.X86.AVX512VL:
 		initAVX512()
 	case cpu.X86.AVX && cpu.X86.FMA:
 		initAVX()
+	case cpu.X86.AVX:
+		initAVXNoFMA()
 	case cpu.X86.SSE2:
 		initSSE2()
 	default:
@@ -88,6 +91,7 @@ func initAVX512() {
 	negImpl = negAVX512
 	sqrtImpl = sqrtAVX512
 	reciprocalImpl = reciprocalAVX512
+	roundImpl = roundAVX
 	fmaImpl = fmaAVX512
 	clampImpl = clampAVX512
 	varianceImpl = varianceAVX512
@@ -98,6 +102,7 @@ func initAVX512() {
 }
 
 func initAVX() {
+	minSIMDElements = minAVXElements
 	dotProductImpl = dotProductAVX
 	addImpl = addAVX
 	subImpl = subAVX
@@ -112,6 +117,7 @@ func initAVX() {
 	negImpl = negAVX
 	sqrtImpl = sqrtAVX
 	reciprocalImpl = reciprocalAVX
+	roundImpl = roundAVX
 	fmaImpl = fmaAVX
 	clampImpl = clampAVX
 	varianceImpl = varianceAVX
@@ -119,6 +125,36 @@ func initAVX() {
 	interleave2Impl = interleave2AVX
 	deinterleave2Impl = deinterleave2AVX
 	addScaledImpl = addScaledAVX
+}
+
+// initAVXNoFMA runs on AVX-capable CPUs that lack FMA (rare but possible:
+// some early Sandy/Ivy Bridge generations, certain Atom/Pentium SKUs).
+// AVX kernels that don't depend on FMA stay on AVX paths; FMA-dependent kernels
+// fall back to SSE2 variants which use scalar/SSE multiply-add sequences.
+func initAVXNoFMA() {
+	minSIMDElements = minAVXElements
+	dotProductImpl = dotProductSSE2
+	addImpl = addAVX
+	subImpl = subAVX
+	mulImpl = mulAVX
+	divImpl = divAVX
+	scaleImpl = scaleAVX
+	addScalarImpl = addScalarAVX
+	sumImpl = sumAVX
+	minImpl = minAVX
+	maxImpl = maxAVX
+	absImpl = absAVX
+	negImpl = negAVX
+	sqrtImpl = sqrtAVX
+	reciprocalImpl = reciprocalAVX
+	roundImpl = roundAVX
+	fmaImpl = fmaSSE2
+	clampImpl = clampAVX
+	varianceImpl = varianceSSE2
+	euclideanDistanceImpl = euclideanDistanceSSE2
+	interleave2Impl = interleave2AVX
+	deinterleave2Impl = deinterleave2AVX
+	addScaledImpl = addScaledSSE2
 }
 
 func initSSE2() {
@@ -136,6 +172,7 @@ func initSSE2() {
 	negImpl = negSSE2
 	sqrtImpl = sqrtSSE2
 	reciprocalImpl = reciprocalSSE2
+	roundImpl = round64Go
 	fmaImpl = fmaSSE2
 	clampImpl = clampSSE2
 	varianceImpl = varianceSSE2
@@ -160,6 +197,7 @@ func initGo() {
 	negImpl = negGo
 	sqrtImpl = sqrt64Go
 	reciprocalImpl = reciprocal64Go
+	roundImpl = round64Go
 	fmaImpl = fmaGo
 	clampImpl = clampGo
 	varianceImpl = variance64Go
@@ -199,6 +237,17 @@ func addScalar(dst, a []float64, s float64) {
 	addScalarImpl(dst, a, s)
 }
 
+func subFromScalar64(dst, a []float64, s float64) {
+	// Compose using existing SIMD primitives: (s - a) == (-a) + s.
+	// Each step uses a SIMD-vectorized kernel; two passes over memory but stays in cache.
+	if cpu.X86.AVX || cpu.X86.SSE2 {
+		neg64(dst, a)
+		addScalar(dst, dst, s)
+		return
+	}
+	subFromScalarGo(dst, a, s)
+}
+
 func sum(a []float64) float64 {
 	return sumImpl(a)
 }
@@ -235,6 +284,10 @@ func fma64(dst, a, b, c []float64) {
 
 func clamp64(dst, a []float64, minVal, maxVal float64) {
 	clampImpl(dst, a, minVal, maxVal)
+}
+
+func round64(dst, src []float64) {
+	roundImpl(dst, src)
 }
 
 func sqrt64(dst, a []float64) {
@@ -412,6 +465,9 @@ func absAVX(dst, a []float64)
 
 //go:noescape
 func negAVX(dst, a []float64)
+
+//go:noescape
+func roundAVX(dst, src []float64)
 
 //go:noescape
 func fmaAVX(dst, a, b, c []float64)

--- a/f64/f64_amd64.s
+++ b/f64/f64_amd64.s
@@ -32,6 +32,12 @@ DATA roundf64_half<>+0x10(SB)/8, $0x3fe0000000000000
 DATA roundf64_half<>+0x18(SB)/8, $0x3fe0000000000000
 GLOBL roundf64_half<>(SB), RODATA|NOPTR, $32
 
+DATA roundf64_one<>+0x00(SB)/8, $0x3ff0000000000000
+DATA roundf64_one<>+0x08(SB)/8, $0x3ff0000000000000
+DATA roundf64_one<>+0x10(SB)/8, $0x3ff0000000000000
+DATA roundf64_one<>+0x18(SB)/8, $0x3ff0000000000000
+GLOBL roundf64_one<>(SB), RODATA|NOPTR, $32
+
 // ============================================================================
 // AVX+FMA IMPLEMENTATIONS (256-bit, 4x float64 per iteration)
 // ============================================================================
@@ -3631,9 +3637,17 @@ TEXT ·roundAVX(SB), NOSPLIT, $0-48
     MOVQ dst_len+8(FP), CX
     MOVQ src_base+24(FP), SI
 
+    // Algorithm: round-half-away-from-zero matching math.Round.
+    //   t   = trunc(x)
+    //   f   = x - t                     // signed fractional part in (-1, 1)
+    //   inc = (|f| >= 0.5) ? sign(x)*1.0 : 0
+    //   result = t + inc
+    // This avoids the trunc(|x|+0.5) overcounting at |x|=nextafter(0.5,0),
+    // where the FP add rounds up to exactly 1.0.
     VMOVUPD roundf64_absmask<>(SB), Y3
     VMOVUPD roundf64_signmask<>(SB), Y4
     VMOVUPD roundf64_half<>(SB), Y5
+    VMOVUPD roundf64_one<>(SB), Y11
 
     MOVQ CX, AX
     SHRQ $2, AX
@@ -3641,11 +3655,14 @@ TEXT ·roundAVX(SB), NOSPLIT, $0-48
 
 round_avx_loop4:
     VMOVUPD (SI), Y0                  // Y0 = x
-    VANDPD Y3, Y0, Y1                 // Y1 = abs(x)
-    VADDPD Y5, Y1, Y1                 // Y1 = abs(x) + 0.5
-    VROUNDPD $3, Y1, Y1               // Y1 = trunc(abs(x)+0.5)
-    VANDPD Y4, Y0, Y2                 // Y2 = signbit(x)
-    VORPD Y2, Y1, Y1                  // Y1 = apply sign
+    VROUNDPD $3, Y0, Y1                // Y1 = trunc(x)
+    VSUBPD Y1, Y0, Y2                  // Y2 = x - trunc(x) = signed frac
+    VANDPD Y3, Y2, Y6                  // Y6 = |frac|
+    VCMPPD $5, Y5, Y6, Y7              // Y7 = mask: |frac| NLT 0.5  (|frac| >= 0.5)
+    VANDPD Y11, Y7, Y8                 // Y8 = 1.0 where mask, else 0
+    VANDPD Y4, Y0, Y9                  // Y9 = signbit(x)
+    VORPD Y9, Y8, Y8                   // Y8 = ±1.0 (or ±0.0 when no increment)
+    VADDPD Y8, Y1, Y1                  // Y1 = trunc(x) + ±1 or +0
     VMOVUPD Y1, (DX)
     ADDQ $32, SI
     ADDQ $32, DX
@@ -3659,14 +3676,18 @@ round_avx_remainder:
     VMOVSD roundf64_absmask<>(SB), X3
     VMOVSD roundf64_signmask<>(SB), X4
     VMOVSD roundf64_half<>(SB), X5
+    VMOVSD roundf64_one<>(SB), X11
 
 round_avx_scalar:
     VMOVSD (SI), X0                   // X0 = x
-    VANDPD X3, X0, X1                 // X1 = abs(x)
-    VADDSD X5, X1, X1                 // X1 = abs(x)+0.5
-    VROUNDSD $3, X1, X1, X1           // X1 = trunc(abs(x)+0.5)
-    VANDPD X4, X0, X2                 // X2 = signbit(x)
-    VORPD X2, X1, X1                  // X1 = apply sign
+    VROUNDSD $3, X0, X0, X1            // X1 = trunc(x)
+    VSUBSD X1, X0, X2                  // X2 = signed frac
+    VANDPD X3, X2, X6                  // X6 = |frac|
+    VCMPSD $5, X5, X6, X7              // X7 = mask: |frac| NLT 0.5
+    VANDPD X11, X7, X8                 // X8 = 1.0 where mask else 0
+    VANDPD X4, X0, X9                  // X9 = signbit(x)
+    VORPD X9, X8, X8                   // X8 = ±1 or ±0
+    VADDSD X8, X1, X1                  // X1 = trunc(x) + inc
     VMOVSD X1, (DX)
     ADDQ $8, SI
     ADDQ $8, DX

--- a/f64/f64_amd64.s
+++ b/f64/f64_amd64.s
@@ -13,7 +13,9 @@ DATA absf64mask<>+0x30(SB)/8, $0x7fffffffffffffff
 DATA absf64mask<>+0x38(SB)/8, $0x7fffffffffffffff
 GLOBL absf64mask<>(SB), RODATA|NOPTR, $64
 
-// Constants for Round (half away from zero): trunc(abs(x)+0.5) with sign restore.
+// Constants for Round (half away from zero): result = trunc(x) + copysign(1, x)
+// when |x - trunc(x)| >= 0.5, otherwise result = trunc(x). Ties (|frac|==0.5)
+// round away from zero, matching math.Round.
 DATA roundf64_signmask<>+0x00(SB)/8, $0x8000000000000000
 DATA roundf64_signmask<>+0x08(SB)/8, $0x8000000000000000
 DATA roundf64_signmask<>+0x10(SB)/8, $0x8000000000000000

--- a/f64/f64_amd64.s
+++ b/f64/f64_amd64.s
@@ -13,6 +13,25 @@ DATA absf64mask<>+0x30(SB)/8, $0x7fffffffffffffff
 DATA absf64mask<>+0x38(SB)/8, $0x7fffffffffffffff
 GLOBL absf64mask<>(SB), RODATA|NOPTR, $64
 
+// Constants for Round (half away from zero): trunc(abs(x)+0.5) with sign restore.
+DATA roundf64_signmask<>+0x00(SB)/8, $0x8000000000000000
+DATA roundf64_signmask<>+0x08(SB)/8, $0x8000000000000000
+DATA roundf64_signmask<>+0x10(SB)/8, $0x8000000000000000
+DATA roundf64_signmask<>+0x18(SB)/8, $0x8000000000000000
+GLOBL roundf64_signmask<>(SB), RODATA|NOPTR, $32
+
+DATA roundf64_absmask<>+0x00(SB)/8, $0x7fffffffffffffff
+DATA roundf64_absmask<>+0x08(SB)/8, $0x7fffffffffffffff
+DATA roundf64_absmask<>+0x10(SB)/8, $0x7fffffffffffffff
+DATA roundf64_absmask<>+0x18(SB)/8, $0x7fffffffffffffff
+GLOBL roundf64_absmask<>(SB), RODATA|NOPTR, $32
+
+DATA roundf64_half<>+0x00(SB)/8, $0x3fe0000000000000
+DATA roundf64_half<>+0x08(SB)/8, $0x3fe0000000000000
+DATA roundf64_half<>+0x10(SB)/8, $0x3fe0000000000000
+DATA roundf64_half<>+0x18(SB)/8, $0x3fe0000000000000
+GLOBL roundf64_half<>(SB), RODATA|NOPTR, $32
+
 // ============================================================================
 // AVX+FMA IMPLEMENTATIONS (256-bit, 4x float64 per iteration)
 // ============================================================================
@@ -3097,34 +3116,101 @@ TEXT ·cubicInterpDotAVX(SB), NOSPLIT, $0-136
     // Broadcast x to all lanes of Y7
     VBROADCASTSD x+120(FP), Y7
 
-    // Initialize accumulator to zero
-    VXORPD Y0, Y0, Y0          // Y0 = accumulator
+    // Independent accumulators for ILP.
+    VXORPD Y0, Y0, Y0
+    VXORPD Y11, Y11, Y11
+    VXORPD Y12, Y12, Y12
+    VXORPD Y13, Y13, Y13
 
-    // Process 4 elements per iteration (one YMM register)
+    // Process 16 elements per iteration (4 YMM × 4 doubles)
     MOVQ CX, AX
-    SHRQ $2, AX                // AX = len / 4
+    SHRQ $4, AX                // AX = len / 16
+    JZ   cubic_avx_loop4_check
+
+cubic_avx_loop16:
+    // Multi-stage Horner with four independent chains.
+    // VFMADD213PD dst, mul, add: dst = dst*mul + add (Y7 = broadcast x).
+
+    // Stage 1: p = c + x*d (4 parallel chains)
+    VMOVUPD 0(R9), Y1
+    VMOVUPD 0(R10), Y5
+    VFMADD231PD Y5, Y7, Y1
+
+    VMOVUPD 32(R9), Y2
+    VMOVUPD 32(R10), Y5
+    VFMADD231PD Y5, Y7, Y2
+
+    VMOVUPD 64(R9), Y3
+    VMOVUPD 64(R10), Y5
+    VFMADD231PD Y5, Y7, Y3
+
+    VMOVUPD 96(R9), Y4
+    VMOVUPD 96(R10), Y5
+    VFMADD231PD Y5, Y7, Y4
+
+    // Stage 2: p = b + x*p
+    VMOVUPD 0(R8), Y5
+    VFMADD213PD Y5, Y7, Y1
+    VMOVUPD 32(R8), Y5
+    VFMADD213PD Y5, Y7, Y2
+    VMOVUPD 64(R8), Y5
+    VFMADD213PD Y5, Y7, Y3
+    VMOVUPD 96(R8), Y5
+    VFMADD213PD Y5, Y7, Y4
+
+    // Stage 3: coef = a + x*p
+    VMOVUPD 0(DI), Y5
+    VFMADD213PD Y5, Y7, Y1
+    VMOVUPD 32(DI), Y5
+    VFMADD213PD Y5, Y7, Y2
+    VMOVUPD 64(DI), Y5
+    VFMADD213PD Y5, Y7, Y3
+    VMOVUPD 96(DI), Y5
+    VFMADD213PD Y5, Y7, Y4
+
+    // Accumulate: Σ hist * coef with independent accumulators.
+    VMOVUPD 0(SI), Y5
+    VFMADD231PD Y5, Y1, Y0
+    VMOVUPD 32(SI), Y5
+    VFMADD231PD Y5, Y2, Y11
+    VMOVUPD 64(SI), Y5
+    VFMADD231PD Y5, Y3, Y12
+    VMOVUPD 96(SI), Y5
+    VFMADD231PD Y5, Y4, Y13
+
+    ADDQ $128, SI
+    ADDQ $128, DI
+    ADDQ $128, R8
+    ADDQ $128, R9
+    ADDQ $128, R10
+    DECQ AX
+    JNZ  cubic_avx_loop16
+
+    // Combine accumulators.
+    VADDPD Y11, Y0, Y0
+    VADDPD Y12, Y0, Y0
+    VADDPD Y13, Y0, Y0
+
+cubic_avx_loop4_check:
+    // Handle remaining 4-element vectors.
+    ANDQ $15, CX
+    MOVQ CX, AX
+    SHRQ $2, AX
     JZ   cubic_avx_remainder
 
 cubic_avx_loop4:
-    // Load coefficient vectors
-    VMOVUPD (R10), Y1          // Y1 = d[i:i+4]
-    VMOVUPD (R9), Y2           // Y2 = c[i:i+4]
-    VMOVUPD (R8), Y3           // Y3 = b[i:i+4]
-    VMOVUPD (DI), Y4           // Y4 = a[i:i+4]
-    VMOVUPD (SI), Y5           // Y5 = hist[i:i+4]
+    VMOVUPD (R10), Y1          // d
+    VMOVUPD (R9), Y2           // c
+    VMOVUPD (R8), Y3           // b
+    VMOVUPD (DI), Y4           // a
+    VMOVUPD (SI), Y5           // hist
 
     // Horner's method: coef = a + x*(b + x*(c + x*d))
-    // Step 1: Y2 = c + x*d (using VFMADD231: dst = src1*src2 + dst)
-    VFMADD231PD Y1, Y7, Y2     // Y2 = d*x + c
-    // Step 2: Y3 = b + x*(c + x*d)
-    VFMADD231PD Y2, Y7, Y3     // Y3 = (d*x+c)*x + b
-    // Step 3: Y4 = a + x*(b + x*(c + x*d))
-    VFMADD231PD Y3, Y7, Y4     // Y4 = ((d*x+c)*x+b)*x + a = coef
+    VFMADD231PD Y1, Y7, Y2
+    VFMADD231PD Y2, Y7, Y3
+    VFMADD231PD Y3, Y7, Y4
+    VFMADD231PD Y5, Y4, Y0
 
-    // Accumulate: acc += hist * coef
-    VFMADD231PD Y5, Y4, Y0     // Y0 = hist * coef + Y0
-
-    // Advance pointers
     ADDQ $32, SI
     ADDQ $32, DI
     ADDQ $32, R8
@@ -3532,5 +3618,61 @@ tanh64_scalar:
     JNZ  tanh64_scalar
 
 tanh64_done:
+    VZEROUPPER
+    RET
+
+// ============================================================================
+// roundAVX: round-half-away-from-zero
+// ============================================================================
+
+// func roundAVX(dst, src []float64)
+TEXT ·roundAVX(SB), NOSPLIT, $0-48
+    MOVQ dst_base+0(FP), DX
+    MOVQ dst_len+8(FP), CX
+    MOVQ src_base+24(FP), SI
+
+    VMOVUPD roundf64_absmask<>(SB), Y3
+    VMOVUPD roundf64_signmask<>(SB), Y4
+    VMOVUPD roundf64_half<>(SB), Y5
+
+    MOVQ CX, AX
+    SHRQ $2, AX
+    JZ   round_avx_remainder
+
+round_avx_loop4:
+    VMOVUPD (SI), Y0                  // Y0 = x
+    VANDPD Y3, Y0, Y1                 // Y1 = abs(x)
+    VADDPD Y5, Y1, Y1                 // Y1 = abs(x) + 0.5
+    VROUNDPD $3, Y1, Y1               // Y1 = trunc(abs(x)+0.5)
+    VANDPD Y4, Y0, Y2                 // Y2 = signbit(x)
+    VORPD Y2, Y1, Y1                  // Y1 = apply sign
+    VMOVUPD Y1, (DX)
+    ADDQ $32, SI
+    ADDQ $32, DX
+    DECQ AX
+    JNZ  round_avx_loop4
+
+round_avx_remainder:
+    ANDQ $3, CX
+    JZ   round_avx_done
+
+    VMOVSD roundf64_absmask<>(SB), X3
+    VMOVSD roundf64_signmask<>(SB), X4
+    VMOVSD roundf64_half<>(SB), X5
+
+round_avx_scalar:
+    VMOVSD (SI), X0                   // X0 = x
+    VANDPD X3, X0, X1                 // X1 = abs(x)
+    VADDSD X5, X1, X1                 // X1 = abs(x)+0.5
+    VROUNDSD $3, X1, X1, X1           // X1 = trunc(abs(x)+0.5)
+    VANDPD X4, X0, X2                 // X2 = signbit(x)
+    VORPD X2, X1, X1                  // X1 = apply sign
+    VMOVSD X1, (DX)
+    ADDQ $8, SI
+    ADDQ $8, DX
+    DECQ CX
+    JNZ  round_avx_scalar
+
+round_avx_done:
     VZEROUPPER
     RET

--- a/f64/f64_arm64.go
+++ b/f64/f64_arm64.go
@@ -64,13 +64,11 @@ func addScalar(dst, a []float64, s float64) {
 }
 
 func subFromScalar64(dst, a []float64, s float64) {
-	// Compose using existing NEON primitives: (s - a) == (-a) + s.
-	if hasNEON && len(dst) >= 2 {
-		neg64(dst, a)
-		addScalar(dst, dst, s)
-		return
-	}
-	subFromScalarGo(dst, a, s)
+	// Compose using already-dispatched primitives: (s - a) == (-a) + s.
+	// neg64 and addScalar each gate on hasNEON internally and fall back to
+	// pure Go when NEON is unavailable, so no extra guard is needed here.
+	neg64(dst, a)
+	addScalar(dst, dst, s)
 }
 
 func sum(a []float64) float64 {

--- a/f64/f64_arm64.go
+++ b/f64/f64_arm64.go
@@ -63,6 +63,16 @@ func addScalar(dst, a []float64, s float64) {
 	addScalarGo(dst, a, s)
 }
 
+func subFromScalar64(dst, a []float64, s float64) {
+	// Compose using existing NEON primitives: (s - a) == (-a) + s.
+	if hasNEON && len(dst) >= 2 {
+		neg64(dst, a)
+		addScalar(dst, dst, s)
+		return
+	}
+	subFromScalarGo(dst, a, s)
+}
+
 func sum(a []float64) float64 {
 	if hasNEON && len(a) >= 2 {
 		return sumNEON(a)
@@ -122,6 +132,14 @@ func sqrt64(dst, a []float64) {
 		return
 	}
 	sqrt64Go(dst, a)
+}
+
+func round64(dst, src []float64) {
+	if hasNEON && len(dst) >= 2 {
+		roundNEON(dst, src)
+		return
+	}
+	round64Go(dst, src)
 }
 
 func reciprocal64(dst, a []float64) {
@@ -228,6 +246,9 @@ func sqrtNEON(dst, a []float64)
 
 //go:noescape
 func reciprocalNEON(dst, a []float64)
+
+//go:noescape
+func roundNEON(dst, src []float64)
 
 //go:noescape
 func varianceNEON(a []float64, mean float64) float64

--- a/f64/f64_arm64.s
+++ b/f64/f64_arm64.s
@@ -1163,3 +1163,33 @@ clampscale64_neon_scalar_loop:
 
 clampscale64_neon_done:
     RET
+
+// ============================================================================
+// roundNEON: round-half-away-from-zero using FRINTA
+// ============================================================================
+
+// func roundNEON(dst, src []float64)
+TEXT ·roundNEON(SB), NOSPLIT, $0-48
+    MOVD dst_base+0(FP), R0
+    MOVD dst_len+8(FP), R2
+    MOVD src_base+24(FP), R1
+
+    LSR $1, R2, R3
+    CBZ R3, round_scalar
+
+round_loop2:
+    VLD1.P 16(R1), [V0.D2]
+    WORD $0x6E618800           // FRINTA V0.2D, V0.2D
+    VST1.P [V0.D2], 16(R0)
+    SUB $1, R3
+    CBNZ R3, round_loop2
+
+round_scalar:
+    AND $1, R2
+    CBZ R2, round_done
+    FMOVD (R1), F0
+    WORD $0x1E664000           // FRINTA D0, D0
+    FMOVD F0, (R0)
+
+round_done:
+    RET

--- a/f64/f64_go.go
+++ b/f64/f64_go.go
@@ -178,24 +178,40 @@ func clampGo(dst, a []float64, minVal, maxVal float64) {
 }
 
 func sqrt64Go(dst, a []float64) {
+	if len(dst) == 0 {
+		return
+	}
+	_ = a[len(dst)-1]
 	for i := range dst {
 		dst[i] = math.Sqrt(a[i])
 	}
 }
 
 func round64Go(dst, src []float64) {
+	if len(dst) == 0 {
+		return
+	}
+	_ = src[len(dst)-1]
 	for i := range dst {
 		dst[i] = math.Round(src[i])
 	}
 }
 
 func subFromScalarGo(dst, a []float64, s float64) {
+	if len(dst) == 0 {
+		return
+	}
+	_ = a[len(dst)-1]
 	for i := range dst {
 		dst[i] = s - a[i]
 	}
 }
 
 func reciprocal64Go(dst, a []float64) {
+	if len(dst) == 0 {
+		return
+	}
+	_ = a[len(dst)-1]
 	for i := range dst {
 		dst[i] = 1.0 / a[i]
 	}
@@ -369,6 +385,10 @@ func maxIdxGo64(a []float64) int {
 }
 
 func addScaledGo64(dst []float64, alpha float64, s []float64) {
+	if len(dst) == 0 {
+		return
+	}
+	_ = s[len(dst)-1]
 	for i := range dst {
 		dst[i] += alpha * s[i]
 	}
@@ -377,6 +397,10 @@ func addScaledGo64(dst []float64, alpha float64, s []float64) {
 // sigmoid64Go computes sigmoid(x) = 1 / (1 + e^(-x)) using math.Exp.
 // This is accurate but slower than SIMD approximations.
 func sigmoid64Go(dst, src []float64) {
+	if len(dst) == 0 {
+		return
+	}
+	_ = src[len(dst)-1]
 	for i := range dst {
 		x := src[i]
 		// Clamp extreme values for numerical stability
@@ -393,6 +417,10 @@ func sigmoid64Go(dst, src []float64) {
 
 // relu64Go computes ReLU activation: dst[i] = max(0, src[i]).
 func relu64Go(dst, src []float64) {
+	if len(dst) == 0 {
+		return
+	}
+	_ = src[len(dst)-1]
 	for i := range dst {
 		if src[i] > 0 {
 			dst[i] = src[i]
@@ -405,6 +433,10 @@ func relu64Go(dst, src []float64) {
 // clampScale64Go performs fused clamp and scale operation.
 // dst[i] = (clamp(src[i], minVal, maxVal) - minVal) * scale
 func clampScale64Go(dst, src []float64, minVal, maxVal, scale float64) {
+	if len(dst) == 0 {
+		return
+	}
+	_ = src[len(dst)-1]
 	for i := range dst {
 		v := src[i]
 		if v < minVal {
@@ -419,6 +451,10 @@ func clampScale64Go(dst, src []float64, minVal, maxVal, scale float64) {
 // tanh64Go computes hyperbolic tangent using math.Tanh for accuracy.
 // This is the accurate implementation used as a fallback when SIMD is unavailable.
 func tanh64Go(dst, src []float64) {
+	if len(dst) == 0 {
+		return
+	}
+	_ = src[len(dst)-1]
 	for i := range dst {
 		dst[i] = math.Tanh(src[i])
 	}
@@ -427,6 +463,10 @@ func tanh64Go(dst, src []float64) {
 // exp64Go computes exponential function: dst[i] = e^src[i].
 // Uses math.Exp with overflow/underflow protection.
 func exp64Go(dst, src []float64) {
+	if len(dst) == 0 {
+		return
+	}
+	_ = src[len(dst)-1]
 	for i := range dst {
 		x := src[i]
 		// Clamp to prevent overflow/underflow

--- a/f64/f64_go.go
+++ b/f64/f64_go.go
@@ -38,36 +38,64 @@ func dotProductGo(a, b []float64) float64 {
 }
 
 func addGo(dst, a, b []float64) {
+	if len(dst) == 0 {
+		return
+	}
+	_ = a[len(dst)-1]
+	_ = b[len(dst)-1]
 	for i := range dst {
 		dst[i] = a[i] + b[i]
 	}
 }
 
 func subGo(dst, a, b []float64) {
+	if len(dst) == 0 {
+		return
+	}
+	_ = a[len(dst)-1]
+	_ = b[len(dst)-1]
 	for i := range dst {
 		dst[i] = a[i] - b[i]
 	}
 }
 
 func mulGo(dst, a, b []float64) {
+	if len(dst) == 0 {
+		return
+	}
+	_ = a[len(dst)-1]
+	_ = b[len(dst)-1]
 	for i := range dst {
 		dst[i] = a[i] * b[i]
 	}
 }
 
 func divGo(dst, a, b []float64) {
+	if len(dst) == 0 {
+		return
+	}
+	_ = a[len(dst)-1]
+	_ = b[len(dst)-1]
 	for i := range dst {
 		dst[i] = a[i] / b[i]
 	}
 }
 
 func scaleGo(dst, a []float64, s float64) {
+	if len(dst) == 0 {
+		return
+	}
+	_ = a[len(dst)-1]
 	for i := range dst {
 		dst[i] = a[i] * s
 	}
 }
 
 func addScalarGo(dst, a []float64, s float64) {
+	if len(dst) == 0 {
+		return
+	}
+	_ = a[len(dst)-1]
 	for i := range dst {
 		dst[i] = a[i] + s
 	}
@@ -102,24 +130,42 @@ func maxGo(a []float64) float64 {
 }
 
 func absGo(dst, a []float64) {
+	if len(dst) == 0 {
+		return
+	}
+	_ = a[len(dst)-1]
 	for i := range dst {
 		dst[i] = math.Abs(a[i])
 	}
 }
 
 func negGo(dst, a []float64) {
+	if len(dst) == 0 {
+		return
+	}
+	_ = a[len(dst)-1]
 	for i := range dst {
 		dst[i] = -a[i]
 	}
 }
 
 func fmaGo(dst, a, b, c []float64) {
+	if len(dst) == 0 {
+		return
+	}
+	_ = a[len(dst)-1]
+	_ = b[len(dst)-1]
+	_ = c[len(dst)-1]
 	for i := range dst {
 		dst[i] = math.FMA(a[i], b[i], c[i])
 	}
 }
 
 func clampGo(dst, a []float64, minVal, maxVal float64) {
+	if len(dst) == 0 {
+		return
+	}
+	_ = a[len(dst)-1]
 	for i := range dst {
 		v := a[i]
 		if v < minVal {
@@ -134,6 +180,18 @@ func clampGo(dst, a []float64, minVal, maxVal float64) {
 func sqrt64Go(dst, a []float64) {
 	for i := range dst {
 		dst[i] = math.Sqrt(a[i])
+	}
+}
+
+func round64Go(dst, src []float64) {
+	for i := range dst {
+		dst[i] = math.Round(src[i])
+	}
+}
+
+func subFromScalarGo(dst, a []float64, s float64) {
+	for i := range dst {
+		dst[i] = s - a[i]
 	}
 }
 

--- a/f64/f64_other.go
+++ b/f64/f64_other.go
@@ -11,6 +11,7 @@ func mul(dst, a, b []float64)                          { mulGo(dst, a, b) }
 func div(dst, a, b []float64)                          { divGo(dst, a, b) }
 func scale(dst, a []float64, s float64)                { scaleGo(dst, a, s) }
 func addScalar(dst, a []float64, s float64)            { addScalarGo(dst, a, s) }
+func subFromScalar64(dst, a []float64, s float64)      { subFromScalarGo(dst, a, s) }
 func sum(a []float64) float64                          { return sumGo(a) }
 func min64(a []float64) float64                        { return minGo(a) }
 func max64(a []float64) float64                        { return maxGo(a) }
@@ -20,6 +21,7 @@ func fma64(dst, a, b, c []float64)                     { fmaGo(dst, a, b, c) }
 func clamp64(dst, a []float64, minVal, maxVal float64) { clampGo(dst, a, minVal, maxVal) }
 func sqrt64(dst, a []float64)                          { sqrt64Go(dst, a) }
 func reciprocal64(dst, a []float64)                    { reciprocal64Go(dst, a) }
+func round64(dst, src []float64)                       { round64Go(dst, src) }
 func variance64(a []float64, mean float64) float64     { return variance64Go(a, mean) }
 func euclideanDistance64(a, b []float64) float64       { return euclideanDistance64Go(a, b) }
 func cumulativeSum64(dst, a []float64)                 { cumulativeSum64Go(dst, a) }

--- a/f64/go_impl_amd64_test.go
+++ b/f64/go_impl_amd64_test.go
@@ -3,22 +3,107 @@
 package f64
 
 import (
+	"reflect"
 	"testing"
 
 	"github.com/tphakala/simd/cpu"
 )
 
+// snapshotImpls captures every dispatch function pointer plus minSIMDElements
+// so a test that calls one of the init* functions can restore them in t.Cleanup.
+type implSnapshot struct {
+	dotProduct        dotProductFunc
+	add               binaryOpFunc
+	sub               binaryOpFunc
+	mul               binaryOpFunc
+	div               binaryOpFunc
+	scale             scaleFunc
+	addScalar         scaleFunc
+	sum               reduceFunc
+	min               reduceFunc
+	max               reduceFunc
+	abs               unaryOpFunc
+	neg               unaryOpFunc
+	sqrt              unaryOpFunc
+	reciprocal        unaryOpFunc
+	round             unaryOpFunc
+	fma               fmaFunc
+	clamp             clampFunc
+	variance          varianceFunc
+	euclideanDistance euclideanDistanceFunc
+	interleave2       interleave2Func
+	deinterleave2     deinterleave2Func
+	addScaled         addScaledFunc
+	minSIMDElements   int
+}
+
+func snapshotDispatch() implSnapshot {
+	return implSnapshot{
+		dotProduct:        dotProductImpl,
+		add:               addImpl,
+		sub:               subImpl,
+		mul:               mulImpl,
+		div:               divImpl,
+		scale:             scaleImpl,
+		addScalar:         addScalarImpl,
+		sum:               sumImpl,
+		min:               minImpl,
+		max:               maxImpl,
+		abs:               absImpl,
+		neg:               negImpl,
+		sqrt:              sqrtImpl,
+		reciprocal:        reciprocalImpl,
+		round:             roundImpl,
+		fma:               fmaImpl,
+		clamp:             clampImpl,
+		variance:          varianceImpl,
+		euclideanDistance: euclideanDistanceImpl,
+		interleave2:       interleave2Impl,
+		deinterleave2:     deinterleave2Impl,
+		addScaled:         addScaledImpl,
+		minSIMDElements:   minSIMDElements,
+	}
+}
+
+func restoreDispatch(s implSnapshot) {
+	dotProductImpl = s.dotProduct
+	addImpl = s.add
+	subImpl = s.sub
+	mulImpl = s.mul
+	divImpl = s.div
+	scaleImpl = s.scale
+	addScalarImpl = s.addScalar
+	sumImpl = s.sum
+	minImpl = s.min
+	maxImpl = s.max
+	absImpl = s.abs
+	negImpl = s.neg
+	sqrtImpl = s.sqrt
+	reciprocalImpl = s.reciprocal
+	roundImpl = s.round
+	fmaImpl = s.fma
+	clampImpl = s.clamp
+	varianceImpl = s.variance
+	euclideanDistanceImpl = s.euclideanDistance
+	interleave2Impl = s.interleave2
+	deinterleave2Impl = s.deinterleave2
+	addScaledImpl = s.addScaled
+	minSIMDElements = s.minSIMDElements
+}
+
+func samePointer(a, b interface{}) bool {
+	return reflect.ValueOf(a).Pointer() == reflect.ValueOf(b).Pointer()
+}
+
 // Tests for init functions to ensure they properly configure function pointers
 // These tests are AMD64-specific because they test x86 SIMD initialization paths.
 
 func TestInitGo(t *testing.T) {
-	// Save current state
-	savedDotProduct := dotProductImpl
+	saved := snapshotDispatch()
+	t.Cleanup(func() { restoreDispatch(saved) })
 
-	// Call initGo
 	initGo()
 
-	// Test that operations work with Go implementations
 	a := []float64{1, 2, 3, 4}
 	b := []float64{4, 3, 2, 1}
 
@@ -27,13 +112,14 @@ func TestInitGo(t *testing.T) {
 	if got != want {
 		t.Errorf("After initGo, dotProduct = %v, want %v", got, want)
 	}
-
-	// Restore
-	dotProductImpl = savedDotProduct
+	if roundImpl == nil {
+		t.Error("initGo: roundImpl is nil")
+	}
 }
 
 func TestInitSSE2(t *testing.T) {
-	savedDotProduct := dotProductImpl
+	saved := snapshotDispatch()
+	t.Cleanup(func() { restoreDispatch(saved) })
 
 	initSSE2()
 
@@ -45,8 +131,9 @@ func TestInitSSE2(t *testing.T) {
 	if got != want {
 		t.Errorf("After initSSE2, dotProduct = %v, want %v", got, want)
 	}
-
-	dotProductImpl = savedDotProduct
+	if roundImpl == nil {
+		t.Error("initSSE2: roundImpl is nil")
+	}
 }
 
 func TestInitAVX512(t *testing.T) {
@@ -54,8 +141,8 @@ func TestInitAVX512(t *testing.T) {
 		t.Skip("AVX-512 not supported on this CPU")
 	}
 
-	savedDotProduct := dotProductImpl
-	savedMinSIMD := minSIMDElements
+	saved := snapshotDispatch()
+	t.Cleanup(func() { restoreDispatch(saved) })
 
 	initAVX512()
 
@@ -68,13 +155,12 @@ func TestInitAVX512(t *testing.T) {
 		t.Errorf("After initAVX512, dotProduct = %v, want %v", got, want)
 	}
 
-	// Verify minSIMDElements was set
 	if minSIMDElements != minAVX512Elements {
 		t.Errorf("initAVX512 didn't set minSIMDElements correctly")
 	}
-
-	dotProductImpl = savedDotProduct
-	minSIMDElements = savedMinSIMD
+	if !samePointer(roundImpl, roundAVX) {
+		t.Error("initAVX512: roundImpl should route to roundAVX")
+	}
 }
 
 func TestInitAVXNoFMA(t *testing.T) {
@@ -84,35 +170,72 @@ func TestInitAVXNoFMA(t *testing.T) {
 		t.Skip("AVX not supported on this CPU")
 	}
 
-	savedDotProduct := dotProductImpl
-	savedAdd := addImpl
-	savedMinSIMD := minSIMDElements
-	t.Cleanup(func() {
-		dotProductImpl = savedDotProduct
-		addImpl = savedAdd
-		minSIMDElements = savedMinSIMD
-	})
+	saved := snapshotDispatch()
+	t.Cleanup(func() { restoreDispatch(saved) })
 
 	initAVXNoFMA()
 
-	a := []float64{1, 2, 3, 4}
-	b := []float64{4, 3, 2, 1}
-
-	// dotProduct in AVX-no-FMA mode routes to SSE2 (FMA-free).
-	if got := dotProductImpl(a, b); got != 20 {
-		t.Errorf("After initAVXNoFMA, dotProduct = %v, want 20", got)
+	// FMA-free AVX kernels stay on AVX paths.
+	for _, c := range []struct {
+		name string
+		got  interface{}
+		want interface{}
+	}{
+		{"addImpl", addImpl, addAVX},
+		{"subImpl", subImpl, subAVX},
+		{"mulImpl", mulImpl, mulAVX},
+		{"divImpl", divImpl, divAVX},
+		{"scaleImpl", scaleImpl, scaleAVX},
+		{"addScalarImpl", addScalarImpl, addScalarAVX},
+		{"sumImpl", sumImpl, sumAVX},
+		{"minImpl", minImpl, minAVX},
+		{"maxImpl", maxImpl, maxAVX},
+		{"absImpl", absImpl, absAVX},
+		{"negImpl", negImpl, negAVX},
+		{"sqrtImpl", sqrtImpl, sqrtAVX},
+		{"reciprocalImpl", reciprocalImpl, reciprocalAVX},
+		{"roundImpl", roundImpl, roundAVX},
+		{"clampImpl", clampImpl, clampAVX},
+		{"interleave2Impl", interleave2Impl, interleave2AVX},
+		{"deinterleave2Impl", deinterleave2Impl, deinterleave2AVX},
+	} {
+		if !samePointer(c.got, c.want) {
+			t.Errorf("initAVXNoFMA: %s not routed to AVX kernel", c.name)
+		}
 	}
 
-	// Non-FMA arithmetic kernels still use AVX implementations.
-	dst := make([]float64, len(a))
-	addImpl(dst, a, b)
-	for i, want := range []float64{5, 5, 5, 5} {
-		if dst[i] != want {
-			t.Errorf("After initAVXNoFMA, add[%d] = %v, want %v", i, dst[i], want)
+	// FMA-dependent kernels fall back to SSE2/scalar variants.
+	for _, c := range []struct {
+		name string
+		got  interface{}
+		want interface{}
+	}{
+		{"dotProductImpl", dotProductImpl, dotProductSSE2},
+		{"fmaImpl", fmaImpl, fmaSSE2},
+		{"varianceImpl", varianceImpl, varianceSSE2},
+		{"euclideanDistanceImpl", euclideanDistanceImpl, euclideanDistanceSSE2},
+		{"addScaledImpl", addScaledImpl, addScaledSSE2},
+	} {
+		if !samePointer(c.got, c.want) {
+			t.Errorf("initAVXNoFMA: %s should fall back to SSE2 (FMA-free)", c.name)
 		}
 	}
 
 	if minSIMDElements != minAVXElements {
 		t.Errorf("initAVXNoFMA: minSIMDElements = %d, want %d", minSIMDElements, minAVXElements)
+	}
+
+	// Sanity check the kernels still produce correct values.
+	a := []float64{1, 2, 3, 4}
+	b := []float64{4, 3, 2, 1}
+	if got := dotProductImpl(a, b); got != 20 {
+		t.Errorf("dotProductImpl(a,b) = %v, want 20", got)
+	}
+	dst := make([]float64, len(a))
+	addImpl(dst, a, b)
+	for i, want := range []float64{5, 5, 5, 5} {
+		if dst[i] != want {
+			t.Errorf("addImpl[%d] = %v, want %v", i, dst[i], want)
+		}
 	}
 }

--- a/f64/go_impl_amd64_test.go
+++ b/f64/go_impl_amd64_test.go
@@ -65,7 +65,7 @@ func snapshotDispatch() implSnapshot {
 	}
 }
 
-func restoreDispatch(s implSnapshot) {
+func restoreDispatch(s *implSnapshot) {
 	dotProductImpl = s.dotProduct
 	addImpl = s.add
 	subImpl = s.sub
@@ -91,7 +91,7 @@ func restoreDispatch(s implSnapshot) {
 	minSIMDElements = s.minSIMDElements
 }
 
-func samePointer(a, b interface{}) bool {
+func samePointer(a, b any) bool {
 	return reflect.ValueOf(a).Pointer() == reflect.ValueOf(b).Pointer()
 }
 
@@ -100,7 +100,7 @@ func samePointer(a, b interface{}) bool {
 
 func TestInitGo(t *testing.T) {
 	saved := snapshotDispatch()
-	t.Cleanup(func() { restoreDispatch(saved) })
+	t.Cleanup(func() { restoreDispatch(&saved) })
 
 	initGo()
 
@@ -119,7 +119,7 @@ func TestInitGo(t *testing.T) {
 
 func TestInitSSE2(t *testing.T) {
 	saved := snapshotDispatch()
-	t.Cleanup(func() { restoreDispatch(saved) })
+	t.Cleanup(func() { restoreDispatch(&saved) })
 
 	initSSE2()
 
@@ -142,7 +142,7 @@ func TestInitAVX512(t *testing.T) {
 	}
 
 	saved := snapshotDispatch()
-	t.Cleanup(func() { restoreDispatch(saved) })
+	t.Cleanup(func() { restoreDispatch(&saved) })
 
 	initAVX512()
 
@@ -171,15 +171,15 @@ func TestInitAVXNoFMA(t *testing.T) {
 	}
 
 	saved := snapshotDispatch()
-	t.Cleanup(func() { restoreDispatch(saved) })
+	t.Cleanup(func() { restoreDispatch(&saved) })
 
 	initAVXNoFMA()
 
 	// FMA-free AVX kernels stay on AVX paths.
 	for _, c := range []struct {
 		name string
-		got  interface{}
-		want interface{}
+		got  any
+		want any
 	}{
 		{"addImpl", addImpl, addAVX},
 		{"subImpl", subImpl, subAVX},
@@ -207,8 +207,8 @@ func TestInitAVXNoFMA(t *testing.T) {
 	// FMA-dependent kernels fall back to SSE2/scalar variants.
 	for _, c := range []struct {
 		name string
-		got  interface{}
-		want interface{}
+		got  any
+		want any
 	}{
 		{"dotProductImpl", dotProductImpl, dotProductSSE2},
 		{"fmaImpl", fmaImpl, fmaSSE2},

--- a/f64/go_impl_amd64_test.go
+++ b/f64/go_impl_amd64_test.go
@@ -76,3 +76,43 @@ func TestInitAVX512(t *testing.T) {
 	dotProductImpl = savedDotProduct
 	minSIMDElements = savedMinSIMD
 }
+
+func TestInitAVXNoFMA(t *testing.T) {
+	// initAVXNoFMA assigns AVX kernels (e.g. addAVX) to the global impl pointers.
+	// Skip on CPUs without AVX so calling addImpl after init can't SIGILL.
+	if !cpu.X86.AVX {
+		t.Skip("AVX not supported on this CPU")
+	}
+
+	savedDotProduct := dotProductImpl
+	savedAdd := addImpl
+	savedMinSIMD := minSIMDElements
+	t.Cleanup(func() {
+		dotProductImpl = savedDotProduct
+		addImpl = savedAdd
+		minSIMDElements = savedMinSIMD
+	})
+
+	initAVXNoFMA()
+
+	a := []float64{1, 2, 3, 4}
+	b := []float64{4, 3, 2, 1}
+
+	// dotProduct in AVX-no-FMA mode routes to SSE2 (FMA-free).
+	if got := dotProductImpl(a, b); got != 20 {
+		t.Errorf("After initAVXNoFMA, dotProduct = %v, want 20", got)
+	}
+
+	// Non-FMA arithmetic kernels still use AVX implementations.
+	dst := make([]float64, len(a))
+	addImpl(dst, a, b)
+	for i, want := range []float64{5, 5, 5, 5} {
+		if dst[i] != want {
+			t.Errorf("After initAVXNoFMA, add[%d] = %v, want %v", i, dst[i], want)
+		}
+	}
+
+	if minSIMDElements != minAVXElements {
+		t.Errorf("initAVXNoFMA: minSIMDElements = %d, want %d", minSIMDElements, minAVXElements)
+	}
+}

--- a/f64/go_impl_newops_test.go
+++ b/f64/go_impl_newops_test.go
@@ -1,0 +1,142 @@
+package f64
+
+import (
+	"math"
+	"testing"
+)
+
+// These tests exercise the Go fallback implementations and the BCE-hint
+// guard branches that aren't normally hit on AVX/NEON-capable test hosts.
+
+func TestRound64Go(t *testing.T) {
+	src := []float64{-2.5, -1.5, -0.5, 0.4, 0.5, 1.5, 2.5}
+	dst := make([]float64, len(src))
+	round64Go(dst, src)
+	for i, v := range src {
+		want := math.Round(v)
+		if dst[i] != want {
+			t.Errorf("round64Go[%d](%v) = %v, want %v", i, v, dst[i], want)
+		}
+	}
+}
+
+func TestSubFromScalarGo(t *testing.T) {
+	a := []float64{1, -2, 3.5}
+	dst := make([]float64, len(a))
+	subFromScalarGo(dst, a, 7.0)
+	want := []float64{6, 9, 3.5}
+	for i := range dst {
+		if dst[i] != want[i] {
+			t.Errorf("subFromScalarGo[%d] = %v, want %v", i, dst[i], want[i])
+		}
+	}
+}
+
+// emptyDstGuards verifies that every BCE-hint-guarded Go fallback returns
+// safely (no panic) when len(dst) == 0, even with a non-empty src argument.
+// This exercises the `if len(dst) == 0 { return }` branch that's otherwise
+// only hit at boundaries.
+func TestGoFallbacks_EmptyDst(_ *testing.T) {
+	src := []float64{1, 2, 3}
+	dst := []float64{}
+
+	addGo(dst, src, src)
+	subGo(dst, src, src)
+	mulGo(dst, src, src)
+	divGo(dst, src, src)
+	scaleGo(dst, src, 2)
+	addScalarGo(dst, src, 1)
+	subFromScalarGo(dst, src, 1)
+	absGo(dst, src)
+	negGo(dst, src)
+	fmaGo(dst, src, src, src)
+	clampGo(dst, src, 0, 1)
+	sqrt64Go(dst, src)
+	round64Go(dst, src)
+	reciprocal64Go(dst, src)
+	addScaledGo64(dst, 1, src)
+	sigmoid64Go(dst, src)
+	relu64Go(dst, src)
+	clampScale64Go(dst, src, 0, 1, 1)
+	tanh64Go(dst, src)
+	exp64Go(dst, src)
+}
+
+func TestRound64Go_EmptyDst(_ *testing.T) {
+	// Hit the BCE-hint empty-slice branch with len(src) != 0.
+	round64Go(nil, []float64{1, 2})
+}
+
+func TestSubFromScalarGo_EmptyDst(_ *testing.T) {
+	subFromScalarGo(nil, []float64{1, 2}, 0)
+}
+
+// TestSigmoid64Go_Saturation hits both saturation branches (x > +threshold
+// and x < -threshold) in the new BCE-hinted sigmoid64Go fallback.
+func TestSigmoid64Go_Saturation(t *testing.T) {
+	src := []float64{sigmoidClampThreshold + 1, -sigmoidClampThreshold - 1, 0}
+	dst := make([]float64, len(src))
+	sigmoid64Go(dst, src)
+	if dst[0] != 1.0 {
+		t.Errorf("sigmoid64Go(+large) = %v, want 1", dst[0])
+	}
+	if dst[1] != 0.0 {
+		t.Errorf("sigmoid64Go(-large) = %v, want 0", dst[1])
+	}
+	if dst[2] != 0.5 {
+		t.Errorf("sigmoid64Go(0) = %v, want 0.5", dst[2])
+	}
+}
+
+// TestExp64Go_Saturation hits the overflow / underflow clamp branches.
+func TestExp64Go_Saturation(t *testing.T) {
+	src := []float64{expOverflowThreshold + 1, -expOverflowThreshold - 1, 0}
+	dst := make([]float64, len(src))
+	exp64Go(dst, src)
+	if dst[0] != math.Exp(expOverflowThreshold) {
+		t.Errorf("exp64Go(+large) = %v, want exp(709)", dst[0])
+	}
+	if dst[1] != 0.0 {
+		t.Errorf("exp64Go(-large) = %v, want 0", dst[1])
+	}
+	if dst[2] != 1.0 {
+		t.Errorf("exp64Go(0) = %v, want 1", dst[2])
+	}
+}
+
+func TestRelu64Go(t *testing.T) {
+	src := []float64{-1, 0, 1, 2.5}
+	dst := make([]float64, len(src))
+	relu64Go(dst, src)
+	want := []float64{0, 0, 1, 2.5}
+	for i := range dst {
+		if dst[i] != want[i] {
+			t.Errorf("relu64Go[%d] = %v, want %v", i, dst[i], want[i])
+		}
+	}
+}
+
+func TestClampScale64Go(t *testing.T) {
+	src := []float64{-2, 0.5, 5}
+	dst := make([]float64, len(src))
+	clampScale64Go(dst, src, 0, 1, 2)
+	want := []float64{0, 1, 2}
+	for i := range dst {
+		if dst[i] != want[i] {
+			t.Errorf("clampScale64Go[%d] = %v, want %v", i, dst[i], want[i])
+		}
+	}
+}
+
+func TestTanh64Go(t *testing.T) {
+	src := []float64{-1, 0, 1}
+	dst := make([]float64, len(src))
+	tanh64Go(dst, src)
+	for i, v := range src {
+		want := math.Tanh(v)
+		if math.Abs(dst[i]-want) > 1e-12 {
+			t.Errorf("tanh64Go[%d] = %v, want %v", i, dst[i], want)
+		}
+	}
+}
+

--- a/f64/newops_test.go
+++ b/f64/newops_test.go
@@ -1,0 +1,76 @@
+package f64
+
+import (
+	"math"
+	"testing"
+)
+
+func TestSubFromScalar(t *testing.T) {
+	src := []float64{1, -2, 3.5, 10}
+	dst := make([]float64, len(src))
+	SubFromScalar(dst, src, 7.0)
+
+	want := []float64{6, 9, 3.5, -3}
+	for i := range dst {
+		if dst[i] != want[i] {
+			t.Errorf("SubFromScalar()[%d] = %v, want %v", i, dst[i], want[i])
+		}
+	}
+}
+
+func TestSubFromScalar_EmptySlices(t *testing.T) {
+	SubFromScalar(nil, nil, 1)
+	SubFromScalar([]float64{}, []float64{1, 2}, 1)
+	SubFromScalar([]float64{1, 2}, nil, 1)
+}
+
+func TestSubFromScalar_LongerInputs(t *testing.T) {
+	for _, n := range []int{1, 3, 4, 7, 8, 15, 16, 17, 31, 32, 33, 64, 65, 127, 128} {
+		src := make([]float64, n)
+		for i := range src {
+			src[i] = float64(i) - 50
+		}
+		dst := make([]float64, n)
+		SubFromScalar(dst, src, 3.5)
+		for i, v := range src {
+			want := 3.5 - v
+			if math.Abs(dst[i]-want) > 1e-12 {
+				t.Fatalf("n=%d: SubFromScalar[%d]=%v, want %v", n, i, dst[i], want)
+			}
+		}
+	}
+}
+
+func TestWeightedSum(t *testing.T) {
+	weights := []float64{0.5, -1, 2, 0.25}
+	src := []float64{8, 3, -2, 4}
+
+	got := WeightedSum(weights, src)
+	want := 0.5*8 + (-1)*3 + 2*(-2) + 0.25*4
+	if got != want {
+		t.Errorf("WeightedSum() = %v, want %v", got, want)
+	}
+
+	if WeightedSum(nil, src) != 0 {
+		t.Errorf("WeightedSum(nil, src) should return 0")
+	}
+	if WeightedSum(weights, nil) != 0 {
+		t.Errorf("WeightedSum(w, nil) should return 0")
+	}
+}
+
+func TestSumOfSquares(t *testing.T) {
+	src := []float64{3, 4, -12}
+	got := SumOfSquares(src)
+	want := 9.0 + 16.0 + 144.0
+	if got != want {
+		t.Errorf("SumOfSquares() = %v, want %v", got, want)
+	}
+
+	if SumOfSquares(nil) != 0 {
+		t.Errorf("SumOfSquares(nil) should return 0")
+	}
+	if SumOfSquares([]float64{}) != 0 {
+		t.Errorf("SumOfSquares([]) should return 0")
+	}
+}

--- a/f64/newops_test.go
+++ b/f64/newops_test.go
@@ -18,7 +18,7 @@ func TestSubFromScalar(t *testing.T) {
 	}
 }
 
-func TestSubFromScalar_EmptySlices(t *testing.T) {
+func TestSubFromScalar_EmptySlices(_ *testing.T) {
 	SubFromScalar(nil, nil, 1)
 	SubFromScalar([]float64{}, []float64{1, 2}, 1)
 	SubFromScalar([]float64{1, 2}, nil, 1)

--- a/f64/round_test.go
+++ b/f64/round_test.go
@@ -36,7 +36,7 @@ func TestRound_SpecialValues(t *testing.T) {
 	}
 }
 
-func TestRound_EmptySlices(t *testing.T) {
+func TestRound_EmptySlices(_ *testing.T) {
 	Round(nil, nil)
 	Round([]float64{}, []float64{1, 2, 3})
 	Round([]float64{1, 2, 3}, nil)

--- a/f64/round_test.go
+++ b/f64/round_test.go
@@ -1,0 +1,60 @@
+package f64
+
+import (
+	"math"
+	"testing"
+)
+
+func TestRound(t *testing.T) {
+	src := []float64{-2.5, -1.5, -0.5, 0.4, 0.5, 1.5, 2.5, 3.49, 3.5}
+	dst := make([]float64, len(src))
+
+	Round(dst, src)
+
+	for i := range src {
+		want := math.Round(src[i])
+		if dst[i] != want {
+			t.Errorf("Round()[%d] = %v, want %v", i, dst[i], want)
+		}
+	}
+}
+
+func TestRound_SpecialValues(t *testing.T) {
+	src := []float64{math.NaN(), math.Inf(1), math.Inf(-1)}
+	dst := make([]float64, len(src))
+
+	Round(dst, src)
+
+	if !math.IsNaN(dst[0]) {
+		t.Errorf("Round(NaN) = %v, want NaN", dst[0])
+	}
+	if !math.IsInf(dst[1], 1) {
+		t.Errorf("Round(+Inf) = %v, want +Inf", dst[1])
+	}
+	if !math.IsInf(dst[2], -1) {
+		t.Errorf("Round(-Inf) = %v, want -Inf", dst[2])
+	}
+}
+
+func TestRound_EmptySlices(t *testing.T) {
+	Round(nil, nil)
+	Round([]float64{}, []float64{1, 2, 3})
+	Round([]float64{1, 2, 3}, nil)
+}
+
+func TestRound_LongerInputs(t *testing.T) {
+	for _, n := range []int{1, 3, 4, 7, 8, 15, 16, 17, 31, 32, 33, 64, 65, 127, 128} {
+		src := make([]float64, n)
+		for i := range src {
+			src[i] = float64(i)*0.5 - 4
+		}
+		dst := make([]float64, n)
+		Round(dst, src)
+		for i, v := range src {
+			want := math.Round(v)
+			if dst[i] != want {
+				t.Fatalf("n=%d: Round[%d]=%v, want %v", n, i, dst[i], want)
+			}
+		}
+	}
+}

--- a/f64/round_test.go
+++ b/f64/round_test.go
@@ -42,6 +42,38 @@ func TestRound_EmptySlices(t *testing.T) {
 	Round([]float64{1, 2, 3}, nil)
 }
 
+func TestRound_FPEdgeCases(t *testing.T) {
+	// Inputs that would break a naive trunc(abs(x)+0.5) implementation
+	// because abs(x)+0.5 rounds to a value whose trunc is one too large.
+	belowHalf := math.Nextafter(0.5, 0)              // largest float < 0.5
+	negBelowHalf := math.Nextafter(-0.5, 0)          // smallest-magnitude float > -0.5
+	belowOneHalf := math.Nextafter(1.5, 1)           // largest float < 1.5
+	negBelowOneHalf := math.Nextafter(-1.5, -1)      // smallest-magnitude float > -1.5
+
+	src := []float64{
+		belowHalf,
+		negBelowHalf,
+		belowOneHalf,
+		negBelowOneHalf,
+		0.5,
+		-0.5,
+		1.5,
+		-1.5,
+		math.Copysign(0, 1),
+		math.Copysign(0, -1),
+	}
+	dst := make([]float64, len(src))
+	Round(dst, src)
+
+	for i, v := range src {
+		want := math.Round(v)
+		if dst[i] != want || math.Signbit(dst[i]) != math.Signbit(want) {
+			t.Errorf("Round(%g)=%g (signbit=%v), want %g (signbit=%v)",
+				v, dst[i], math.Signbit(dst[i]), want, math.Signbit(want))
+		}
+	}
+}
+
 func TestRound_LongerInputs(t *testing.T) {
 	for _, n := range []int{1, 3, 4, 7, 8, 15, 16, 17, 31, 32, 33, 64, 65, 127, 128} {
 		src := make([]float64, n)


### PR DESCRIPTION
## Summary

Cherry-picks the verified-good portions of PR #15 onto current main, with the FMA operand-order bug fixed and several correctness/hygiene issues caught during pre-push review addressed.

PR #15 had several real wins but mixed in regressions, dead code, and doc rollbacks that conflict with already-merged PRs (#16, #18). This branch keeps the wins, drops the regressions, and fixes the bugs.

### Performance wins (verified on i7-1260P AVX+FMA + rpi5 Cortex-A76)

| Operation | Before | After | Notes |
|-----------|--------|-------|-------|
| `c128.Abs` SIMD (AMD64, n=1024) | 1823 ns/op | 768 ns/op | absAVX 1→2 elems/iter, absAVX512 2→4 elems/iter |
| `f64.CubicInterpDot` AVX (n=1000) | 232 ns/op | 148 ns/op | Multi-stage Horner with 4 independent accumulators |
| `f32.CubicInterpDot` AVX (n=1000) | 83 ns/op | 77 ns/op | Two-chain interleave inside loop16 |
| `f64.Round` SIMD vs scalar loop (n=1024) | 1452 ns/op | 249 ns/op | New op; AVX VROUNDPD + NEON FRINTA |
| `f64.SubFromScalar` vs scalar loop (n=1024) | 363 ns/op | 189 ns/op | Composed neg+addScalar (no new asm) |

ARM64 cubic interp benchmarks are unchanged (Cortex-A76 already extracts ILP from the single-chain Horner).

### New helpers

- `f64.Round(dst, src)` - half-away-from-zero (`math.Round` semantics), AVX/NEON/Go fallback
- `f64.SubFromScalar(dst, a, s)` - `s - a[i]`, composed via existing neg + addScalar primitives
- `f64.WeightedSum(weights, src)` - alias for `DotProduct` for self-documenting call sites
- `f64.SumOfSquares(src)` - `DotProduct(src, src)`

### Dispatch

- New `initAVXNoFMA` path keeps FMA-free AVX kernels on AVX paths for rare AVX-only CPUs (early Sandy/Ivy Bridge, some Atom/Pentium SKUs) instead of falling all the way to SSE2.
- `sigmoid64` dropped its incorrect `cpu.X86.FMA` requirement (sigmoidAVX uses VMULPD/VADDPD/VDIVPD only - no FMA).
- `subFromScalar64` dropped redundant outer CPU/length guards; the composed `neg64 + addScalar` already dispatches via global impl pointers with proper Go fallbacks.

### Critical bug fixed (vs PR #15's original draft)

PR #15's cubic AVX multi-stage Horner had the FMA operand order reversed in stages 2 and 3 (`VFMADD213PD Y7, Y5, Y1` with Y7=x broadcast as the addend instead of the multiplicand), so it computed `Y1 = b*(c+xd) + x` instead of `Y1 = b + x*(c+xd)`. All cubic interp tests failed on AMD64 in PR #15; corrected here using `VFMADD213PD Y5, Y7, Y1`.

ARM64 NEON cubic was already correct (FMLA semantics differ).

### Critical bug fixed (introduced by this branch, caught by /gate review)

The first version of `roundAVX` computed `trunc(|x| + 0.5)` then restored the sign. For `x = math.Nextafter(0.5, 0) = 0.49999999999999994`, the FP add rounds `|x| + 0.5` up to exactly 1.0, so trunc returns 1 even though `math.Round` returns 0. Replaced with `t = trunc(x); inc = (|x-t| >= 0.5) ? copysign(1, x) : 0; result = t + inc`. Verified against `math.Round` across 17 817 random + edge-case inputs.

### Defensive hygiene

- Bound-check hint pattern (`if len(dst) == 0 { return }; _ = a[len(dst)-1]`) applied across all `*Go` fallbacks in c128, c64, f16, f32, f64. Lets the compiler hoist per-iteration bounds checks out of hot loops.
- `TestInitAVX512/SSE2/Go/AVXNoFMA` rewritten with `snapshotDispatch`/`restoreDispatch`/`samePointer` helpers so test failures cannot leak dispatch state into later tests, and every init path's `roundImpl` assignment is verified by function-pointer identity (not just the numerical result).

### Intentionally NOT cherry-picked from PR #15

- `Sin`/`Cos`/`SinCos` - the Go-composed pipeline runs 2-7x slower than `math.Sin` in a loop; the assembly `sinCosAVX`/`sinCosNEON` ship as dead code.
- `Gather`/`Scatter` - dispatcher does an O(n) bounds-check pass in Go before calling the SIMD kernel, so they're slower than a scalar Go loop on both arches.
- `Min`/`Max` NaN-propagation doc rewrite and `TestMinMax_SpecialValues` - directly conflicts with #18, which correctly documented the architecture-dependent SIMD behavior; PR #15's test also fails on AMD64 because SIMD VMAXPD/VMINPD don't propagate NaN.
- `DotProductUnsafe` doc rollback - conflicts with #16's fix.
- f16 ARM64 dot product FP32-widen-then-mul - fixes a real overflow (300*300 = Inf in native FP16) but costs 1.8x throughput. Tracked separately as #22 with proposed opt-in `DotProductF32` API.

### Related issues

Follow-ups filed during review:
- #22 - f16 DotProduct overflow on ARM64 (opt-in DotProductF32 proposal)
- #23 - c128 AbsSq SIMD loops not widened the same way as Abs
- #24 - c128 missing initAVXNoFMA dispatch path
- #25 - f16 minGo/maxGo/minIdxGo/maxIdxGo panic on empty slice

Credit to @TheApeMachine for the original PR #15 proposal.

## Test plan

- [x] \`go test -race ./...\` passes on AMD64 (i7-1260P, AVX+FMA, no AVX-512) — 1750 tests
- [x] \`go test ./...\` passes on ARM64 (rpi5, Cortex-A76) — same count
- [x] roundAVX fuzzed against \`math.Round\` across 17 817 random + edge-case inputs (0 mismatches)
- [x] c128 Abs SIMD benchmark confirms ~2.4x speedup vs main
- [x] f64 cubic interp benchmark confirms ~1.6x speedup vs main
- [x] All cubic interp test cases pass (PR #15's broken FMA order produced 7-500x error)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added four new float64 operations: `WeightedSum`, `SumOfSquares`, `SubFromScalar`, and `Round` for enhanced numerical computation capabilities.

* **Performance Improvements**
  * Optimized magnitude computations and rounding operations across architectures with improved SIMD implementations.
  * Enhanced bounds checking in fallback routines for better compiler optimization.

* **Documentation**
  * Updated feature table in README with newly supported operations.

* **Tests**
  * Added comprehensive test coverage for new float64 operations.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/tphakala/simd/pull/26?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->