### PR TITLE
fix(arm64): correct NEON FNEG/FRINTN encodings in tanh/sigmoid (#6)

### DIFF
--- a/f32/f32_arm64.s
+++ b/f32/f32_arm64.s
@@ -15,6 +15,7 @@
 // FMAX Vd.4S, Vn.4S, Vm.4S: 0x4E20F400 | (Vm << 16) | (Vn << 5) | Vd
 // FABS Vd.4S, Vn.4S:        0x4EA0F800 | (Vn << 5) | Vd
 // FNEG Vd.4S, Vn.4S:        0x6EA0F800 | (Vn << 5) | Vd
+// FRINTN Vd.4S, Vn.4S:      0x4E218800 | (Vn << 5) | Vd  (round to nearest, ties to even)
 // FMLA Vd.4S, Vn.4S, Vm.4S: 0x4E20CC00 | (Vm << 16) | (Vn << 5) | Vd
 // FADDP Vd.4S, Vn.4S, Vm.4S: 0x6E20D400 | (Vm << 16) | (Vn << 5) | Vd
 // FADDP Sd, Vn.2S:          0x7E30D800 | (Vn << 5) | Vd
@@ -1052,7 +1053,7 @@ sigmoid32_neon_loop4:
     VLD1.P 16(R1), [V0.S4]        // V0 = x
 
     // Negate: V0 = -x
-    WORD $0x6EA07C00              // FNEG V0.4S, V0.4S
+    WORD $0x6EA0F800              // FNEG V0.4S, V0.4S
 
     // Clamp -x to [-20, 20]
     WORD $0x4EBBF400              // FMIN V0.4S, V0.4S, V27.4S  (clamp upper to 20)
@@ -1060,7 +1061,7 @@ sigmoid32_neon_loop4:
 
     // Range reduction: k = round(-x * log2e), r = -x - k * ln2
     WORD $0x6E34DC01              // FMUL V1.4S, V0.4S, V20.4S   V1 = -x * log2e
-    WORD $0x4E218C22              // FRINTN V2.4S, V1.4S         V2 = k = round(V1)
+    WORD $0x4E218822              // FRINTN V2.4S, V1.4S         V2 = k = round(V1)
     // V3 = V0 - V2 * ln2
     WORD $0x6E35DC44              // FMUL V4.4S, V2.4S, V21.4S   V4 = k * ln2
     WORD $0x4EA4D403              // FSUB V3.4S, V0.4S, V4.4S    V3 = r = -x - k * ln2
@@ -1269,7 +1270,7 @@ tanh32_neon_loop4:
     VLD1.P 16(R1), [V0.S4]            // V0 = x
 
     // Compute -2x: negate then multiply by 2
-    WORD $0x6EA07C00                  // FNEG V0.4S, V0.4S           V0 = -x
+    WORD $0x6EA0F800                  // FNEG V0.4S, V0.4S           V0 = -x
     WORD $0x6E33DC00                  // FMUL V0.4S, V0.4S, V19.4S   V0 = -2x
 
     // Clamp -2x to [-20, 20]
@@ -1278,7 +1279,7 @@ tanh32_neon_loop4:
 
     // Range reduction: k = round(-2x * log2e), r = -2x - k * ln2
     WORD $0x6E34DC01                  // FMUL V1.4S, V0.4S, V20.4S   V1 = -2x * log2e
-    WORD $0x4E218C22                  // FRINTN V2.4S, V1.4S         V2 = k = round(V1)
+    WORD $0x4E218822                  // FRINTN V2.4S, V1.4S         V2 = k = round(V1)
     WORD $0x6E35DC44                  // FMUL V4.4S, V2.4S, V21.4S   V4 = k * ln2
     WORD $0x4EA4D403                  // FSUB V3.4S, V0.4S, V4.4S    V3 = r = -2x - k * ln2
 

--- a/f32/f32_test.go
+++ b/f32/f32_test.go
@@ -186,6 +186,44 @@ func TestClamp(t *testing.T) {
 	}
 }
 
