### PR TITLE
c128: widen AbsSq SIMD kernels and add AVX-without-FMA dispatch

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ A high-performance SIMD (Single Instruction, Multiple Data) library for Go provi
 ## Features
 
 - **Pure Go assembly** - Native Go assembler, simple cross-compilation
-- **Runtime CPU detection** - Automatically selects optimal implementation (AVX-512, AVX+FMA, SSE4.1, NEON, NEON+FP16, or pure Go)
+- **Runtime CPU detection** - Automatically selects optimal implementation (AVX-512, AVX+FMA, AVX without FMA, SSE4.1, NEON, NEON+FP16, or pure Go)
 - **Zero allocations** - All operations work on pre-allocated slices
 - **80+ operations** - Arithmetic, reduction, statistical, vector, signal processing, activation functions, and complex number operations
 - **Multi-architecture** - AMD64 (AVX-512/AVX+FMA/SSE4.1) and ARM64 (NEON/NEON+FP16) with pure Go fallback
@@ -280,8 +280,8 @@ c128.Abs(magnitude, signalFFT)                  // Extract magnitude for display
 | MulConj   | 340 ns  | 749 ns  | **2.2x**  |
 | Scale     | 253 ns  | 551 ns  | **2.2x**  |
 | Add       | 86 ns   | 189 ns  | **2.2x**  |
-| Abs       | 1326 ns | 2260 ns | **1.7x**  |
-| AbsSq     | 367 ns  | 504 ns  | **1.37x** |
+| Abs       | 743 ns  | 2530 ns | **3.4x**  |
+| AbsSq     | 258 ns  | 476 ns  | **1.85x** |
 | Conj      | 304 ns  | 474 ns  | **1.56x** |
 
 ### `c64` - complex64 Operations
@@ -417,7 +417,7 @@ c64.Abs(magnitude, signalFFT)              // Extract magnitude
 | -------- | --------------- | ------------ | ------------ |
 | **f32**  | **6.5x**        | 21.8x (Abs)  | 35 functions |
 | **f64**  | **3.2x**        | 7.9x (Clamp) | 32 functions |
-| **c128** | **1.77x**       | 2.2x (Mul)   | 8 functions  |
+| **c128** | **2.2x**        | 3.4x (Abs)   | 8 functions  |
 | **c64**  | **~2x**         | ~3x (Mul)    | 9 functions  |
 
 ### ARM64 (Raspberry Pi 5, NEON)

