### PR TITLE
c128: VEX-clean conjAVX + widen to 2 elems/iter; fix f64 ReLU/ClampScale README table

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,10 +114,10 @@ fmt.Println(cpu.HasFP16())   // true/false (ARM64 half-precision SIMD)
 |                 | `CumulativeSum(dst, a)`             | Running sum                   | Sequential                          |
 | **Range**       | `Clamp(dst, a, min, max)`           | Clamp to range                | 8x / 4x / 2x                        |
 | **Activation**  | `Sigmoid(dst, src)`                 | Sigmoid: 1/(1+e^-x)           | 4x (AVX2) / 2x (NEON)               |
-|                 | `ReLU(dst, src)`                    | Rectified Linear Unit         | 8x / 4x / 2x                        |
+|                 | `ReLU(dst, src)`                    | Rectified Linear Unit         | 4x (AVX) / 2x (NEON)                |
 |                 | `Tanh(dst, src)`                    | Hyperbolic tangent            | 4x (AVX2) / 2x (NEON)               |
 |                 | `Exp(dst, src)`                     | Exponential e^x               | 4x (AVX2) / 2x (NEON)               |
-|                 | `ClampScale(dst, src, min, max, s)` | Fused clamp and scale         | 8x / 4x / 2x                        |
+|                 | `ClampScale(dst, src, min, max, s)` | Fused clamp and scale         | 4x (AVX) / 2x (NEON)                |
 | **Batch**       | `DotProductBatch(r, rows, v)`       | Multiple dot products         | 8x / 4x / 2x                        |
 | **Signal**      | `ConvolveValid(dst, sig, k)`        | FIR filter / convolution      | 8x / 4x / 2x                        |
 |                 | `ConvolveValidMulti(dsts, sig, ks)` | Multi-kernel convolution      | 8x / 4x / 2x                        |

--- a/c128/c128_amd64.s
+++ b/c128/c128_amd64.s
@@ -1038,31 +1038,43 @@ conj_avx512_done:
     VZEROUPPER
     RET
 
+// conjSignMask flips the sign bit of the imaginary lane of each packed
+// complex128: XOR [re0, im0, re1, im1] -> [re0, -im0, re1, -im1].
+// The low 128 bits ([0.0, -0.0]) serve the single-element remainder.
+DATA conjSignMask<>+0(SB)/8, $0x0000000000000000
+DATA conjSignMask<>+8(SB)/8, $0x8000000000000000
+DATA conjSignMask<>+16(SB)/8, $0x0000000000000000
+DATA conjSignMask<>+24(SB)/8, $0x8000000000000000
+GLOBL conjSignMask<>(SB), RODATA|NOPTR, $32
+
 // func conjAVX(dst, a []complex128)
 TEXT ·conjAVX(SB), NOSPLIT, $0-48
     MOVQ dst_base+0(FP), DX
     MOVQ dst_len+8(FP), CX
     MOVQ a_base+24(FP), SI
 
-    TESTQ CX, CX
+    VMOVUPD conjSignMask<>(SB), Y2 // [0.0, -0.0, 0.0, -0.0]
+
+    MOVQ CX, AX
+    SHRQ $1, AX            // AX = pairs (2 complex128 per iter, YMM)
+    JZ   conj_avx_remainder
+
+conj_avx_loop2:
+    VMOVUPD (SI), Y0       // [re0, im0, re1, im1]
+    VXORPD  Y2, Y0, Y0     // [re0, -im0, re1, -im1]
+    VMOVUPD Y0, (DX)
+    ADDQ $32, SI
+    ADDQ $32, DX
+    DECQ AX
+    JNZ  conj_avx_loop2
+
+conj_avx_remainder:
+    ANDQ $1, CX
     JZ   conj_avx_done
 
-conj_avx_loop:
-    VMOVUPD (SI), X0       // [real, imag]
-
-    // Create negated copy: [-real, -imag]
-    VXORPD X1, X1, X1      // Clear X1 = [0, 0]
-    VSUBPD X0, X1, X1      // X1 = -X0 = [-real, -imag]
-
-    // Use SHUFPD to blend/reconstruct: [real, -imag]
-    SHUFPD $2, X1, X0      // X0 = [low(X0)=real, high(X1)=-imag]
-
+    VMOVUPD (SI), X0       // [re, im]
+    VXORPD  X2, X0, X0     // [re, -im] (X2 = low lane of Y2)
     VMOVUPD X0, (DX)