+// relErrF32 returns the relative error of got vs want, falling back to
+// absolute error when want is near zero (where relative error is unstable).
+func relErrF32(got, want float32) float64 {
+	diff := math.Abs(float64(got - want))
+	if math.Abs(float64(want)) > 1e-6 {
+		return diff / math.Abs(float64(want))
+	}
+	return diff
+}
+
+// checkSigmoid32 verifies a single Sigmoid output against the reference. It
+// rejects NaN/Inf first: ordered comparisons are always false for NaN, so a
+// non-finite result would otherwise slip through every range and accuracy
+// check unnoticed.
+func checkSigmoid32(t *testing.T, x, got float32, i int) {
+	t.Helper()
+	if math.IsNaN(float64(got)) || math.IsInf(float64(got), 0) {
+		t.Errorf("Sigmoid(%v)[%d] = %v, expected a finite value", x, i, got)
+		return
+	}
+	if got < 0 || got > 1 {
+		t.Errorf("Sigmoid(%v)[%d] = %v, expected value in range (0, 1)", x, i, got)
+	}
+	expected := float32(1.0 / (1.0 + math.Exp(-float64(x))))
+	if relErr := relErrF32(got, expected); relErr > 1e-4 {
+		t.Errorf("Sigmoid(%v)[%d] = %v, want %v (error: %v)", x, i, got, expected, relErr)
+	}
+	if x == 0 && math.Abs(float64(got-0.5)) > 0.01 {
+		t.Errorf("Sigmoid(0)[%d] = %v, expected ~0.5", i, got)
+	}
+	if x > 10 && got < 0.99 {
+		t.Errorf("Sigmoid(%v)[%d] = %v, expected > 0.99", x, i, got)
+	}
+	if x < -10 && got > 0.01 {
+		t.Errorf("Sigmoid(%v)[%d] = %v, expected < 0.01", x, i, got)
+	}
+}
+
 func TestSigmoid(t *testing.T) {
 	testCases := []struct {
 		name string
@@ -216,43 +254,9 @@ func TestSigmoid(t *testing.T) {
 			// Test Sigmoid
 			Sigmoid(dst, tc.src)
 
-			// Verify results are in valid range (0, 1)
+			// Verify each result (range, finiteness, accuracy, saturation).
 			for i, v := range dst {
-				// Reject NaN/Inf explicitly: ordered comparisons below are
-				// always false for NaN, so a NaN result would otherwise slip
-				// through every range and accuracy check unnoticed.
-				if math.IsNaN(float64(v)) || math.IsInf(float64(v), 0) {
-					t.Errorf("Sigmoid(%v)[%d] = %v, expected a finite value", tc.src[i], i, v)
-					continue
-				}
-
-				if v < 0 || v > 1 {
-					t.Errorf("Sigmoid()[%d] = %v, expected value in range (0, 1)", i, v)
-				}
-
-				// Verify accuracy against the reference sigmoid.
-				expected := float32(1.0 / (1.0 + math.Exp(-float64(tc.src[i]))))
-				diff := math.Abs(float64(v - expected))
-				var relErr float64
-				if math.Abs(float64(expected)) > 1e-6 {
-					relErr = diff / math.Abs(float64(expected))
-				} else {
-					relErr = diff
-				}
-				if relErr > 1e-4 {
-					t.Errorf("Sigmoid(%v)[%d] = %v, want %v (error: %v)", tc.src[i], i, v, expected, relErr)
-				}
-
-				// Test specific values
-				if tc.src[i] == 0 && math.Abs(float64(v-0.5)) > 0.01 {
-					t.Errorf("Sigmoid(0)[%d] = %v, expected ~0.5", i, v)
-				}
-				if tc.src[i] > 10 && v < 0.99 {
-					t.Errorf("Sigmoid(%v)[%d] = %v, expected > 0.99", tc.src[i], i, v)
-				}
-				if tc.src[i] < -10 && v > 0.01 {
-					t.Errorf("Sigmoid(%v)[%d] = %v, expected < 0.01", tc.src[i], i, v)
-				}
+				checkSigmoid32(t, tc.src[i], v, i)
 			}
 
 			// Test SigmoidInPlace
@@ -262,7 +266,9 @@ func TestSigmoid(t *testing.T) {
 
 			// Verify in-place results match
 			for i, v := range src2 {
-				if math.Abs(float64(v-dst[i])) > 1e-6 {
+				// math.Abs(NaN) > tol is false, so guard against a NaN
+				// regression that the difference check would miss.
+				if math.IsNaN(float64(v)) || math.Abs(float64(v-dst[i])) > 1e-6 {
 					t.Errorf("SigmoidInPlace()[%d] = %v, Sigmoid() = %v, expected same", i, v, dst[i])
 				}
 			}
@@ -363,17 +369,7 @@ func TestTanh(t *testing.T) {
 
 				// Verify accuracy against math.Tanh
 				expected := float32(math.Tanh(float64(tc.src[i])))
-				diff := math.Abs(float64(v - expected))
-
-				// Use relative error for values away from zero, absolute for near-zero
-				var relErr float64
-				if math.Abs(float64(expected)) > 1e-6 {
-					relErr = diff / math.Abs(float64(expected))
-				} else {
-					relErr = diff
-				}
-
-				if relErr > epsilon {
+				if relErr := relErrF32(v, expected); relErr > epsilon {
 					t.Errorf("Tanh(%v)[%d] = %v, want %v (error: %v)", tc.src[i], i, v, expected, relErr)
 				}
 			}
@@ -391,7 +387,9 @@ func TestTanh(t *testing.T) {
 		TanhInPlace(inPlace)
 
 		for i := range dst {
-			if math.Abs(float64(dst[i]-inPlace[i])) > 1e-6 {
+			// math.Abs(NaN) > tol is false, so guard against a NaN regression
+			// that the difference check would miss.
+			if math.IsNaN(float64(inPlace[i])) || math.Abs(float64(dst[i]-inPlace[i])) > 1e-6 {
 				t.Errorf("TanhInPlace()[%d] = %v, Tanh() = %v, expected same", i, inPlace[i], dst[i])
 			}
 		}

--- a/f32/f32_test.go
+++ b/f32/f32_test.go
@@ -218,8 +218,29 @@ func TestSigmoid(t *testing.T) {
 
 			// Verify results are in valid range (0, 1)
 			for i, v := range dst {
+				// Reject NaN/Inf explicitly: ordered comparisons below are
+				// always false for NaN, so a NaN result would otherwise slip
+				// through every range and accuracy check unnoticed.
+				if math.IsNaN(float64(v)) || math.IsInf(float64(v), 0) {
+					t.Errorf("Sigmoid(%v)[%d] = %v, expected a finite value", tc.src[i], i, v)
+					continue
+				}
+
 				if v < 0 || v > 1 {
 					t.Errorf("Sigmoid()[%d] = %v, expected value in range (0, 1)", i, v)
+				}
+
+				// Verify accuracy against the reference sigmoid.
+				expected := float32(1.0 / (1.0 + math.Exp(-float64(tc.src[i]))))
+				diff := math.Abs(float64(v - expected))
+				var relErr float64
+				if math.Abs(float64(expected)) > 1e-6 {
+					relErr = diff / math.Abs(float64(expected))
+				} else {
+					relErr = diff
+				}
+				if relErr > 1e-4 {
+					t.Errorf("Sigmoid(%v)[%d] = %v, want %v (error: %v)", tc.src[i], i, v, expected, relErr)
 				}
 
 				// Test specific values
@@ -327,6 +348,14 @@ func TestTanh(t *testing.T) {
 			Tanh(dst, tc.src)
 
 			for i, v := range dst {
+				// Reject NaN/Inf explicitly: ordered comparisons below are
+				// always false for NaN, so a NaN result would otherwise slip
+				// through both the range and accuracy checks unnoticed.
+				if math.IsNaN(float64(v)) || math.IsInf(float64(v), 0) {
+					t.Errorf("Tanh(%v)[%d] = %v, expected a finite value", tc.src[i], i, v)
+					continue
+				}
+
 				// Verify results are in valid range [-1, 1]
 				if v < -1 || v > 1 {
 					t.Errorf("Tanh(%v)[%d] = %v, expected value in range [-1, 1]", tc.src[i], i, v)

--- a/f64/f64_arm64.s
+++ b/f64/f64_arm64.s
@@ -16,6 +16,7 @@
 // FMAX Vd.2D, Vn.2D, Vm.2D: 0x4E60F400 | (Vm << 16) | (Vn << 5) | Vd
 // FABS Vd.2D, Vn.2D:        0x4EE0F800 | (Vn << 5) | Vd
 // FNEG Vd.2D, Vn.2D:        0x6EE0F800 | (Vn << 5) | Vd
+// FRINTN Vd.2D, Vn.2D:      0x4E618800 | (Vn << 5) | Vd  (round to nearest, ties to even)
 // FMLA Vd.2D, Vn.2D, Vm.2D: 0x4E60CC00 | (Vm << 16) | (Vn << 5) | Vd
 // FADDP Dd, Vn.2D:          0x7E70D800 | (Vn << 5) | Vd
 
@@ -1007,7 +1008,7 @@ tanh64_neon_loop2:
 
     // Range reduction: k = round(-2x * log2e), r = -2x - k * ln2
     WORD $0x6E74DC01                  // FMUL V1.2D, V0.2D, V20.2D   V1 = -2x * log2e
-    WORD $0x4E619822                  // FRINTN V2.2D, V1.2D         V2 = k = round(V1)
+    WORD $0x4E618822                  // FRINTN V2.2D, V1.2D         V2 = k = round(V1)
     WORD $0x6E75DC44                  // FMUL V4.2D, V2.2D, V21.2D   V4 = k * ln2
     WORD $0x4EE4D403                  // FSUB V3.2D, V0.2D, V4.2D    V3 = r = -2x - k * ln2
 

--- a/f64/f64_test.go
+++ b/f64/f64_test.go
@@ -934,7 +934,9 @@ func TestSigmoid(t *testing.T) {
 			copy(inPlace, tc.src)
 			SigmoidInPlace(inPlace)
 			for i := range dst {
-				if math.Abs(dst[i]-inPlace[i]) > 1e-10 {
+				// math.Abs(NaN) > tol is false, so guard against a NaN
+				// regression that the difference check would miss.
+				if math.IsNaN(inPlace[i]) || math.Abs(dst[i]-inPlace[i]) > 1e-10 {
 					t.Errorf("SigmoidInPlace mismatch at %d: got %v, want %v", i, inPlace[i], dst[i])
 				}
 			}
@@ -1076,7 +1078,9 @@ func TestTanh(t *testing.T) {
 		TanhInPlace(inPlace)
 
 		for i := range dst {
-			if math.Abs(dst[i]-inPlace[i]) > 1e-10 {
+			// math.Abs(NaN) > tol is false, so guard against a NaN regression
+			// that the difference check would miss.
+			if math.IsNaN(inPlace[i]) || math.Abs(dst[i]-inPlace[i]) > 1e-10 {
 				t.Errorf("TanhInPlace()[%d] = %v, Tanh() = %v, expected same", i, inPlace[i], dst[i])
 			}
 		}
@@ -1106,7 +1110,9 @@ func TestExp(t *testing.T) {
 	copy(inPlace, src)
 	ExpInPlace(inPlace)
 	for i := range dst {
-		if math.Abs(dst[i]-inPlace[i]) > 1e-10 {
+		// math.Abs(NaN) > tol is false, so guard against a NaN regression
+		// that the difference check would miss.
+		if math.IsNaN(inPlace[i]) || math.Abs(dst[i]-inPlace[i]) > 1e-10 {
 			t.Errorf("ExpInPlace mismatch at %d: got %v, want %v", i, inPlace[i], dst[i])
 		}
 	}

--- a/f64/f64_test.go
+++ b/f64/f64_test.go
@@ -910,6 +910,12 @@ func TestSigmoid(t *testing.T) {
 
 			// Verify all values are in [0,1]
 			for i, v := range dst {
+				// Reject NaN/Inf explicitly: ordered comparisons are always
+				// false for NaN, so a NaN result would otherwise pass silently.
+				if math.IsNaN(v) || math.IsInf(v, 0) {
+					t.Errorf("sigmoid(%v) = %v, expected a finite value", tc.src[i], v)
+					continue
+				}
 				if v < 0 || v > 1 {
 					t.Errorf("sigmoid(%v) = %v, want in range [0,1]", tc.src[i], v)
 				}
@@ -1027,6 +1033,14 @@ func TestTanh(t *testing.T) {
 			Tanh(dst, tc.src)
 
 			for i, v := range dst {
+				// Reject NaN/Inf explicitly: ordered comparisons below are
+				// always false for NaN, so a NaN result would otherwise slip
+				// through both the range and accuracy checks unnoticed.
+				if math.IsNaN(v) || math.IsInf(v, 0) {
+					t.Errorf("Tanh(%v)[%d] = %v, expected a finite value", tc.src[i], i, v)
+					continue
+				}
+
 				// Verify results are in valid range [-1, 1]
 				if v < -1 || v > 1 {
 					t.Errorf("Tanh(%v)[%d] = %v, expected value in range [-1, 1]", tc.src[i], i, v)


### PR DESCRIPTION
## Summary

The hand-encoded `WORD` directives for two NEON instructions in the f32 sigmoid/tanh and f64 tanh exp pipelines held wrong machine code. Go's assembler does not validate `WORD`, so they silently assembled into entirely different instructions:

| Site | Bad `WORD` | Silently became | Corrected |
|------|-----------|-----------------|-----------|
| f32 sigmoid + tanh (FNEG `V0.4S`) | `0x6EA07C00` | `VUABA` (a no-op negate, so `-x` stayed `x`) | `0x6EA0F800` |
| f32 sigmoid + tanh (FRINTN `V2.4S`) | `0x4E218C22` | `VCMTST` (garbage `k`) | `0x4E218822` |
| f64 tanh (FRINTN `V2.2D`) | `0x4E619822` | `FRINTM` (floor, not round-to-nearest) | `0x4E618822` |

The corrupted FRINTN poisoned the range-reduction exponent `k`, so the NEON vector path returned **NaN** for every nonzero input. `x == 0` worked only because the corrupted terms multiply to zero. Both sigmoid and tanh on f32 were affected since they share the exp pipeline.

### Why the tests missed it

Every ordered comparison is false for NaN, so NaN slipped straight through both the range checks (`v < -1 || v > 1`) and the relative-error checks. This PR hardens `TestTanh`/`TestSigmoid` (f32 + f64) to reject NaN/Inf explicitly, and adds a real accuracy assertion to the f32 `Sigmoid` test (which previously checked only range).

The corrected encodings were verified bit-for-bit with `objdump`/`go tool asm` (`FNEG V0.4S`, `FRINTN V2.4S`, `FRINTN V2.2D`), and Go's assembler does not accept these as mnemonics, so corrected `WORD`s are the in-style fix. The asm header comments now document the FRINTN encoding too.

## Related Issues

Fixes #6

## Test Plan

Verified on ARM64 hardware (Raspberry Pi 5, Go 1.26):

- [x] `go test ./...` passes on arm64 (all packages) and amd64
- [x] Dense 20001-point sweep over [-15, 15]: max relative error 8.97e-6 (f32 tanh), 3.67e-6 (f32 sigmoid), 8.95e-6 (f64 tanh); zero NaN/Inf
- [x] Negative control: re-introducing the broken encoding makes the hardened tests fail (they passed before, proving the guard works)
- [x] Benchmarks: NEON path ~10x faster than Go fallback (f32 tanh/sigmoid), ~5x (f64 tanh), 0 allocs
- [x] CI exercises the arm64 path on `macos-latest` (Apple Silicon)

Note: f64 `Sigmoid` uses a separate, cruder approximation (`0.5 + 0.5*x/(1+|x|)`) than f32, so its test gets only the NaN/Inf guard, not the tight accuracy assertion. That algorithm inconsistency is pre-existing and tracked separately.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced sigmoid and tanh functions to better handle edge cases and improve numerical stability
  * Updated optimized implementations for improved floating-point accuracy

* **Tests**
  * Added explicit validation in sigmoid and tanh tests to detect and fail on non-finite outputs
  * Prevents invalid results from bypassing range and accuracy assertions

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/tphakala/simd/pull/32?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->