### PR TITLE
fix(f16): add DotProductF32 + empty-slice guards (#22, #25)

### DIFF
--- a/README.md
+++ b/README.md
@@ -190,6 +190,7 @@ f16.ReLU(dst, a)             // Activation functions
 |                 | `Sqrt(dst, a)`                      | Square root                   | 8x (NEON+FP16)   |
 |                 | `Reciprocal(dst, a)`                | Reciprocal (1/x)              | 8x (NEON+FP16)   |
 | **Reduction**   | `DotProduct(a, b)` → float32        | Dot product                   | 8x (NEON+FP16)   |
+|                 | `DotProductF32(a, b)` → float32     | Dot product (FP32 widen)      | 8x (NEON+FP32)   |
 |                 | `Sum(a)` → float32                  | Sum of elements               | 8x (NEON+FP16)   |
 |                 | `Min(a)`                            | Minimum value                 | 8x (NEON+FP16)   |
 |                 | `Max(a)`                            | Maximum value                 | 8x (NEON+FP16)   |
@@ -219,6 +220,7 @@ f16.ReLU(dst, a)             // Activation functions
 - **Precision**: ~3.3 decimal digits, range ~6×10⁻⁸ to 65504
 - **Reductions**: Accumulate in float32 for numerical stability
 - **Memory efficiency**: 2x bandwidth vs float32 (8 elements per 128-bit NEON vector)
+- **DotProduct saturation**: On ARM64 with FP16 SIMD, `DotProduct` computes per-element products in FP16 and saturates to ±Inf when `|a[i] * b[i]| > 65504`. Use `DotProductF32` (FP32 widening before multiply, ~1.5-2x slower) for audio DSP or raw-signal inputs that can produce out-of-range products.
 
 **Hardware requirements:**
 

--- a/f16/benchmark_test.go
+++ b/f16/benchmark_test.go
@@ -93,6 +93,37 @@ func BenchmarkDotProduct(b *testing.B) {
 	}
 }
 
+// BenchmarkDotProductF32 measures the FP32-widened DotProduct variant
+// against the native (potentially-saturating) DotProduct and the pure-Go
+// reference. On ARM64 with asimdhp, Native uses dotProductNEON (FP16 FMUL)
+// while F32Wide uses dotProductWideNEON (FP32 FMLA after widening). On
+// AMD64 both F32Wide and Native call dotProductGo, so they should report
+// near-identical times.
+func BenchmarkDotProductF32(b *testing.B) {
+	for _, size := range benchSizes {
+		a16, b16, _, _ := makeBenchDataF16(size)
+
+		b.Run(fmt.Sprintf("F32Wide_%d", size), func(b *testing.B) {
+			for i := 0; i < b.N; i++ {
+				sink32 = DotProductF32(a16, b16)
+			}
+			reportThroughput16(b, size*2)
+		})
+		b.Run(fmt.Sprintf("Native_%d", size), func(b *testing.B) {
+			for i := 0; i < b.N; i++ {
+				sink32 = DotProduct(a16, b16)
+			}
+			reportThroughput16(b, size*2)
+		})
+		b.Run(fmt.Sprintf("F16_Go_%d", size), func(b *testing.B) {
+			for i := 0; i < b.N; i++ {
+				sink32 = dotProductGo(a16, b16)
+			}
+			reportThroughput16(b, size*2)
+		})
+	}
+}
+
 // =============================================================================
 // Element-wise Binary Operations
 // =============================================================================

--- a/f16/f16.go
+++ b/f16/f16.go
@@ -189,17 +189,19 @@ func Sigmoid(dst, src []Float16) {
 }
 
 // Min returns the minimum value.
+// Returns +Inf for empty slices.
 func Min(a []Float16) Float16 {
 	if len(a) == 0 {
-		return fromFloat32Go(float32(math.Inf(1)))
+		return fp16Infinity
 	}
 	return min16(a)
 }
 
 // Max returns the maximum value.
+// Returns -Inf for empty slices.
 func Max(a []Float16) Float16 {
 	if len(a) == 0 {
-		return fromFloat32Go(float32(math.Inf(-1)))
+		return fp16Infinity | fp16SignMask
 	}
 	return max16(a)
 }

