### PR TITLE
Fix broken ARM64 NEON encodings and add a WORD-encoding validator

### DIFF
--- a/asmcheck_test.go
+++ b/asmcheck_test.go
@@ -58,7 +58,9 @@ func findArm64Asm(t *testing.T) []string {
 			return err
 		}
 		if !d.IsDir() && strings.HasSuffix(p, "_arm64.s") {
-			files = append(files, p)
+			// Normalize to forward slashes so allow-list matching and
+			// reporting are identical on Windows (WalkDir yields backslashes).
+			files = append(files, filepath.ToSlash(p))
 		}
 		return nil
 	})

--- a/asmcheck_test.go
+++ b/asmcheck_test.go
@@ -1,0 +1,174 @@
+package simd
+
+import (
+	"os"
+	"path/filepath"
+	"strconv"
+	"strings"
+	"testing"
+
+	"github.com/tphakala/simd/internal/asmencoding"
+)
+
+// asmException documents a WORD directive the checker cannot mechanically
+// verify, with the reason it is exempt. The current exemptions are all ARMv8.2
+// half-precision (.8H) SIMD instructions, which golang.org/x/arch/arm64asm
+// cannot decode. These are covered by the on-hardware numeric tests instead.
+type asmException struct {
+	file   string // path suffix relative to the module root
+	hex    uint32
+	expect string // intended instruction, for human reference
+	reason string
+}
+
+// fp16Reason applies to every entry below: golang.org/x/arch/arm64asm cannot
+// decode ARMv8.2 half-precision (.8H) SIMD instructions. Each encoding here was
+// instead verified with aarch64 GNU objdump (binutils 2.44) to match its
+// comment, and is exercised by the on-hardware numeric tests in f16.
+const fp16Reason = "ARMv8.2 FP16 (.8H) SIMD; not decodable by arm64asm; verified via aarch64 objdump"
+
+var asmAllowlist = []asmException{
+	{"f16/f16_arm64.s", 0x4E403484, "FMAX V4.8H, V4.8H, V0.8H", fp16Reason},
+	{"f16/f16_arm64.s", 0x4E410C02, "FMLA V2.8H, V0.8H, V1.8H", fp16Reason},
+	{"f16/f16_arm64.s", 0x4E411400, "FADD V0.8H, V0.8H, V1.8H", fp16Reason},
+	{"f16/f16_arm64.s", 0x4E411402, "FADD V2.8H, V0.8H, V1.8H", fp16Reason},
+	{"f16/f16_arm64.s", 0x4E413402, "FMAX V2.8H, V0.8H, V1.8H", fp16Reason},
+	{"f16/f16_arm64.s", 0x4E421400, "FADD V0.8H, V0.8H, V2.8H", fp16Reason},
+	{"f16/f16_arm64.s", 0x4E423401, "FMAX V1.8H, V0.8H, V2.8H", fp16Reason},
+	{"f16/f16_arm64.s", 0x4EC03484, "FMIN V4.8H, V4.8H, V0.8H", fp16Reason},
+	{"f16/f16_arm64.s", 0x4EC11402, "FSUB V2.8H, V0.8H, V1.8H", fp16Reason},
+	{"f16/f16_arm64.s", 0x4EC33421, "FMIN V1.8H, V1.8H, V3.8H", fp16Reason},
+	{"f16/f16_arm64.s", 0x4EF8F801, "FABS V1.8H, V0.8H", fp16Reason},
+	{"f16/f16_arm64.s", 0x6E403C41, "FDIV V1.8H, V2.8H, V0.8H", fp16Reason},
+	{"f16/f16_arm64.s", 0x6E411C02, "FMUL V2.8H, V0.8H, V1.8H", fp16Reason},
+	{"f16/f16_arm64.s", 0x6E411C62, "FMUL V2.8H, V3.8H, V1.8H", fp16Reason},
+	{"f16/f16_arm64.s", 0x6E413C02, "FDIV V2.8H, V0.8H, V1.8H", fp16Reason},
+	{"f16/f16_arm64.s", 0x6E443484, "FMAXP V4.8H, V4.8H, V4.8H", fp16Reason},
+	{"f16/f16_arm64.s", 0x6EC43484, "FMINP V4.8H, V4.8H, V4.8H", fp16Reason},
+	{"f16/f16_arm64.s", 0x6EF8F801, "FNEG V1.8H, V0.8H", fp16Reason},
+	{"f16/f16_arm64.s", 0x6EF9F801, "FSQRT V1.8H, V0.8H", fp16Reason},
+}
+
+// findArm64Asm returns every *_arm64.s file under the module root.
+func findArm64Asm(t *testing.T) []string {
+	t.Helper()
+	var files []string
+	err := filepath.WalkDir(".", func(p string, d os.DirEntry, err error) error {
+		if err != nil {
+			return err
+		}
+		if !d.IsDir() && strings.HasSuffix(p, "_arm64.s") {
+			files = append(files, p)
+		}
+		return nil
+	})
+	if err != nil {
+		t.Fatalf("walk: %v", err)
+	}
+	if len(files) == 0 {
+		t.Fatal("no *_arm64.s files found; is the test running from the module root?")
+	}
+	return files
+}
+
+func allowed(file string, hex uint32, used map[int]bool) bool {
+	for i, e := range asmAllowlist {
+		if e.hex == hex && strings.HasSuffix(file, e.file) {
+			used[i] = true
+			return true
+		}
+	}
+	return false
+}
+
+// TestArm64WordEncodings decodes every hand-encoded WORD directive in the ARM64
+// assembly and asserts it matches the instruction named in its comment.
+func TestArm64WordEncodings(t *testing.T) {
+	usedExceptions := map[int]bool{}
+
+	for _, file := range findArm64Asm(t) {
+		src, err := os.ReadFile(file)
+		if err != nil {
+			t.Fatalf("read %s: %v", file, err)
+		}
+		directives := asmencoding.ScanSource(string(src))
+
+		// Hexes that verified cleanly somewhere in this file; used to accept
+		// uncommented repeats of an already-validated instruction.
+		matched := map[uint32]bool{}
+		for _, d := range directives {
+			if d.Source != asmencoding.NoComment {
+				if asmencoding.Verify(d.Hex, d.Comment).Status == asmencoding.Match {
+					matched[d.Hex] = true
+				}
+			}
+		}
+
+		for _, d := range directives {
+			if d.Source == asmencoding.NoComment {
+				if matched[d.Hex] || allowed(file, d.Hex, usedExceptions) {
+					continue
+				}
+				t.Errorf("%s:%d  0x%08X  uncommented WORD, cannot validate (add a comment)", file, d.Line, d.Hex)
+				continue
+			}
+			res := asmencoding.Verify(d.Hex, d.Comment)
+			switch res.Status {
+			case asmencoding.Match:
+				// ok
+			case asmencoding.Mismatch:
+				if allowed(file, d.Hex, usedExceptions) {
+					continue
+				}
+				t.Errorf("%s:%d  0x%08X  claims=%q  decodes=%q", file, d.Line, d.Hex, res.Claimed, res.Decoded)
+			case asmencoding.Undecodable:
+				if allowed(file, d.Hex, usedExceptions) {
+					continue
+				}
+				t.Errorf("%s:%d  0x%08X  claims=%q  not decodable and not allow-listed (%v)", file, d.Line, d.Hex, d.Comment, res.Err)
+			}
+		}
+	}
+
+	for i, e := range asmAllowlist {
+		if !usedExceptions[i] {
+			t.Errorf("stale allow-list entry never matched: %s 0x%08X (%s)", e.file, e.hex, e.expect)
+		}
+	}
+}
+
+// TestNoUncheckedAmd64Encodings is a warn-only tripwire: amd64 currently has no
+// hand-encoded instructions. If any appear (for example from AVX-512 work that
+// the Go assembler cannot express as mnemonics), this logs them so they can be
+// brought under a decoder-based check too. It does not fail the build.
+func TestNoUncheckedAmd64Encodings(t *testing.T) {
+	var hits []string
+	err := filepath.WalkDir(".", func(p string, d os.DirEntry, err error) error {
+		if err != nil {
+			return err
+		}
+		if d.IsDir() || !strings.HasSuffix(p, "_amd64.s") {
+			return nil
+		}
+		src, err := os.ReadFile(p)
+		if err != nil {
+			return err
+		}
+		for i, line := range strings.Split(string(src), "\n") {
+			trimmed := strings.TrimSpace(line)
+			for _, kw := range []string{"BYTE $0x", "WORD $0x", "LONG $0x", "QUAD $0x"} {
+				if strings.HasPrefix(trimmed, kw) {
+					hits = append(hits, p+":"+strconv.Itoa(i+1)+"  "+trimmed)
+				}
+			}
+		}
+		return nil
+	})
+	if err != nil {
+		t.Fatalf("walk: %v", err)
+	}
+	if len(hits) > 0 {
+		t.Logf("WARNING: %d hand-encoded amd64 directive(s) are not decoder-checked:\n  %s",
+			len(hits), strings.Join(hits, "\n  "))
+	}
+}

