### PR TITLE
f16: gate DotProductF32 on hasNEON instead of hasFP16

### DIFF
--- a/README.md
+++ b/README.md
@@ -192,7 +192,7 @@ f16.ReLU(dst, a)             // Activation functions
 |                 | `Sqrt(dst, a)`                      | Square root                   | 8x (NEON+FP16)   |
 |                 | `Reciprocal(dst, a)`                | Reciprocal (1/x)              | 8x (NEON+FP16)   |
 | **Reduction**   | `DotProduct(a, b)` → float32        | Dot product                   | 8x (NEON+FP16)   |
-|                 | `DotProductF32(a, b)` → float32     | Dot product (FP32 widen)      | 8x (NEON+FP32)   |
+|                 | `DotProductF32(a, b)` → float32     | Dot product (FP32 widen)      | 8x (NEON)        |
 |                 | `Sum(a)` → float32                  | Sum of elements               | 8x (NEON+FP16)   |
 |                 | `Min(a)`                            | Minimum value                 | 8x (NEON+FP16)   |
 |                 | `Max(a)`                            | Maximum value                 | 8x (NEON+FP16)   |
@@ -223,7 +223,7 @@ f16.ReLU(dst, a)             // Activation functions
 - **Reductions**: Accumulate in float32 for numerical stability
 - **Memory efficiency**: 2x bandwidth vs float32 (8 elements per 128-bit NEON vector)
 - **DotProduct saturation**: On ARM64 with FP16 SIMD, `DotProduct` computes per-element products in FP16 and saturates to ±Inf when `|a[i] * b[i]| > 65504`. Use `DotProductF32` (FP32 widening before multiply, ~1.5-2x slower) for audio DSP or raw-signal inputs that can produce out-of-range products.
-- **FP32-widened ops**: `EuclideanDistance`, `Variance`, `StdDev`, and `ClampScale` widen each FP16 lane to FP32 before arithmetic (like `DotProductF32`), so they match the pure-Go reference and never saturate. They use only base-NEON instructions (the `FCVTL`/`FCVTN` conversions are ARMv8.0-A, not the FEAT_FP16 extension), so they run on any ARM64 NEON core, including non-FP16 parts (Cortex-A72/A53). `Interleave2`/`Deinterleave2` are likewise bit-exact 16-bit lane permutes (`ZIP`/`UZP`) that run on any ARM64 NEON core.
+- **FP32-widened ops**: `DotProductF32`, `EuclideanDistance`, `Variance`, `StdDev`, and `ClampScale` widen each FP16 lane to FP32 before arithmetic, so they match the pure-Go reference and never saturate. They use only base-NEON instructions (the `FCVTL`/`FCVTN` conversions are ARMv8.0-A, not the FEAT_FP16 extension), so they run on any ARM64 NEON core, including non-FP16 parts (Cortex-A72/A53). `Interleave2`/`Deinterleave2` are likewise bit-exact 16-bit lane permutes (`ZIP`/`UZP`) that run on any ARM64 NEON core.
 
 **Benchmark (1024 elements, Raspberry Pi 5 / Cortex-A76, zero allocations):**
 

