### PR TITLE
f16: NEON SIMD for EuclideanDistance, Variance/StdDev, Interleave2/Deinterleave2, ClampScale

### DIFF
--- a/README.md
+++ b/README.md
@@ -199,13 +199,13 @@ f16.ReLU(dst, a)             // Activation functions
 |                 | `MinIdx(a)`                         | Index of minimum              | Pure Go          |
 |                 | `MaxIdx(a)`                         | Index of maximum              | Pure Go          |
 | **Statistical** | `Mean(a)` → float32                 | Arithmetic mean               | 8x (NEON+FP16)   |
-|                 | `Variance(a)` → float32             | Population variance           | Pure Go          |
-|                 | `StdDev(a)` → float32               | Standard deviation            | Pure Go          |
-| **Vector**      | `EuclideanDistance(a, b)` → float32 | L2 distance                   | Pure Go          |
+|                 | `Variance(a)` → float32             | Population variance           | 8x (NEON+FP16)   |
+|                 | `StdDev(a)` → float32               | Standard deviation            | 8x (NEON+FP16)   |
+| **Vector**      | `EuclideanDistance(a, b)` → float32 | L2 distance                   | 8x (NEON+FP16)   |
 |                 | `Normalize(dst, a)`                 | Unit vector normalization     | 8x (NEON+FP16)   |
 |                 | `CumulativeSum(dst, a)`             | Running sum                   | Sequential       |
 | **Range**       | `Clamp(dst, a, min, max)`           | Clamp to range                | 8x (NEON+FP16)   |
-|                 | `ClampScale(dst, src, min, max, s)` | Fused clamp and scale         | Pure Go          |
+|                 | `ClampScale(dst, src, min, max, s)` | Fused clamp and scale         | 8x (NEON+FP16)   |
 | **Activation**  | `ReLU(dst, src)`                    | Rectified Linear Unit         | 8x (NEON+FP16)   |
 |                 | `Sigmoid(dst, src)`                 | Sigmoid: 1/(1+e^-x)           | Pure Go          |
 |                 | `Tanh(dst, src)`                    | Hyperbolic tangent            | Pure Go          |
@@ -213,8 +213,8 @@ f16.ReLU(dst, a)             // Activation functions
 | **Batch**       | `DotProductBatch(r, rows, v)`       | Multiple dot products         | 8x (NEON+FP16)   |
 | **Signal**      | `ConvolveValid(dst, sig, k)`        | FIR filter / convolution      | Pure Go          |
 |                 | `AccumulateAdd(dst, src, off)`      | Overlap-add: dst[off:] += src | 8x (NEON+FP16)   |
-| **Audio**       | `Interleave2(dst, a, b)`            | Pack stereo: [L,R,L,R,...]    | Pure Go          |
-|                 | `Deinterleave2(a, b, src)`          | Unpack stereo to channels     | Pure Go          |
+| **Audio**       | `Interleave2(dst, a, b)`            | Pack stereo: [L,R,L,R,...]    | 8x (NEON)        |
+|                 | `Deinterleave2(a, b, src)`          | Unpack stereo to channels     | 8x (NEON)        |
 
 **Key characteristics:**
 
@@ -223,6 +223,17 @@ f16.ReLU(dst, a)             // Activation functions
 - **Reductions**: Accumulate in float32 for numerical stability
 - **Memory efficiency**: 2x bandwidth vs float32 (8 elements per 128-bit NEON vector)
 - **DotProduct saturation**: On ARM64 with FP16 SIMD, `DotProduct` computes per-element products in FP16 and saturates to ±Inf when `|a[i] * b[i]| > 65504`. Use `DotProductF32` (FP32 widening before multiply, ~1.5-2x slower) for audio DSP or raw-signal inputs that can produce out-of-range products.
+- **FP32-widened ops**: `EuclideanDistance`, `Variance`, `StdDev`, and `ClampScale` widen each FP16 lane to FP32 before arithmetic (like `DotProductF32`), so they match the pure-Go reference and never saturate. `Interleave2`/`Deinterleave2` are bit-exact 16-bit lane permutes (`ZIP`/`UZP`) that run on any ARM64 NEON core, including non-FP16 parts (Cortex-A72/A53).
+
+**Benchmark (1024 elements, Raspberry Pi 5 / Cortex-A76, zero allocations):**
+
+| Operation         | SIMD   | Pure Go  | Speedup   |
+| ----------------- | ------ | -------- | --------- |
+| EuclideanDistance | 481 ns | 5995 ns  | **12.5x** |
+| Variance          | 524 ns | 5455 ns  | **10.4x** |
+| Interleave2       | 178 ns | 2163 ns  | **12.2x** |
+| Deinterleave2     | 178 ns | 2167 ns  | **12.2x** |
+| ClampScale        | 531 ns | 12211 ns | **23.0x** |
 
 **Hardware requirements:**
 

--- a/README.md
+++ b/README.md
@@ -230,7 +230,7 @@ f16.ReLU(dst, a)             // Activation functions
 | Operation         | SIMD   | Pure Go  | Speedup   |
 | ----------------- | ------ | -------- | --------- |
 | EuclideanDistance | 481 ns | 5995 ns  | **12.5x** |
-| Variance          | 524 ns | 5455 ns  | **10.4x** |
+| Variance          | 506 ns | 8901 ns  | **17.6x** |
 | Interleave2       | 178 ns | 2163 ns  | **12.2x** |
 | Deinterleave2     | 178 ns | 2167 ns  | **12.2x** |
 | ClampScale        | 531 ns | 12211 ns | **23.0x** |

--- a/README.md
+++ b/README.md
@@ -199,13 +199,13 @@ f16.ReLU(dst, a)             // Activation functions
 |                 | `MinIdx(a)`                         | Index of minimum              | Pure Go          |
 |                 | `MaxIdx(a)`                         | Index of maximum              | Pure Go          |
 | **Statistical** | `Mean(a)` → float32                 | Arithmetic mean               | 8x (NEON+FP16)   |