--- a/f16/f16_arm64.s
+++ b/f16/f16_arm64.s
@@ -461,7 +461,7 @@ min16_loop8:
     ADD $16, R0
 
     // FMIN V4.8H, V4.8H, V0.8H
-    WORD $0x4EC03480
+    WORD $0x4EC03484
 
     SUB $1, R3
     CBNZ R3, min16_loop8
@@ -497,7 +497,7 @@ max16_loop8:
     ADD $16, R0
 
     // FMAX V4.8H, V4.8H, V0.8H
-    WORD $0x4E403480
+    WORD $0x4E403484
 
     SUB $1, R3
     CBNZ R3, max16_loop8
@@ -651,7 +651,7 @@ TEXT ·reciprocalNEON(SB), NOSPLIT, $0-48
     FMOVD R4, F2
     MOVD $0x3C003C003C003C00, R4
     FMOVD R4, F3
-    WORD $0x4E032042            // INS V2.D[1], V3.D[0]
+    WORD $0x6E180462            // INS V2.D[1], V3.D[0]
 
     LSR $3, R3, R4
     CBZ R4, recip16_done

--- a/f16/vector_path_test.go
+++ b/f16/vector_path_test.go
@@ -1,0 +1,59 @@
+package f16
+
+import (
+	"math"
+	"testing"
+)
+
+// These tests exercise the NEON-dispatched paths for lengths at or beyond the
+// 8-lane vector width, including non-multiples of 8 so the scalar/Go remainder
+// also runs. They guard against encoding bugs that only surface when the
+// assembly loop actually executes: the earlier reciprocal/min/max tests used
+// fewer than 16 elements, so the looping NEON code never ran and three broken
+// WORD encodings shipped undetected. Each result is cross-checked against the
+// pure-Go fallback, which is the trusted reference.
+
+func relClose(got, want float32) bool {
+	d := math.Abs(float64(got - want))
+	return d <= 0.02*math.Abs(float64(want))+0.002
+}
+
+func TestReciprocalVectorPath(t *testing.T) {
+	for _, n := range []int{8, 11, 16, 19, 24} {
+		a := make([]Float16, n)
+		for i := range a {
+			a[i] = FromFloat32(float32(i + 1)) // 1..n, never zero
+		}
+		gotDst := make([]Float16, n)
+		wantDst := make([]Float16, n)
+		Reciprocal(gotDst, a)
+		reciprocalGo(wantDst, a)
+		for i := range gotDst {
+			got, want := ToFloat32(gotDst[i]), ToFloat32(wantDst[i])
+			if !relClose(got, want) {
+				t.Errorf("n=%d Reciprocal[%d] = %v, want %v (Go fallback, input %v)",
+					n, i, got, want, ToFloat32(a[i]))
+			}
+		}
+	}
+}
+
+func TestMinMaxVectorPath(t *testing.T) {
+	for _, n := range []int{16, 19, 24, 32} {
+		a := make([]Float16, n)
+		for i := range a {
+			a[i] = FromFloat32(float32((i*7+3)%40) - 5)
+		}
+		// Put the true extremum past the first 8-lane block so a loop that
+		// fails to update its accumulator cannot find it.
+		a[n-4] = FromFloat32(-100)
+		a[n-3] = FromFloat32(100)
+
+		if got, want := ToFloat32(Min(a)), ToFloat32(minGo(a)); !almostEqual32(got, want, 0.01) {
+			t.Errorf("n=%d Min() = %v, want %v (Go fallback)", n, got, want)
+		}
+		if got, want := ToFloat32(Max(a)), ToFloat32(maxGo(a)); !almostEqual32(got, want, 0.01) {
+			t.Errorf("n=%d Max() = %v, want %v (Go fallback)", n, got, want)
+		}
+	}
+}