-
-    ADDQ $16, SI
-    ADDQ $16, DX
-    DECQ CX
-    JNZ  conj_avx_loop
 
 conj_avx_done:
     VZEROUPPER

--- a/c128/c128_test.go
+++ b/c128/c128_test.go
@@ -553,6 +553,25 @@ func TestAbsSqGo(t *testing.T) {
 	}
 }
 
+func TestConj_OddLarge(t *testing.T) {
+	// Exercises the 2-wide conjAVX loop plus the single-element remainder
+	// after many iterations (odd length greater than the SIMD width).
+	for _, n := range []int{99, 101, 1001} {
+		a := make([]complex128, n)
+		for i := range n {
+			a[i] = complex(float64(i+1), float64(-i-2))
+		}
+		dst := make([]complex128, n)
+		Conj(dst, a)
+		for i := range n {
+			expected := cmplx.Conj(a[i])
+			if !complexClose(dst[i], expected) {
+				t.Fatalf("Conj_OddLarge(n=%d)[%d] = %v, want %v", n, i, dst[i], expected)
+			}
+		}
+	}
+}
+
 func TestConjGo(t *testing.T) {
 	a := []complex128{1 + 2i, 3 + 4i}
 	dst := make([]complex128, 2)


### PR DESCRIPTION
## Summary

Two items from the #36/#39 review backlog, both fully verifiable on AVX2 hardware.

### #37 - conjAVX: drop legacy SSE in the hot loop and widen to 2/iter

`conjAVX` processed one complex128 per iteration on XMM and built the conjugate with a zero/subtract/SHUFPD-blend sequence. The `SHUFPD` is a legacy-SSE encoding sitting in the hot loop next to VEX ops (`VMOVUPD`/`VXORPD`/`VSUBPD`), so every iteration risked an AVX-SSE transition penalty, and the 1/iter width lagged `absAVX`/`absSqAVX`.

It now negates the imaginary lanes with one hoisted XOR sign mask (`[0.0, -0.0, 0.0, -0.0]`) and runs 2 complex128/iter on YMM with a 1-element XMM remainder. The loop is fully VEX-encoded, and the XOR also matches `cmplx.Conj` bit-for-bit on signed zero.

`conjAVX512` is left at 1/iter; widening it needs AVX-512 hardware to verify (see #27).

**Benchmark** (i7-1260P, AVX2, performance governor, `benchstat` n=10, `BenchmarkConj` size=1024). The widened SIMD path is roughly 2x faster and statistically significant (p=0.000), but the exact figure swings run to run because this small fixed-size benchmark is sensitive to turbo/thermal noise. Two clean runs:

```
run 1:  Conj/SIMD  1006.0n -> 488.1n  -51.48%   (after CV ~20%)
run 2:  Conj/SIMD   964.7n -> 247.9n  -74.30%   (after CV ~47%)
```

B/s more than doubles in both runs. The takeaway is a solid ~2x win; I would not read the precise percentage too literally given the variance.

### #40 - README: f64 ReLU/ClampScale overstated AVX-512

The ReLU and ClampScale rows in the f64 capability table read `8x / 4x / 2x`, implying an AVX-512 kernel that does not exist (there is no `reluAVX512`/`clampScaleAVX512`). Relabeled to `4x (AVX) / 2x (NEON)`, matching the actual plain-AVX kernels and distinct from the AVX2-gated Sigmoid/Tanh/Exp rows (already fixed in #39).

## Testing

- `go test -race ./c128/` passes; added `TestConj_OddLarge` (n=99,101,1001) to cover the widened loop plus the remainder.
- `golangci-lint run ./c128/`: 0 issues.
- `go vet`, `gofmt -l`, `go build ./...` clean.

Closes #40. Refs #37 (conjAVX done; conjAVX512 widening deferred, see #27).
