### PR TITLE
Fix min/max Go fallbacks for empty slices

### DIFF
--- a/f32/f32_go.go
+++ b/f32/f32_go.go
@@ -113,6 +113,9 @@ func sumGo(a []float32) float32 {
 }
 
 func minGo(a []float32) float32 {
+	if len(a) == 0 {
+		return posInf
+	}
 	m := a[0]
 	for _, v := range a[1:] {
 		if v < m {
@@ -123,6 +126,9 @@ func minGo(a []float32) float32 {
 }
 
 func maxGo(a []float32) float32 {
+	if len(a) == 0 {
+		return negInf
+	}
 	m := a[0]
 	for _, v := range a[1:] {
 		if v > m {

--- a/f32/go_impl_test.go
+++ b/f32/go_impl_test.go
@@ -53,6 +53,7 @@ func TestMinGo(t *testing.T) {
 		a    []float32
 		want float32
 	}{
+		{"empty", []float32{}, float32(math.Inf(1))},
 		{"single", []float32{5}, 5},
 		{"min_first", []float32{1, 2, 3}, 1},
 		{"min_middle", []float32{3, 1, 2}, 1},
@@ -77,6 +78,7 @@ func TestMaxGo(t *testing.T) {
 		a    []float32
 		want float32
 	}{
+		{"empty", []float32{}, float32(math.Inf(-1))},
 		{"single", []float32{5}, 5},
 		{"max_first", []float32{3, 2, 1}, 3},
 		{"max_middle", []float32{1, 3, 2}, 3},

--- a/f64/f64_go.go
+++ b/f64/f64_go.go
@@ -110,6 +110,9 @@ func sumGo(a []float64) float64 {
 }
 
 func minGo(a []float64) float64 {
+	if len(a) == 0 {
+		return posInf
+	}
 	m := a[0]
 	for _, v := range a[1:] {
 		if v < m {
@@ -120,6 +123,9 @@ func minGo(a []float64) float64 {
 }
 
 func maxGo(a []float64) float64 {
+	if len(a) == 0 {
+		return negInf
+	}
 	m := a[0]
 	for _, v := range a[1:] {
 		if v > m {

--- a/f64/go_impl_test.go
+++ b/f64/go_impl_test.go
@@ -53,6 +53,7 @@ func TestMinGo(t *testing.T) {
 		a    []float64
 		want float64
 	}{
+		{"empty", []float64{}, math.Inf(1)},
 		{"single", []float64{5}, 5},
 		{"min_first", []float64{1, 2, 3}, 1},
 		{"min_middle", []float64{3, 1, 2}, 1},
@@ -77,6 +78,7 @@ func TestMaxGo(t *testing.T) {
 		a    []float64
 		want float64
 	}{
+		{"empty", []float64{}, math.Inf(-1)},
 		{"single", []float64{5}, 5},
 		{"max_first", []float64{3, 2, 1}, 3},
 		{"max_middle", []float64{1, 3, 2}, 3},


### PR DESCRIPTION
## Summary
- Guard f32/f64 Go fallback minGo and maxGo against empty slices.
- Return the same sentinels as the public APIs: +Inf for min, -Inf for max.
- Add regression coverage for empty fallback min/max calls.

Closes #29

## Test Plan
- [x] go test -count=1 ./...


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved stability of min/max operations. These operations now properly handle empty input slices by returning appropriate infinity values instead of encountering errors.

* **Tests**
  * Added test coverage for edge cases in min/max operations, ensuring robust behavior with empty input slices across all supported numeric types.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/tphakala/simd/pull/31?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->