### PR TITLE
feat: add SIMD Exp for f32 and f64 (AVX + NEON)

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,7 +116,7 @@ fmt.Println(cpu.HasFP16())   // true/false (ARM64 half-precision SIMD)
 | **Activation**  | `Sigmoid(dst, src)`                 | Sigmoid: 1/(1+e^-x)           | 4x (AVX) / 2x (NEON)                |
 |                 | `ReLU(dst, src)`                    | Rectified Linear Unit         | 8x / 4x / 2x                        |
 |                 | `Tanh(dst, src)`                    | Hyperbolic tangent            | 8x / 4x / 2x                        |
-|                 | `Exp(dst, src)`                     | Exponential e^x               | Pure Go                             |
+|                 | `Exp(dst, src)`                     | Exponential e^x               | 8x / 4x / 2x                        |
 |                 | `ClampScale(dst, src, min, max, s)` | Fused clamp and scale         | 8x / 4x / 2x                        |
 | **Batch**       | `DotProductBatch(r, rows, v)`       | Multiple dot products         | 8x / 4x / 2x                        |
 | **Signal**      | `ConvolveValid(dst, sig, k)`        | FIR filter / convolution      | 8x / 4x / 2x                        |
@@ -376,6 +376,7 @@ c64.Abs(magnitude, signalFFT)              // Extract magnitude
 | Sigmoid    | 138       | 5906     | **43x**    | 59.3 GB/s       |
 | ReLU       | 39        | 662      | **17x**    | 211 GB/s        |
 | Tanh       | 138       | 28116    | **204x**   | 59.5 GB/s       |
+| Exp        | 312       | 5555     | **18x**    | 26.3 GB/s       |
 
 **float64 (1024 elements):**
 
@@ -383,12 +384,14 @@ c64.Abs(magnitude, signalFFT)              // Extract magnitude
 | ---------- | --------- | -------- | ---------- | --------------- |
 | ReLU       | 68        | 646      | **9.5x**   | 240 GB/s        |
 | Tanh       | 445       | 6230     | **14x**    | 36.8 GB/s       |
+| Exp        | 1600      | 5140     | **3.2x**   | 10.2 GB/s       |
 
 **Key Characteristics:**
 
 - **Tanh**: 200x+ speedup for f32 - fast approximation with saturation vs math.Tanh
 - **ReLU**: Highest throughput (211-240 GB/s) - simple max(0, x) operation
 - **Sigmoid**: 43x speedup for f32 - fast approximation with exponential
+- **Exp**: 18x speedup for f32 (12x on ARM64 NEON) via range reduction plus a degree-5 polynomial; max relative error ~7e-6 (f32), ~3e-6 (f64)
 
 #### Batch & Signal Processing (varied sizes)
 

--- a/f32/benchmark_test.go
+++ b/f32/benchmark_test.go
@@ -348,6 +348,28 @@ func BenchmarkSigmoid(b *testing.B) {
 	}
 }
 