-|                 | `Variance(a)` → float32             | Population variance           | 8x (NEON+FP16)   |
-|                 | `StdDev(a)` → float32               | Standard deviation            | 8x (NEON+FP16)   |
-| **Vector**      | `EuclideanDistance(a, b)` → float32 | L2 distance                   | 8x (NEON+FP16)   |
+|                 | `Variance(a)` → float32             | Population variance           | 8x (NEON)        |
+|                 | `StdDev(a)` → float32               | Standard deviation            | 8x (NEON)        |
+| **Vector**      | `EuclideanDistance(a, b)` → float32 | L2 distance                   | 8x (NEON)        |
 |                 | `Normalize(dst, a)`                 | Unit vector normalization     | 8x (NEON+FP16)   |
 |                 | `CumulativeSum(dst, a)`             | Running sum                   | Sequential       |
 | **Range**       | `Clamp(dst, a, min, max)`           | Clamp to range                | 8x (NEON+FP16)   |
-|                 | `ClampScale(dst, src, min, max, s)` | Fused clamp and scale         | 8x (NEON+FP16)   |
+|                 | `ClampScale(dst, src, min, max, s)` | Fused clamp and scale         | 8x (NEON)        |
 | **Activation**  | `ReLU(dst, src)`                    | Rectified Linear Unit         | 8x (NEON+FP16)   |
 |                 | `Sigmoid(dst, src)`                 | Sigmoid: 1/(1+e^-x)           | Pure Go          |
 |                 | `Tanh(dst, src)`                    | Hyperbolic tangent            | Pure Go          |
@@ -223,7 +223,7 @@ f16.ReLU(dst, a)             // Activation functions
 - **Reductions**: Accumulate in float32 for numerical stability
 - **Memory efficiency**: 2x bandwidth vs float32 (8 elements per 128-bit NEON vector)
 - **DotProduct saturation**: On ARM64 with FP16 SIMD, `DotProduct` computes per-element products in FP16 and saturates to ±Inf when `|a[i] * b[i]| > 65504`. Use `DotProductF32` (FP32 widening before multiply, ~1.5-2x slower) for audio DSP or raw-signal inputs that can produce out-of-range products.
-- **FP32-widened ops**: `EuclideanDistance`, `Variance`, `StdDev`, and `ClampScale` widen each FP16 lane to FP32 before arithmetic (like `DotProductF32`), so they match the pure-Go reference and never saturate. `Interleave2`/`Deinterleave2` are bit-exact 16-bit lane permutes (`ZIP`/`UZP`) that run on any ARM64 NEON core, including non-FP16 parts (Cortex-A72/A53).
+- **FP32-widened ops**: `EuclideanDistance`, `Variance`, `StdDev`, and `ClampScale` widen each FP16 lane to FP32 before arithmetic (like `DotProductF32`), so they match the pure-Go reference and never saturate. They use only base-NEON instructions (the `FCVTL`/`FCVTN` conversions are ARMv8.0-A, not the FEAT_FP16 extension), so they run on any ARM64 NEON core, including non-FP16 parts (Cortex-A72/A53). `Interleave2`/`Deinterleave2` are likewise bit-exact 16-bit lane permutes (`ZIP`/`UZP`) that run on any ARM64 NEON core.
 
 **Benchmark (1024 elements, Raspberry Pi 5 / Cortex-A76, zero allocations):**
 

--- a/f16/benchmark_test.go
+++ b/f16/benchmark_test.go
@@ -483,3 +483,107 @@ func BenchmarkMemoryBandwidth(b *testing.B) {
 		})
 	}
 }
+
+// =============================================================================
+// EuclideanDistance / Variance / StdDev / Interleave / ClampScale (new SIMD)
+// =============================================================================
+
+func BenchmarkEuclideanDistance(b *testing.B) {
+	for _, size := range benchSizes {
+		a16, b16, _, _ := makeBenchDataF16(size)
+		b.Run(fmt.Sprintf("F16_SIMD_%d", size), func(b *testing.B) {
+			for i := 0; i < b.N; i++ {
+				sink32 = EuclideanDistance(a16, b16)
+			}
+			reportThroughput16(b, size)
+		})
+		b.Run(fmt.Sprintf("F16_Go_%d", size), func(b *testing.B) {
+			for i := 0; i < b.N; i++ {
+				sink32 = euclideanDistanceGo(a16, b16)
+			}
+			reportThroughput16(b, size)
+		})
+	}
+}
+
+func BenchmarkVariance(b *testing.B) {
+	for _, size := range benchSizes {
+		a16, _, _, _ := makeBenchDataF16(size)
+		b.Run(fmt.Sprintf("F16_SIMD_%d", size), func(b *testing.B) {
+			for i := 0; i < b.N; i++ {
+				sink32 = Variance(a16)
+			}
+			reportThroughput16(b, size)
+		})
+		b.Run(fmt.Sprintf("F16_Go_%d", size), func(b *testing.B) {
+			mean := Mean(a16)
+			for i := 0; i < b.N; i++ {
+				sink32 = varianceGo(a16, mean)
+			}
+			reportThroughput16(b, size)
+		})
+	}
+}
+
+func BenchmarkInterleave2(b *testing.B) {
+	for _, size := range benchSizes {
+		a16, b16, _, _ := makeBenchDataF16(size)
+		dst := make([]Float16, size*2)
+		b.Run(fmt.Sprintf("F16_SIMD_%d", size), func(b *testing.B) {
+			for i := 0; i < b.N; i++ {
+				Interleave2(dst, a16, b16)
+			}
+			reportThroughput16(b, size)
+		})
+		b.Run(fmt.Sprintf("F16_Go_%d", size), func(b *testing.B) {
+			for i := 0; i < b.N; i++ {
+				interleave2Go(dst, a16, b16)
+			}
+			reportThroughput16(b, size)
+		})
+	}
+}
+
+func BenchmarkDeinterleave2(b *testing.B) {
+	for _, size := range benchSizes {
+		src := make([]Float16, size*2)
+		for i := range src {
+			src[i] = FromFloat32(float32(i%100) + 0.5)
+		}
+		a16 := make([]Float16, size)
+		b16 := make([]Float16, size)
+		b.Run(fmt.Sprintf("F16_SIMD_%d", size), func(b *testing.B) {
+			for i := 0; i < b.N; i++ {
+				Deinterleave2(a16, b16, src)
+			}
+			reportThroughput16(b, size)
+		})
+		b.Run(fmt.Sprintf("F16_Go_%d", size), func(b *testing.B) {
+			for i := 0; i < b.N; i++ {
+				deinterleave2Go(a16, b16, src)
+			}
+			reportThroughput16(b, size)
+		})
+	}
+}
+
+func BenchmarkClampScale(b *testing.B) {
+	minV := FromFloat32(10)
+	maxV := FromFloat32(90)
+	sc := FromFloat32(0.0125)
+	for _, size := range benchSizes {
+		a16, _, _, dst := makeBenchDataF16(size)
+		b.Run(fmt.Sprintf("F16_SIMD_%d", size), func(b *testing.B) {
+			for i := 0; i < b.N; i++ {
+				ClampScale(dst, a16, minV, maxV, sc)
+			}
+			reportThroughput16(b, size)
+		})
+		b.Run(fmt.Sprintf("F16_Go_%d", size), func(b *testing.B) {
+			for i := 0; i < b.N; i++ {
+				clampScaleGo(dst, a16, minV, maxV, sc)
+			}
+			reportThroughput16(b, size)
+		})
+	}
+}