--- a/f32/f32_arm64.s
+++ b/f32/f32_arm64.s
@@ -360,7 +360,7 @@ min32_scalar:
     CBZ R1, min32_reduce
 
     // Reduce vector FIRST before scalar ops
-    WORD $0x6EB0F400           // FMINP V0.4S, V0.4S, V0.4S
+    WORD $0x6EA0F400           // FMINP V0.4S, V0.4S, V0.4S
     WORD $0x7EB0F800           // FMINP S0, V0.2S
 
 min32_loop1:
@@ -375,7 +375,7 @@ min32_loop1:
 
 min32_reduce:
     // Horizontal min when no scalar remainder
-    WORD $0x6EB0F400           // FMINP V0.4S, V0.4S, V0.4S
+    WORD $0x6EA0F400           // FMINP V0.4S, V0.4S, V0.4S
     WORD $0x7EB0F800           // FMINP S0, V0.2S
     FMOVS F0, ret+24(FP)
     RET
@@ -402,7 +402,7 @@ max32_scalar:
     CBZ R1, max32_reduce
 
     // Reduce vector FIRST before scalar ops
-    WORD $0x6E30F400           // FMAXP V0.4S, V0.4S, V0.4S
+    WORD $0x6E20F400           // FMAXP V0.4S, V0.4S, V0.4S
     WORD $0x7E30F800           // FMAXP S0, V0.2S
 
 max32_loop1:
@@ -417,7 +417,7 @@ max32_loop1:
 
 max32_reduce:
     // Horizontal max when no scalar remainder
-    WORD $0x6E30F400           // FMAXP V0.4S, V0.4S, V0.4S
+    WORD $0x6E20F400           // FMAXP V0.4S, V0.4S, V0.4S
     WORD $0x7E30F800           // FMAXP S0, V0.2S
     FMOVS F0, ret+24(FP)
     RET

--- a/go.mod
+++ b/go.mod
@@ -4,6 +4,7 @@ go 1.25.0
 
 require (
 	github.com/stretchr/testify v1.11.1
+	golang.org/x/arch v0.27.0
 	golang.org/x/sys v0.45.0
 )
 

--- a/go.sum
+++ b/go.sum
@@ -4,6 +4,8 @@ github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZb
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/stretchr/testify v1.11.1 h1:7s2iGBzp5EwR7/aIZr8ao5+dra3wiQyKjjFuvgVKu7U=
 github.com/stretchr/testify v1.11.1/go.mod h1:wZwfW3scLgRK+23gO65QZefKpKQRnfz6sD981Nm4B6U=
+golang.org/x/arch v0.27.0 h1:0WNVcR8u9yFz8j5FvdHpgwNp3FS5U4guYdzHwEiGjoU=
+golang.org/x/arch v0.27.0/go.mod h1:0X+GdSIP+kL5wPmpK7sdkEVTt2XoYP0cSjQSbZBwOi8=
 golang.org/x/sys v0.45.0 h1:dO4czNzziLiiXplLQgBCEpCvXQ3dnkn0SdaZSYdQ+FY=
 golang.org/x/sys v0.45.0/go.mod h1:4GL1E5IUh+htKOUEOaiffhrAeqysfVGipDYzABqnCmw=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=