--- a/c128/c128_amd64.go
+++ b/c128/c128_amd64.go
@@ -34,12 +34,14 @@ var (
 
 func init() {
 	// Select optimal implementation based on CPU features
-	// Priority: AVX-512 > AVX+FMA > SSE2 > Go
+	// Priority: AVX-512 > AVX+FMA > AVX (no FMA) > SSE2 > Go
 	switch {
 	case cpu.X86.AVX512F && cpu.X86.AVX512VL:
 		initAVX512()
 	case cpu.X86.AVX && cpu.X86.FMA:
 		initAVX()
+	case cpu.X86.AVX:
+		initAVXNoFMA()
 	case cpu.X86.SSE2:
 		initSSE2()
 	default:
@@ -62,6 +64,21 @@ func initAVX() {
 	mulImpl = mulAVX
 	mulConjImpl = mulConjAVX
 	scaleImpl = scaleAVX
+	addImpl = addAVX
+	subImpl = subAVX
+	absImpl = absAVX
+	absSqImpl = absSqAVX
+	conjImpl = conjAVX
+}
+
+// initAVXNoFMA runs on AVX-capable CPUs that lack FMA (rare but possible:
+// some early Sandy/Ivy Bridge generations, certain Atom/Pentium SKUs).
+// The mul/mulConj/scale AVX kernels depend on VFMADDSUB213PD, so they fall
+// back to SSE2; the FMA-free AVX kernels (add/sub/abs/absSq/conj) stay on AVX.
+func initAVXNoFMA() {
+	mulImpl = mulSSE2
+	mulConjImpl = mulConjSSE2
+	scaleImpl = scaleSSE2
 	addImpl = addAVX
 	subImpl = subAVX
 	absImpl = absAVX

--- a/c128/c128_amd64.go
+++ b/c128/c128_amd64.go
@@ -33,16 +33,27 @@ var (
 )
 
 func init() {
-	// Select optimal implementation based on CPU features
-	// Priority: AVX-512 > AVX+FMA > AVX (no FMA) > SSE2 > Go
+	selectImpl(
+		cpu.X86.AVX512F && cpu.X86.AVX512VL,
+		cpu.X86.AVX && cpu.X86.FMA,
+		cpu.X86.AVX,
+		cpu.X86.SSE2,
+	)
+}
+
+// selectImpl assigns the operation implementations from CPU feature predicates.
+// Priority: AVX-512 > AVX+FMA > AVX (no FMA) > SSE2 > Go.
+// It is split out from init so the dispatch priority can be unit-tested on any
+// host, including the AVX-without-FMA path that never runs on FMA-capable CI.
+func selectImpl(avx512, avxFMA, avx, sse2 bool) {
 	switch {
-	case cpu.X86.AVX512F && cpu.X86.AVX512VL:
+	case avx512:
 		initAVX512()
-	case cpu.X86.AVX && cpu.X86.FMA:
+	case avxFMA:
 		initAVX()
-	case cpu.X86.AVX:
+	case avx:
 		initAVXNoFMA()
-	case cpu.X86.SSE2:
+	case sse2:
 		initSSE2()
 	default:
 		initGo()

--- a/c128/c128_amd64.s
+++ b/c128/c128_amd64.s
@@ -856,95 +856,119 @@ abs_sse2_done:
 // ============================================================================
 
 // func absSqAVX512(dst []float64, a []complex128)
-// Fixed: Use VHADDPD + proper packing (same approach as absAVX512)
+// Mirrors absAVX512 (4 complex128 per iteration) without the final VSQRTPD.
 TEXT ·absSqAVX512(SB), NOSPLIT, $0-48
     MOVQ dst_base+0(FP), DX
     MOVQ dst_len+8(FP), CX
     MOVQ a_base+24(FP), SI
 
     MOVQ CX, AX
-    SHRQ $1, AX            // Process 2 complex128 per iteration
-    JZ   abssq_avx512_remainder
+    SHRQ $2, AX            // Process 4 elements per iteration
+    JZ   abssq_avx512_loop2_check
+
+abssq_avx512_loop4:
+    // Load 4 complex128 = 8 float64: [r0, i0, r1, i1, r2, i2, r3, i3]
+    VMOVUPD (SI), Z0
+
+    // Compute [r²+i²] with shuffle+add (no horizontal add dependency).
+    VMULPD Z0, Z0, Z0
+    VSHUFPD $0x55, Z0, Z0, Z1
+    VADDPD Z0, Z1, Z2      // [s0, s0, s1, s1, s2, s2, s3, s3]
+
+    // Pack duplicated sums into contiguous lanes: [s0, s1, s2, s3].
+    VEXTRACTF64X4 $1, Z2, Y3
+    VEXTRACTF128 $1, Y2, X4
+    VUNPCKLPD X4, X2, X2
+    VEXTRACTF128 $1, Y3, X5
+    VUNPCKLPD X5, X3, X3
+    VINSERTF128 $1, X3, Y2, Y2
+
+    VMOVUPD Y2, (DX)       // no sqrt for AbsSq
+
+    ADDQ $64, SI           // 4 complex128 = 64 bytes
+    ADDQ $32, DX           // 4 float64 = 32 bytes
+    DECQ AX
+    JNZ  abssq_avx512_loop4
+
+abssq_avx512_loop2_check:
+    ANDQ $3, CX
+    MOVQ CX, AX
+    SHRQ $1, AX
+    JZ   abssq_avx512_remainder1
 
 abssq_avx512_loop2:
     // Load 2 complex128 = 4 float64: [r0, i0, r1, i1]
     VMOVUPD (SI), Y0
-
-    // Square all elements: [r0², i0², r1², i1²]
     VMULPD Y0, Y0, Y0
+    VSHUFPD $0x55, Y0, Y0, Y1
+    VADDPD Y0, Y1, Y0      // [s0, s0, s1, s1]
 
-    // Horizontal add pairs within each 128-bit lane
-    // VHADDPD Y0, Y0, Y0 produces:
-    //   Lane 0: [r0²+i0², r0²+i0²]
-    //   Lane 1: [r1²+i1², r1²+i1²]
-    // Result: [r0²+i0², r0²+i0², r1²+i1², r1²+i1²]
-    VHADDPD Y0, Y0, Y0
-
-    // Pack results: elements 0 and 2 contain the sums we need
-    // Extract upper 128 bits: X1 = [r1²+i1², r1²+i1²]
     VEXTRACTF128 $1, Y0, X1
-    // Unpack low elements: X0 = [r0²+i0², r1²+i1²]
-    VUNPCKLPD X1, X0, X0
+    VUNPCKLPD X1, X0, X0   // [s0, s1]
+    VMOVUPD X0, (DX)       // no sqrt for AbsSq
 
-    // Store 2 results (no sqrt for AbsSq)
-    VMOVUPD X0, (DX)
-
-    ADDQ $32, SI           // 2 complex128 = 32 bytes
-    ADDQ $16, DX           // 2 float64 = 16 bytes
+    ADDQ $32, SI
+    ADDQ $16, DX
     DECQ AX
     JNZ  abssq_avx512_loop2
 
-abssq_avx512_remainder:
+abssq_avx512_remainder1:
     ANDQ $1, CX
     JZ   abssq_avx512_done
 
     // Handle 1 remaining element using XMM
-abssq_avx512_remainder_loop:
     MOVUPD (SI), X0        // Load one complex128
-
-    // X0 = [real, imag]
     VMOVDDUP X0, X1        // X1 = [real, real]
     VSHUFPD $1, X0, X0, X2 // X2 = [imag, imag]
 
     VMULPD X1, X1, X1      // real²
     VMULPD X2, X2, X2      // imag²
     VADDPD X2, X1, X1      // r² + i²
-
-    VMOVSD X1, (DX)
-
-    ADDQ $16, SI
-    ADDQ $8, DX
-    DECQ CX
-    JNZ  abssq_avx512_remainder_loop
+    VMOVSD X1, (DX)        // no sqrt for AbsSq
 
 abssq_avx512_done:
     VZEROUPPER
     RET
 
 // func absSqAVX(dst []float64, a []complex128)
+// Mirrors absAVX (2 complex128 per iteration) without the final VSQRTPD.
 TEXT ·absSqAVX(SB), NOSPLIT, $0-48
     MOVQ dst_base+0(FP), DX
     MOVQ dst_len+8(FP), CX
     MOVQ a_base+24(FP), SI
 
-    TESTQ CX, CX
+    MOVQ CX, AX
+    SHRQ $1, AX            // Process 2 complex128 per iteration
+    JZ   abssq_avx_remainder
+
+abssq_avx_loop2:
+    // Load 2 complex128 = 4 float64: [r0, i0, r1, i1]
+    VMOVUPD (SI), Y0
+    VMULPD Y0, Y0, Y0
+    VSHUFPD $0x55, Y0, Y0, Y1
+    VADDPD Y0, Y1, Y0      // [s0, s0, s1, s1]
+
+    VEXTRACTF128 $1, Y0, X1
+    VUNPCKLPD X1, X0, X0   // [s0, s1]
+    VMOVUPD X0, (DX)       // no sqrt for AbsSq
+
+    ADDQ $32, SI
+    ADDQ $16, DX
+    DECQ AX
+    JNZ  abssq_avx_loop2
+
+abssq_avx_remainder:
+    ANDQ $1, CX
     JZ   abssq_avx_done
 
-abssq_avx_loop:
-    VMOVUPD (SI), X0
-
-    VMULPD X0, X0, X1      // [r², i²]
-
-    VMOVDDUP X1, X2        // X2 = [r², r²]
-    SHUFPD $1, X1, X1      // X1 = [i², i²]
-    VADDPD X1, X2, X2      // r² + i²
-
-    VMOVSD X2, (DX)
-
-    ADDQ $16, SI
-    ADDQ $8, DX
-    DECQ CX
-    JNZ  abssq_avx_loop
+    // Handle 1 remaining element
+    MOVUPD (SI), X0
+    VMOVDDUP X0, X1
+    VSHUFPD $1, X0, X0, X2
+    VMULPD X1, X1, X1
+    VMULPD X2, X2, X2
+    VADDPD X2, X1, X1
+    VMOVSD X1, (DX)        // no sqrt for AbsSq
 
 abssq_avx_done:
     VZEROUPPER

--- a/c128/c128_amd64.s
+++ b/c128/c128_amd64.s
@@ -761,7 +761,7 @@ abs_avx512_remainder1:
     JZ   abs_avx512_done
 
     // Handle 1 remaining element using XMM
-    MOVUPD (SI), X0        // Load one complex128
+    VMOVUPD (SI), X0       // Load one complex128 (VEX-encoded: avoid AVX-SSE transition)
     VMOVDDUP X0, X1        // X1 = [real, real]
     VSHUFPD $1, X0, X0, X2 // X2 = [imag, imag]
 
@@ -807,7 +807,7 @@ abs_avx_remainder:
     JZ   abs_avx_done
 
     // Handle 1 remaining element
-    MOVUPD (SI), X0
+    VMOVUPD (SI), X0       // VEX-encoded: avoid AVX-SSE transition penalty
     VMOVDDUP X0, X1
     VSHUFPD $1, X0, X0, X2
     VMULPD X1, X1, X1
@@ -917,7 +917,7 @@ abssq_avx512_remainder1:
     JZ   abssq_avx512_done
 
     // Handle 1 remaining element using XMM
-    MOVUPD (SI), X0        // Load one complex128
+    VMOVUPD (SI), X0       // Load one complex128 (VEX-encoded: avoid AVX-SSE transition)
     VMOVDDUP X0, X1        // X1 = [real, real]
     VSHUFPD $1, X0, X0, X2 // X2 = [imag, imag]
 
@@ -962,7 +962,7 @@ abssq_avx_remainder:
     JZ   abssq_avx_done
 
     // Handle 1 remaining element
-    MOVUPD (SI), X0
+    VMOVUPD (SI), X0       // VEX-encoded: avoid AVX-SSE transition penalty
     VMOVDDUP X0, X1
     VSHUFPD $1, X0, X0, X2
     VMULPD X1, X1, X1

--- a/c128/c128_amd64_test.go
+++ b/c128/c128_amd64_test.go
@@ -3,6 +3,7 @@
 package c128
 
 import (
+	"math"
 	"testing"
 
 	"github.com/tphakala/simd/cpu"
@@ -67,4 +68,91 @@ func TestInitAVX512(t *testing.T) {
 	}
 
 	mulImpl = savedMul
+}
+
+// TestInitAVXNoFMA verifies the AVX-without-FMA dispatch path: FMA-dependent
+// kernels (mul/mulConj/scale) fall back to SSE2, while FMA-free AVX kernels
+// (add/sub/abs/absSq/conj) stay on AVX. Runs on any AVX-capable CPU by calling
+// initAVXNoFMA directly, even when the CPU also has FMA.
+func TestInitAVXNoFMA(t *testing.T) {
+	if !cpu.X86.AVX {
+		t.Skip("AVX not supported on this CPU")
+	}
+
+	// Save every pointer initAVXNoFMA reassigns so later tests are unaffected.
+	saved := struct {
+		mul, mulConj, add, sub binaryOpFunc
+		scale                  scaleFunc
+		abs, absSq             unaryAbsFunc
+		conj                   unaryConjFunc
+	}{mulImpl, mulConjImpl, addImpl, subImpl, scaleImpl, absImpl, absSqImpl, conjImpl}
+	defer func() {
+		mulImpl, mulConjImpl, addImpl, subImpl = saved.mul, saved.mulConj, saved.add, saved.sub
+		scaleImpl = saved.scale
+		absImpl, absSqImpl = saved.abs, saved.absSq
+		conjImpl = saved.conj
+	}()
+
+	initAVXNoFMA()
+
+	// SSE2-routed kernel (FMA-dependent): mul.
+	a := []complex128{1 + 2i, 5 + 6i}
+	b := []complex128{3 + 4i, 7 + 8i}
+	mdst := make([]complex128, 2)
+	mulImpl(mdst, a, b)
+	for i := range mdst {
+		if want := a[i] * b[i]; !complexClose(mdst[i], want) {
+			t.Errorf("After initAVXNoFMA, mul[%d] = %v, want %v", i, mdst[i], want)
+		}
+	}
+
+	// AVX-routed kernel (FMA-free): absSq.
+	sdst := make([]float64, len(a))
+	absSqImpl(sdst, a)
+	for i := range sdst {
+		r, im := real(a[i]), imag(a[i])
+		if want := r*r + im*im; math.Abs(sdst[i]-want) > epsilon {
+			t.Errorf("After initAVXNoFMA, absSq[%d] = %v, want %v", i, sdst[i], want)
+		}
+	}
+}
+
+// TestAbsSqKernels compares each available AbsSq assembly kernel against the Go
+// reference across sizes that exercise the wide loop, narrow loop, and scalar
+// remainder paths. Guards #23 (loop widening) against tail-handling bugs.
+func TestAbsSqKernels(t *testing.T) {
+	sizes := []int{0, 1, 2, 3, 4, 5, 7, 8, 9, 16, 17}
+
+	kernels := []struct {
+		name string
+		fn   unaryAbsFunc
+		skip bool
+	}{
+		{"SSE2", absSqSSE2, !cpu.X86.SSE2},
+		{"AVX", absSqAVX, !cpu.X86.AVX},
+		{"AVX512", absSqAVX512, !cpu.X86.AVX512F || !cpu.X86.AVX512VL},
+	}
+
+	for _, k := range kernels {
+		if k.skip {
+			continue
+		}
+		t.Run(k.name, func(t *testing.T) {
+			for _, n := range sizes {
+				a := make([]complex128, n)
+				for i := range a {
+					a[i] = complex(float64(i+1), float64(2*i+3))
+				}
+				got := make([]float64, n)
+				want := make([]float64, n)
+				k.fn(got, a)
+				absSqGo(want, a)
+				for i := range got {
+					if math.Abs(got[i]-want[i]) > epsilon {
+						t.Errorf("%s n=%d: AbsSq[%d] = %v, want %v", k.name, n, i, got[i], want[i])
+					}
+				}
+			}
+		})
+	}
 }

--- a/c128/c128_amd64_test.go
+++ b/c128/c128_amd64_test.go
@@ -124,7 +124,8 @@ func TestSelectImpl(t *testing.T) {
 	}
 	for _, c := range cases {
 		selectImpl(c.avx512, c.avxFMA, c.avx, c.sse2)
-		if mulImpl == nil || absSqImpl == nil || conjImpl == nil {
+		if mulImpl == nil || mulConjImpl == nil || scaleImpl == nil || addImpl == nil ||
+			subImpl == nil || absImpl == nil || absSqImpl == nil || conjImpl == nil {
 			t.Fatalf("%s: selectImpl left a nil implementation pointer", c.name)
 		}
 	}

--- a/c128/c128_amd64_test.go
+++ b/c128/c128_amd64_test.go
@@ -4,10 +4,24 @@ package c128
 
 import (
 	"math"
+	"reflect"
+	"runtime"
 	"testing"
 
 	"github.com/tphakala/simd/cpu"
 )
+
+// implName returns the symbol name of a dispatch function pointer, for use in
+// assertion failure messages.
+func implName(f any) string {
+	return runtime.FuncForPC(reflect.ValueOf(f).Pointer()).Name()
+}
+
+// sameImpl reports whether two dispatch function pointers refer to the same
+// function. Go does not allow func == func, so compare program counters.
+func sameImpl(a, b any) bool {
+	return reflect.ValueOf(a).Pointer() == reflect.ValueOf(b).Pointer()
+}
 
 // Tests for init functions to ensure they properly configure function pointers
 // These tests are AMD64-specific because they test x86 SIMD initialization paths.
@@ -70,6 +84,52 @@ func TestInitAVX512(t *testing.T) {
 	mulImpl = savedMul
 }
 
+// c128Impls snapshots the dispatch function pointers so a test that mutates
+// them via an init*/selectImpl call can restore them for later tests.
+type c128Impls struct {
+	mul, mulConj, add, sub binaryOpFunc
+	scale                  scaleFunc
+	abs, absSq             unaryAbsFunc
+	conj                   unaryConjFunc
+}
+
+func saveImpls() c128Impls {
+	return c128Impls{mulImpl, mulConjImpl, addImpl, subImpl, scaleImpl, absImpl, absSqImpl, conjImpl}
+}
+
+func restoreImpls(s c128Impls) {
+	mulImpl, mulConjImpl, addImpl, subImpl = s.mul, s.mulConj, s.add, s.sub
+	scaleImpl = s.scale
+	absImpl, absSqImpl = s.abs, s.absSq
+	conjImpl = s.conj
+}
+
+// TestSelectImpl exercises every dispatch arm of selectImpl on any host,
+// including the AVX-without-FMA arm that never runs through init() on
+// FMA-capable CI hardware. It only assigns function pointers (no kernel is
+// executed), so it is safe regardless of the host's actual CPU features.
+func TestSelectImpl(t *testing.T) {
+	saved := saveImpls()
+	defer restoreImpls(saved)
+
+	cases := []struct {
+		name                      string
+		avx512, avxFMA, avx, sse2 bool
+	}{
+		{"avx512", true, false, false, false},
+		{"avxFMA", false, true, false, false},
+		{"avxNoFMA", false, false, true, false},
+		{"sse2", false, false, false, true},
+		{"go", false, false, false, false},
+	}
+	for _, c := range cases {
+		selectImpl(c.avx512, c.avxFMA, c.avx, c.sse2)
+		if mulImpl == nil || absSqImpl == nil || conjImpl == nil {
+			t.Fatalf("%s: selectImpl left a nil implementation pointer", c.name)
+		}
+	}
+}
+
 // TestInitAVXNoFMA verifies the AVX-without-FMA dispatch path: FMA-dependent
 // kernels (mul/mulConj/scale) fall back to SSE2, while FMA-free AVX kernels
 // (add/sub/abs/absSq/conj) stay on AVX. Runs on any AVX-capable CPU by calling
@@ -79,21 +139,34 @@ func TestInitAVXNoFMA(t *testing.T) {
 		t.Skip("AVX not supported on this CPU")
 	}
 
-	// Save every pointer initAVXNoFMA reassigns so later tests are unaffected.
-	saved := struct {
-		mul, mulConj, add, sub binaryOpFunc
-		scale                  scaleFunc
-		abs, absSq             unaryAbsFunc
-		conj                   unaryConjFunc
-	}{mulImpl, mulConjImpl, addImpl, subImpl, scaleImpl, absImpl, absSqImpl, conjImpl}
-	defer func() {
-		mulImpl, mulConjImpl, addImpl, subImpl = saved.mul, saved.mulConj, saved.add, saved.sub
-		scaleImpl = saved.scale
-		absImpl, absSqImpl = saved.abs, saved.absSq
-		conjImpl = saved.conj
-	}()
+	// Restore every pointer initAVXNoFMA reassigns so later tests are unaffected.
+	saved := saveImpls()
+	defer restoreImpls(saved)
 
 	initAVXNoFMA()
+
+	// Assert the dispatch targets, not just numeric results: a wrong impl
+	// (e.g. mulAVX or absSqSSE2) could still produce correct numbers and hide a
+	// regression. FMA-dependent kernels must fall back to SSE2; FMA-free kernels
+	// must stay on AVX.
+	targets := []struct {
+		name      string
+		got, want any
+	}{
+		{"mulImpl", mulImpl, mulSSE2},
+		{"mulConjImpl", mulConjImpl, mulConjSSE2},
+		{"scaleImpl", scaleImpl, scaleSSE2},
+		{"addImpl", addImpl, addAVX},
+		{"subImpl", subImpl, subAVX},
+		{"absImpl", absImpl, absAVX},
+		{"absSqImpl", absSqImpl, absSqAVX},
+		{"conjImpl", conjImpl, conjAVX},
+	}
+	for _, tt := range targets {
+		if !sameImpl(tt.got, tt.want) {
+			t.Errorf("%s dispatch = %s, want %s", tt.name, implName(tt.got), implName(tt.want))
+		}
+	}
 
 	// SSE2-routed kernel (FMA-dependent): mul.
 	a := []complex128{1 + 2i, 5 + 6i}


### PR DESCRIPTION
## Summary

Completes two follow-ups that were left after the abs-family widening in #15, both in the `c128` package on AMD64.

**Widen the AbsSq kernels (#23).** The `abs*` kernels were widened in #15 but the matching `absSq*` kernels were left at the old loop widths:
- `absSqAVX`: 1 -> **2 complex128 per iteration** (YMM), mirroring `absAVX`.
- `absSqAVX512`: 2 -> **4 complex128 per iteration** (ZMM), mirroring `absAVX512`.

`absSq` is `abs` without the final `VSQRTPD`, so each kernel is a direct structural copy of the proven `abs` counterpart. Measured **~1.4 to 1.8x faster** on the AVX path (i7-1260P): `405 -> 258 ns/op` at 1024 elements, geomean -33% time / +50% throughput across sizes 16 to 16384.

**Add `initAVXNoFMA` dispatch (#24).** `c128` previously had only AVX-512 / AVX+FMA / SSE2 / Go init paths, so AVX-capable CPUs without FMA dropped the whole package to SSE2. This adds the AVX-without-FMA tier mirroring `f64`: the FMA-dependent `mul`/`mulConj`/`scale` kernels (which use `VFMADDSUB213PD`) fall back to SSE2, while the FMA-free `add`/`sub`/`abs`/`absSq`/`conj` kernels stay on AVX. Verified every "FMA-free" kernel uses only AVX1 instructions (no YMM-integer ops), so there is no SIGILL risk on AVX1-only CPUs.

## Related Issues

Closes #23
Closes #24

Follow-up: #27 (VCOMPRESSPD lane packing for the AVX-512 abs/absSq kernels) is left out; it needs AVX-512 hardware to benchmark and verify, which is not available here.

## Test Plan

- [x] `go test ./...` passes on amd64 (1785 tests).
- [x] `go vet` and `golangci-lint` clean; `gofmt` clean.
- [x] `GOARCH=arm64 go build ./...` and vet pass (changed files are amd64-only).
- [x] New `TestAbsSqKernels` compares every AbsSq kernel against the Go reference across sizes that hit the wide loop, narrow loop, and scalar remainder.
- [x] New `TestInitAVXNoFMA` verifies the SSE2-routed and AVX-routed kernels under the new dispatch path.
- [x] `absSqAVX` benchmarked before/after with `benchstat` (8 runs): statistically clean speedup at every size above n=4.
- [x] `absSqAVX512` verified by machine-code byte diff against the production-proven `absAVX512`: identical except the three removed `VSQRTPD` instructions. It could not be executed locally (no AVX-512 hardware; qemu TCG lacks AVX-512).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added optimized support for AVX-capable processors without FMA instruction support.

* **Performance**
  * Improved SIMD performance for magnitude squared calculations on AVX and AVX-512 systems.
  * Updated and revised benchmark results for complex number operations.

* **Documentation**
  * Updated feature description to reflect new AVX variant support and revised performance metrics.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/tphakala/simd/pull/36?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->