--- a/f16/benchmark_test.go
+++ b/f16/benchmark_test.go
@@ -428,9 +428,9 @@ func BenchmarkSummary(b *testing.B) {
 	scalar16 := FromFloat32(2.5)
 
 	ops := []struct {
-		name   string
-		f16    func()
-		f32    func()
+		name string
+		f16  func()
+		f32  func()
 	}{
 		{"DotProduct", func() { sink32 = DotProduct(a16, b16) }, func() { sink32 = f32.DotProduct(a32, b32) }},
 		{"Add", func() { Add(dst16, a16, b16) }, func() { f32.Add(dst32, a32, b32) }},
@@ -495,13 +495,13 @@ func BenchmarkEuclideanDistance(b *testing.B) {
 			for i := 0; i < b.N; i++ {
 				sink32 = EuclideanDistance(a16, b16)
 			}
-			reportThroughput16(b, size)
+			reportThroughput16(b, size*2) // reads a + b
 		})
 		b.Run(fmt.Sprintf("F16_Go_%d", size), func(b *testing.B) {
 			for i := 0; i < b.N; i++ {
 				sink32 = euclideanDistanceGo(a16, b16)
 			}
-			reportThroughput16(b, size)
+			reportThroughput16(b, size*2) // reads a + b
 		})
 	}
 }
@@ -515,10 +515,12 @@ func BenchmarkVariance(b *testing.B) {
 			}
 			reportThroughput16(b, size)
 		})
+		// Fair comparison: Variance(a16) computes the mean each call, so the Go
+		// path must compute the mean (in pure Go) inside the loop too.
 		b.Run(fmt.Sprintf("F16_Go_%d", size), func(b *testing.B) {
-			mean := Mean(a16)
+			n := float32(len(a16))
 			for i := 0; i < b.N; i++ {
-				sink32 = varianceGo(a16, mean)
+				sink32 = varianceGo(a16, sumGo(a16)/n)
 			}
 			reportThroughput16(b, size)
 		})
@@ -533,13 +535,13 @@ func BenchmarkInterleave2(b *testing.B) {
 			for i := 0; i < b.N; i++ {
 				Interleave2(dst, a16, b16)
 			}
-			reportThroughput16(b, size)
+			reportThroughput16(b, size*4) // reads a + b, writes dst (2*size)
 		})
 		b.Run(fmt.Sprintf("F16_Go_%d", size), func(b *testing.B) {
 			for i := 0; i < b.N; i++ {
 				interleave2Go(dst, a16, b16)
 			}
-			reportThroughput16(b, size)
+			reportThroughput16(b, size*4) // reads a + b, writes dst (2*size)
 		})
 	}
 }
@@ -556,13 +558,13 @@ func BenchmarkDeinterleave2(b *testing.B) {
 			for i := 0; i < b.N; i++ {
 				Deinterleave2(a16, b16, src)
 			}
-			reportThroughput16(b, size)
+			reportThroughput16(b, size*4) // reads src (2*size), writes a + b
 		})
 		b.Run(fmt.Sprintf("F16_Go_%d", size), func(b *testing.B) {
 			for i := 0; i < b.N; i++ {
 				deinterleave2Go(a16, b16, src)
 			}
-			reportThroughput16(b, size)
+			reportThroughput16(b, size*4) // reads src (2*size), writes a + b
 		})
 	}
 }
@@ -577,13 +579,13 @@ func BenchmarkClampScale(b *testing.B) {
 			for i := 0; i < b.N; i++ {
 				ClampScale(dst, a16, minV, maxV, sc)
 			}
-			reportThroughput16(b, size)
+			reportThroughput16(b, size*2) // reads src + writes dst
 		})
 		b.Run(fmt.Sprintf("F16_Go_%d", size), func(b *testing.B) {
 			for i := 0; i < b.N; i++ {
 				clampScaleGo(dst, a16, minV, maxV, sc)
 			}
-			reportThroughput16(b, size)
+			reportThroughput16(b, size*2) // reads src + writes dst
 		})
 	}
 }

--- a/f16/f16_arm64.go
+++ b/f16/f16_arm64.go
@@ -2,7 +2,11 @@
 
 package f16
 