+func BenchmarkExp(b *testing.B) {
+	for _, size := range benchSizes {
+		a, _, _, dst := makeBenchData32(size)
+		// Use values in a reasonable range for exp
+		for i := range a {
+			a[i] = (a[i] - 50) / 10 // Range roughly -5 to +5
+		}
+		b.Run(fmt.Sprintf("SIMD_%d", size), func(b *testing.B) {
+			for i := 0; i < b.N; i++ {
+				Exp(dst, a)
+			}
+			reportThroughput32(b, size*2)
+		})
+		b.Run(fmt.Sprintf("Go_%d", size), func(b *testing.B) {
+			for i := 0; i < b.N; i++ {
+				exp32Go(dst, a)
+			}
+			reportThroughput32(b, size*2)
+		})
+	}
+}
+
 func BenchmarkReLU(b *testing.B) {
 	for _, size := range benchSizes {
 		a, _, _, dst := makeBenchData32(size)

--- a/f32/f32.go
+++ b/f32/f32.go
@@ -537,7 +537,7 @@ func TanhInPlace(a []float32) {
 // results stay finite (exp(88) is near MaxFloat32); inputs below about -88
 // underflow to 0. This matches the pure-Go fallback's clamping.
 //
-// Uses AVX+FMA on AMD64 (8x float32), NEON on ARM64 (4x float32), and falls
+// Uses AVX2 on AMD64 (8x float32), NEON on ARM64 (4x float32), and falls
 // back to math.Exp otherwise.
 func Exp(dst, src []float32) {
 	n := min(len(dst), len(src))

--- a/f32/f32.go
+++ b/f32/f32.go
@@ -530,10 +530,15 @@ func TanhInPlace(a []float32) {
 }
 
 // Exp computes the exponential function: dst[i] = e^src[i].
-// Uses polynomial approximation for reasonable accuracy and performance.
 // Processes min(len(dst), len(src)) elements.
 //
-// Uses AVX+FMA on AMD64 (8x float32), NEON on ARM64 (4x float32).
+// The SIMD paths use range reduction plus a degree-5 polynomial, giving a
+// maximum relative error of about 7e-6. Inputs are clamped to [-88, 88] so
+// results stay finite (exp(88) is near MaxFloat32); inputs below about -88
+// underflow to 0. This matches the pure-Go fallback's clamping.
+//
+// Uses AVX+FMA on AMD64 (8x float32), NEON on ARM64 (4x float32), and falls
+// back to math.Exp otherwise.
 func Exp(dst, src []float32) {
 	n := min(len(dst), len(src))
 	if n == 0 {

--- a/f32/f32_amd64.go
+++ b/f32/f32_amd64.go
@@ -533,10 +533,15 @@ func tanh32(dst, src []float32) {
 func tanhAVX(dst, src []float32)
 
 func exp32(dst, src []float32) {
-	// Exp is complex, use Go implementation with math.Exp for now
-	// Can be optimized with AVX polynomial approximation later
+	if cpu.X86.AVX && cpu.X86.FMA && len(dst) >= minAVXElements && len(src) >= minAVXElements {
+		expAVX(dst, src)
+		return
+	}
 	exp32Go(dst, src)
 }
+
+//go:noescape
+func expAVX(dst, src []float32)
 
 func int32ToFloat32Scale(dst []float32, src []int32, scale float32) {
 	// Use AVX if available and have enough elements

--- a/f32/f32_amd64.go
+++ b/f32/f32_amd64.go
@@ -533,7 +533,10 @@ func tanh32(dst, src []float32) {
 func tanhAVX(dst, src []float32)
 
 func exp32(dst, src []float32) {
-	if cpu.X86.AVX && cpu.X86.FMA && len(dst) >= minAVXElements && len(src) >= minAVXElements {
+	// Requires AVX2: the 2^k reconstruction uses 256-bit integer ops
+	// (VPSLLD/VPADDD/VCVTPS2DQ on YMM) that are not available on AVX1-only
+	// CPUs. FMA is not used, so AVX2 alone is the correct guard.
+	if cpu.X86.AVX2 && len(dst) >= minAVXElements && len(src) >= minAVXElements {
 		expAVX(dst, src)
 		return
 	}

--- a/f32/f32_amd64.s
+++ b/f32/f32_amd64.s
@@ -3202,15 +3202,15 @@ exp32_remainder:
     VMOVSS exp_c3<>(SB), X12
     VMOVSS exp_c4<>(SB), X13
     VMOVSS exp_c5<>(SB), X14
+    VMOVSS exp_clamp_hi<>(SB), X6        // clamp bounds in X6/X7: X1/X2 are
+    VMOVSS exp_clamp_lo<>(SB), X7        // reused as temporaries in the loop
 
 exp32_scalar:
     VMOVSS (SI), X0                     // X0 = x
 
     // Clamp
-    VMOVSS exp_clamp_hi<>(SB), X1
-    VMOVSS exp_clamp_lo<>(SB), X2
-    VMINSS X1, X0, X0
-    VMAXSS X2, X0, X0
+    VMINSS X6, X0, X0
+    VMAXSS X7, X0, X0
 
     // Range reduction
     VMULSS X8, X0, X1                   // X1 = x * log2e

--- a/f32/f32_amd64.s
+++ b/f32/f32_amd64.s
@@ -2920,6 +2920,29 @@ DATA exp_bias<>+0x18(SB)/4, $0x3f800000
 DATA exp_bias<>+0x1c(SB)/4, $0x3f800000
 GLOBL exp_bias<>(SB), RODATA|NOPTR, $32
 
+// Exp clamp thresholds: ±88.0 keeps the 2^k reconstruction inside the
+// representable float32 range (exp(88) ~= 1.65e38 < MaxFloat32). Matches the
+// pure-Go fallback's overflow/underflow clamp.
+DATA exp_clamp_hi<>+0x00(SB)/4, $0x42b00000  // 88.0
+DATA exp_clamp_hi<>+0x04(SB)/4, $0x42b00000
+DATA exp_clamp_hi<>+0x08(SB)/4, $0x42b00000
+DATA exp_clamp_hi<>+0x0c(SB)/4, $0x42b00000
+DATA exp_clamp_hi<>+0x10(SB)/4, $0x42b00000
+DATA exp_clamp_hi<>+0x14(SB)/4, $0x42b00000
+DATA exp_clamp_hi<>+0x18(SB)/4, $0x42b00000
+DATA exp_clamp_hi<>+0x1c(SB)/4, $0x42b00000
+GLOBL exp_clamp_hi<>(SB), RODATA|NOPTR, $32
+
+DATA exp_clamp_lo<>+0x00(SB)/4, $0xc2b00000  // -88.0
+DATA exp_clamp_lo<>+0x04(SB)/4, $0xc2b00000
+DATA exp_clamp_lo<>+0x08(SB)/4, $0xc2b00000
+DATA exp_clamp_lo<>+0x0c(SB)/4, $0xc2b00000
+DATA exp_clamp_lo<>+0x10(SB)/4, $0xc2b00000
+DATA exp_clamp_lo<>+0x14(SB)/4, $0xc2b00000
+DATA exp_clamp_lo<>+0x18(SB)/4, $0xc2b00000
+DATA exp_clamp_lo<>+0x1c(SB)/4, $0xc2b00000
+GLOBL exp_clamp_lo<>(SB), RODATA|NOPTR, $32
+
 // Constants for exp-based tanh (float32)
 DATA tanh32_two<>+0x00(SB)/4, $0x40000000  // 2.0
 DATA tanh32_two<>+0x04(SB)/4, $0x40000000
@@ -3098,6 +3121,130 @@ sigmoid32_scalar:
     JNZ  sigmoid32_scalar
 
 sigmoid32_done:
+    VZEROUPPER
+    RET
+
+// func expAVX(dst, src []float32)
+// Computes e^x using range reduction and a degree-5 polynomial, the same exp
+// core as sigmoidAVX but without the negation and the final 1/(1+exp) wrap.
+// Inputs are clamped to [-88, 88] to match the pure-Go fallback: results stay
+// finite and large-negative inputs underflow to 0.
+TEXT ·expAVX(SB), NOSPLIT, $0-48
+    MOVQ dst_base+0(FP), DI
+    MOVQ dst_len+8(FP), CX
+    MOVQ src_base+24(FP), SI
+
+    // Load constants into registers
+    VMOVUPS exp_log2e<>(SB), Y8         // Y8 = log2(e)
+    VMOVUPS exp_ln2<>(SB), Y9           // Y9 = ln(2)
+    VMOVUPS exp_one<>(SB), Y10          // Y10 = 1.0
+    VMOVUPS exp_c2<>(SB), Y11           // Y11 = c2 = 0.5
+    VMOVUPS exp_c3<>(SB), Y12           // Y12 = c3 = 1/6
+    VMOVUPS exp_c4<>(SB), Y13           // Y13 = c4 = 1/24
+    VMOVUPS exp_c5<>(SB), Y14           // Y14 = c5 = 1/120
+    VMOVUPS exp_magic<>(SB), Y15        // Y15 = magic for rounding
+
+    // Process 8 elements per iteration
+    MOVQ CX, AX
+    SHRQ $3, AX
+    JZ   exp32_remainder
+
+exp32_loop8:
+    VMOVUPS (SI), Y0                    // Y0 = x
+
+    // Clamp x to [-88, 88]
+    VMOVUPS exp_clamp_hi<>(SB), Y1
+    VMOVUPS exp_clamp_lo<>(SB), Y2
+    VMINPS Y1, Y0, Y0                   // clamp upper
+    VMAXPS Y2, Y0, Y0                   // clamp lower
+
+    // Range reduction: k = round(x * log2e), r = x - k * ln2
+    VMULPS Y8, Y0, Y1                   // Y1 = x * log2e
+    VADDPS Y15, Y1, Y2                  // Y2 = x*log2e + magic
+    VSUBPS Y15, Y2, Y3                  // Y3 = k = round(x * log2e) as float
+    VMULPS Y9, Y3, Y4                   // Y4 = k * ln2
+    VSUBPS Y4, Y0, Y0                   // Y0 = r = x - k * ln2
+
+    // Polynomial: exp(r) ~= 1 + r*(1 + r*(c2 + r*(c3 + r*(c4 + r*c5))))
+    VMULPS Y0, Y14, Y1                  // Y1 = r * c5
+    VADDPS Y13, Y1, Y1                  // Y1 = c4 + r*c5
+    VMULPS Y0, Y1, Y1                   // Y1 = r*(c4 + r*c5)
+    VADDPS Y12, Y1, Y1                  // Y1 = c3 + r*(...)
+    VMULPS Y0, Y1, Y1                   // Y1 = r*(c3 + ...)
+    VADDPS Y11, Y1, Y1                  // Y1 = c2 + r*(...)
+    VMULPS Y0, Y1, Y1                   // Y1 = r*(c2 + ...)
+    VADDPS Y10, Y1, Y1                  // Y1 = 1 + r*(...)
+    VMULPS Y0, Y1, Y1                   // Y1 = r*(1 + ...)
+    VADDPS Y10, Y1, Y1                  // Y1 = exp(r)
+
+    // Reconstruct: exp(x) = exp(r) * 2^k
+    VCVTPS2DQ Y3, Y4                    // Y4 = int(k)
+    VPSLLD $23, Y4, Y4                  // Y4 = k << 23
+    VPADDD Y10, Y4, Y4                  // Y4 = 2^k (add to 1.0's bits)
+    VMULPS Y4, Y1, Y1                   // Y1 = exp(x)
+
+    VMOVUPS Y1, (DI)                    // store result
+
+    ADDQ $32, SI
+    ADDQ $32, DI
+    DECQ AX
+    JNZ  exp32_loop8
+
+exp32_remainder:
+    ANDQ $7, CX
+    JZ   exp32_done
+
+    VMOVSS exp_log2e<>(SB), X8
+    VMOVSS exp_ln2<>(SB), X9
+    VMOVSS exp_magic<>(SB), X15
+    VMOVSS exp_one<>(SB), X10
+    VMOVSS exp_c2<>(SB), X11
+    VMOVSS exp_c3<>(SB), X12
+    VMOVSS exp_c4<>(SB), X13
+    VMOVSS exp_c5<>(SB), X14
+
+exp32_scalar:
+    VMOVSS (SI), X0                     // X0 = x
+
+    // Clamp
+    VMOVSS exp_clamp_hi<>(SB), X1
+    VMOVSS exp_clamp_lo<>(SB), X2
+    VMINSS X1, X0, X0
+    VMAXSS X2, X0, X0
+
+    // Range reduction
+    VMULSS X8, X0, X1                   // X1 = x * log2e
+    VADDSS X15, X1, X2
+    VSUBSS X15, X2, X3                  // X3 = k
+    VMULSS X9, X3, X4
+    VSUBSS X4, X0, X0                   // X0 = r
+
+    // Polynomial
+    VMULSS X0, X14, X1
+    VADDSS X13, X1, X1
+    VMULSS X0, X1, X1
+    VADDSS X12, X1, X1
+    VMULSS X0, X1, X1
+    VADDSS X11, X1, X1
+    VMULSS X0, X1, X1
+    VADDSS X10, X1, X1
+    VMULSS X0, X1, X1
+    VADDSS X10, X1, X1                  // X1 = exp(r)
+
+    // Reconstruct 2^k
+    VCVTSS2SI X3, AX                    // AX = int(k)
+    SHLL $23, AX                        // AX = k << 23
+    ADDL $0x3f800000, AX                // AX = 2^k bits (add 127<<23 bias)
+    VMOVD AX, X4
+    VMULSS X4, X1, X1                   // X1 = exp(x)
+    VMOVSS X1, (DI)
+
+    ADDQ $4, SI
+    ADDQ $4, DI
+    DECQ CX
+    JNZ  exp32_scalar
+
+exp32_done:
     VZEROUPPER
     RET
 

--- a/f32/f32_arm64.go
+++ b/f32/f32_arm64.go
@@ -339,8 +339,16 @@ func tanh32(dst, src []float32) {
 func tanhNEON(dst, src []float32)
 
 func exp32(dst, src []float32) {
+	// Assumes len(src) >= len(dst); caller ensures this via public API
+	if hasNEON && len(dst) >= 4 {
+		expNEON(dst, src)
+		return
+	}
 	exp32Go(dst, src)
 }
+
+//go:noescape
+func expNEON(dst, src []float32)
 
 func int32ToFloat32Scale(dst []float32, src []int32, scale float32) {
 	if hasNEON && len(dst) >= 4 {

--- a/f32/f32_arm64.s
+++ b/f32/f32_arm64.s
@@ -1166,6 +1166,163 @@ sigmoid32_neon_scalar_loop:
 sigmoid32_neon_done:
     RET
 
+// func expNEON(dst, src []float32)
+// Computes e^x using range reduction and a degree-5 polynomial, the same exp
+// core as sigmoidNEON but without the negation and the final 1/(1+exp) wrap.
+// Inputs are clamped to [-88, 88] to match the pure-Go fallback: results stay
+// finite and large-negative inputs underflow to 0.
+TEXT ·expNEON(SB), NOSPLIT, $0-48
+    MOVD dst_base+0(FP), R0
+    MOVD dst_len+8(FP), R3
+    MOVD src_base+24(FP), R1
+
+    // log2(e) = 1.442695041 = 0x3fb8aa3b
+    MOVW $0x3fb8aa3b, R10
+    VMOV R10, V20.S[0]
+    VDUP V20.S[0], V20.S4         // V20 = log2(e)
+
+    // ln(2) = 0.693147181 = 0x3f317218
+    MOVW $0x3f317218, R10
+    VMOV R10, V21.S[0]
+    VDUP V21.S[0], V21.S4         // V21 = ln(2)
+
+    // 1.0
+    FMOVS $1.0, F22
+    VDUP V22.S[0], V22.S4         // V22 = 1.0
+
+    // c2 = 0.5
+    FMOVS $0.5, F23
+    VDUP V23.S[0], V23.S4         // V23 = c2 = 0.5
+
+    // c3 = 1/6 = 0x3e2aaaab
+    MOVW $0x3e2aaaab, R10
+    VMOV R10, V24.S[0]
+    VDUP V24.S[0], V24.S4         // V24 = c3 = 1/6
+
+    // c4 = 1/24 = 0x3d2aaaab
+    MOVW $0x3d2aaaab, R10
+    VMOV R10, V25.S[0]
+    VDUP V25.S[0], V25.S4         // V25 = c4 = 1/24
+
+    // c5 = 1/120 = 0x3c088889
+    MOVW $0x3c088889, R10
+    VMOV R10, V26.S[0]
+    VDUP V26.S[0], V26.S4         // V26 = c5 = 1/120
+
+    // Clamp thresholds: ±88.0 = 0x42b00000 / 0xc2b00000
+    MOVW $0x42b00000, R10
+    VMOV R10, V27.S[0]
+    VDUP V27.S[0], V27.S4         // V27 = 88.0 (clamp_hi)
+
+    MOVW $0xc2b00000, R10
+    VMOV R10, V28.S[0]
+    VDUP V28.S[0], V28.S4         // V28 = -88.0 (clamp_lo)
+
+    // Process 4 elements per iteration
+    LSR $2, R3, R4
+    CBZ R4, exp32_neon_scalar
+
+exp32_neon_loop4:
+    VLD1.P 16(R1), [V0.S4]        // V0 = x
+
+    // Clamp x to [-88, 88]
+    WORD $0x4EBBF400              // FMIN V0.4S, V0.4S, V27.4S
+    WORD $0x4E3CF400              // FMAX V0.4S, V0.4S, V28.4S
+
+    // Range reduction: k = round(x * log2e), r = x - k * ln2
+    WORD $0x6E34DC01              // FMUL V1.4S, V0.4S, V20.4S   V1 = x * log2e
+    WORD $0x4E218822              // FRINTN V2.4S, V1.4S         V2 = k = round(V1)
+    WORD $0x6E35DC44              // FMUL V4.4S, V2.4S, V21.4S   V4 = k * ln2
+    WORD $0x4EA4D403              // FSUB V3.4S, V0.4S, V4.4S    V3 = r = x - k * ln2
+
+    // Polynomial: exp(r) ~= 1 + r*(1 + r*(c2 + r*(c3 + r*(c4 + r*c5))))
+    WORD $0x6E3ADC64              // FMUL V4.4S, V3.4S, V26.4S   V4 = r * c5
+    WORD $0x4E39D484              // FADD V4.4S, V4.4S, V25.4S   V4 = c4 + r*c5
+    WORD $0x6E23DC84              // FMUL V4.4S, V4.4S, V3.4S    V4 = r*(c4 + r*c5)
+    WORD $0x4E38D484              // FADD V4.4S, V4.4S, V24.4S   V4 = c3 + r*(...)
+    WORD $0x6E23DC84              // FMUL V4.4S, V4.4S, V3.4S    V4 = r*(c3 + ...)
+    WORD $0x4E37D484              // FADD V4.4S, V4.4S, V23.4S   V4 = c2 + r*(...)
+    WORD $0x6E23DC84              // FMUL V4.4S, V4.4S, V3.4S    V4 = r*(c2 + ...)
+    WORD $0x4E36D484              // FADD V4.4S, V4.4S, V22.4S   V4 = 1 + r*(...)
+    WORD $0x6E23DC84              // FMUL V4.4S, V4.4S, V3.4S    V4 = r*(1 + ...)
+    WORD $0x4E36D484              // FADD V4.4S, V4.4S, V22.4S   V4 = exp(r)
+
+    // Reconstruct: exp(x) = exp(r) * 2^k
+    WORD $0x4EA1B841              // FCVTZS V1.4S, V2.4S         V1 = int(k)
+    WORD $0x4F375421              // SHL V1.4S, V1.4S, #23       V1 = k << 23
+    WORD $0x4EB68421              // ADD V1.4S, V1.4S, V22.4S    V1 = 2^k (add 1.0's bits)
+    WORD $0x6E21DC84              // FMUL V4.4S, V4.4S, V1.4S    V4 = exp(x)
+
+    VST1.P [V4.S4], 16(R0)        // store result
+
+    SUB $1, R4
+    CBNZ R4, exp32_neon_loop4
+
+exp32_neon_scalar:
+    AND $3, R3
+    CBZ R3, exp32_neon_done
+
+exp32_neon_scalar_loop:
+    FMOVS (R1), F0                // F0 = x
+
+    // Clamp to [-88, 88]
+    MOVW $0x42b00000, R10
+    FMOVS R10, F1
+    MOVW $0xc2b00000, R10
+    FMOVS R10, F2
+    FMINS F1, F0, F0
+    FMAXS F2, F0, F0
+
+    // Range reduction
+    MOVW $0x3fb8aa3b, R10
+    FMOVS R10, F8
+    FMULS F8, F0, F1              // F1 = x * log2e
+    FRINTNS F1, F2                // F2 = k = round(F1)
+
+    MOVW $0x3f317218, R10
+    FMOVS R10, F9
+    FMULS F9, F2, F3              // F3 = k * ln2
+    FSUBS F3, F0, F0              // F0 = r = x - k * ln2
+
+    // Polynomial coefficients
+    FMOVS $1.0, F10               // c1 = 1.0
+    FMOVS $0.5, F11               // c2 = 0.5
+    MOVW $0x3e2aaaab, R10
+    FMOVS R10, F12                // c3 = 1/6
+    MOVW $0x3d2aaaab, R10
+    FMOVS R10, F13                // c4 = 1/24
+    MOVW $0x3c088889, R10
+    FMOVS R10, F14                // c5 = 1/120
+
+    // Horner's method
+    FMULS F0, F14, F4             // F4 = r * c5
+    FADDS F13, F4, F4
+    FMULS F0, F4, F4
+    FADDS F12, F4, F4
+    FMULS F0, F4, F4
+    FADDS F11, F4, F4
+    FMULS F0, F4, F4
+    FADDS F10, F4, F4
+    FMULS F0, F4, F4
+    FADDS F10, F4, F4             // F4 = exp(r)
+
+    // Reconstruct 2^k
+    FCVTZSS F2, R10               // R10 = int(k)
+    LSL $23, R10, R10            // R10 = k << 23
+    MOVW $0x3f800000, R11
+    ADD R11, R10, R10            // R10 = 2^k bits
+    FMOVS R10, F5
+    FMULS F5, F4, F4             // F4 = exp(x)
+    FMOVS F4, (R0)              // store result
+
+    ADD $4, R0
+    ADD $4, R1
+    SUB $1, R3
+    CBNZ R3, exp32_neon_scalar_loop
+
+exp32_neon_done:
+    RET
+
 // func reluNEON(dst, src []float32)
 // Computes ReLU: dst[i] = max(0, src[i])
 TEXT ·reluNEON(SB), NOSPLIT, $0-48

--- a/f32/f32_arm64.s
+++ b/f32/f32_arm64.s
@@ -1262,29 +1262,16 @@ exp32_neon_scalar:
     AND $3, R3
     CBZ R3, exp32_neon_done
 
-exp32_neon_scalar_loop:
-    FMOVS (R1), F0                // F0 = x
-
-    // Clamp to [-88, 88]
+    // Hoist loop-invariant constants out of the remainder loop. The clamp
+    // bounds live in F6/F7 because F1/F2 are reused as temporaries below.
     MOVW $0x42b00000, R10
-    FMOVS R10, F1
+    FMOVS R10, F6                 // F6 = 88.0 (clamp_hi)
     MOVW $0xc2b00000, R10
-    FMOVS R10, F2
-    FMINS F1, F0, F0
-    FMAXS F2, F0, F0
-
-    // Range reduction
+    FMOVS R10, F7                 // F7 = -88.0 (clamp_lo)
     MOVW $0x3fb8aa3b, R10
-    FMOVS R10, F8
-    FMULS F8, F0, F1              // F1 = x * log2e
-    FRINTNS F1, F2                // F2 = k = round(F1)
-
+    FMOVS R10, F8                 // F8 = log2(e)
     MOVW $0x3f317218, R10
-    FMOVS R10, F9
-    FMULS F9, F2, F3              // F3 = k * ln2
-    FSUBS F3, F0, F0              // F0 = r = x - k * ln2
-
-    // Polynomial coefficients
+    FMOVS R10, F9                 // F9 = ln(2)
     FMOVS $1.0, F10               // c1 = 1.0
     FMOVS $0.5, F11               // c2 = 0.5
     MOVW $0x3e2aaaab, R10
@@ -1293,6 +1280,20 @@ exp32_neon_scalar_loop:
     FMOVS R10, F13                // c4 = 1/24
     MOVW $0x3c088889, R10
     FMOVS R10, F14                // c5 = 1/120
+    MOVW $0x3f800000, R11         // R11 = 1.0's bits (exponent bias)
+
+exp32_neon_scalar_loop:
+    FMOVS (R1), F0                // F0 = x
+
+    // Clamp to [-88, 88]
+    FMINS F6, F0, F0
+    FMAXS F7, F0, F0
+
+    // Range reduction
+    FMULS F8, F0, F1              // F1 = x * log2e
+    FRINTNS F1, F2                // F2 = k = round(F1)
+    FMULS F9, F2, F3              // F3 = k * ln2
+    FSUBS F3, F0, F0              // F0 = r = x - k * ln2
 
     // Horner's method
     FMULS F0, F14, F4             // F4 = r * c5
@@ -1309,7 +1310,6 @@ exp32_neon_scalar_loop:
     // Reconstruct 2^k
     FCVTZSS F2, R10               // R10 = int(k)
     LSL $23, R10, R10            // R10 = k << 23
-    MOVW $0x3f800000, R11
     ADD R11, R10, R10            // R10 = 2^k bits
     FMOVS R10, F5
     FMULS F5, F4, F4             // F4 = exp(x)

--- a/f32/f32_test.go
+++ b/f32/f32_test.go
@@ -459,6 +459,28 @@ func TestExpAccuracy(t *testing.T) {
 	}
 }
 
+// TestExpLengths runs Exp over every length from 1 to 33 so the scalar
+// remainder loop is exercised with 1, 2 and 3 trailing elements (the NEON
+// body consumes 4 at a time). This guards against remainder-loop bugs that a
+// single trailing element would miss, e.g. clobbering hoisted clamp constants.
+func TestExpLengths(t *testing.T) {
+	for n := 1; n <= 33; n++ {
+		src := make([]float32, n)
+		dst := make([]float32, n)
+		for i := range src {
+			// Distinct, non-trivial values across the loop body and remainder.
+			src[i] = float32(-6.0 + 0.7*float64(i))
+		}
+		Exp(dst, src)
+		for i, x := range src {
+			want := float32(math.Exp(float64(x)))
+			if relErr := relErrF32(dst[i], want); relErr > 1e-4 {
+				t.Errorf("len=%d Exp(%v)[%d] = %v, want %v (relErr %v)", n, x, i, dst[i], want, relErr)
+			}
+		}
+	}
+}
+
 // Benchmarks
 
 func BenchmarkDotProduct_100(b *testing.B) {

--- a/f32/f32_test.go
+++ b/f32/f32_test.go
@@ -424,6 +424,41 @@ func TestExp(t *testing.T) {
 	}
 }
 
+// TestExpAccuracy checks Exp against math.Exp across the full clamp range,
+// exercising both the SIMD body (len >= 8) and the scalar remainder. The
+// reference mirrors the pure-Go fallback semantics: inputs are clamped to
+// [-88, 88], large-positive results saturate at exp(88), and large-negative
+// inputs underflow to 0.
+func TestExpAccuracy(t *testing.T) {
+	src := []float32{
+		-90, -88, -50, -20, -10, -5, -2, -1,
+		-0.5, 0, 0.5, 1, 2, 5, 10, 50,
+		88, 90, 3.3, -3.3, 7.7, // 21 elements: 2 SIMD blocks + 5 remainder
+	}
+	dst := make([]float32, len(src))
+	Exp(dst, src)
+
+	for i, x := range src {
+		got := dst[i]
+		if math.IsNaN(float64(got)) || got < 0 {
+			t.Errorf("Exp(%v)[%d] = %v, expected a finite non-negative value", x, i, got)
+			continue
+		}
+		var want float32
+		switch {
+		case x > 88:
+			want = float32(math.Exp(88))
+		case x < -88:
+			want = 0
+		default:
+			want = float32(math.Exp(float64(x)))
+		}
+		if relErr := relErrF32(got, want); relErr > 1e-4 {
+			t.Errorf("Exp(%v)[%d] = %v, want %v (relErr %v)", x, i, got, want, relErr)
+		}
+	}
+}
+
 // Benchmarks
 
 func BenchmarkDotProduct_100(b *testing.B) {

--- a/f64/benchmark_test.go
+++ b/f64/benchmark_test.go
@@ -644,6 +644,28 @@ func BenchmarkTanh(b *testing.B) {
 	}
 }
 
+func BenchmarkExp(b *testing.B) {
+	for _, size := range benchSizes {
+		a, _, _, dst := makeBenchData64(size)
+		// Use values in a reasonable range for exp
+		for i := range a {
+			a[i] = (a[i] - 50) / 10 // Range roughly -5 to +5
+		}
+		b.Run(fmt.Sprintf("SIMD_%d", size), func(b *testing.B) {
+			for i := 0; i < b.N; i++ {
+				Exp(dst, a)
+			}
+			reportThroughput64(b, size*2)
+		})
+		b.Run(fmt.Sprintf("Go_%d", size), func(b *testing.B) {
+			for i := 0; i < b.N; i++ {
+				exp64Go(dst, a)
+			}
+			reportThroughput64(b, size*2)
+		})
+	}
+}
+
 // =============================================================================
 // Quick Summary Benchmark
 // =============================================================================

--- a/f64/f64.go
+++ b/f64/f64.go
@@ -587,10 +587,15 @@ func TanhInPlace(a []float64) {
 }
 
 // Exp computes the exponential function: dst[i] = e^src[i].
-// Uses polynomial approximation for reasonable accuracy and performance.
 // Processes min(len(dst), len(src)) elements.
 //
-// Uses AVX+FMA on AMD64 (4x float64), NEON on ARM64 (2x float64).
+// The SIMD paths use range reduction plus a degree-5 polynomial, giving a
+// maximum relative error of about 3e-6. Inputs are clamped to [-709, 709] so
+// results stay finite (exp(709) is near MaxFloat64); inputs below about -709
+// underflow to 0. This matches the pure-Go fallback's clamping.
+//
+// Uses AVX on AMD64 (2x float64), NEON on ARM64 (2x float64), and falls back
+// to math.Exp otherwise.
 func Exp(dst, src []float64) {
 	n := min(len(dst), len(src))
 	if n == 0 {

--- a/f64/f64_amd64.go
+++ b/f64/f64_amd64.go
@@ -418,10 +418,15 @@ func tanh64(dst, src []float64) {
 func tanhAVX(dst, src []float64)
 
 func exp64(dst, src []float64) {
-	// Exp is complex, use Go implementation with math.Exp for now
-	// Can be optimized with AVX polynomial approximation later
+	if cpu.X86.AVX && len(dst) >= minAVXElements && len(src) >= minAVXElements {
+		expAVX(dst, src)
+		return
+	}
 	exp64Go(dst, src)
 }
+
+//go:noescape
+func expAVX(dst, src []float64)
 
 //go:noescape
 func sigmoidAVX(dst, src []float64)

--- a/f64/f64_amd64.go
+++ b/f64/f64_amd64.go
@@ -418,7 +418,7 @@ func tanh64(dst, src []float64) {
 func tanhAVX(dst, src []float64)
 
 func exp64(dst, src []float64) {
-	if cpu.X86.AVX && len(dst) >= minAVXElements && len(src) >= minAVXElements {
+	if cpu.X86.AVX && len(dst) >= minAVXElements {
 		expAVX(dst, src)
 		return
 	}

--- a/f64/f64_amd64.s
+++ b/f64/f64_amd64.s
@@ -3722,10 +3722,8 @@ exp64_scalar:
     VMOVSD (SI), X0                    // X0 = x
 
     // Clamp to [-709, 709]
-    MOVQ $0x4086280000000000, AX       // 709.0
-    VMOVQ AX, X1
-    MOVQ $0xC086280000000000, AX       // -709.0
-    VMOVQ AX, X2
+    VMOVSD exp_clamp_hi64<>(SB), X1
+    VMOVSD exp_clamp_lo64<>(SB), X2
     VMINSD X1, X0, X0
     VMAXSD X2, X0, X0
 

--- a/f64/f64_amd64.s
+++ b/f64/f64_amd64.s
@@ -3330,6 +3330,17 @@ DATA tanh64_clamp_lo<>+0x10(SB)/8, $0xC034000000000000
 DATA tanh64_clamp_lo<>+0x18(SB)/8, $0xC034000000000000
 GLOBL tanh64_clamp_lo<>(SB), RODATA|NOPTR, $32
 
+// Exp clamp thresholds: ±709.0 keeps the 2^k reconstruction inside the
+// representable float64 range (exp(709) ~= 8.2e307 < MaxFloat64). Matches the
+// pure-Go fallback's overflow/underflow clamp.
+DATA exp_clamp_hi64<>+0x00(SB)/8, $0x4086280000000000  // 709.0
+DATA exp_clamp_hi64<>+0x08(SB)/8, $0x4086280000000000
+GLOBL exp_clamp_hi64<>(SB), RODATA|NOPTR, $16
+
+DATA exp_clamp_lo64<>+0x00(SB)/8, $0xC086280000000000  // -709.0
+DATA exp_clamp_lo64<>+0x08(SB)/8, $0xC086280000000000
+GLOBL exp_clamp_lo64<>(SB), RODATA|NOPTR, $16
+
 // Note: absf64mask is already defined at top of file
 
 // func sigmoidAVX(dst, src []float64)
@@ -3626,6 +3637,131 @@ tanh64_scalar:
     JNZ  tanh64_scalar
 
 tanh64_done:
+    VZEROUPPER
+    RET
+
+// func expAVX(dst, src []float64)
+// Computes e^x using range reduction and a degree-5 polynomial, the same exp
+// core as tanhAVX but without the -2x scaling and the tanh wrap. Inputs are
+// clamped to [-709, 709] to match the pure-Go fallback: results stay finite
+// and large-negative inputs underflow to 0. Processes 2 elements per
+// iteration (XMM = 2 x float64).
+TEXT ·expAVX(SB), NOSPLIT, $0-48
+    MOVQ dst_base+0(FP), DX
+    MOVQ dst_len+8(FP), CX
+    MOVQ src_base+24(FP), SI
+
+    VMOVUPD tanh64_log2e<>(SB), X9     // X9 = log2(e)
+    VMOVUPD tanh64_ln2<>(SB), X10      // X10 = ln(2)
+    VMOVUPD sigmoid_one64<>(SB), X11   // X11 = 1.0
+    VMOVUPD sigmoid_half64<>(SB), X12  // X12 = 0.5 (c2)
+    VMOVUPD tanh64_c3<>(SB), X13       // X13 = 1/6 (c3)
+    VMOVUPD tanh64_c4<>(SB), X14       // X14 = 1/24 (c4)
+    VMOVUPD tanh64_c5<>(SB), X15       // X15 = 1/120 (c5)
+
+    // Process 2 elements per iteration
+    MOVQ CX, R8
+    SHRQ $1, R8
+    JZ   exp64_remainder
+
+exp64_loop2:
+    VMOVUPD (SI), X0                   // X0 = 2 x float64
+
+    // Clamp x to [-709, 709]
+    VMOVUPD exp_clamp_hi64<>(SB), X1
+    VMOVUPD exp_clamp_lo64<>(SB), X2
+    VMINPD X1, X0, X0
+    VMAXPD X2, X0, X0
+
+    // Range reduction: k = round(x * log2e), r = x - k * ln2
+    VMULPD X9, X0, X1                  // X1 = x * log2e
+    VROUNDPD $0, X1, X2                // X2 = k = round(X1)
+    VMULPD X10, X2, X3                 // X3 = k * ln2
+    VSUBPD X3, X0, X3                  // X3 = r = x - k * ln2
+
+    // Polynomial: exp(r) ~= 1 + r*(1 + r*(c2 + r*(c3 + r*(c4 + r*c5))))
+    VMULPD X3, X15, X4                 // X4 = r * c5
+    VADDPD X14, X4, X4                 // X4 = c4 + r*c5
+    VMULPD X3, X4, X4                  // X4 = r*(c4 + r*c5)
+    VADDPD X13, X4, X4                 // X4 = c3 + r*(...)
+    VMULPD X3, X4, X4                  // X4 = r*(c3 + ...)
+    VADDPD X12, X4, X4                 // X4 = c2 + r*(...)
+    VMULPD X3, X4, X4                  // X4 = r*(c2 + ...)
+    VADDPD X11, X4, X4                 // X4 = 1 + r*(...)
+    VMULPD X3, X4, X4                  // X4 = r*(1 + ...)
+    VADDPD X11, X4, X4                 // X4 = exp(r)
+
+    // Reconstruct exp(x) = exp(r) * 2^k for 2 elements
+    // Element 0:
+    VCVTTSD2SI X2, AX                  // AX = int64(k[0])
+    SHLQ $52, AX                       // k[0] << 52
+    MOVQ $0x3FF0000000000000, BX
+    ADDQ BX, AX                        // 2^k[0] bits
+    VMOVQ AX, X5
+    // Element 1:
+    VPSRLDQ $8, X2, X6                 // X6 = k[1]
+    VCVTTSD2SI X6, AX                  // AX = int64(k[1])
+    SHLQ $52, AX
+    MOVQ $0x3FF0000000000000, BX
+    ADDQ BX, AX
+    VMOVQ AX, X6
+    VPUNPCKLQDQ X6, X5, X5             // X5 = {2^k[0], 2^k[1]}
+    VMULPD X5, X4, X4                  // X4 = exp(x)
+
+    VMOVUPD X4, (DX)                   // store 2 results
+    ADDQ $16, SI
+    ADDQ $16, DX
+    DECQ R8
+    JNZ  exp64_loop2
+
+exp64_remainder:
+    ANDQ $1, CX
+    JZ   exp64_done
+
+exp64_scalar:
+    VMOVSD (SI), X0                    // X0 = x
+
+    // Clamp to [-709, 709]
+    MOVQ $0x4086280000000000, AX       // 709.0
+    VMOVQ AX, X1
+    MOVQ $0xC086280000000000, AX       // -709.0
+    VMOVQ AX, X2
+    VMINSD X1, X0, X0
+    VMAXSD X2, X0, X0
+
+    // Range reduction
+    VMULSD X9, X0, X1
+    VROUNDSD $0, X1, X1, X2            // X2 = k
+    VMULSD X10, X2, X3
+    VSUBSD X3, X0, X3                  // X3 = r
+
+    // Polynomial
+    VMULSD X3, X15, X4
+    VADDSD X14, X4, X4
+    VMULSD X3, X4, X4
+    VADDSD X13, X4, X4
+    VMULSD X3, X4, X4
+    VADDSD X12, X4, X4
+    VMULSD X3, X4, X4
+    VADDSD X11, X4, X4
+    VMULSD X3, X4, X4
+    VADDSD X11, X4, X4                 // X4 = exp(r)
+
+    // Reconstruct 2^k
+    VCVTTSD2SI X2, AX                  // AX = int64(k)
+    SHLQ $52, AX
+    MOVQ $0x3FF0000000000000, BX
+    ADDQ BX, AX
+    VMOVQ AX, X5
+    VMULSD X5, X4, X4                  // X4 = exp(x)
+
+    VMOVSD X4, (DX)
+    ADDQ $8, SI
+    ADDQ $8, DX
+    DECQ CX
+    JNZ  exp64_scalar
+
+exp64_done:
     VZEROUPPER
     RET
 

--- a/f64/f64_arm64.go
+++ b/f64/f64_arm64.go
@@ -352,8 +352,16 @@ func tanh64(dst, src []float64) {
 }
 
 func exp64(dst, src []float64) {
+	// Assumes len(src) >= len(dst); caller ensures this via public API
+	if hasNEON && len(dst) >= 2 {
+		expNEON64(dst, src)
+		return
+	}
 	exp64Go(dst, src)
 }
+
+//go:noescape
+func expNEON64(dst, src []float64)
 
 //go:noescape
 func sigmoidNEON64(dst, src []float64)

--- a/f64/f64_arm64.s
+++ b/f64/f64_arm64.s
@@ -1117,6 +1117,163 @@ tanh64_neon_scalar_loop:
 tanh64_neon_done:
     RET
 
+// func expNEON64(dst, src []float64)
+// Computes e^x using range reduction and a degree-5 polynomial, the same exp
+// core as tanhNEON64 but without the -2x scaling and the tanh wrap. Inputs are
+// clamped to [-709, 709] to match the pure-Go fallback: results stay finite
+// and large-negative inputs underflow to 0. Processes 2 elements per iteration.
+TEXT ·expNEON64(SB), NOSPLIT, $0-48
+    MOVD dst_base+0(FP), R0
+    MOVD dst_len+8(FP), R3
+    MOVD src_base+24(FP), R1
+
+    // log2(e) = 1.4426950408889634 = 0x3FF71547652B82FE
+    MOVD $0x3FF71547652B82FE, R10
+    VMOV R10, V20.D[0]
+    VDUP V20.D[0], V20.D2             // V20 = log2(e)
+
+    // ln(2) = 0.6931471805599453 = 0x3FE62E42FEFA39EF
+    MOVD $0x3FE62E42FEFA39EF, R10
+    VMOV R10, V21.D[0]
+    VDUP V21.D[0], V21.D2             // V21 = ln(2)
+
+    // 1.0
+    FMOVD $1.0, F22
+    VDUP V22.D[0], V22.D2             // V22 = 1.0
+
+    // c2 = 0.5
+    FMOVD $0.5, F23
+    VDUP V23.D[0], V23.D2             // V23 = c2 = 0.5
+
+    // c3 = 1/6 = 0x3FC5555555555555
+    MOVD $0x3FC5555555555555, R10
+    VMOV R10, V24.D[0]
+    VDUP V24.D[0], V24.D2             // V24 = c3 = 1/6
+
+    // c4 = 1/24 = 0x3FA5555555555555
+    MOVD $0x3FA5555555555555, R10
+    VMOV R10, V25.D[0]
+    VDUP V25.D[0], V25.D2             // V25 = c4 = 1/24
+
+    // c5 = 1/120 = 0x3F81111111111111
+    MOVD $0x3F81111111111111, R10
+    VMOV R10, V26.D[0]
+    VDUP V26.D[0], V26.D2             // V26 = c5 = 1/120
+
+    // Clamp thresholds: ±709.0 = 0x4086280000000000 / 0xC086280000000000
+    MOVD $0x4086280000000000, R10
+    VMOV R10, V27.D[0]
+    VDUP V27.D[0], V27.D2             // V27 = 709.0 (clamp_hi)
+
+    MOVD $0xC086280000000000, R10
+    VMOV R10, V28.D[0]
+    VDUP V28.D[0], V28.D2             // V28 = -709.0 (clamp_lo)
+
+    // Process 2 elements per iteration
+    LSR $1, R3, R4
+    CBZ R4, exp64_neon_scalar
+
+exp64_neon_loop2:
+    VLD1.P 16(R1), [V0.D2]            // V0 = x
+
+    // Clamp x to [-709, 709]
+    WORD $0x4EFBF400                  // FMIN V0.2D, V0.2D, V27.2D
+    WORD $0x4E7CF400                  // FMAX V0.2D, V0.2D, V28.2D
+
+    // Range reduction: k = round(x * log2e), r = x - k * ln2
+    WORD $0x6E74DC01                  // FMUL V1.2D, V0.2D, V20.2D   V1 = x * log2e
+    WORD $0x4E618822                  // FRINTN V2.2D, V1.2D         V2 = k = round(V1)
+    WORD $0x6E75DC44                  // FMUL V4.2D, V2.2D, V21.2D   V4 = k * ln2
+    WORD $0x4EE4D403                  // FSUB V3.2D, V0.2D, V4.2D    V3 = r = x - k * ln2
+
+    // Polynomial: exp(r) ~= 1 + r*(1 + r*(c2 + r*(c3 + r*(c4 + r*c5))))
+    WORD $0x6E7ADC64                  // FMUL V4.2D, V3.2D, V26.2D   V4 = r * c5
+    WORD $0x4E79D484                  // FADD V4.2D, V4.2D, V25.2D   V4 = c4 + r*c5
+    WORD $0x6E63DC84                  // FMUL V4.2D, V4.2D, V3.2D    V4 = r*(c4 + r*c5)
+    WORD $0x4E78D484                  // FADD V4.2D, V4.2D, V24.2D   V4 = c3 + r*(...)
+    WORD $0x6E63DC84                  // FMUL V4.2D, V4.2D, V3.2D    V4 = r*(c3 + ...)
+    WORD $0x4E77D484                  // FADD V4.2D, V4.2D, V23.2D   V4 = c2 + r*(...)
+    WORD $0x6E63DC84                  // FMUL V4.2D, V4.2D, V3.2D    V4 = r*(c2 + ...)
+    WORD $0x4E76D484                  // FADD V4.2D, V4.2D, V22.2D   V4 = 1 + r*(...)
+    WORD $0x6E63DC84                  // FMUL V4.2D, V4.2D, V3.2D    V4 = r*(1 + ...)
+    WORD $0x4E76D484                  // FADD V4.2D, V4.2D, V22.2D   V4 = exp(r)
+
+    // Reconstruct: exp(x) = exp(r) * 2^k (float64: shift by 52)
+    WORD $0x4EE1B841                  // FCVTZS V1.2D, V2.2D         V1 = int(k)
+    WORD $0x4F745421                  // SHL V1.2D, V1.2D, #52       V1 = k << 52
+    WORD $0x4EF68421                  // ADD V1.2D, V1.2D, V22.2D    V1 = 2^k (add 1.0's bits)
+    WORD $0x6E61DC84                  // FMUL V4.2D, V4.2D, V1.2D    V4 = exp(x)
+
+    VST1.P [V4.D2], 16(R0)            // store result
+
+    SUB $1, R4
+    CBNZ R4, exp64_neon_loop2
+
+exp64_neon_scalar:
+    AND $1, R3
+    CBZ R3, exp64_neon_done
+
+exp64_neon_scalar_loop:
+    FMOVD (R1), F0                    // F0 = x
+
+    // Clamp to [-709, 709]
+    MOVD $0x4086280000000000, R10
+    FMOVD R10, F1
+    MOVD $0xC086280000000000, R10
+    FMOVD R10, F2
+    FMIND F1, F0, F0
+    FMAXD F2, F0, F0
+
+    // Range reduction
+    MOVD $0x3FF71547652B82FE, R10     // log2(e)
+    FMOVD R10, F8
+    FMULD F8, F0, F1                  // F1 = x * log2e
+    FRINTND F1, F2                    // F2 = k = round(F1)
+
+    MOVD $0x3FE62E42FEFA39EF, R10     // ln(2)
+    FMOVD R10, F9
+    FMULD F9, F2, F3                  // F3 = k * ln2
+    FSUBD F3, F0, F0                  // F0 = r = x - k * ln2
+
+    // Polynomial coefficients
+    FMOVD $1.0, F10                   // c1 = 1.0
+    FMOVD $0.5, F11                   // c2 = 0.5
+    MOVD $0x3FC5555555555555, R10     // c3 = 1/6
+    FMOVD R10, F12
+    MOVD $0x3FA5555555555555, R10     // c4 = 1/24
+    FMOVD R10, F13
+    MOVD $0x3F81111111111111, R10     // c5 = 1/120
+    FMOVD R10, F14
+
+    // Horner's method
+    FMULD F0, F14, F4                 // F4 = r * c5
+    FADDD F13, F4, F4
+    FMULD F0, F4, F4
+    FADDD F12, F4, F4
+    FMULD F0, F4, F4
+    FADDD F11, F4, F4
+    FMULD F0, F4, F4
+    FADDD F10, F4, F4
+    FMULD F0, F4, F4
+    FADDD F10, F4, F4                 // F4 = exp(r)
+
+    // Reconstruct 2^k (float64: shift by 52)
+    FCVTZSD F2, R10
+    LSL $52, R10, R10
+    MOVD $0x3FF0000000000000, R11
+    ADD R11, R10, R10
+    FMOVD R10, F5
+    FMULD F5, F4, F4                  // F4 = exp(x)
+    FMOVD F4, (R0)                    // store result
+
+    ADD $8, R0
+    ADD $8, R1
+    SUB $1, R3
+    CBNZ R3, exp64_neon_scalar_loop
+
+exp64_neon_done:
+    RET
+
 // func clampScaleNEON64(dst, src []float64, minVal, maxVal, scale float64)
 // Performs fused clamp and scale: dst[i] = (clamp(src[i], minVal, maxVal) - minVal) * scale
 TEXT ·clampScaleNEON64(SB), NOSPLIT, $0-72

--- a/f64/f64_test.go
+++ b/f64/f64_test.go
@@ -1158,3 +1158,28 @@ func TestExpAccuracy(t *testing.T) {
 		}
 	}
 }
+
+// TestExpLengths runs Exp over every length from 1 to 33 so the scalar
+// remainder loop is exercised alongside the SIMD body (the NEON/AVX bodies
+// consume 2 elements at a time for float64).
+func TestExpLengths(t *testing.T) {
+	for n := 1; n <= 33; n++ {
+		src := make([]float64, n)
+		dst := make([]float64, n)
+		for i := range src {
+			src[i] = -6.0 + 0.7*float64(i)
+		}
+		Exp(dst, src)
+		for i, x := range src {
+			want := math.Exp(x)
+			diff := math.Abs(dst[i] - want)
+			relErr := diff
+			if math.Abs(want) > 1e-12 {
+				relErr = diff / math.Abs(want)
+			}
+			if relErr > 1e-5 {
+				t.Errorf("len=%d Exp(%v)[%d] = %v, want %v (relErr %v)", n, x, i, dst[i], want, relErr)
+			}
+		}
+	}
+}

--- a/f64/f64_test.go
+++ b/f64/f64_test.go
@@ -1117,3 +1117,44 @@ func TestExp(t *testing.T) {
 		}
 	}
 }
+
+// TestExpAccuracy checks Exp against math.Exp across the full clamp range,
+// exercising both the SIMD body (len >= 4, two lanes per iteration) and the
+// scalar remainder. The reference mirrors the pure-Go fallback semantics:
+// inputs are clamped to [-709, 709], large-positive results saturate at
+// exp(709), and large-negative inputs underflow to 0. The exp core uses a
+// degree-5 polynomial, so the achievable relative error is ~3e-6.
+func TestExpAccuracy(t *testing.T) {
+	src := []float64{
+		-720, -709, -100, -20, -10, -5, -2, -1,
+		-0.5, 0, 0.5, 1, 2, 5, 10, 100,
+		709, 720, 3.3, -3.3, 7.7, // 21 elements: SIMD body + remainder
+	}
+	dst := make([]float64, len(src))
+	Exp(dst, src)
+
+	for i, x := range src {
+		got := dst[i]
+		if math.IsNaN(got) || got < 0 {
+			t.Errorf("Exp(%v)[%d] = %v, expected a finite non-negative value", x, i, got)
+			continue
+		}
+		var want float64
+		switch {
+		case x > 709:
+			want = math.Exp(709)
+		case x < -709:
+			want = 0
+		default:
+			want = math.Exp(x)
+		}
+		diff := math.Abs(got - want)
+		relErr := diff
+		if math.Abs(want) > 1e-12 {
+			relErr = diff / math.Abs(want)
+		}
+		if relErr > 1e-5 {
+			t.Errorf("Exp(%v)[%d] = %v, want %v (relErr %v)", x, i, got, want, relErr)
+		}
+	}
+}


### PR DESCRIPTION
## Summary

Implements vectorized `Exp` (e^x) for f32 and f64 on both AMD64 (AVX) and ARM64 (NEON), replacing the previous `math.Exp`-only fallback.

The exp core (range reduction plus a degree-5 polynomial) already lived inside the `sigmoid`/`tanh` kernels, so the new `expAVX`/`expNEON`/`expNEON64` paths reuse that proven math, dropping the negation and the sigmoid/tanh wrapper. The ARM64 paths use the corrected `FRINTN` encodings from the recent NEON fix and use no `FNEG` at all.

Inputs are clamped to `[-88, 88]` (f32) / `[-709, 709]` (f64) to match the pure-Go fallback's overflow handling: results stay finite (exp(88)/exp(709) are near the type max), and inputs below the negative clamp underflow to 0. Below the per-arch SIMD length threshold the code still falls back to `math.Exp`.

### Accuracy (measured vs math.Exp)

- f32: max relative error ~7e-6
- f64: max relative error ~3e-6

Both are the degree-5 polynomial limit, the same core used by the existing sigmoid/tanh.

### Performance (1024 elements)

| Arch  | f32            | f64            |
| ----- | -------------- | -------------- |
| AMD64 | ~18x (26 GB/s) | ~3.2x (10 GB/s)|
| ARM64 | ~12x (4 GB/s)  | ~5.9x (4 GB/s) |

f64 AVX is limited to 2 lanes per XMM (same Go-assembler constraint as the existing f64 tanh).

## Related Issues

Fixes #7

## Test Plan

- [x] `go test ./...` on amd64 (full suite, 1779 tests)
- [x] golangci-lint clean, gofmt/vet clean
- [x] Cross-compiled arm64 and ran the full f32 + f64 suites on real ARM64 hardware (Raspberry Pi 5)
- [x] New `TestExpAccuracy` (f32 + f64) compares SIMD output against `math.Exp` across the full clamp range, exercising both the SIMD body and the scalar remainder
- [x] New `BenchmarkExp` for both packages