### PR TITLE
perf(f64): single index register in cubicInterpDotAVX loop16

### DIFF
--- a/f64/f64_amd64.s
+++ b/f64/f64_amd64.s
@@ -3135,62 +3135,63 @@ TEXT ·cubicInterpDotAVX(SB), NOSPLIT, $0-136
     SHRQ $4, AX                // AX = len / 16
     JZ   cubic_avx_loop4_check
 
+    // R11 is a shared byte-offset index for all 5 streams (hist, a, b, c, d),
+    // so a single increment per iteration replaces five pointer advances.
+    XORQ R11, R11
+
 cubic_avx_loop16:
     // Multi-stage Horner with four independent chains.
     // VFMADD213PD dst, mul, add: dst = dst*mul + add (Y7 = broadcast x).
+    // All loads use base+R11 indexing; R11 is the shared byte offset.
 
     // Stage 1: p = c + x*d (4 parallel chains)
-    VMOVUPD 0(R9), Y1
-    VMOVUPD 0(R10), Y5
+    VMOVUPD 0(R9)(R11*1), Y1
+    VMOVUPD 0(R10)(R11*1), Y5
     VFMADD231PD Y5, Y7, Y1
 
-    VMOVUPD 32(R9), Y2
-    VMOVUPD 32(R10), Y5
+    VMOVUPD 32(R9)(R11*1), Y2
+    VMOVUPD 32(R10)(R11*1), Y5
     VFMADD231PD Y5, Y7, Y2
 
-    VMOVUPD 64(R9), Y3
-    VMOVUPD 64(R10), Y5
+    VMOVUPD 64(R9)(R11*1), Y3
+    VMOVUPD 64(R10)(R11*1), Y5
     VFMADD231PD Y5, Y7, Y3
 
-    VMOVUPD 96(R9), Y4
-    VMOVUPD 96(R10), Y5
+    VMOVUPD 96(R9)(R11*1), Y4
+    VMOVUPD 96(R10)(R11*1), Y5
     VFMADD231PD Y5, Y7, Y4
 
     // Stage 2: p = b + x*p
-    VMOVUPD 0(R8), Y5
+    VMOVUPD 0(R8)(R11*1), Y5
     VFMADD213PD Y5, Y7, Y1
-    VMOVUPD 32(R8), Y5
+    VMOVUPD 32(R8)(R11*1), Y5
     VFMADD213PD Y5, Y7, Y2
-    VMOVUPD 64(R8), Y5
+    VMOVUPD 64(R8)(R11*1), Y5
     VFMADD213PD Y5, Y7, Y3
-    VMOVUPD 96(R8), Y5
+    VMOVUPD 96(R8)(R11*1), Y5
     VFMADD213PD Y5, Y7, Y4
 
     // Stage 3: coef = a + x*p
-    VMOVUPD 0(DI), Y5
+    VMOVUPD 0(DI)(R11*1), Y5
     VFMADD213PD Y5, Y7, Y1
-    VMOVUPD 32(DI), Y5
+    VMOVUPD 32(DI)(R11*1), Y5
     VFMADD213PD Y5, Y7, Y2
-    VMOVUPD 64(DI), Y5
+    VMOVUPD 64(DI)(R11*1), Y5
     VFMADD213PD Y5, Y7, Y3
-    VMOVUPD 96(DI), Y5
+    VMOVUPD 96(DI)(R11*1), Y5
     VFMADD213PD Y5, Y7, Y4
 
     // Accumulate: Σ hist * coef with independent accumulators.
-    VMOVUPD 0(SI), Y5
+    VMOVUPD 0(SI)(R11*1), Y5
     VFMADD231PD Y5, Y1, Y0
-    VMOVUPD 32(SI), Y5
+    VMOVUPD 32(SI)(R11*1), Y5
     VFMADD231PD Y5, Y2, Y11
-    VMOVUPD 64(SI), Y5
+    VMOVUPD 64(SI)(R11*1), Y5
     VFMADD231PD Y5, Y3, Y12
-    VMOVUPD 96(SI), Y5
+    VMOVUPD 96(SI)(R11*1), Y5
     VFMADD231PD Y5, Y4, Y13
 