-import "github.com/tphakala/simd/cpu"
+import (
+	"math"
+
+	"github.com/tphakala/simd/cpu"
+)
 
 // neonWidth is the number of FP16 elements per NEON vector (128-bit / 16-bit = 8).
 const neonWidth = 8
@@ -295,11 +299,24 @@ func addScaled16(dst []Float16, alpha Float16, s []Float16) {
 }
 
 func euclideanDistance16(a, b []Float16) float32 {
-	// Use Go implementation - could optimize later
+	n := min(len(a), len(b))
+	if hasFP16 && n >= neonWidth {
+		nVec := (n / neonWidth) * neonWidth
+		sumSq := sumSqDiffNEON(a[:nVec], b[:nVec])
+		sumSq += sumSqDiffGo(a[nVec:n], b[nVec:n])
+		return float32(math.Sqrt(float64(sumSq)))
+	}
 	return euclideanDistanceGo(a, b)
 }
 
 func variance16(a []Float16, mean float32) float32 {
+	n := len(a)
+	if hasFP16 && n >= neonWidth {
+		nVec := (n / neonWidth) * neonWidth
+		sumSq := sumSqDevNEON(a[:nVec], mean)
+		sumSq += sumSqDevGo(a[nVec:], mean)
+		return sumSq / float32(n)
+	}
 	return varianceGo(a, mean)
 }
 
@@ -331,14 +348,38 @@ func convolveValid16(dst, signal, kernel []Float16) {
 }
 
 func interleave2_16(dst, a, b []Float16) {
+	n := len(a) // == len(b); dst has length 2n (caller slices)
+	if hasNEON && n >= neonWidth {
+		nVec := (n / neonWidth) * neonWidth
+		interleave2NEON(dst[:nVec*2], a[:nVec], b[:nVec])
+		interleave2Go(dst[nVec*2:], a[nVec:], b[nVec:])
+		return
+	}
 	interleave2Go(dst, a, b)
 }
 
 func deinterleave2_16(a, b, src []Float16) {
+	n := len(a) // == len(b); src has length 2n (caller slices)
+	if hasNEON && n >= neonWidth {
+		nVec := (n / neonWidth) * neonWidth
+		deinterleave2NEON(a[:nVec], b[:nVec], src[:nVec*2])
+		deinterleave2Go(a[nVec:], b[nVec:], src[nVec*2:])
+		return
+	}
 	deinterleave2Go(a, b, src)
 }
 
 func clampScale16(dst, src []Float16, minVal, maxVal, scale Float16) {
+	n := len(dst)
+	if hasFP16 && n >= neonWidth {
+		nVec := (n / neonWidth) * neonWidth
+		minF := toFloat32Go(minVal)
+		maxF := toFloat32Go(maxVal)
+		scaleF := toFloat32Go(scale)
+		clampScaleNEON(dst[:nVec], src[:nVec], minF, maxF, scaleF)
+		clampScaleGo(dst[nVec:], src[nVec:], minVal, maxVal, scale)
+		return
+	}
 	clampScaleGo(dst, src, minVal, maxVal, scale)
 }
 
@@ -407,3 +448,18 @@ func addScaledNEON(dst []Float16, alpha Float16, s []Float16)
 
 //go:noescape
 func accumulateAddNEON(dst, src []Float16)
+
+//go:noescape
+func sumSqDiffNEON(a, b []Float16) float32
+
+//go:noescape
+func sumSqDevNEON(a []Float16, mean float32) float32
+
+//go:noescape
+func interleave2NEON(dst, a, b []Float16)
+
+//go:noescape
+func deinterleave2NEON(a, b, src []Float16)
+
+//go:noescape
+func clampScaleNEON(dst, src []Float16, minF, maxF, scaleF float32)

