### PR TITLE
c128: EVEX-clean conjAVX512 at 4/iter (#37); VCOMPRESSPD for abs/absSq (#27)

### DIFF
--- a/c128/c128_amd64.s
+++ b/c128/c128_amd64.s
@@ -1020,7 +1020,7 @@ TEXT ·conjAVX512(SB), NOSPLIT, $0-48
 
 conj_avx512_loop4:
     VMOVUPD (SI), Z0
-    VXORPD  Z2, Z0, Z0     // flip imaginary sign bits
+    VPXORQ  Z2, Z0, Z0     // flip imaginary sign bits (VPXORQ is AVX512F; VXORPD needs AVX512DQ)
     VMOVUPD Z0, (DX)
     ADDQ $64, SI
     ADDQ $64, DX

--- a/c128/c128_amd64.s
+++ b/c128/c128_amd64.s
@@ -704,6 +704,10 @@ TEXT ·absAVX512(SB), NOSPLIT, $0-48
     MOVQ dst_len+8(FP), CX
     MOVQ a_base+24(FP), SI
 
+    // Mask for VCOMPRESSPD: pick even lanes (0,2,4,6) from duplicated sums.
+    MOVB $0x55, R8
+    KMOVB R8, K1
+
     MOVQ CX, AX
     SHRQ $2, AX            // Process 4 elements per iteration
     JZ   abs_avx512_loop2_check
@@ -718,12 +722,7 @@ abs_avx512_loop4:
     VADDPD Z0, Z1, Z2      // [s0, s0, s1, s1, s2, s2, s3, s3]
 
     // Pack duplicated sums into contiguous lanes: [s0, s1, s2, s3].
-    VEXTRACTF64X4 $1, Z2, Y3
-    VEXTRACTF128 $1, Y2, X4
-    VUNPCKLPD X4, X2, X2
-    VEXTRACTF128 $1, Y3, X5
-    VUNPCKLPD X5, X3, X3
-    VINSERTF128 $1, X3, Y2, Y2
+    VCOMPRESSPD Z2, K1, Z2
 
     VSQRTPD Y2, Y2
     VMOVUPD Y2, (DX)
@@ -862,6 +861,10 @@ TEXT ·absSqAVX512(SB), NOSPLIT, $0-48
     MOVQ dst_len+8(FP), CX
     MOVQ a_base+24(FP), SI
 
+    // Mask for VCOMPRESSPD: pick even lanes (0,2,4,6) from duplicated sums.
+    MOVB $0x55, R8
+    KMOVB R8, K1
+
     MOVQ CX, AX
     SHRQ $2, AX            // Process 4 elements per iteration
     JZ   abssq_avx512_loop2_check
@@ -876,12 +879,7 @@ abssq_avx512_loop4:
     VADDPD Z0, Z1, Z2      // [s0, s0, s1, s1, s2, s2, s3, s3]
 
     // Pack duplicated sums into contiguous lanes: [s0, s1, s2, s3].
-    VEXTRACTF64X4 $1, Z2, Y3
-    VEXTRACTF128 $1, Y2, X4
-    VUNPCKLPD X4, X2, X2
-    VEXTRACTF128 $1, Y3, X5
-    VUNPCKLPD X5, X3, X3
-    VINSERTF128 $1, X3, Y2, Y2
+    VCOMPRESSPD Z2, K1, Z2
 
     VMOVUPD Y2, (DX)       // no sqrt for AbsSq
 
@@ -1012,27 +1010,43 @@ TEXT ·conjAVX512(SB), NOSPLIT, $0-48
     MOVQ dst_len+8(FP), CX
     MOVQ a_base+24(FP), SI
 
-    TESTQ CX, CX
+    VMOVUPD conjSignMask<>(SB), Z2  // Z2 = [0,-0,0,-0,0,-0,0,-0]
+
+    MOVQ CX, AX
+    SHRQ $2, AX            // AX = groups of 4 complex128
+    JZ   conj_avx512_loop2_check
+
+conj_avx512_loop4:
+    VMOVUPD (SI), Z0
+    VXORPD  Z2, Z0, Z0     // flip imaginary sign bits
+    VMOVUPD Z0, (DX)
+    ADDQ $64, SI
+    ADDQ $64, DX
+    DECQ AX
+    JNZ  conj_avx512_loop4
+
+conj_avx512_loop2_check:
+    ANDQ $3, CX
+    MOVQ CX, AX
+    SHRQ $1, AX
+    JZ   conj_avx512_remainder1
+
+conj_avx512_loop2:
+    VMOVUPD (SI), Y0
+    VXORPD  Y2, Y0, Y0     // Y2 = low half of Z2
+    VMOVUPD Y0, (DX)
+    ADDQ $32, SI
+    ADDQ $32, DX
+    DECQ AX
+    JNZ  conj_avx512_loop2
+
+conj_avx512_remainder1:
+    ANDQ $1, CX
     JZ   conj_avx512_done
 
-    // Use scalar loop (same as SSE2 but through dispatch)
-    // AVX512 doesn't provide a simpler conjugate operation than mixing scalars
-conj_avx512_loop:
-    MOVUPD (SI), X0        // [real, imag]
-
-    // Create negated copy: [-real, -imag]
-    XORPD X1, X1           // Clear X1 = [0, 0]
-    SUBPD X0, X1           // X1 = -X0 = [-real, -imag]
-
-    // Use SHUFPD to blend/reconstruct: [real, -imag]
-    SHUFPD $2, X1, X0      // X0 = [low(X0)=real, high(X1)=-imag]
-
-    MOVUPD X0, (DX)
-
-    ADDQ $16, SI
-    ADDQ $16, DX
-    DECQ CX
-    JNZ  conj_avx512_loop
+    VMOVUPD (SI), X0
+    VXORPD  X2, X0, X0     // X2 = low quarter of Z2
+    VMOVUPD X0, (DX)
 
 conj_avx512_done:
     VZEROUPPER
@@ -1040,12 +1054,16 @@ conj_avx512_done:
 
 // conjSignMask flips the sign bit of the imaginary lane of each packed
 // complex128: XOR [re0, im0, re1, im1] -> [re0, -im0, re1, -im1].
-// The low 128 bits ([0.0, -0.0]) serve the single-element remainder.
+// 64 bytes: low 32 bytes serve AVX (YMM), full 64 bytes serve AVX-512 (ZMM).
 DATA conjSignMask<>+0(SB)/8, $0x0000000000000000
 DATA conjSignMask<>+8(SB)/8, $0x8000000000000000
 DATA conjSignMask<>+16(SB)/8, $0x0000000000000000
 DATA conjSignMask<>+24(SB)/8, $0x8000000000000000
-GLOBL conjSignMask<>(SB), RODATA|NOPTR, $32
+DATA conjSignMask<>+32(SB)/8, $0x0000000000000000
+DATA conjSignMask<>+40(SB)/8, $0x8000000000000000
+DATA conjSignMask<>+48(SB)/8, $0x0000000000000000
+DATA conjSignMask<>+56(SB)/8, $0x8000000000000000
+GLOBL conjSignMask<>(SB), RODATA|NOPTR, $64
 
 // func conjAVX(dst, a []complex128)
 TEXT ·conjAVX(SB), NOSPLIT, $0-48

--- a/c128/c128_amd64.s
+++ b/c128/c128_amd64.s
@@ -705,8 +705,9 @@ TEXT ·absAVX512(SB), NOSPLIT, $0-48
     MOVQ a_base+24(FP), SI
 
     // Mask for VCOMPRESSPD: pick even lanes (0,2,4,6) from duplicated sums.
-    MOVB $0x55, R8
-    KMOVB R8, K1
+    // Use KMOVW (AVX512F) instead of KMOVB (AVX512DQ) for baseline compatibility.
+    MOVL $0x55, AX
+    KMOVW AX, K1
 
     MOVQ CX, AX
     SHRQ $2, AX            // Process 4 elements per iteration
@@ -862,8 +863,9 @@ TEXT ·absSqAVX512(SB), NOSPLIT, $0-48
     MOVQ a_base+24(FP), SI
 
     // Mask for VCOMPRESSPD: pick even lanes (0,2,4,6) from duplicated sums.
-    MOVB $0x55, R8
-    KMOVB R8, K1
+    // Use KMOVW (AVX512F) instead of KMOVB (AVX512DQ) for baseline compatibility.
+    MOVL $0x55, AX
+    KMOVW AX, K1
 
     MOVQ CX, AX
     SHRQ $2, AX            // Process 4 elements per iteration
@@ -1027,18 +1029,14 @@ conj_avx512_loop4:
 
 conj_avx512_loop2_check:
     ANDQ $3, CX
-    MOVQ CX, AX
-    SHRQ $1, AX
+    TESTQ $2, CX
     JZ   conj_avx512_remainder1
 
-conj_avx512_loop2:
     VMOVUPD (SI), Y0
     VXORPD  Y2, Y0, Y0     // Y2 = low half of Z2
     VMOVUPD Y0, (DX)
     ADDQ $32, SI
     ADDQ $32, DX
-    DECQ AX
-    JNZ  conj_avx512_loop2
 
 conj_avx512_remainder1:
     ANDQ $1, CX


### PR DESCRIPTION
## Summary

- **conjAVX512 (#37):** Replace legacy-SSE scalar loop (1 complex128/iter with `MOVUPD`/`XORPD`/`SUBPD`/`SHUFPD` mixing VEX and non-VEX encodings) with sign-mask `VXORPD` on ZMM registers at 4 complex128/iter. Extends `conjSignMask` to 64 bytes; YMM (2/iter) and XMM (1/iter) remainder loops reuse its lower lanes.
- **absAVX512/absSqAVX512 (#27):** Replace 6-instruction extract/unpack/insert packing with single `VCOMPRESSPD Z2, K1, Z2` using mask `0x55` to compress even lanes from duplicated sums.

## Benchmark results (Intel Xeon Platinum 8362, AVX-512)

### Conj — 3.2x faster (was barely beating Go)

| | Before | After |
|---|---|---|
| SIMD ns/op | 523.2 | **162.7** |
| SIMD MB/s | 62,629 | **201,352** |
| vs Go | 1.14x | **3.65x** |

### AbsSq — 2.3x faster (packing cost fully visible without sqrt)

| | Before | After |
|---|---|---|
| SIMD ns/op | 543.8 | **237.3** |
| SIMD MB/s | 30,127 | **69,051** |
| vs Go | 1.14x | **2.50x** |

### Abs — neutral (VSQRTPD dominates latency)

| | Before | After |
|---|---|---|
| SIMD ns/op | 906.2 | 917.6 |

## Test plan

- [x] All c128 tests pass on AVX-512 hardware (TestConj, TestConj_Large, TestConj_OddLarge, TestAbs, TestAbs_Large, TestAbsSq, TestAbsSq_Large, TestAbsSqKernels/AVX512)
- [x] All c128 tests pass on ARM64 (Go fallback path)
- [x] Benchmarked before/after on AVX-512 with `benchtime=2s`

Closes #37, closes #27.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Performance Improvements**
  * Optimized complex number mathematical operations including magnitude and conjugation calculations for significantly improved computational speed and efficiency
  * Enhanced underlying algorithms to better leverage modern processor hardware capabilities, providing measurable performance gains for mathematical-intensive operations
  * Streamlined computation pathways to reduce execution overhead and improve responsiveness across all supported platforms

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/tphakala/simd/pull/43?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->