-    ADDQ $128, SI
-    ADDQ $128, DI
-    ADDQ $128, R8
-    ADDQ $128, R9
-    ADDQ $128, R10
+    ADDQ $128, R11             // single index advance (was 5 pointer adds)
     DECQ AX
     JNZ  cubic_avx_loop16
 
@@ -3198,6 +3199,14 @@ cubic_avx_loop16:
     VADDPD Y11, Y0, Y0
     VADDPD Y12, Y0, Y0
     VADDPD Y13, Y0, Y0
+
+    // Advance base pointers once past the bytes consumed by loop16 so the
+    // loop4 and scalar tails resume at the correct offset.
+    ADDQ R11, SI
+    ADDQ R11, DI
+    ADDQ R11, R8
+    ADDQ R11, R9
+    ADDQ R11, R10
 
 cubic_avx_loop4_check:
     // Handle remaining 4-element vectors.

--- a/f64/f64_amd64.s
+++ b/f64/f64_amd64.s
@@ -3135,63 +3135,63 @@ TEXT ·cubicInterpDotAVX(SB), NOSPLIT, $0-136
     SHRQ $4, AX                // AX = len / 16
     JZ   cubic_avx_loop4_check
 
-    // R11 is a shared byte-offset index for all 5 streams (hist, a, b, c, d),
+    // DX is a shared byte-offset index for all 5 streams (hist, a, b, c, d),
     // so a single increment per iteration replaces five pointer advances.
-    XORQ R11, R11
+    XORQ DX, DX
 
 cubic_avx_loop16:
     // Multi-stage Horner with four independent chains.
     // VFMADD213PD dst, mul, add: dst = dst*mul + add (Y7 = broadcast x).
-    // All loads use base+R11 indexing; R11 is the shared byte offset.
+    // All loads use base+DX indexing; DX is the shared byte offset.
 
     // Stage 1: p = c + x*d (4 parallel chains)
-    VMOVUPD 0(R9)(R11*1), Y1
-    VMOVUPD 0(R10)(R11*1), Y5
+    VMOVUPD 0(R9)(DX*1), Y1
+    VMOVUPD 0(R10)(DX*1), Y5
     VFMADD231PD Y5, Y7, Y1
 
-    VMOVUPD 32(R9)(R11*1), Y2
-    VMOVUPD 32(R10)(R11*1), Y5
+    VMOVUPD 32(R9)(DX*1), Y2
+    VMOVUPD 32(R10)(DX*1), Y5
     VFMADD231PD Y5, Y7, Y2
 
-    VMOVUPD 64(R9)(R11*1), Y3
-    VMOVUPD 64(R10)(R11*1), Y5
+    VMOVUPD 64(R9)(DX*1), Y3
+    VMOVUPD 64(R10)(DX*1), Y5
     VFMADD231PD Y5, Y7, Y3
 
-    VMOVUPD 96(R9)(R11*1), Y4
-    VMOVUPD 96(R10)(R11*1), Y5
+    VMOVUPD 96(R9)(DX*1), Y4
+    VMOVUPD 96(R10)(DX*1), Y5
     VFMADD231PD Y5, Y7, Y4
 
     // Stage 2: p = b + x*p
-    VMOVUPD 0(R8)(R11*1), Y5
+    VMOVUPD 0(R8)(DX*1), Y5
     VFMADD213PD Y5, Y7, Y1
-    VMOVUPD 32(R8)(R11*1), Y5
+    VMOVUPD 32(R8)(DX*1), Y5
     VFMADD213PD Y5, Y7, Y2
-    VMOVUPD 64(R8)(R11*1), Y5
+    VMOVUPD 64(R8)(DX*1), Y5
     VFMADD213PD Y5, Y7, Y3
-    VMOVUPD 96(R8)(R11*1), Y5
+    VMOVUPD 96(R8)(DX*1), Y5
     VFMADD213PD Y5, Y7, Y4
 
     // Stage 3: coef = a + x*p
-    VMOVUPD 0(DI)(R11*1), Y5
+    VMOVUPD 0(DI)(DX*1), Y5
     VFMADD213PD Y5, Y7, Y1