--- a/f16/f16_arm64.go
+++ b/f16/f16_arm64.go
@@ -300,7 +300,9 @@ func addScaled16(dst []Float16, alpha Float16, s []Float16) {
 
 func euclideanDistance16(a, b []Float16) float32 {
 	n := min(len(a), len(b))
-	if hasFP16 && n >= neonWidth {
+	// FP32-widened kernel: only FCVTL (base ARMv8.0 convert) + FP32 NEON
+	// arithmetic, so it needs base NEON, not FEAT_FP16.
+	if hasNEON && n >= neonWidth {
 		nVec := (n / neonWidth) * neonWidth
 		sumSq := sumSqDiffNEON(a[:nVec], b[:nVec])
 		sumSq += sumSqDiffGo(a[nVec:n], b[nVec:n])
@@ -311,7 +313,8 @@ func euclideanDistance16(a, b []Float16) float32 {
 
 func variance16(a []Float16, mean float32) float32 {
 	n := len(a)
-	if hasFP16 && n >= neonWidth {
+	// FP32-widened kernel: base NEON only (FCVTL + FP32 arithmetic), not FP16.
+	if hasNEON && n >= neonWidth {
 		nVec := (n / neonWidth) * neonWidth
 		sumSq := sumSqDevNEON(a[:nVec], mean)
 		sumSq += sumSqDevGo(a[nVec:], mean)
@@ -371,7 +374,8 @@ func deinterleave2_16(a, b, src []Float16) {
 
 func clampScale16(dst, src []Float16, minVal, maxVal, scale Float16) {
 	n := len(dst)
-	if hasFP16 && n >= neonWidth {
+	// FP32-widened kernel: base NEON only (FCVTL/FCVTN + FP32 arithmetic).
+	if hasNEON && n >= neonWidth {
 		nVec := (n / neonWidth) * neonWidth
 		minF := toFloat32Go(minVal)
 		maxF := toFloat32Go(maxVal)

--- a/f16/f16_arm64.s
+++ b/f16/f16_arm64.s
@@ -734,3 +734,199 @@ accadd16_loop8:
 
 accadd16_done:
     RET
+
+// func sumSqDiffNEON(a, b []Float16) float32
+// Returns sum((a[i]-b[i])^2). Each FP16 lane is widened to FP32 before the
+// subtract and square, so large differences do not saturate. Length must be a
+// multiple of 8 (caller guarantees via dispatch).
+TEXT ·sumSqDiffNEON(SB), NOSPLIT, $0-52
+    MOVD a_base+0(FP), R0
+    MOVD a_len+8(FP), R2
+    MOVD b_base+24(FP), R1
+
+    VEOR V4.B16, V4.B16, V4.B16   // acc lower 4 lanes
+    VEOR V5.B16, V5.B16, V5.B16   // acc upper 4 lanes
+
+    LSR $3, R2, R3
+    CBZ R3, ssd_reduce
+
+ssd_loop8:
+    VLD1 (R0), [V0.H8]            // 8 FP16 from a
+    ADD $16, R0
+    VLD1 (R1), [V1.H8]            // 8 FP16 from b
+    ADD $16, R1
+
+    WORD $0x0E217802             // FCVTL  V2.4S, V0.4H (a lower)
+    WORD $0x4E217803             // FCVTL2 V3.4S, V0.8H (a upper)
+    WORD $0x0E217826             // FCVTL  V6.4S, V1.4H (b lower)
+    WORD $0x4E217827             // FCVTL2 V7.4S, V1.8H (b upper)
+
+    WORD $0x4EA6D442             // FSUB V2.4S, V2.4S, V6.4S (diff lower)
+    WORD $0x4EA7D463             // FSUB V3.4S, V3.4S, V7.4S (diff upper)
+
+    WORD $0x4E22CC44             // FMLA V4.4S, V2.4S, V2.4S (acc += diff^2)
+    WORD $0x4E23CC65             // FMLA V5.4S, V3.4S, V3.4S (acc += diff^2)
+
+    SUB $1, R3
+    CBNZ R3, ssd_loop8
+
+    WORD $0x4E25D484             // FADD V4.4S, V4.4S, V5.4S
+
+ssd_reduce:
+    WORD $0x6E24D484             // FADDP V4.4S, V4.4S, V4.4S
+    WORD $0x7E30D884             // FADDP S4, V4.2S
+    FMOVS F4, ret+48(FP)
+    RET
+
+// func sumSqDevNEON(a []Float16, mean float32) float32
+// Returns sum((a[i]-mean)^2), widened to FP32 before subtract/square.
+// Length must be a multiple of 8 (caller guarantees via dispatch).
+// Result is 8-byte aligned after the 28-byte args, so it lands at +32.
+TEXT ·sumSqDevNEON(SB), NOSPLIT, $0-36
+    MOVD a_base+0(FP), R0
+    MOVD a_len+8(FP), R2
+
+    FMOVS mean+24(FP), F1        // mean -> S1
+    WORD $0x4E040421             // DUP V1.4S, V1.S[0] (broadcast mean)
+
+    VEOR V4.B16, V4.B16, V4.B16  // acc lower
+    VEOR V5.B16, V5.B16, V5.B16  // acc upper
+
+    LSR $3, R2, R3
+    CBZ R3, ssv_reduce
+
+ssv_loop8:
+    VLD1 (R0), [V0.H8]
+    ADD $16, R0
+
+    WORD $0x0E217802            // FCVTL  V2.4S, V0.4H (lower)
+    WORD $0x4E217803            // FCVTL2 V3.4S, V0.8H (upper)
+
+    WORD $0x4EA1D442            // FSUB V2.4S, V2.4S, V1.4S (x-mean lower)
+    WORD $0x4EA1D463            // FSUB V3.4S, V3.4S, V1.4S (x-mean upper)
+
+    WORD $0x4E22CC44           // FMLA V4.4S, V2.4S, V2.4S (acc += dev^2)
+    WORD $0x4E23CC65           // FMLA V5.4S, V3.4S, V3.4S (acc += dev^2)
+
+    SUB $1, R3
+    CBNZ R3, ssv_loop8
+
+    WORD $0x4E25D484           // FADD V4.4S, V4.4S, V5.4S
+
+ssv_reduce:
+    WORD $0x6E24D484           // FADDP V4.4S, V4.4S, V4.4S
+    WORD $0x7E30D884           // FADDP S4, V4.2S
+    FMOVS F4, ret+32(FP)
+    RET
+
+// func interleave2NEON(dst, a, b []Float16)
+// dst[2i]=a[i], dst[2i+1]=b[i]. Processes a/b in blocks of 8 pairs (16 outputs
+// per iteration). a_len must be a multiple of 8 (caller guarantees).
+TEXT ·interleave2NEON(SB), NOSPLIT, $0-72
+    MOVD dst_base+0(FP), R0
+    MOVD a_base+24(FP), R1
+    MOVD a_len+32(FP), R3        // number of input pairs
+    MOVD b_base+48(FP), R2
+
+    LSR $3, R3, R4
+    CBZ R4, il2_done
+
+il2_loop8:
+    VLD1 (R1), [V0.H8]           // 8 from a
+    ADD $16, R1
+    VLD1 (R2), [V1.H8]           // 8 from b
+    ADD $16, R2
+
+    WORD $0x4E413802            // ZIP1 V2.8H, V0.8H, V1.8H (a0 b0 .. a3 b3)
+    WORD $0x4E417803            // ZIP2 V3.8H, V0.8H, V1.8H (a4 b4 .. a7 b7)
+
+    VST1 [V2.H8], (R0)
+    ADD $16, R0
+    VST1 [V3.H8], (R0)
+    ADD $16, R0
+
+    SUB $1, R4
+    CBNZ R4, il2_loop8
+
+il2_done:
+    RET
+
+// func deinterleave2NEON(a, b, src []Float16)
+// a[i]=src[2i], b[i]=src[2i+1]. Processes 8 outputs per channel per iteration
+// (16 inputs). a_len must be a multiple of 8 (caller guarantees).
+TEXT ·deinterleave2NEON(SB), NOSPLIT, $0-72
+    MOVD a_base+0(FP), R0
+    MOVD a_len+8(FP), R3         // outputs per channel
+    MOVD b_base+24(FP), R1
+    MOVD src_base+48(FP), R2
+
+    LSR $3, R3, R4
+    CBZ R4, dil2_done
+
+dil2_loop8:
+    VLD1 (R2), [V0.H8]           // src[0..7]
+    ADD $16, R2
+    VLD1 (R2), [V1.H8]           // src[8..15]
+    ADD $16, R2
+
+    WORD $0x4E411802            // UZP1 V2.8H, V0.8H, V1.8H (even lanes -> a)
+    WORD $0x4E415803            // UZP2 V3.8H, V0.8H, V1.8H (odd lanes  -> b)
+
+    VST1 [V2.H8], (R0)
+    ADD $16, R0
+    VST1 [V3.H8], (R1)
+    ADD $16, R1
+
+    SUB $1, R4
+    CBNZ R4, dil2_loop8
+
+dil2_done:
+    RET
+
+// func clampScaleNEON(dst, src []Float16, minF, maxF, scaleF float32)
+// dst[i] = (clamp(src[i], minF, maxF) - minF) * scaleF, widened to FP32 for the
+// full expression and rounded to FP16 once. Length must be a multiple of 8.
+TEXT ·clampScaleNEON(SB), NOSPLIT, $0-60
+    MOVD dst_base+0(FP), R0
+    MOVD dst_len+8(FP), R3
+    MOVD src_base+24(FP), R1
+
+    FMOVS minF+48(FP), F1
+    WORD $0x4E040421            // DUP V1.4S, V1.S[0] (minF)
+    FMOVS maxF+52(FP), F2
+    WORD $0x4E040442            // DUP V2.4S, V2.S[0] (maxF)
+    FMOVS scaleF+56(FP), F3
+    WORD $0x4E040463            // DUP V3.4S, V3.S[0] (scaleF)
+
+    LSR $3, R3, R4
+    CBZ R4, clampscale16_done
+
+clampscale16_loop8:
+    VLD1 (R1), [V0.H8]
+    ADD $16, R1
+
+    WORD $0x0E217804           // FCVTL  V4.4S, V0.4H (lower)
+    WORD $0x4E217805           // FCVTL2 V5.4S, V0.8H (upper)
+
+    WORD $0x4E21F484           // FMAX V4.4S, V4.4S, V1.4S (clamp low, lower)
+    WORD $0x4EA2F484           // FMIN V4.4S, V4.4S, V2.4S (clamp high, lower)
+    WORD $0x4E21F4A5           // FMAX V5.4S, V5.4S, V1.4S (clamp low, upper)
+    WORD $0x4EA2F4A5           // FMIN V5.4S, V5.4S, V2.4S (clamp high, upper)
+
+    WORD $0x4EA1D484           // FSUB V4.4S, V4.4S, V1.4S (subtract min, lower)
+    WORD $0x4EA1D4A5           // FSUB V5.4S, V5.4S, V1.4S (subtract min, upper)
+
+    WORD $0x6E23DC84           // FMUL V4.4S, V4.4S, V3.4S (scale lower)
+    WORD $0x6E23DCA5           // FMUL V5.4S, V5.4S, V3.4S (scale upper)
+
+    WORD $0x0E216886           // FCVTN  V6.4H, V4.4S (narrow lower)
+    WORD $0x4E2168A6           // FCVTN2 V6.8H, V5.4S (narrow upper)
+
+    VST1 [V6.H8], (R0)
+    ADD $16, R0
+
+    SUB $1, R4
+    CBNZ R4, clampscale16_loop8
+
+clampscale16_done:
+    RET

--- a/f16/f16_go.go
+++ b/f16/f16_go.go
@@ -460,24 +460,36 @@ func addScaledGo(dst []Float16, alpha Float16, s []Float16) {
 	}
 }
 
-// euclideanDistanceGo computes Euclidean distance.
-func euclideanDistanceGo(a, b []Float16) float32 {
+// sumSqDiffGo returns sum((a[i]-b[i])^2) computed in float32. Callers slice a
+// and b to equal length; it is shared by the Go fallback and the SIMD remainder.
+func sumSqDiffGo(a, b []Float16) float32 {
 	var sum float32
 	for i := range a {
 		d := toFloat32Go(a[i]) - toFloat32Go(b[i])
 		sum += d * d
 	}
-	return float32(math.Sqrt(float64(sum)))
+	return sum
 }
 
-// varianceGo computes variance given the mean.
-func varianceGo(a []Float16, mean float32) float32 {
+// sumSqDevGo returns sum((a[i]-mean)^2) computed in float32. Shared by the Go
+// fallback and the SIMD remainder.
+func sumSqDevGo(a []Float16, mean float32) float32 {
 	var sum float32
 	for i := range a {
 		d := toFloat32Go(a[i]) - mean
 		sum += d * d
 	}
-	return sum / float32(len(a))
+	return sum
+}
+
+// euclideanDistanceGo computes Euclidean distance.
+func euclideanDistanceGo(a, b []Float16) float32 {
+	return float32(math.Sqrt(float64(sumSqDiffGo(a, b))))
+}
+
+// varianceGo computes variance given the mean.
+func varianceGo(a []Float16, mean float32) float32 {
+	return sumSqDevGo(a, mean) / float32(len(a))
 }
 
 // cumulativeSumGo computes cumulative sum.

--- a/f16/f16_go.go
+++ b/f16/f16_go.go
@@ -5,38 +5,38 @@ import "math"
 // IEEE 754 half-precision format constants.
 const (
 	// FP16 bit layout
-	fp16SignShift     = 15
-	fp16ExpShift      = 10
-	fp16ExpMask       = 0x1F
-	fp16MantMask      = 0x3FF
-	fp16MantHighBit   = 0x400
-	fp16ExpMax        = 31
-	fp16ExpBias       = 15
-	fp16Infinity      = 0x7C00
-	fp16SignMask      = 0x8000
-	fp16AbsMask       = 0x7FFF
-	fp16NormExpMax    = 30
+	fp16SignShift   = 15
+	fp16ExpShift    = 10
+	fp16ExpMask     = 0x1F
+	fp16MantMask    = 0x3FF
+	fp16MantHighBit = 0x400
+	fp16ExpMax      = 31
+	fp16ExpBias     = 15
+	fp16Infinity    = 0x7C00
+	fp16SignMask    = 0x8000
+	fp16AbsMask     = 0x7FFF
+	fp16NormExpMax  = 30
 
 	// FP32 bit layout
-	fp32SignShift     = 31
-	fp32ExpShift      = 23
-	fp32ExpMask       = 0xFF
-	fp32MantMask      = 0x7FFFFF
-	fp32Infinity      = 0x7F800000
-	fp32ExpBias       = 127
-	fp32SignMask      = 0x8000
-	fp32MantHighBit   = 0x800000
+	fp32SignShift   = 31
+	fp32ExpShift    = 23
+	fp32ExpMask     = 0xFF
+	fp32MantMask    = 0x7FFFFF
+	fp32Infinity    = 0x7F800000
+	fp32ExpBias     = 127
+	fp32SignMask    = 0x8000
+	fp32MantHighBit = 0x800000
 
 	// Conversion constants
-	fp32MantShift     = 13                             // FP32 mantissa bits to shift for FP16
-	fp32SignExtract   = 16                             // Shift to extract sign from FP32 to FP16 position
-	fp32RoundBit      = 0x1000                         // Bit 12 for rounding
-	fp32RoundMask     = 0xFFF                          // Bits below round bit
-	fp32RoundCheck    = 0x2000                         // Bit 13 for round-to-even check
-	expBiasDiff       = fp32ExpBias - fp16ExpBias      // 112
-	expOverflow       = fp32ExpBias + fp16ExpBias      // 142 - overflow threshold
-	expUnderflow      = fp32ExpBias - 24               // 103 - underflow threshold
-	expDenormThresh   = fp32ExpBias - fp16ExpBias + 1  // 113 - denormalized threshold
+	fp32MantShift   = 13                            // FP32 mantissa bits to shift for FP16
+	fp32SignExtract = 16                            // Shift to extract sign from FP32 to FP16 position
+	fp32RoundBit    = 0x1000                        // Bit 12 for rounding
+	fp32RoundMask   = 0xFFF                         // Bits below round bit
+	fp32RoundCheck  = 0x2000                        // Bit 13 for round-to-even check
+	expBiasDiff     = fp32ExpBias - fp16ExpBias     // 112
+	expOverflow     = fp32ExpBias + fp16ExpBias     // 142 - overflow threshold
+	expUnderflow    = fp32ExpBias - 24              // 103 - underflow threshold
+	expDenormThresh = fp32ExpBias - fp16ExpBias + 1 // 113 - denormalized threshold
 )
 
 // toFloat32Go converts Float16 to float32 using pure Go.
@@ -484,7 +484,8 @@ func sumSqDevGo(a []Float16, mean float32) float32 {
 
 // euclideanDistanceGo computes Euclidean distance.
 func euclideanDistanceGo(a, b []Float16) float32 {
-	return float32(math.Sqrt(float64(sumSqDiffGo(a, b))))
+	n := min(len(a), len(b))
+	return float32(math.Sqrt(float64(sumSqDiffGo(a[:n], b[:n]))))
 }
 
 // varianceGo computes variance given the mean.

--- a/f16/vector_path_test.go
+++ b/f16/vector_path_test.go
@@ -57,3 +57,101 @@ func TestMinMaxVectorPath(t *testing.T) {
 		}
 	}
 }
+
+func TestEuclideanDistanceVectorPath(t *testing.T) {
+	for _, n := range []int{8, 11, 16, 19, 24, 32} {
+		a := make([]Float16, n)
+		b := make([]Float16, n)
+		for i := range a {
+			a[i] = FromFloat32(float32((i*3+1)%17) - 8)
+			b[i] = FromFloat32(float32((i*5+2)%13) - 6)
+		}
+		got := EuclideanDistance(a, b)
+		want := euclideanDistanceGo(a, b)
+		if !relClose(got, want) {
+			t.Errorf("n=%d EuclideanDistance() = %v, want %v (Go fallback)", n, got, want)
+		}
+	}
+}
+
+func TestVarianceStdDevVectorPath(t *testing.T) {
+	for _, n := range []int{8, 11, 16, 19, 24, 32} {
+		a := make([]Float16, n)
+		for i := range a {
+			a[i] = FromFloat32(float32((i*7+3)%50) - 20)
+		}
+		gotV := Variance(a)
+		wantV := varianceGo(a, Mean(a))
+		if !relClose(gotV, wantV) {
+			t.Errorf("n=%d Variance() = %v, want %v (Go fallback)", n, gotV, wantV)
+		}
+		gotS := StdDev(a)
+		wantS := float32(math.Sqrt(float64(wantV)))
+		if !relClose(gotS, wantS) {
+			t.Errorf("n=%d StdDev() = %v, want %v (Go fallback)", n, gotS, wantS)
+		}
+	}
+}
+
+func TestInterleave2VectorPath(t *testing.T) {
+	for _, n := range []int{8, 11, 16, 19, 24} {
+		a := make([]Float16, n)
+		b := make([]Float16, n)
+		for i := range a {
+			a[i] = FromFloat32(float32(i + 1))
+			b[i] = FromFloat32(float32(100 + i))
+		}
+		got := make([]Float16, 2*n)
+		want := make([]Float16, 2*n)
+		Interleave2(got, a, b)
+		interleave2Go(want, a, b)
+		for i := range got {
+			if got[i] != want[i] {
+				t.Errorf("n=%d Interleave2[%d] = 0x%04X, want 0x%04X", n, i, got[i], want[i])
+			}
+		}
+	}
+}
+
+func TestDeinterleave2VectorPath(t *testing.T) {
+	for _, n := range []int{8, 11, 16, 19, 24} {
+		src := make([]Float16, 2*n)
+		for i := range src {
+			src[i] = FromFloat32(float32(i + 1))
+		}
+		gotA := make([]Float16, n)
+		gotB := make([]Float16, n)
+		wantA := make([]Float16, n)
+		wantB := make([]Float16, n)
+		Deinterleave2(gotA, gotB, src)
+		deinterleave2Go(wantA, wantB, src)
+		for i := range gotA {
+			if gotA[i] != wantA[i] || gotB[i] != wantB[i] {
+				t.Errorf("n=%d Deinterleave2[%d] = (0x%04X,0x%04X), want (0x%04X,0x%04X)",
+					n, i, gotA[i], gotB[i], wantA[i], wantB[i])
+			}
+		}
+	}
+}
+
+func TestClampScaleVectorPath(t *testing.T) {
+	minV := FromFloat32(-2)
+	maxV := FromFloat32(5)
+	sc := FromFloat32(0.25)
+	for _, n := range []int{8, 11, 16, 19, 24} {
+		src := make([]Float16, n)
+		for i := range src {
+			src[i] = FromFloat32(float32(i%20) - 8) // below min, in range, above max
+		}
+		got := make([]Float16, n)
+		want := make([]Float16, n)
+		ClampScale(got, src, minV, maxV, sc)
+		clampScaleGo(want, src, minV, maxV, sc)
+		for i := range got {
+			if !relClose(ToFloat32(got[i]), ToFloat32(want[i])) {
+				t.Errorf("n=%d ClampScale[%d] = %v, want %v (Go fallback)",
+					n, i, ToFloat32(got[i]), ToFloat32(want[i]))
+			}
+		}
+	}
+}

--- a/f16/vector_path_test.go
+++ b/f16/vector_path_test.go
@@ -58,6 +58,16 @@ func TestMinMaxVectorPath(t *testing.T) {
 	}
 }
 
+func TestEuclideanDistanceUnequalLen(t *testing.T) {
+	// euclideanDistanceGo must not panic when len(a) > len(b); it computes over
+	// the common prefix, consistent with the public API which slices to min.
+	a := []Float16{FromFloat32(3), FromFloat32(4), FromFloat32(99)}
+	b := []Float16{FromFloat32(0), FromFloat32(0)}
+	if got := euclideanDistanceGo(a, b); !almostEqual32(got, 5, 0.1) {
+		t.Errorf("euclideanDistanceGo(unequal len) = %v, want 5", got)
+	}
+}
+
 func TestEuclideanDistanceVectorPath(t *testing.T) {
 	for _, n := range []int{8, 11, 16, 19, 24, 32} {
 		a := make([]Float16, n)


### PR DESCRIPTION
## Summary

Adds ARM64 NEON SIMD paths for five `f16` functions that previously ran pure Go on every platform. Each keeps its pure-Go fallback (the trusted reference); on ARM64 the dispatcher routes the 8-lane-aligned prefix to a new hand-encoded NEON routine and handles the remainder in Go.

- **EuclideanDistance** and **Variance/StdDev**: FP32-widened sum-of-squares. Each FP16 lane is widened to FP32 before the subtract and square (same anti-saturation approach as `DotProductF32`), so results match the pure-Go reference and never saturate.
- **Interleave2 / Deinterleave2**: bit-exact 16-bit lane permutes via `ZIP1/ZIP2` and `UZP1/UZP2`. These need only base NEON (no FP16 extension), so they also accelerate non-FP16 ARM cores (Cortex-A72/A53). Gated on `hasNEON`.
- **ClampScale**: FP32-widened clamp + scale (`FMAX`/`FMIN`/`FSUB`/`FMUL`, narrow once), matching the reference's single final rounding.

`MinIdx`/`MaxIdx` and `CumulativeSum` are intentionally left pure Go (argmax and prefix-sum do not vectorize cleanly; consistent with f32/f64).

## Implementation notes

- All 23 new hand-encoded `WORD` directives decode cleanly via `arm64asm` and are validated by the existing `TestArm64WordEncodings` on any platform (no allow-list entries needed). The FP32-widened ClampScale was chosen over a native-FP16 variant precisely so every encoding is statically decodable.
- New `sumSqDiffGo`/`sumSqDevGo` reference helpers are shared by the Go fallback and the SIMD remainder (DRY).
- Zero allocations on all paths.

## Test Plan

- [x] `go test ./...` (amd64) - all packages pass, including the WORD-encoding validator
- [x] `go vet ./...` clean; arm64 asm vet clean for all five new routines
- [x] Cross-compiled and run on Raspberry Pi 5 (Cortex-A76, FEAT_FP16): all 62 f16 tests pass, including new vector-path equivalence tests (sizes 8/11/16/19/24/32, exercising loop + Go remainder) cross-checked against the pure-Go reference
- [x] Benchmarks on Pi 5 (1024 elem, zero allocs): EuclideanDistance 12.5x, Variance 10.4x, Interleave2/Deinterleave2 12.2x, ClampScale 23x vs pure Go

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added ARM64 NEON acceleration for multiple f16 operations: `EuclideanDistance`, `Variance`, `StdDev`, `Interleave2`, `Deinterleave2`, `ClampScale`, and activation functions for improved performance on ARM64 platforms.

* **Documentation**
  * Updated documentation with ARM64 benchmark results and clarified FP16 precision handling for specific operations.

* **Tests**
  * Added comprehensive test coverage and performance benchmarks for newly accelerated operations.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/tphakala/simd/pull/47?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->