--- a/internal/asmencoding/asmencoding.go
+++ b/internal/asmencoding/asmencoding.go
@@ -62,9 +62,11 @@ func ScanSource(src string) []Directive {
 			d.Source = InlineComment
 		case i > 0:
 			if prev := strings.TrimSpace(lines[i-1]); strings.HasPrefix(prev, "//") {
-				// A commented-out WORD directly above is disabled code, not a
-				// description of this instruction.
-				if text := strings.TrimSpace(strings.TrimPrefix(prev, "//")); !strings.HasPrefix(text, "WORD") {
+				// Use the line above as the description only if it is a
+				// non-empty comment that is not itself a commented-out WORD
+				// directive (matched case-insensitively).
+				text := strings.TrimSpace(strings.TrimPrefix(prev, "//"))
+				if text != "" && !strings.HasPrefix(strings.ToUpper(text), "WORD") {
 					d.Comment = text
 					d.Source = PrecedingComment
 				}

--- a/internal/asmencoding/asmencoding.go
+++ b/internal/asmencoding/asmencoding.go
@@ -49,7 +49,7 @@ type Directive struct {
 // its inline comment, or the comment on the line directly above it.
 func ScanSource(src string) []Directive {
 	lines := strings.Split(src, "\n")
-	var out []Directive
+	out := make([]Directive, 0, len(lines))
 	for i, line := range lines {
 		hex, inline, ok := ParseWordLine(line)
 		if !ok {
@@ -62,8 +62,12 @@ func ScanSource(src string) []Directive {
 			d.Source = InlineComment
 		case i > 0:
 			if prev := strings.TrimSpace(lines[i-1]); strings.HasPrefix(prev, "//") {
-				d.Comment = strings.TrimSpace(strings.TrimPrefix(prev, "//"))
-				d.Source = PrecedingComment
+				// A commented-out WORD directly above is disabled code, not a
+				// description of this instruction.
+				if text := strings.TrimSpace(strings.TrimPrefix(prev, "//")); !strings.HasPrefix(text, "WORD") {
+					d.Comment = text
+					d.Source = PrecedingComment
+				}
 			}
 		}
 		out = append(out, d)
@@ -91,6 +95,13 @@ var commentRe = regexp.MustCompile(`//\s*(.*)$`)
 // ParseWordLine extracts the hex value and inline comment from a single
 // assembly line. ok is false when the line is not a WORD $0x... directive.
 func ParseWordLine(line string) (hex uint32, comment string, ok bool) {
+	// Ignore commented-out directives like "// WORD $0x...": if WORD appears
+	// only after a // on the line, it is disabled code, not an instruction.
+	if c := strings.Index(line, "//"); c != -1 {
+		if w := strings.Index(line, "WORD"); w > c {
+			return 0, "", false
+		}
+	}
 	m := wordLineRe.FindStringSubmatch(line)
 	if m == nil {
 		return 0, "", false
@@ -121,6 +132,7 @@ func Decode(hex uint32) (string, error) {
 func Normalize(s string) string {
 	s = strings.ToUpper(strings.TrimSpace(s))
 	s = strings.Join(strings.Fields(s), " ")
+	s = strings.ReplaceAll(s, " ,", ",")
 	s = strings.ReplaceAll(s, ", ", ",")
 	mnem, rest, hasRest := strings.Cut(s, " ")
 	if canon, found := aliases[mnem]; found {

--- a/internal/asmencoding/asmencoding.go
+++ b/internal/asmencoding/asmencoding.go
@@ -1,0 +1,149 @@
+// Package asmencoding validates hand-encoded ARM64 WORD directives against
+// the instruction described in their comment. It decodes each 32-bit word with
+// the same disassembler go tool objdump uses, so it runs on any architecture
+// with no ARM hardware.
+package asmencoding
+
+import (
+	"encoding/binary"
+	"regexp"
+	"strconv"
+	"strings"
+
+	"golang.org/x/arch/arm64/arm64asm"
+)
+
+// Status is the outcome of verifying one WORD directive.
+type Status int
+
+const (
+	// Match means the decoded instruction matches the comment.
+	Match Status = iota + 1
+	// Mismatch means the bytes decode to a different instruction than claimed.
+	Mismatch
+	// Undecodable means the disassembler could not decode the bytes.
+	Undecodable
+)
+
+// CommentSource records where a directive's describing comment came from.
+type CommentSource int
+
+const (
+	// NoComment means the WORD directive has no associated comment.
+	NoComment CommentSource = iota
+	// InlineComment means the comment is on the same line as the WORD.
+	InlineComment
+	// PrecedingComment means the comment is on the line directly above.
+	PrecedingComment
+)
+
+// Directive is one parsed WORD $0x... line with its associated comment.
+type Directive struct {
+	Line    int    // 1-based line number
+	Hex     uint32 // the 32-bit instruction word
+	Comment string // the claimed instruction text, empty if NoComment
+	Source  CommentSource
+}
+
+// ScanSource parses every WORD $0x... directive in src, associating each with
+// its inline comment, or the comment on the line directly above it.
+func ScanSource(src string) []Directive {
+	lines := strings.Split(src, "\n")
+	var out []Directive
+	for i, line := range lines {
+		hex, inline, ok := ParseWordLine(line)
+		if !ok {
+			continue
+		}
+		d := Directive{Line: i + 1, Hex: hex}
+		switch {
+		case inline != "":
+			d.Comment = inline
+			d.Source = InlineComment
+		case i > 0:
+			if prev := strings.TrimSpace(lines[i-1]); strings.HasPrefix(prev, "//") {
+				d.Comment = strings.TrimSpace(strings.TrimPrefix(prev, "//"))
+				d.Source = PrecedingComment
+			}
+		}
+		out = append(out, d)
+	}
+	return out
+}
+
+// Result is the outcome of Verify.
+type Result struct {
+	Status  Status
+	Decoded string // normalized decoded instruction (empty when Undecodable)
+	Claimed string // normalized claimed instruction
+	Err     error  // decode error when Undecodable
+}
+
+// aliases maps mnemonics the comments use to the form the disassembler emits.
+// INS (element) and MOV (element) are documented aliases; objdump prefers MOV.
+var aliases = map[string]string{
+	"INS": "MOV",
+}
+
+var wordLineRe = regexp.MustCompile(`WORD\s+\$0x([0-9A-Fa-f]{1,8})\b`)
+var commentRe = regexp.MustCompile(`//\s*(.*)$`)
+
+// ParseWordLine extracts the hex value and inline comment from a single
+// assembly line. ok is false when the line is not a WORD $0x... directive.
+func ParseWordLine(line string) (hex uint32, comment string, ok bool) {
+	m := wordLineRe.FindStringSubmatch(line)
+	if m == nil {
+		return 0, "", false
+	}
+	v, err := strconv.ParseUint(m[1], 16, 32)
+	if err != nil {
+		return 0, "", false
+	}
+	if cm := commentRe.FindStringSubmatch(line); cm != nil {
+		comment = strings.TrimSpace(cm[1])
+	}
+	return uint32(v), comment, true
+}
+
+// Decode returns the GNU-syntax disassembly of a 32-bit ARM64 instruction word.
+func Decode(hex uint32) (string, error) {
+	var b [4]byte
+	binary.LittleEndian.PutUint32(b[:], hex)
+	inst, err := arm64asm.Decode(b[:])
+	if err != nil {
+		return "", err
+	}
+	return arm64asm.GNUSyntax(inst), nil
+}
+
+// Normalize canonicalizes an instruction string for comparison: upper case,
+// single-spaced, no space after commas, with aliased mnemonics folded.
+func Normalize(s string) string {
+	s = strings.ToUpper(strings.TrimSpace(s))
+	s = strings.Join(strings.Fields(s), " ")
+	s = strings.ReplaceAll(s, ", ", ",")
+	mnem, rest, hasRest := strings.Cut(s, " ")
+	if canon, found := aliases[mnem]; found {
+		mnem = canon
+	}
+	if hasRest {
+		return mnem + " " + rest
+	}
+	return mnem
+}
+
+// Verify decodes hex and checks it against the claimed instruction text. The
+// decoded instruction must equal the claim or be a token-boundary prefix of it,
+// so comments may carry a trailing free-form annotation after the operands.
+func Verify(hex uint32, claimed string) Result {
+	gnu, err := Decode(hex)
+	if err != nil {
+		return Result{Status: Undecodable, Err: err}
+	}
+	nd := Normalize(gnu)
+	nc := Normalize(claimed)
+	if nc == nd || strings.HasPrefix(nc, nd+" ") {
+		return Result{Status: Match, Decoded: nd, Claimed: nc}
+	}
+	return Result{Status: Mismatch, Decoded: nd, Claimed: nc}
+}

--- a/internal/asmencoding/asmencoding_test.go
+++ b/internal/asmencoding/asmencoding_test.go
@@ -1,0 +1,146 @@
+package asmencoding
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestScanSource(t *testing.T) {
+	src := strings.Join([]string{
+		"TEXT ·foo(SB), NOSPLIT, $0-48",                     // 1
+		"    WORD $0x4E24CC40  // FMLA V0.4S, V2.4S, V4.4S", // 2 inline comment
+		"    // FDIV V1.8H, V2.8H, V0.8H (1.0 / x)",         // 3 comment line
+		"    WORD $0x6E403C41",                              // 4 preceding-line comment
+		"    WORD $0x6E443484",                              // 5 no comment (prev line is a WORD)
+		"    FADD V0.4S, V0.4S, V1.4S",                      // 6 not a WORD directive
+	}, "\n")
+
+	got := ScanSource(src)
+	want := []Directive{
+		{Line: 2, Hex: 0x4E24CC40, Comment: "FMLA V0.4S, V2.4S, V4.4S", Source: InlineComment},
+		{Line: 4, Hex: 0x6E403C41, Comment: "FDIV V1.8H, V2.8H, V0.8H (1.0 / x)", Source: PrecedingComment},
+		{Line: 5, Hex: 0x6E443484, Comment: "", Source: NoComment},
+	}
+	if len(got) != len(want) {
+		t.Fatalf("ScanSource returned %d directives, want %d: %+v", len(got), len(want), got)
+	}
+	for i := range want {
+		if got[i] != want[i] {
+			t.Errorf("directive[%d] = %+v, want %+v", i, got[i], want[i])
+		}
+	}
+}
+
+func TestParseWordLine(t *testing.T) {
+	tests := []struct {
+		name        string
+		line        string
+		wantHex     uint32
+		wantComment string
+		wantOK      bool
+	}{
+		{
+			name:        "inline comment",
+			line:        "    WORD $0x4E24CC40           // FMLA V0.4S, V2.4S, V4.4S",
+			wantHex:     0x4E24CC40,
+			wantComment: "FMLA V0.4S, V2.4S, V4.4S",
+			wantOK:      true,
+		},
+		{
+			name:        "bare word without inline comment",
+			line:        "    WORD $0x6E403C41",
+			wantHex:     0x6E403C41,
+			wantComment: "",
+			wantOK:      true,
+		},
+		{
+			name:   "non-word instruction line",
+			line:   "    FADD V0.4S, V0.4S, V1.4S",
+			wantOK: false,
+		},
+		{
+			name:   "comment only line",
+			line:   "    // FADD V2.8H, V0.8H, V1.8H",
+			wantOK: false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			hex, comment, ok := ParseWordLine(tt.line)
+			if ok != tt.wantOK {
+				t.Fatalf("ok = %v, want %v", ok, tt.wantOK)
+			}
+			if !ok {
+				return
+			}
+			if hex != tt.wantHex {
+				t.Errorf("hex = 0x%08X, want 0x%08X", hex, tt.wantHex)
+			}
+			if comment != tt.wantComment {
+				t.Errorf("comment = %q, want %q", comment, tt.wantComment)
+			}
+		})
+	}
+}
+
+func TestDecode(t *testing.T) {
+	gnu, err := Decode(0x4E24CC40)
+	if err != nil {
+		t.Fatalf("Decode(0x4E24CC40) error: %v", err)
+	}
+	if gnu != "fmla v0.4s, v2.4s, v4.4s" {
+		t.Errorf("Decode(0x4E24CC40) = %q, want %q", gnu, "fmla v0.4s, v2.4s, v4.4s")
+	}
+
+	// FP16 .8H FMUL is not decodable by arm64asm; must report an error.
+	if _, err := Decode(0x6E411C02); err == nil {
+		t.Errorf("Decode(0x6E411C02) err = nil, want non-nil (FP16 .8H unsupported)")
+	}
+}
+
+func TestNormalize(t *testing.T) {
+	tests := []struct {
+		in, want string
+	}{
+		{"FMLA V0.4S, V2.4S, V4.4S", "FMLA V0.4S,V2.4S,V4.4S"},
+		{"fmla v0.4s,  v2.4s,v4.4s", "FMLA V0.4S,V2.4S,V4.4S"},
+	}
+	for _, tt := range tests {
+		if got := Normalize(tt.in); got != tt.want {
+			t.Errorf("Normalize(%q) = %q, want %q", tt.in, got, tt.want)
+		}
+	}
+
+	// INS and MOV (element) are aliases; they must normalize equal.
+	if Normalize("INS V2.D[1], V3.D[0]") != Normalize("MOV V2.D[1], V3.D[0]") {
+		t.Errorf("INS/MOV element forms should normalize equal: %q vs %q",
+			Normalize("INS V2.D[1], V3.D[0]"), Normalize("MOV V2.D[1], V3.D[0]"))
+	}
+}
+
+func TestVerify(t *testing.T) {
+	tests := []struct {
+		name    string
+		hex     uint32
+		claimed string
+		want    Status
+	}{
+		{"exact match", 0x4E24CC40, "FMLA V0.4S, V2.4S, V4.4S", Match},
+		{"match with trailing annotation", 0x6E34DC01, "FMUL V1.4S, V0.4S, V20.4S V1 = -X * LOG2E", Match},
+		{"match via INS/MOV alias", 0x6E180462, "INS V2.D[1], V3.D[0]", Match},
+		{"corrected FMINP matches", 0x6EA0F400, "FMINP V0.4S, V0.4S, V0.4S", Match},
+		{"wrong register mismatch (FMINP V16)", 0x6EB0F400, "FMINP V0.4S, V0.4S, V0.4S", Mismatch},
+		{"INS encoded as TBL mismatch", 0x4E032042, "INS V2.D[1], V3.D[0]", Mismatch},
+		{"register prefix must not false-match (V1 vs V10)", 0x6E21DC02, "FMUL V2.4S, V0.4S, V10.4S", Mismatch},
+		{"FP16 undecodable", 0x6E411C02, "FMUL V2.8H, V0.8H, V1.8H", Undecodable},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := Verify(tt.hex, tt.claimed)
+			if got.Status != tt.want {
+				t.Errorf("Verify(0x%08X, %q).Status = %v, want %v (decoded=%q)",
+					tt.hex, tt.claimed, got.Status, tt.want, got.Decoded)
+			}
+		})
+	}
+}

--- a/internal/asmencoding/asmencoding_test.go
+++ b/internal/asmencoding/asmencoding_test.go
@@ -31,6 +31,21 @@ func TestScanSource(t *testing.T) {
 	}
 }
 
+func TestScanSourceIgnoresCommentedOutWord(t *testing.T) {
+	// Line 1 is a commented-out directive; line 2 is the real one.
+	src := "    // WORD $0x4EC03480\n    WORD $0x4E24CC40"
+	got := ScanSource(src)
+	if len(got) != 1 {
+		t.Fatalf("expected 1 directive (commented-out one ignored), got %d: %+v", len(got), got)
+	}
+	if got[0].Hex != 0x4E24CC40 {
+		t.Errorf("hex = 0x%08X, want 0x4E24CC40", got[0].Hex)
+	}
+	if got[0].Source != NoComment {
+		t.Errorf("Source = %v, want NoComment (commented-out WORD must not become a comment)", got[0].Source)
+	}
+}
+
 func TestParseWordLine(t *testing.T) {
 	tests := []struct {
 		name        string
@@ -61,6 +76,11 @@ func TestParseWordLine(t *testing.T) {
 		{
 			name:   "comment only line",
 			line:   "    // FADD V2.8H, V0.8H, V1.8H",
+			wantOK: false,
+		},
+		{
+			name:   "commented-out word directive",
+			line:   "    // WORD $0x4EC03480",
 			wantOK: false,
 		},
 	}
@@ -104,6 +124,7 @@ func TestNormalize(t *testing.T) {
 	}{
 		{"FMLA V0.4S, V2.4S, V4.4S", "FMLA V0.4S,V2.4S,V4.4S"},
 		{"fmla v0.4s,  v2.4s,v4.4s", "FMLA V0.4S,V2.4S,V4.4S"},
+		{"FMLA V0.4S , V2.4S", "FMLA V0.4S,V2.4S"},
 	}
 	for _, tt := range tests {
 		if got := Normalize(tt.in); got != tt.want {

--- a/internal/asmencoding/asmencoding_test.go
+++ b/internal/asmencoding/asmencoding_test.go
@@ -46,6 +46,18 @@ func TestScanSourceIgnoresCommentedOutWord(t *testing.T) {
 	}
 }
 
+func TestScanSourceEmptyCommentAbove(t *testing.T) {
+	// An empty "//" line above a directive must not become an empty comment.
+	src := "    //\n    WORD $0x4E24CC40"
+	got := ScanSource(src)
+	if len(got) != 1 {
+		t.Fatalf("expected 1 directive, got %d: %+v", len(got), got)
+	}
+	if got[0].Source != NoComment {
+		t.Errorf("Source = %v, want NoComment (empty comment line must not be used)", got[0].Source)
+	}
+}
+
 func TestParseWordLine(t *testing.T) {
 	tests := []struct {
 		name        string


### PR DESCRIPTION
## Summary

Adds a static validator for hand-encoded ARM64 `WORD $0x...` directives and fixes three shipping NEON bugs it helped surface.

The validator (`internal/asmencoding` + `asmcheck_test.go`) decodes every `WORD` directive with `golang.org/x/arch/arm64asm` and asserts it matches the instruction named in its comment. It only decodes bytes, so it runs under `go test ./...` on any architecture and guards CI without ARM hardware. It would have caught the historical FNEG/FRINTN (#6) and REV64 encoding regressions.

Bugs fixed (all hardware-confirmed on a Raspberry Pi 5, all hidden by tests that used fewer elements than the SIMD vector width, so the NEON path never ran):

- **f16 `Reciprocal`** returned 0 for any length >= 8. `0x4E032042` decoded to `TBL`, not `INS V2.D[1],V3.D[0]`, which zeroed the `1.0h` numerator. Fixed to `0x6E180462`.
- **f16 `Min` / `Max`** ignored every element past the first 8 lanes. `0x4EC03480` / `0x4E403480` wrote the result to `V0` instead of the `V4` accumulator. Fixed to `0x4EC03484` / `0x4E403484`.
- **f32 FMINP / FMAXP** reductions encoded `Vm=V16` instead of `V0` at four sites (`0x6EB0F400` -> `0x6EA0F400`, `0x6E30F400` -> `0x6E20F400`). Harmless today because the polluted lanes are discarded, but the encoding read an unintended register.

FP16 `.8H` instructions cannot be decoded by `arm64asm`; the 19 distinct ones are allow-listed, each verified once with a native aarch64 `objdump`.

## Related Issues

- Relates to #44 (statically validate FP16 encodings via objdump cross-check)
- Relates to #45 (audit SIMD test coverage for vector-width threshold gaps)

## Test Plan

- [x] `go test ./...` green on x86 (1810 tests)
- [x] `go test ./...` green on real ARM64 (rpi5, Go 1.26.1)
- [x] New f16 vector-path tests fail on the old encodings and pass on the fixed ones (verified on hardware)
- [x] `asmcheck` reports zero findings after the fixes; `golangci-lint` and `go vet` clean


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added comprehensive test coverage for ARM64 vector operation paths, including reciprocal, minimum, and maximum functions with edge cases.
  * Added validation tests for hand-encoded ARM64 assembly directives.

* **Chores**
  * Updated dependency: added `golang.org/x/arch v0.27.0`.

* **Optimizations**
  * Optimized ARM64 NEON instructions for floating-point minimum, maximum, and reciprocal operations across FP16 and FP32 implementations.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/tphakala/simd/pull/46?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->