--- a/f16/f16.go
+++ b/f16/f16.go
@@ -66,12 +66,36 @@ func FromFloat32Slice(dst []Float16, src []float32) {
 // Returns sum(a[i] * b[i]) for i in 0..min(len(a), len(b)).
 // Accumulates in float32 for numerical stability.
 //
-// Uses native FP16 SIMD on ARM64 with FP16 support.
+// Uses native FP16 SIMD on ARM64 with FP16 support. On ARM64 with FP16
+// SIMD, intermediate products are computed in FP16 and may saturate to
+// ±Inf when |a[i] * b[i]| > 65504. Use DotProductF32 if the dynamic range
+// of your inputs can produce such products.
 func DotProduct(a, b []Float16) float32 {
 	if len(a) == 0 || len(b) == 0 {
 		return 0
 	}
 	return dotProduct(a, b)
+}
+
+// DotProductF32 computes the dot product with FP32 widening before multiply.
+//
+// Unlike DotProduct, intermediate products do not saturate when |a[i] * b[i]|
+// exceeds the FP16 representable maximum (~65504). The cost on ARM64 with
+// native FP16 SIMD is roughly 1.5-2x more work than DotProduct.
+//
+// Use this for audio/signal-processing inputs whose per-element products may
+// fall outside the FP16 range. For ML workloads with inputs normalized to
+// [-1, 1], DotProduct is faster with equivalent accuracy on every supported
+// platform.
+//
+// Returns sum(float32(a[i]) * float32(b[i])) for i in 0..min(len(a), len(b)),
+// or 0 if either slice is empty. Accumulates in float32 for numerical
+// stability.
+func DotProductF32(a, b []Float16) float32 {
+	if len(a) == 0 || len(b) == 0 {
+		return 0
+	}
+	return dotProductF32(a, b)
 }
 
 // Add computes element-wise addition: dst[i] = a[i] + b[i].

--- a/f16/f16_arm64.go
+++ b/f16/f16_arm64.go
@@ -60,10 +60,15 @@ func dotProduct(a, b []Float16) float32 {
 }
 
 func dotProductF32(a, b []Float16) float32 {
-	// Task 3 will swap this to a NEON kernel that widens FP16 to FP32 first.
-	// For now, the Go fallback already widens before multiplying, so it
-	// gives the right answer on every input, just slower than the eventual
-	// NEON path.
+	n := min(len(a), len(b))
+	if hasFP16 && n >= neonWidth {
+		// Process vectorized portion
+		nVec := (n / neonWidth) * neonWidth
+		result := dotProductWideNEON(a[:nVec], b[:nVec])
+		// Handle remainder with Go
+		result += dotProductGo(a[nVec:n], b[nVec:n])
+		return result
+	}
 	return dotProductGo(a, b)
 }
 
@@ -345,6 +350,9 @@ func fromFloat32SliceNEON(dst []Float16, src []float32)
 
 //go:noescape
 func dotProductNEON(a, b []Float16) float32
+
+//go:noescape
+func dotProductWideNEON(a, b []Float16) float32
 
 //go:noescape
 func addNEON(dst, a, b []Float16)

--- a/f16/f16_arm64.go
+++ b/f16/f16_arm64.go
@@ -59,6 +59,14 @@ func dotProduct(a, b []Float16) float32 {
 	return dotProductGo(a, b)
 }
 
+func dotProductF32(a, b []Float16) float32 {
+	// Task 3 will swap this to a NEON kernel that widens FP16 to FP32 first.
+	// For now, the Go fallback already widens before multiplying, so it
+	// gives the right answer on every input, just slower than the eventual
+	// NEON path.
+	return dotProductGo(a, b)
+}
+
 func add(dst, a, b []Float16) {
 	n := len(dst)
 	if hasFP16 && n >= neonWidth {

--- a/f16/f16_arm64.s
+++ b/f16/f16_arm64.s
@@ -133,6 +133,52 @@ dot16_reduce:
     FMOVS F4, ret+48(FP)
     RET
 
+// func dotProductWideNEON(a, b []Float16) float32
+// FP32-widened dot product: each FP16 lane is widened to FP32 BEFORE the
+// multiply, so |a[i] * b[i]| > 65504 does not saturate. Length must be a
+// multiple of 8 (caller guarantees via dispatch).
+TEXT ·dotProductWideNEON(SB), NOSPLIT, $0-52
+    MOVD a_base+0(FP), R0
+    MOVD a_len+8(FP), R2
+    MOVD b_base+24(FP), R1
+
+    // Zero accumulators (4 FP32 each)
+    VEOR V4.B16, V4.B16, V4.B16
+    VEOR V5.B16, V5.B16, V5.B16
+
+    LSR $3, R2, R3
+    CBZ R3, dotF32_reduce
+
+dotF32_loop8:
+    VLD1 (R0), [V0.H8]          // Load 8 FP16 from a
+    ADD $16, R0
+    VLD1 (R1), [V1.H8]          // Load 8 FP16 from b
+    ADD $16, R1
+
+    // Widen to FP32 BEFORE multiplying. Each FCVTL/FCVTL2 expands 4 FP16
+    // lanes into 4 FP32 lanes.
+    WORD $0x0E217802            // FCVTL  V2.4S, V0.4H (a lower)
+    WORD $0x4E217803            // FCVTL2 V3.4S, V0.8H (a upper)
+    WORD $0x0E217826            // FCVTL  V6.4S, V1.4H (b lower)
+    WORD $0x4E217827            // FCVTL2 V7.4S, V1.8H (b upper)
+
+    // Fused multiply-add in FP32: V4 += V2*V6 ; V5 += V3*V7
+    WORD $0x4E26CC44            // FMLA V4.4S, V2.4S, V6.4S
+    WORD $0x4E27CC65            // FMLA V5.4S, V3.4S, V7.4S
+
+    SUB $1, R3
+    CBNZ R3, dotF32_loop8
+
+    // Combine accumulators
+    WORD $0x4E25D484            // FADD V4.4S, V4.4S, V5.4S
+
+dotF32_reduce:
+    // Horizontal sum of V4.4S -> S4
+    WORD $0x6E24D484            // FADDP V4.4S, V4.4S, V4.4S
+    WORD $0x7E30D884            // FADDP S4, V4.2S
+    FMOVS F4, ret+48(FP)
+    RET
+
 // func addNEON(dst, a, b []Float16)
 // Length must be multiple of 8.
 TEXT ·addNEON(SB), NOSPLIT, $0-72

--- a/f16/f16_go.go
+++ b/f16/f16_go.go
@@ -295,6 +295,9 @@ func sigmoidGo(dst, src []Float16) {
 
 // minGo returns the minimum value.
 func minGo(a []Float16) Float16 {
+	if len(a) == 0 {
+		return fromFloat32Go(float32(math.Inf(1)))
+	}
 	minVal := a[0]
 	minF := toFloat32Go(minVal)
 	for i := 1; i < len(a); i++ {
@@ -309,6 +312,9 @@ func minGo(a []Float16) Float16 {
 
 // maxGo returns the maximum value.
 func maxGo(a []Float16) Float16 {
+	if len(a) == 0 {
+		return fromFloat32Go(float32(math.Inf(-1)))
+	}
 	maxVal := a[0]
 	maxF := toFloat32Go(maxVal)
 	for i := 1; i < len(a); i++ {
@@ -409,7 +415,11 @@ func tanhGo(dst, src []Float16) {
 }
 
 // minIdxGo returns the index of the minimum value.
+// Returns -1 for empty slices.
 func minIdxGo(a []Float16) int {
+	if len(a) == 0 {
+		return -1
+	}
 	minIdx := 0
 	minF := toFloat32Go(a[0])
 	for i := 1; i < len(a); i++ {
@@ -423,7 +433,11 @@ func minIdxGo(a []Float16) int {
 }
 
 // maxIdxGo returns the index of the maximum value.
+// Returns -1 for empty slices.
 func maxIdxGo(a []Float16) int {
+	if len(a) == 0 {
+		return -1
+	}
 	maxIdx := 0
 	maxF := toFloat32Go(a[0])
 	for i := 1; i < len(a); i++ {

--- a/f16/f16_go.go
+++ b/f16/f16_go.go
@@ -294,9 +294,10 @@ func sigmoidGo(dst, src []Float16) {
 }
 
 // minGo returns the minimum value.
+// Returns +Inf (FP16 0x7C00) for empty slices.
 func minGo(a []Float16) Float16 {
 	if len(a) == 0 {
-		return fromFloat32Go(float32(math.Inf(1)))
+		return fp16Infinity
 	}
 	minVal := a[0]
 	minF := toFloat32Go(minVal)
@@ -311,9 +312,10 @@ func minGo(a []Float16) Float16 {
 }
 
 // maxGo returns the maximum value.
+// Returns -Inf (FP16 0xFC00) for empty slices.
 func maxGo(a []Float16) Float16 {
 	if len(a) == 0 {
-		return fromFloat32Go(float32(math.Inf(-1)))
+		return fp16Infinity | fp16SignMask
 	}
 	maxVal := a[0]
 	maxF := toFloat32Go(maxVal)

--- a/f16/f16_other.go
+++ b/f16/f16_other.go
@@ -22,6 +22,10 @@ func dotProduct(a, b []Float16) float32 {
 	return dotProductGo(a, b)
 }
 
+func dotProductF32(a, b []Float16) float32 {
+	return dotProductGo(a, b)
+}
+
 func add(dst, a, b []Float16) {
 	addGo(dst, a, b)
 }

--- a/f16/f16_test.go
+++ b/f16/f16_test.go
@@ -494,11 +494,12 @@ func TestSigmoid(t *testing.T) {
 // Edge Case Tests
 // =============================================================================
 
-func TestEmptySlices(_ *testing.T) {
+func TestEmptySlices(t *testing.T) {
 	// These should not panic
 	var empty []Float16
 
 	DotProduct(empty, empty)
+	DotProductF32(empty, empty)
 	Add(empty, empty, empty)
 	Sub(empty, empty, empty)
 	Mul(empty, empty, empty)
@@ -510,6 +511,20 @@ func TestEmptySlices(_ *testing.T) {
 	ReLU(empty, empty)
 	Sigmoid(empty, empty)
 	Mean(empty)
+
+	// Reductions with sentinel returns on empty input.
+	if got := Min(empty); got != 0x7C00 {
+		t.Errorf("Min(empty): got 0x%04X, want 0x7C00 (+Inf)", got)
+	}
+	if got := Max(empty); got != 0xFC00 {
+		t.Errorf("Max(empty): got 0x%04X, want 0xFC00 (-Inf)", got)
+	}
+	if got := MinIdx(empty); got != -1 {
+		t.Errorf("MinIdx(empty): got %d, want -1", got)
+	}
+	if got := MaxIdx(empty); got != -1 {
+		t.Errorf("MaxIdx(empty): got %d, want -1", got)
+	}
 
 	var emptyF32 []float32
 	var emptyF16 []Float16

--- a/f16/f16_test.go
+++ b/f16/f16_test.go
@@ -1149,23 +1149,6 @@ func TestMaxIdxGo_EmptySlice(t *testing.T) {
 	}
 }
 
-func TestDotProductF32_NoOverflow(t *testing.T) {
-	const n = 8
-	a := make([]Float16, n)
-	b := make([]Float16, n)
-	for i := range a {
-		a[i] = FromFloat32(300)
-		b[i] = FromFloat32(300)
-	}
-	got := DotProductF32(a, b)
-	// 300 is exact in FP16 (1.171875 * 2^8). Each product 300*300 = 90000
-	// overflows FP16 max (65504) but fits FP32 easily; sum is 720000.
-	const want = float32(720000)
-	if got != want {
-		t.Fatalf("DotProductF32: got %v, want %v", got, want)
-	}
-}
-
 func TestDotProductF32_MatchesGoSum(t *testing.T) {
 	sizes := []int{8, 16, 64, 256, 1024}
 	rng := rand.New(rand.NewSource(42))
@@ -1224,10 +1207,15 @@ func TestDotProductF32_TailLessThanWidth(t *testing.T) {
 	}
 }
 
-// TestDotProductF32_Repro22 reproduces the scenario from issue #22 and logs
-// both APIs for cross-platform comparison. Asserts only DotProductF32; the
-// DotProduct value is logged for the PR description (it is +Inf on ARM64
-// with native FP16 SIMD and 720000 on AMD64).
+// TestDotProductF32_Repro22 reproduces the scenario from issue #22 and
+// asserts that DotProductF32 does not saturate. 300 is exact in FP16
+// (1.171875 * 2^8), each product 300*300 = 90000 overflows FP16 max
+// (65504) but fits FP32 easily; sum of 8 products is 720000.
+//
+// Logs both APIs for cross-platform comparison: DotProduct is +Inf on
+// ARM64 with native FP16 SIMD and 720000 on AMD64 (where the Go fallback
+// already widens before multiplying). The log line is captured in PR
+// descriptions to document the platform-specific saturation.
 func TestDotProductF32_Repro22(t *testing.T) {
 	const n = 8
 	a := make([]Float16, n)

--- a/f16/f16_test.go
+++ b/f16/f16_test.go
@@ -3,6 +3,7 @@ package f16
 import (
 	"fmt"
 	"math"
+	"math/rand"
 	"testing"
 
 	"github.com/tphakala/simd/cpu"
@@ -1145,5 +1146,100 @@ func TestMinIdxGo_EmptySlice(t *testing.T) {
 func TestMaxIdxGo_EmptySlice(t *testing.T) {
 	if got := maxIdxGo(nil); got != -1 {
 		t.Errorf("maxIdxGo(nil): got %d, want -1", got)
+	}
+}
+
+func TestDotProductF32_NoOverflow(t *testing.T) {
+	const n = 8
+	a := make([]Float16, n)
+	b := make([]Float16, n)
+	for i := range a {
+		a[i] = FromFloat32(300)
+		b[i] = FromFloat32(300)
+	}
+	got := DotProductF32(a, b)
+	// 300 is exact in FP16 (1.171875 * 2^8). Each product 300*300 = 90000
+	// overflows FP16 max (65504) but fits FP32 easily; sum is 720000.
+	const want = float32(720000)
+	if got != want {
+		t.Fatalf("DotProductF32: got %v, want %v", got, want)
+	}
+}
+
+func TestDotProductF32_MatchesGoSum(t *testing.T) {
+	sizes := []int{8, 16, 64, 256, 1024}
+	rng := rand.New(rand.NewSource(42))
+	for _, n := range sizes {
+		a := make([]Float16, n)
+		b := make([]Float16, n)
+		for i := range a {
+			a[i] = FromFloat32(rng.Float32()*2 - 1) // [-1, 1]
+			b[i] = FromFloat32(rng.Float32()*2 - 1)
+		}
+
+		got := DotProductF32(a, b)
+		want := dotProductGo(a, b)
+
+		// Reference and SIMD differ in summation order; bound generously to
+		// absorb up to n*ULP per accumulator chain.
+		tol := math.Abs(float64(want))*float64(n)*1e-6 + 1e-5
+		if math.Abs(float64(got-want)) > tol {
+			t.Errorf("n=%d: got %v, want %v (tol %v)", n, got, want, tol)
+		}
+	}
+}
+
+func TestDotProductF32_Empty(t *testing.T) {
+	if got := DotProductF32(nil, nil); got != 0 {
+		t.Errorf("nil,nil: got %v, want 0", got)
+	}
+	if got := DotProductF32(nil, []Float16{FromFloat32(1), FromFloat32(2)}); got != 0 {
+		t.Errorf("nil,non-nil: got %v, want 0", got)
+	}
+}
+
+func TestDotProductF32_LengthMismatch(t *testing.T) {
+	a := []Float16{FromFloat32(1), FromFloat32(2), FromFloat32(3)}
+	b := []Float16{FromFloat32(4), FromFloat32(5)}
+	// min(len) = 2; expected = 1*4 + 2*5 = 14
+	if got := DotProductF32(a, b); got != 14 {
+		t.Errorf("length-mismatch: got %v, want 14", got)
+	}
+}
+
+func TestDotProductF32_TailLessThanWidth(t *testing.T) {
+	// n = 11 exercises 1 NEON iteration (8) + 3 Go tail on ARM64,
+	// and the all-Go path on AMD64.
+	const n = 11
+	a := make([]Float16, n)
+	b := make([]Float16, n)
+	for i := range a {
+		a[i] = FromFloat32(float32(i + 1))
+		b[i] = FromFloat32(float32(i + 1))
+	}
+	want := dotProductGo(a, b)
+	got := DotProductF32(a, b)
+	if math.Abs(float64(got-want)) > 1e-4 {
+		t.Errorf("tail handling: got %v, want %v", got, want)
+	}
+}
+
+// TestDotProductF32_Repro22 reproduces the scenario from issue #22 and logs
+// both APIs for cross-platform comparison. Asserts only DotProductF32; the
+// DotProduct value is logged for the PR description (it is +Inf on ARM64
+// with native FP16 SIMD and 720000 on AMD64).
+func TestDotProductF32_Repro22(t *testing.T) {
+	const n = 8
+	a := make([]Float16, n)
+	b := make([]Float16, n)
+	for i := range a {
+		a[i] = FromFloat32(300)
+		b[i] = FromFloat32(300)
+	}
+	native := DotProduct(a, b)
+	wide := DotProductF32(a, b)
+	t.Logf("issue #22 reproducer: DotProduct=%v  DotProductF32=%v", native, wide)
+	if wide != 720000 {
+		t.Fatalf("DotProductF32: got %v, want 720000", wide)
 	}
 }

--- a/f16/f16_test.go
+++ b/f16/f16_test.go
@@ -1121,3 +1121,29 @@ func TestNewEmptySlices(_ *testing.T) {
 	ExpInPlace(empty)
 	TanhInPlace(empty)
 }
+
+func TestMinGo_EmptySlice(t *testing.T) {
+	got := minGo(nil)
+	if got != 0x7C00 { // +Inf in FP16
+		t.Errorf("minGo(nil): got 0x%04X, want 0x7C00 (+Inf)", got)
+	}
+}
+
+func TestMaxGo_EmptySlice(t *testing.T) {
+	got := maxGo(nil)
+	if got != 0xFC00 { // -Inf in FP16
+		t.Errorf("maxGo(nil): got 0x%04X, want 0xFC00 (-Inf)", got)
+	}
+}
+
+func TestMinIdxGo_EmptySlice(t *testing.T) {
+	if got := minIdxGo(nil); got != -1 {
+		t.Errorf("minIdxGo(nil): got %d, want -1", got)
+	}
+}
+
+func TestMaxIdxGo_EmptySlice(t *testing.T) {
+	if got := maxIdxGo(nil); got != -1 {
+		t.Errorf("maxIdxGo(nil): got %d, want -1", got)
+	}
+}

--- a/f16/go_impl_bce_test.go
+++ b/f16/go_impl_bce_test.go
@@ -31,4 +31,8 @@ func TestGoFallbacks_EmptyDst(_ *testing.T) {
 	fromFloat32SliceGo(dst, src32)
 	dotProductGo(nil, src)
 	dotProductGo(src, nil)
+	_ = minGo(nil)
+	_ = maxGo(nil)
+	_ = minIdxGo(nil)
+	_ = maxIdxGo(nil)
 }


### PR DESCRIPTION
## Summary

Closes #22 and #25.

- **#22 fix**: adds opt-in `DotProductF32(a, b []Float16) float32` that widens FP16 inputs to FP32 *before* multiplying, so `|a[i] * b[i]| > 65504` does not saturate. On ARM64 with FP16 SIMD a new NEON kernel `dotProductWideNEON` handles the widened path (FCVTL/FCVTL2 then FMLA in FP32 with two parallel accumulators). On every other platform `DotProductF32` calls `dotProductGo`, which already widens. `DotProduct`'s behaviour is unchanged; its godoc gains a saturation note pointing callers at the new API.
- **#25 fix**: adds empty-slice guards to `minGo` / `maxGo` / `minIdxGo` / `maxIdxGo` in `f16/f16_go.go`. Sentinels match the existing public `Min` / `Max` / `MinIdx` / `MaxIdx` guards and the f64 idx-fallback convention (+Inf, -Inf, -1, -1). Defense in depth - the public API already guarded these, but the unexported fallbacks would panic on `a[0]` if called directly. While here, the public `Min` and `Max` guards (and the new fallback guards) use the existing `fp16Infinity` package constant instead of round-tripping `math.Inf()` through `fromFloat32Go`.

## Approach

- `DotProductF32` shares the dispatch shape of `DotProduct` (empty guard, then `dotProductF32(a, b)`), so the API ergonomics are familiar.
- ARM64 dispatch routes to `dotProductWideNEON` for `n >= 8` with `dotProductGo` for the 1-7 element tail (same fold pattern as the existing `dotProductNEON` dispatch).
- The new NEON kernel widens each 8-lane FP16 input via FCVTL/FCVTL2 (4+4 lanes -> 2x FP32 vectors), then accumulates via FMLA into two FP32 lanes (V4 lower, V5 upper), reducing at the end with the same FADD+FADDP horizontal sum used by `dotProductNEON`.
- Cortex-A76 does not have the FHM extension (`asimdfhm`), so FMLAL/FMLAL2 (fused FP16->FP32 multiply-long-add) is unavailable; the kernel uses plain FCVTL + FMLA. Same `hasFP16` gate as the existing kernel; same 8-element cadence.

## Test plan

- [x] `go fmt ./f16/`
- [x] `go vet ./...`
- [x] `golangci-lint run ./...` (0 issues)
- [x] `go test -count=1 ./...` on AMD64 (i7-1260P): all packages pass
- [x] `go test -count=1 ./...` on ARM64 (rpi5 Cortex-A76): all packages pass
- [x] `go test -count=1 -race ./f16/...` on AMD64: clean
- [x] `GOOS=linux GOARCH=arm64 go build ./...`: clean cross-compile

## Issue #22 reproducer

`TestDotProductF32_Repro22` logs both APIs side-by-side with `t.Logf`. Same `n=8` of `FromFloat32(300)*FromFloat32(300)` reproducer from the issue, run on each host:

```
# AMD64 (no f16 SIMD; both paths go through dotProductGo)
f16_test.go:1229: issue #22 reproducer: DotProduct=720000  DotProductF32=720000

# rpi5 ARM64 (native FP16 SIMD saturates; widened path doesn't)
f16_test.go:1229: issue #22 reproducer: DotProduct=+Inf  DotProductF32=720000
```

The rpi5 line is the textbook proof of the fix: the existing `dotProductNEON` (FMUL.8H) saturates `300*300 = 90000` to `+Inf` inside the FP16 lane before widening; the new `dotProductWideNEON` widens first and produces `720000` exactly.

## Benchmarks

### ARM64 (rpi5 Cortex-A76, `fphp`+`asimdhp`, no `asimdfhm`)

`go test -bench=BenchmarkDotProductF32 -benchtime=2s -count=3 ./f16/` -- median ns/op across 3 runs:

| n     | F32Wide ns/op | Native ns/op | F32Wide / Native | F16_Go ns/op | F32Wide vs F16_Go |
|-------|---------------|--------------|------------------|--------------|-------------------|
|   128 |    69.7       |     46.9     | 1.48x slower     |    708.7     | 10.2x faster      |
|   512 |   229.8       |    131.4     | 1.75x slower     |   2792       | 12.1x faster      |
|  1024 |   445.1       |    245.0     | 1.82x slower     |   5568       | 12.5x faster      |
|  4096 |  1727         |    926.2     | 1.86x slower     |  22223       | 12.9x faster      |
| 16384 |  6853         |   3659       | 1.87x slower     |  88916       | 13.0x faster      |
| 65536 | 27374         |  14516       | 1.88x slower     | 356678       | 13.0x faster      |

The F32Wide/Native ratio settles at ~1.88x for sizes that fit in cache; matches the prediction in #22's table (1.75-1.88x). F32Wide is still 10-13x faster than the pure-Go fallback even though it does ~14% more SIMD ops per iteration.

### AMD64 (i7-1260P, AVX2+F16C+FMA, no AVX-512)

`go test -bench=BenchmarkDotProductF32 -benchtime=2s -count=3 ./f16/` -- median ns/op across 3 runs:

| n     | F32Wide ns/op | Native ns/op | F16_Go ns/op |
|-------|---------------|--------------|--------------|
|   128 |    368.7      |    360.4     |    359.9     |
|   512 |   1438        |   1407       |   1421       |
|  1024 |   2996        |   2845       |   3229       |
|  4096 |  11271        |  29385       |  28731       |
| 16384 |  48169        | 150032       | 144823       |
| 65536 | 286064        | 276895       | 273744       |

AMD64 has no f16 SIMD, so `F32Wide`, `Native`, and `F16_Go` all dispatch through `dotProductGo`. The three sub-benches should report near-identical times; the spread in the table is run-to-run noise on a thermally-throttling laptop (notably at 4096 and 16384 where the order of sub-bench execution interacts with thermal effects). The takeaway for AMD64 is that the new API is the same speed as the existing path - no regression, no improvement, identical implementation.

## Files touched

| File | Change |
|------|--------|
| `f16/f16.go` | New `DotProductF32`; `DotProduct` godoc saturation paragraph; `Min`/`Max` guards use `fp16Infinity` constant |
| `f16/f16_arm64.go` | New `dotProductF32` dispatch + `//go:noescape dotProductWideNEON` declaration |
| `f16/f16_arm64.s` | New `dotProductWideNEON` text |
| `f16/f16_other.go` | New `dotProductF32` (calls `dotProductGo`) |
| `f16/f16_go.go` | Empty-slice guards on `minGo`/`maxGo`/`minIdxGo`/`maxIdxGo` |
| `f16/f16_test.go` | Tests: 4 empty-slice guards, 5 DotProductF32 (parity, edge cases, reproducer) |
| `f16/benchmark_test.go` | `BenchmarkDotProductF32` (F32Wide / Native / F16_Go) |
| `f16/go_impl_bce_test.go` | Extend `TestGoFallbacks_EmptyDst` to cover the new branches |
| `README.md` | `DotProductF32` row in API table; saturation note in Key characteristics |

## Follow-up

#29 tracks the analogous pre-existing panic risk in `f32/f32_go.go` and `f64/f64_go.go` `minGo`/`maxGo`. Surfaced by gate reviewers; not user-reachable through the documented public API, but worth fixing for symmetry with the f16 hardening here.

## Out of scope (deferred)

- AMD64 F16C SIMD for `DotProduct` / `DotProductF32`. Would close the AMD64 perf gap entirely (currently runs at Go-fallback speed) but is a separate initiative with a different value proposition.
- `DotProductF32Unsafe` variant matching `DotProductUnsafe`. Add when there is a concrete caller asking for it.
- FMLAL/FMLAL2 paths on ARMv8.2-A FHM-capable hardware (Cortex-A77+, Apple silicon). Would need a separate capability gate; the rpi5 target doesn't have `asimdfhm`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added `DotProductF32` for dot product computations using FP32 widening, providing protection against saturation with large intermediate values.

* **Bug Fixes**
  * Fixed `Min`/`Max` functions to correctly return infinity values for empty slices instead of panicking.
  * Fixed `MinIdx`/`MaxIdx` functions to return -1 for empty slices.

* **Documentation**
  * Updated documentation to clarify saturation behavior and recommend `DotProductF32` for out-of-range scenarios.

* **Tests**
  * Added comprehensive test coverage for the new feature and edge cases.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/tphakala/simd/pull/30?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->