--- a/f16/f16_arm64.go
+++ b/f16/f16_arm64.go
@@ -65,7 +65,9 @@ func dotProduct(a, b []Float16) float32 {
 
 func dotProductF32(a, b []Float16) float32 {
 	n := min(len(a), len(b))
-	if hasFP16 && n >= neonWidth {
+	// FP32-widened kernel: only FCVTL (base ARMv8.0 convert) + FP32 NEON
+	// arithmetic, so it needs base NEON, not FEAT_FP16.
+	if hasNEON && n >= neonWidth {
 		// Process vectorized portion
 		nVec := (n / neonWidth) * neonWidth
 		result := dotProductWideNEON(a[:nVec], b[:nVec])

--- a/f16/f16_arm64_test.go
+++ b/f16/f16_arm64_test.go
@@ -1,0 +1,50 @@
+//go:build arm64
+
+package f16
+
+import (
+	"math"
+	"math/rand"
+	"testing"
+)
+
+// TestDotProductF32_NEONOnlyGate verifies that DotProductF32 still dispatches to
+// the wide-NEON kernel (dotProductWideNEON) and matches the Go reference when
+// FEAT_FP16 is reported absent. This simulates a base ARMv8.0-A NEON core
+// without the FP16 arithmetic extension (Cortex-A53/A72, Raspberry Pi 3/4).
+//
+// The FP32-widened kernel only uses FCVTL/FCVTL2 (base ARMv8.0 converts) and
+// FP32 .4S arithmetic, so it must be gated on hasNEON, not hasFP16 (issue #48).
+// The test forces hasFP16=false with hasNEON=true; it must not call
+// t.Parallel(), since it mutates the package-level dispatch flags.
+func TestDotProductF32_NEONOnlyGate(t *testing.T) {
+	if !hasNEON {
+		t.Skip("requires NEON")
+	}
+	origFP16, origNEON := hasFP16, hasNEON
+	hasFP16, hasNEON = false, true
+	defer func() { hasFP16, hasNEON = origFP16, origNEON }()
+
+	// Mix of exact multiples of neonWidth and non-multiples to also cover the
+	// Go remainder tail under the forced NEON-only gate.
+	sizes := []int{8, 11, 16, 64, 100, 256, 1024}
+	rng := rand.New(rand.NewSource(42))
+	for _, n := range sizes {
+		a := make([]Float16, n)
+		b := make([]Float16, n)
+		for i := range a {
+			a[i] = FromFloat32(rng.Float32()*2 - 1) // [-1, 1]
+			b[i] = FromFloat32(rng.Float32()*2 - 1)
+		}
+
+		got := DotProductF32(a, b)
+		want := dotProductGo(a, b)
+
+		// Reference and SIMD differ in summation order; bound generously to
+		// absorb up to n*ULP per accumulator chain.
+		tol := math.Abs(float64(want))*float64(n)*1e-6 + 1e-5
+		if math.Abs(float64(got-want)) > tol {
+			t.Errorf("n=%d: got %v, want %v (tol %v)", n, got, want, tol)
+		}
+	}
+}


### PR DESCRIPTION
## Summary

`DotProductF32` dispatches to `dotProductWideNEON`, which widens each FP16 lane to FP32 with `FCVTL`/`FCVTL2` (base ARMv8.0-A converts) and does all arithmetic in FP32 `.4S` (`FMLA`/`FADD`/`FADDP`). None of those instructions need the FEAT_FP16 arithmetic extension, so the kernel is valid on any ARM64 NEON core.

It was gated on `hasFP16`, which needlessly excluded non-FP16 cores (Cortex-A53/A72, Raspberry Pi 3/4) from the optimized path. PR #47 applied the same `hasFP16` -> `hasNEON` change to the other FP32-widened ops (`EuclideanDistance`, `Variance`/`StdDev`, `ClampScale`, `Interleave2`/`Deinterleave2`) but left the pre-existing `DotProductF32` untouched to keep that PR scoped. This is the matching one-line consistency fix.

## Changes

- `f16/f16_arm64.go`: change the `dotProductF32` gate from `hasFP16` to `hasNEON`, with an explanatory comment matching the style PR #47 used for the sibling ops.
- `f16/f16_arm64_test.go` (new, `//go:build arm64`): `TestDotProductF32_NEONOnlyGate` forces `hasFP16=false, hasNEON=true` to exercise the NEON-only dispatch and confirm the kernel still matches the Go reference across multiple sizes (including a Go-remainder tail). This is needed because FP16-capable hardware would otherwise never exercise the changed branch.
- `README.md`: relabel `DotProductF32` to `8x (NEON)` to match the other FP32-widened ops, and move it into the documented "FP32-widened ops" group that runs on any ARM64 NEON core including non-FP16 parts.

## Related Issues

Closes #48

## Test Plan

- [x] `go test -run TestArm64WordEncodings .` passes (local + ARM64)
- [x] `GOARCH=arm64 go build ./f16/` and test-binary compile clean
- [x] Verified on ARM64 hardware (Cortex-A76, go1.26.1): full `f16` suite passes, `DotProductF32` matches the Go reference, and the forced NEON-only-gate test passes
- [x] `go test ./...` green on ARM64