-    VMOVUPD 32(DI)(R11*1), Y5
+    VMOVUPD 32(DI)(DX*1), Y5
     VFMADD213PD Y5, Y7, Y2
-    VMOVUPD 64(DI)(R11*1), Y5
+    VMOVUPD 64(DI)(DX*1), Y5
     VFMADD213PD Y5, Y7, Y3
-    VMOVUPD 96(DI)(R11*1), Y5
+    VMOVUPD 96(DI)(DX*1), Y5
     VFMADD213PD Y5, Y7, Y4
 
     // Accumulate: Σ hist * coef with independent accumulators.
-    VMOVUPD 0(SI)(R11*1), Y5
+    VMOVUPD 0(SI)(DX*1), Y5
     VFMADD231PD Y5, Y1, Y0
-    VMOVUPD 32(SI)(R11*1), Y5
+    VMOVUPD 32(SI)(DX*1), Y5
     VFMADD231PD Y5, Y2, Y11
-    VMOVUPD 64(SI)(R11*1), Y5
+    VMOVUPD 64(SI)(DX*1), Y5
     VFMADD231PD Y5, Y3, Y12
-    VMOVUPD 96(SI)(R11*1), Y5
+    VMOVUPD 96(SI)(DX*1), Y5
     VFMADD231PD Y5, Y4, Y13
 
-    ADDQ $128, R11             // single index advance (was 5 pointer adds)
+    ADDQ $128, DX             // single index advance (was 5 pointer adds)
     DECQ AX
     JNZ  cubic_avx_loop16
 
@@ -3202,11 +3202,11 @@ cubic_avx_loop16:
 
     // Advance base pointers once past the bytes consumed by loop16 so the
     // loop4 and scalar tails resume at the correct offset.
-    ADDQ R11, SI
-    ADDQ R11, DI
-    ADDQ R11, R8
-    ADDQ R11, R9
-    ADDQ R11, R10
+    ADDQ DX, SI
+    ADDQ DX, DI
+    ADDQ DX, R8
+    ADDQ DX, R9
+    ADDQ DX, R10
 
 cubic_avx_loop4_check:
     // Handle remaining 4-element vectors.


### PR DESCRIPTION
## What

Consolidates the pointer arithmetic in the 16-element loop of `cubicInterpDotAVX` (`f64/f64_amd64.s`), as proposed in #28. The five separate `ADDQ $128` advances (hist, a, b, c, d) are replaced by a single shared byte-offset index register `R11` with base+index addressing on all 20 loads. Base pointers are advanced once after the loop so the `loop4` and scalar tails resume at the correct offset.

The `loop4` and scalar tails are left as-is: they run at most 3 iterations each, so converting them would add fixup complexity for no measurable gain.

## Performance

Honest result: **neutral**. This trims 4 front-end uops per iteration, but the loop is load-port/memory bound on every config I could test, so throughput does not change. This matches the hypothesis in #28 (the 5-pointer form already runs near memory bandwidth).

Benchmarks were interleaved (base/new alternating), run under `SCHED_FIFO` real-time priority, pinned to a single core with `GOMAXPROCS=1`, to cancel out background load:

| Config | n=64 | n=241 | n=1000 | geomean |
|---|---|---|---|---|
| P-core (Golden Cove), turbo off | ~ (p=0.06) | -1.3% | +0.6% | -0.16% |
| P-core (Golden Cove), turbo on | ~ | ~ | ~ | -0.17% |
| E-core (Gracemont) | ~ | ~ | ~ | -0.07% |

`~` = no statistically significant difference. Tested on a 12th Gen i7-1260P.

I am proposing this as a zero-regression cleanup to the canonical index form. It removes 4 uops/iter and may help microarchitectures that are more front-end bound than the ones available here (e.g. AMD Zen, older Atom), but I have no measured win to claim.

## Correctness

- All 629 `f64` tests pass (`go test ./f64`), including cubic sizes 16/17/32/64/100/241/1000 and edge cases on `x`.
- `go vet ./f64` clean (validates the asm operands/frame).

Resolves #28.