### PR TITLE
Validate FP16 (.8H) WORD encodings via aarch64 objdump cross-check

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,11 +34,22 @@ jobs:
       - name: Download dependencies
         run: go mod download
 
+      - name: Install aarch64 binutils (FP16 .8H encoding cross-check)
+        if: runner.os == 'Linux'
+        run: sudo apt-get update && sudo apt-get install -y binutils-aarch64-linux-gnu
+
       - name: Run tests
+        env:
+          # Require the aarch64 objdump FP16 (.8H) cross-check on Linux, where
+          # binutils-aarch64-linux-gnu is installed above. macOS and Windows
+          # lack it and skip that cross-check cleanly.
+          SIMD_REQUIRE_OBJDUMP: ${{ runner.os == 'Linux' && '1' || '' }}
         run: go test -v -race ./...
 
       - name: Run tests with coverage
         if: matrix.coverage
+        env:
+          SIMD_REQUIRE_OBJDUMP: ${{ runner.os == 'Linux' && '1' || '' }}
         run: go test -coverprofile=coverage.out -covermode=atomic ./...
 
       - name: Upload coverage

--- a/asmcheck_test.go
+++ b/asmcheck_test.go
@@ -1,6 +1,7 @@
 package simd
 
 import (
+	"context"
 	"os"
 	"path/filepath"
 	"strconv"
@@ -10,44 +11,11 @@ import (
 	"github.com/tphakala/simd/internal/asmencoding"
 )
 
-// asmException documents a WORD directive the checker cannot mechanically
-// verify, with the reason it is exempt. The current exemptions are all ARMv8.2
-// half-precision (.8H) SIMD instructions, which golang.org/x/arch/arm64asm
-// cannot decode. These are covered by the on-hardware numeric tests instead.
-type asmException struct {
-	file   string // path suffix relative to the module root
-	hex    uint32
-	expect string // intended instruction, for human reference
-	reason string
-}
-
-// fp16Reason applies to every entry below: golang.org/x/arch/arm64asm cannot
-// decode ARMv8.2 half-precision (.8H) SIMD instructions. Each encoding here was
-// instead verified with aarch64 GNU objdump (binutils 2.44) to match its
-// comment, and is exercised by the on-hardware numeric tests in f16.
-const fp16Reason = "ARMv8.2 FP16 (.8H) SIMD; not decodable by arm64asm; verified via aarch64 objdump"
-
-var asmAllowlist = []asmException{
-	{"f16/f16_arm64.s", 0x4E403484, "FMAX V4.8H, V4.8H, V0.8H", fp16Reason},
-	{"f16/f16_arm64.s", 0x4E410C02, "FMLA V2.8H, V0.8H, V1.8H", fp16Reason},
-	{"f16/f16_arm64.s", 0x4E411400, "FADD V0.8H, V0.8H, V1.8H", fp16Reason},
-	{"f16/f16_arm64.s", 0x4E411402, "FADD V2.8H, V0.8H, V1.8H", fp16Reason},
-	{"f16/f16_arm64.s", 0x4E413402, "FMAX V2.8H, V0.8H, V1.8H", fp16Reason},
-	{"f16/f16_arm64.s", 0x4E421400, "FADD V0.8H, V0.8H, V2.8H", fp16Reason},
-	{"f16/f16_arm64.s", 0x4E423401, "FMAX V1.8H, V0.8H, V2.8H", fp16Reason},
-	{"f16/f16_arm64.s", 0x4EC03484, "FMIN V4.8H, V4.8H, V0.8H", fp16Reason},
-	{"f16/f16_arm64.s", 0x4EC11402, "FSUB V2.8H, V0.8H, V1.8H", fp16Reason},
-	{"f16/f16_arm64.s", 0x4EC33421, "FMIN V1.8H, V1.8H, V3.8H", fp16Reason},
-	{"f16/f16_arm64.s", 0x4EF8F801, "FABS V1.8H, V0.8H", fp16Reason},
-	{"f16/f16_arm64.s", 0x6E403C41, "FDIV V1.8H, V2.8H, V0.8H", fp16Reason},
-	{"f16/f16_arm64.s", 0x6E411C02, "FMUL V2.8H, V0.8H, V1.8H", fp16Reason},
-	{"f16/f16_arm64.s", 0x6E411C62, "FMUL V2.8H, V3.8H, V1.8H", fp16Reason},
-	{"f16/f16_arm64.s", 0x6E413C02, "FDIV V2.8H, V0.8H, V1.8H", fp16Reason},
-	{"f16/f16_arm64.s", 0x6E443484, "FMAXP V4.8H, V4.8H, V4.8H", fp16Reason},
-	{"f16/f16_arm64.s", 0x6EC43484, "FMINP V4.8H, V4.8H, V4.8H", fp16Reason},
-	{"f16/f16_arm64.s", 0x6EF8F801, "FNEG V1.8H, V0.8H", fp16Reason},
-	{"f16/f16_arm64.s", 0x6EF9F801, "FSQRT V1.8H, V0.8H", fp16Reason},
-}
+// requireObjdumpEnv, when set in the environment, makes a missing aarch64
+// objdump a hard failure instead of a skip-with-warning. CI sets it so the
+// FP16 (.8H) cross-check cannot silently regress to "unchecked" if the
+// binutils install ever breaks. Local runs without it stay green.
+const requireObjdumpEnv = "SIMD_REQUIRE_OBJDUMP"
 
 // findArm64Asm returns every *_arm64.s file under the module root.
 func findArm64Asm(t *testing.T) []string {
@@ -58,8 +26,8 @@ func findArm64Asm(t *testing.T) []string {
 			return err
 		}
 		if !d.IsDir() && strings.HasSuffix(p, "_arm64.s") {
-			// Normalize to forward slashes so allow-list matching and
-			// reporting are identical on Windows (WalkDir yields backslashes).
+			// Normalize to forward slashes so reporting is identical on
+			// Windows (WalkDir yields backslashes).
 			files = append(files, filepath.ToSlash(p))
 		}
 		return nil
@@ -73,68 +41,119 @@ func findArm64Asm(t *testing.T) []string {
 	return files
 }
 
-func allowed(file string, hex uint32, used map[int]bool) bool {
-	for i, e := range asmAllowlist {
-		if e.hex == hex && strings.HasSuffix(file, e.file) {
-			used[i] = true
-			return true
-		}
-	}
-	return false
+// fp16Directive is a WORD directive that golang.org/x/arch/arm64asm cannot
+// decode (an ARMv8.2 half-precision .8H FP16 SIMD instruction), deferred to the
+// objdump cross-check.
+type fp16Directive struct {
+	line    int
+	hex     uint32
+	comment string
 }
 
 // TestArm64WordEncodings decodes every hand-encoded WORD directive in the ARM64
 // assembly and asserts it matches the instruction named in its comment.
+// Instructions arm64asm can decode are checked directly; ARMv8.2 FP16 (.8H)
+// instructions, which it cannot decode, are cross-checked with an aarch64
+// objdump when one is available. Without objdump the FP16 directives are
+// accepted unchecked (so the test stays green on machines lacking cross
+// binutils) unless SIMD_REQUIRE_OBJDUMP is set, which CI does.
 func TestArm64WordEncodings(t *testing.T) {
-	usedExceptions := map[int]bool{}
+	tool := asmencoding.FindObjdump()
+	if os.Getenv(requireObjdumpEnv) != "" && tool == "" {
+		t.Fatalf("%s is set but no aarch64-capable objdump was found; install binutils-aarch64-linux-gnu", requireObjdumpEnv)
+	}
+	if tool == "" {
+		t.Logf("no aarch64 objdump found; FP16 (.8H) encodings are accepted unchecked. "+
+			"Install binutils-aarch64-linux-gnu, or set %s=1 to require the cross-check.", requireObjdumpEnv)
+	}
 
 	for _, file := range findArm64Asm(t) {
-		src, err := os.ReadFile(file)
-		if err != nil {
-			t.Fatalf("read %s: %v", file, err)
-		}
-		directives := asmencoding.ScanSource(string(src))
+		checkArm64File(t, file, tool)
+	}
+}
 
-		// Hexes that verified cleanly somewhere in this file; used to accept
-		// uncommented repeats of an already-validated instruction.
-		matched := map[uint32]bool{}
-		for _, d := range directives {
-			if d.Source != asmencoding.NoComment {
-				if asmencoding.Verify(d.Hex, d.Comment).Status == asmencoding.Match {
-					matched[d.Hex] = true
-				}
-			}
-		}
+// checkArm64File validates every WORD directive in one assembly file.
+func checkArm64File(t *testing.T, file, tool string) {
+	t.Helper()
+	src, err := os.ReadFile(file)
+	if err != nil {
+		t.Fatalf("read %s: %v", file, err)
+	}
+	directives := asmencoding.ScanSource(string(src))
 
-		for _, d := range directives {
-			if d.Source == asmencoding.NoComment {
-				if matched[d.Hex] || allowed(file, d.Hex, usedExceptions) {
-					continue
-				}
-				t.Errorf("%s:%d  0x%08X  uncommented WORD, cannot validate (add a comment)", file, d.Line, d.Hex)
-				continue
-			}
-			res := asmencoding.Verify(d.Hex, d.Comment)
-			switch res.Status {
-			case asmencoding.Match:
-				// ok
-			case asmencoding.Mismatch:
-				if allowed(file, d.Hex, usedExceptions) {
-					continue
-				}
-				t.Errorf("%s:%d  0x%08X  claims=%q  decodes=%q", file, d.Line, d.Hex, res.Claimed, res.Decoded)
-			case asmencoding.Undecodable:
-				if allowed(file, d.Hex, usedExceptions) {
-					continue
-				}
-				t.Errorf("%s:%d  0x%08X  claims=%q  not decodable and not allow-listed (%v)", file, d.Line, d.Hex, d.Comment, res.Err)
-			}
+	// matched holds hexes proven to match their comment, whether decoded by
+	// arm64asm or cross-checked by objdump. Uncommented repeats of a matched
+	// hex are then accepted.
+	matched := map[uint32]bool{}
+	var fp16 []fp16Directive
+
+	// Pass 1: every commented directive. Decodable ones are verified now;
+	// undecodable ones (FP16 .8H) are deferred to the objdump cross-check.
+	for _, d := range directives {
+		if d.Source == asmencoding.NoComment {
+			continue
+		}
+		res := asmencoding.Verify(d.Hex, d.Comment)
+		switch res.Status {
+		case asmencoding.Match:
+			matched[d.Hex] = true
+		case asmencoding.Mismatch:
+			t.Errorf("%s:%d  0x%08X  claims=%q  decodes=%q", file, d.Line, d.Hex, res.Claimed, res.Decoded)
+		case asmencoding.Undecodable:
+			fp16 = append(fp16, fp16Directive{line: d.Line, hex: d.Hex, comment: d.Comment})
 		}
 	}
 
-	for i, e := range asmAllowlist {
-		if !usedExceptions[i] {
-			t.Errorf("stale allow-list entry never matched: %s 0x%08X (%s)", e.file, e.hex, e.expect)
+	crossCheckFP16(t, file, tool, fp16, matched)
+
+	// Pass 2: uncommented directives must reuse a hex proven above.
+	for _, d := range directives {
+		if d.Source != asmencoding.NoComment {
+			continue
+		}
+		if matched[d.Hex] {
+			continue
+		}
+		t.Errorf("%s:%d  0x%08X  uncommented WORD, cannot validate (add a comment naming the instruction)", file, d.Line, d.Hex)
+	}
+}
+
+// crossCheckFP16 verifies FP16 (.8H) directives that arm64asm cannot decode by
+// disassembling them with aarch64 objdump and comparing against their comments.
+// When no objdump is available it accepts them (marking each hex matched so
+// uncommented repeats pass) and relies on the warning and SIMD_REQUIRE_OBJDUMP
+// gate in TestArm64WordEncodings.
+func crossCheckFP16(t *testing.T, file, tool string, fp16 []fp16Directive, matched map[uint32]bool) {
+	t.Helper()
+	if len(fp16) == 0 {
+		return
+	}
+	if tool == "" {
+		for _, d := range fp16 {
+			matched[d.hex] = true
+		}
+		return
+	}
+
+	hexes := make([]uint32, 0, len(fp16))
+	for _, d := range fp16 {
+		hexes = append(hexes, d.hex)
+	}
+	decoded, err := asmencoding.DisassembleWords(context.Background(), tool, hexes)
+	if err != nil {
+		t.Fatalf("objdump cross-check of %s failed: %v", file, err)
+	}
+
+	for _, d := range fp16 {
+		got, ok := decoded[d.hex]
+		if !ok {
+			t.Errorf("%s:%d  0x%08X  objdump produced no disassembly", file, d.line, d.hex)
+			continue
+		}
+		if res := asmencoding.VerifyDecoded(got, d.comment); res.Status == asmencoding.Match {
+			matched[d.hex] = true
+		} else {
+			t.Errorf("%s:%d  0x%08X  claims=%q  objdump=%q", file, d.line, d.hex, res.Claimed, res.Decoded)
 		}
 	}
 }

--- a/asmcheck_test.go
+++ b/asmcheck_test.go
@@ -100,6 +100,15 @@ func checkArm64File(t *testing.T, file, tool string) {
 		case asmencoding.Mismatch:
 			t.Errorf("%s:%d  0x%08X  claims=%q  decodes=%q", file, d.Line, d.Hex, res.Claimed, res.Decoded)
 		case asmencoding.Undecodable:
+			// ARMv8.2 FP16 (.8H) SIMD is the only sanctioned reason arm64asm
+			// cannot decode a directive here. Any other undecodable WORD (a
+			// malformed encoding, or a future extension) is a real problem:
+			// fail loudly instead of funneling it into the objdump fallback,
+			// which is lenient when no objdump is installed.
+			if !strings.Contains(strings.ToUpper(d.Comment), ".8H") {
+				t.Errorf("%s:%d  0x%08X  undecodable WORD that is not FP16 (.8H): %q", file, d.Line, d.Hex, d.Comment)
+				continue
+			}
 			fp16 = append(fp16, fp16Directive{line: d.Line, hex: d.Hex, comment: d.Comment})
 		}
 	}

--- a/f16/f16_arm64.s
+++ b/f16/f16_arm64.s
@@ -197,7 +197,7 @@ add16_loop8:
     ADD $16, R2
 
     // FADD V2.8H, V0.8H, V1.8H
-    WORD $0x4E411402
+    WORD $0x4E411402            // FADD V2.8H, V0.8H, V1.8H
 
     VST1 [V2.H8], (R0)
     ADD $16, R0
@@ -226,7 +226,7 @@ sub16_loop8:
     ADD $16, R2
 
     // FSUB V2.8H, V0.8H, V1.8H
-    WORD $0x4EC11402
+    WORD $0x4EC11402            // FSUB V2.8H, V0.8H, V1.8H
 
     VST1 [V2.H8], (R0)
     ADD $16, R0
@@ -255,7 +255,7 @@ mul16_loop8:
     ADD $16, R2
 
     // FMUL V2.8H, V0.8H, V1.8H
-    WORD $0x6E411C02
+    WORD $0x6E411C02            // FMUL V2.8H, V0.8H, V1.8H
 
     VST1 [V2.H8], (R0)
     ADD $16, R0
@@ -287,7 +287,7 @@ scale16_loop8:
     ADD $16, R1
 
     // FMUL V2.8H, V0.8H, V1.8H
-    WORD $0x6E411C02
+    WORD $0x6E411C02            // FMUL V2.8H, V0.8H, V1.8H
 
     VST1 [V2.H8], (R0)
     ADD $16, R0
@@ -319,7 +319,7 @@ fma16_loop8:
     ADD $16, R3
 
     // FMLA V2.8H, V0.8H, V1.8H (V2 = V0*V1 + V2)
-    WORD $0x4E410C02
+    WORD $0x4E410C02            // FMLA V2.8H, V0.8H, V1.8H
 
     VST1 [V2.H8], (R0)
     ADD $16, R0
@@ -376,7 +376,7 @@ abs16_loop8:
     ADD $16, R1
 
     // FABS V1.8H, V0.8H
-    WORD $0x4EF8F801
+    WORD $0x4EF8F801            // FABS V1.8H, V0.8H
 
     VST1 [V1.H8], (R0)
     ADD $16, R0
@@ -402,7 +402,7 @@ neg16_loop8:
     ADD $16, R1
 
     // FNEG V1.8H, V0.8H
-    WORD $0x6EF8F801
+    WORD $0x6EF8F801            // FNEG V1.8H, V0.8H
 
     VST1 [V1.H8], (R0)
     ADD $16, R0
@@ -431,7 +431,7 @@ relu16_loop8:
     ADD $16, R1
 
     // FMAX V2.8H, V0.8H, V1.8H (V1 is zero)
-    WORD $0x4E413402
+    WORD $0x4E413402            // FMAX V2.8H, V0.8H, V1.8H
 
     VST1 [V2.H8], (R0)
     ADD $16, R0
@@ -461,7 +461,7 @@ min16_loop8:
     ADD $16, R0
 
     // FMIN V4.8H, V4.8H, V0.8H
-    WORD $0x4EC03484
+    WORD $0x4EC03484            // FMIN V4.8H, V4.8H, V0.8H
 
     SUB $1, R3
     CBNZ R3, min16_loop8
@@ -497,7 +497,7 @@ max16_loop8:
     ADD $16, R0
 
     // FMAX V4.8H, V4.8H, V0.8H
-    WORD $0x4E403484
+    WORD $0x4E403484            // FMAX V4.8H, V4.8H, V0.8H
 
     SUB $1, R3
     CBNZ R3, max16_loop8
@@ -532,7 +532,7 @@ div16_loop8:
     ADD $16, R2
 
     // FDIV V2.8H, V0.8H, V1.8H
-    WORD $0x6E413C02
+    WORD $0x6E413C02            // FDIV V2.8H, V0.8H, V1.8H
 
     VST1 [V2.H8], (R0)
     ADD $16, R0
@@ -563,7 +563,7 @@ addscalar16_loop8:
     ADD $16, R1
 
     // FADD V2.8H, V0.8H, V1.8H
-    WORD $0x4E411402
+    WORD $0x4E411402            // FADD V2.8H, V0.8H, V1.8H
 
     VST1 [V2.H8], (R0)
     ADD $16, R0
@@ -599,10 +599,10 @@ clamp16_loop8:
     ADD $16, R1
 
     // FMAX V1.8H, V0.8H, V2.8H (clamp to min)
-    WORD $0x4E423401
+    WORD $0x4E423401            // FMAX V1.8H, V0.8H, V2.8H
 
     // FMIN V1.8H, V1.8H, V3.8H (clamp to max)
-    WORD $0x4EC33421
+    WORD $0x4EC33421            // FMIN V1.8H, V1.8H, V3.8H
 
     VST1 [V1.H8], (R0)
     ADD $16, R0
@@ -628,7 +628,7 @@ sqrt16_loop8:
     ADD $16, R1
 
     // FSQRT V1.8H, V0.8H
-    WORD $0x6EF9F801
+    WORD $0x6EF9F801            // FSQRT V1.8H, V0.8H
 
     VST1 [V1.H8], (R0)
     ADD $16, R0
@@ -661,7 +661,7 @@ recip16_loop8:
     ADD $16, R1
 
     // FDIV V1.8H, V2.8H, V0.8H (1.0 / x)
-    WORD $0x6E403C41
+    WORD $0x6E403C41            // FDIV V1.8H, V2.8H, V0.8H
 
     VST1 [V1.H8], (R0)
     ADD $16, R0
@@ -694,10 +694,10 @@ axpy16_loop8:
     ADD $16, R1
 
     // V2 = alpha * s (FMUL V2.8H, V3.8H, V1.8H)
-    WORD $0x6E411C62
+    WORD $0x6E411C62            // FMUL V2.8H, V3.8H, V1.8H
 
     // dst += V2 (FADD V0.8H, V0.8H, V2.8H)
-    WORD $0x4E421400
+    WORD $0x4E421400            // FADD V0.8H, V0.8H, V2.8H
 
     VST1 [V0.H8], (R0)
     ADD $16, R0
@@ -724,7 +724,7 @@ accadd16_loop8:
     ADD $16, R1
 
     // FADD V0.8H, V0.8H, V1.8H
-    WORD $0x4E411400
+    WORD $0x4E411400            // FADD V0.8H, V0.8H, V1.8H
 
     VST1 [V0.H8], (R0)
     ADD $16, R0

--- a/internal/asmencoding/asmencoding.go
+++ b/internal/asmencoding/asmencoding.go
@@ -154,7 +154,17 @@ func Verify(hex uint32, claimed string) Result {
 	if err != nil {
 		return Result{Status: Undecodable, Err: err}
 	}
-	nd := Normalize(gnu)
+	return VerifyDecoded(gnu, claimed)
+}
+
+// VerifyDecoded checks an already-decoded instruction string against the
+// claimed instruction text, using the same normalization and token-boundary
+// prefix rule as Verify. It lets callers supply a disassembly from a source
+// other than arm64asm (for example aarch64 objdump, see objdump.go) while
+// sharing one comparison policy. The status is never Undecodable: the input is
+// already decoded, so the result is either Match or Mismatch.
+func VerifyDecoded(decoded, claimed string) Result {
+	nd := Normalize(decoded)
 	nc := Normalize(claimed)
 	if nc == nd || strings.HasPrefix(nc, nd+" ") {
 		return Result{Status: Match, Decoded: nd, Claimed: nc}

--- a/internal/asmencoding/objdump.go
+++ b/internal/asmencoding/objdump.go
@@ -89,6 +89,12 @@ func FindObjdump() string {
 // are written little-endian (aarch64 byte order) and decoded with
 // `-D -b binary -m aarch64`. Identical words collapse to a single map entry.
 func DisassembleWords(ctx context.Context, tool string, words []uint32) (map[uint32]string, error) {
+	if len(words) == 0 {
+		// Nothing to decode; avoid running objdump on an empty file, which
+		// GNU binutils rejects ("file format not recognized").
+		return map[uint32]string{}, nil
+	}
+
 	f, err := os.CreateTemp("", "asmencoding-*.bin")
 	if err != nil {
 		return nil, fmt.Errorf("create temp: %w", err)

--- a/internal/asmencoding/objdump.go
+++ b/internal/asmencoding/objdump.go
@@ -1,0 +1,131 @@
+package asmencoding
+
+// This file adds an optional cross-check that decodes hand-encoded ARM64 words
+// with an external aarch64 objdump (GNU binutils). It exists because
+// golang.org/x/arch/arm64/arm64asm cannot decode ARMv8.2 half-precision (.8H)
+// FP16 SIMD instructions, so those WORD directives are invisible to the pure-Go
+// path in this package. objdump closes that gap when binutils is installed;
+// callers skip the check cleanly when it is not.
+
+import (
+	"bytes"
+	"context"
+	"encoding/binary"
+	"fmt"
+	"os"
+	"os/exec"
+	"regexp"
+	"runtime"
+	"strconv"
+	"strings"
+	"time"
+)
+
+const (
+	// bytesPerWord is the size in bytes of one ARM64 instruction word.
+	bytesPerWord = 4
+	// objdumpTimeout bounds a single objdump invocation so a wedged tool
+	// cannot hang the test.
+	objdumpTimeout = 20 * time.Second
+	// probeWord is a known FP16 (.8H) instruction used to confirm a candidate
+	// objdump actually targets aarch64. It is FMUL V2.8H, V0.8H, V1.8H.
+	probeWord uint32 = 0x6E411C02
+	// probeExpect is probeWord's expected disassembly.
+	probeExpect = "FMUL V2.8H, V0.8H, V1.8H"
+)
+
+// SIMDObjdumpEnv names an environment variable that, when set, overrides the
+// objdump program used for the aarch64 cross-check (highest priority).
+const SIMDObjdumpEnv = "SIMD_OBJDUMP"
+
+// objdumpLineRe matches one disassembly line from `objdump -D`, capturing the
+// 32-bit instruction word and the instruction text. Example line:
+//
+//	0:	6e411c02 	fmul	v2.8h, v0.8h, v1.8h
+var objdumpLineRe = regexp.MustCompile(`(?m)^\s*[0-9a-fA-F]+:\s+([0-9a-fA-F]{8})\s+(\S.*?)\s*$`)
+
+// objdumpCandidates returns objdump program names to try, in priority order.
+// SIMD_OBJDUMP wins when set. aarch64-linux-gnu-objdump is the cross-binutils
+// name on non-arm64 hosts. The host "objdump" is tried only on a GNU/Linux
+// arm64 host, where it natively targets aarch64; FindObjdump's probe rejects it
+// anywhere else (for example llvm-objdump on macOS).
+func objdumpCandidates() []string {
+	const maxCandidates = 3
+	c := make([]string, 0, maxCandidates)
+	if env := os.Getenv(SIMDObjdumpEnv); env != "" {
+		c = append(c, env)
+	}
+	c = append(c, "aarch64-linux-gnu-objdump")
+	if runtime.GOOS == "linux" && runtime.GOARCH == "arm64" {
+		c = append(c, "objdump")
+	}
+	return c
+}
+
+// FindObjdump returns the path to an objdump that can disassemble aarch64 FP16
+// (.8H) instructions, or "" if none is usable. Each candidate is probed on a
+// known instruction, so a wrong-architecture objdump (or a non-GNU one such as
+// llvm-objdump that does not understand -m aarch64) is rejected rather than
+// trusted.
+func FindObjdump() string {
+	for _, name := range objdumpCandidates() {
+		path, err := exec.LookPath(name)
+		if err != nil {
+			continue
+		}
+		decoded, err := DisassembleWords(context.Background(), path, []uint32{probeWord})
+		if err != nil {
+			continue
+		}
+		if VerifyDecoded(decoded[probeWord], probeExpect).Status == Match {
+			return path
+		}
+	}
+	return ""
+}
+
+// DisassembleWords disassembles each 32-bit word with the given objdump,
+// returning a map from instruction word to its GNU-syntax disassembly. Words
+// are written little-endian (aarch64 byte order) and decoded with
+// `-D -b binary -m aarch64`. Identical words collapse to a single map entry.
+func DisassembleWords(ctx context.Context, tool string, words []uint32) (map[uint32]string, error) {
+	f, err := os.CreateTemp("", "asmencoding-*.bin")
+	if err != nil {
+		return nil, fmt.Errorf("create temp: %w", err)
+	}
+	defer func() { _ = os.Remove(f.Name()) }()
+
+	buf := make([]byte, bytesPerWord*len(words))
+	for i, w := range words {
+		binary.LittleEndian.PutUint32(buf[i*bytesPerWord:], w)
+	}
+	if _, err = f.Write(buf); err != nil {
+		_ = f.Close()
+		return nil, fmt.Errorf("write temp: %w", err)
+	}
+	if err = f.Close(); err != nil {
+		return nil, fmt.Errorf("close temp: %w", err)
+	}
+
+	ctx, cancel := context.WithTimeout(ctx, objdumpTimeout)
+	defer cancel()
+	// -EL forces little-endian decoding so the check still runs on the rare
+	// host whose binutils defaults to AArch64 big-endian, rather than skipping.
+	cmd := exec.CommandContext(ctx, tool, "-D", "-b", "binary", "-m", "aarch64", "-EL", f.Name())
+	var stdout, stderr bytes.Buffer
+	cmd.Stdout = &stdout
+	cmd.Stderr = &stderr
+	if err = cmd.Run(); err != nil {
+		return nil, fmt.Errorf("run %s: %w: %s", tool, err, strings.TrimSpace(stderr.String()))
+	}
+
+	out := make(map[uint32]string, len(words))
+	for _, m := range objdumpLineRe.FindAllStringSubmatch(stdout.String(), -1) {
+		v, perr := strconv.ParseUint(m[1], 16, 32)
+		if perr != nil {
+			continue
+		}
+		out[uint32(v)] = strings.Join(strings.Fields(m[2]), " ")
+	}
+	return out, nil
+}

--- a/internal/asmencoding/objdump_test.go
+++ b/internal/asmencoding/objdump_test.go
@@ -1,0 +1,95 @@
+package asmencoding
+
+import "testing"
+
+// fp16Samples are FP16 (.8H) encodings arm64asm cannot decode, paired with the
+// disassembly aarch64 objdump produces for them.
+var fp16Samples = []struct {
+	hex    uint32
+	expect string
+}{
+	{0x6E411C02, "FMUL V2.8H, V0.8H, V1.8H"},
+	{0x4E411400, "FADD V0.8H, V0.8H, V1.8H"},
+	{0x4EF8F801, "FABS V1.8H, V0.8H"},
+	{0x6EF9F801, "FSQRT V1.8H, V0.8H"},
+	{0x6EC43484, "FMINP V4.8H, V4.8H, V4.8H"},
+}
+
+func TestObjdumpLineRe(t *testing.T) {
+	// A representative `objdump -D -b binary -m aarch64` transcript. Header
+	// lines must be ignored; only instruction rows are captured.
+	sample := "\nfp16.bin:     file format binary\n\n" +
+		"Disassembly of section .data:\n\n" +
+		"0000000000000000 <.data>:\n" +
+		"   0:\t6e411c02 \tfmul\tv2.8h, v0.8h, v1.8h\n" +
+		"   4:\t4ef8f801 \tfabs\tv1.8h, v0.8h\n" +
+		"   8:\t6ef9f801 \tfsqrt\tv1.8h, v0.8h\n"
+
+	ms := objdumpLineRe.FindAllStringSubmatch(sample, -1)
+	if len(ms) != 3 {
+		t.Fatalf("expected 3 instruction rows, got %d: %v", len(ms), ms)
+	}
+	want := []struct{ hex, insn string }{
+		{"6e411c02", "fmul\tv2.8h, v0.8h, v1.8h"},
+		{"4ef8f801", "fabs\tv1.8h, v0.8h"},
+		{"6ef9f801", "fsqrt\tv1.8h, v0.8h"},
+	}
+	for i, m := range ms {
+		if m[1] != want[i].hex || m[2] != want[i].insn {
+			t.Errorf("row %d: got hex=%q insn=%q, want hex=%q insn=%q", i, m[1], m[2], want[i].hex, want[i].insn)
+		}
+	}
+}
+
+func TestObjdumpCandidatesEnvOverride(t *testing.T) {
+	t.Setenv(SIMDObjdumpEnv, "/opt/my/objdump")
+	got := objdumpCandidates()
+	if len(got) == 0 || got[0] != "/opt/my/objdump" {
+		t.Fatalf("SIMD_OBJDUMP override should be tried first, got %v", got)
+	}
+}
+
+// TestDisassembleWordsWithTool exercises the real objdump path end to end. It
+// skips cleanly when no aarch64 objdump is installed, matching the production
+// gate in asmcheck_test.go.
+func TestDisassembleWordsWithTool(t *testing.T) {
+	tool := FindObjdump()
+	if tool == "" {
+		t.Skip("no aarch64 objdump available; install binutils-aarch64-linux-gnu")
+	}
+
+	hexes := make([]uint32, len(fp16Samples))
+	for i, s := range fp16Samples {
+		hexes[i] = s.hex
+	}
+	decoded, err := DisassembleWords(t.Context(), tool, hexes)
+	if err != nil {
+		t.Fatalf("DisassembleWords: %v", err)
+	}
+	for _, s := range fp16Samples {
+		got, ok := decoded[s.hex]
+		if !ok {
+			t.Errorf("0x%08X: no disassembly returned", s.hex)
+			continue
+		}
+		if res := VerifyDecoded(got, s.expect); res.Status != Match {
+			t.Errorf("0x%08X: objdump=%q does not match claim=%q", s.hex, res.Decoded, res.Claimed)
+		}
+	}
+}
+
+// TestFindObjdumpProbe checks that FindObjdump only returns a tool that
+// actually decodes the FP16 probe instruction.
+func TestFindObjdumpProbe(t *testing.T) {
+	tool := FindObjdump()
+	if tool == "" {
+		t.Skip("no aarch64 objdump available")
+	}
+	decoded, err := DisassembleWords(t.Context(), tool, []uint32{probeWord})
+	if err != nil {
+		t.Fatalf("DisassembleWords(probe): %v", err)
+	}
+	if res := VerifyDecoded(decoded[probeWord], probeExpect); res.Status != Match {
+		t.Fatalf("located objdump %q failed the probe: got %q", tool, res.Decoded)
+	}
+}

--- a/internal/asmencoding/objdump_test.go
+++ b/internal/asmencoding/objdump_test.go
@@ -93,3 +93,15 @@ func TestFindObjdumpProbe(t *testing.T) {
 		t.Fatalf("located objdump %q failed the probe: got %q", tool, res.Decoded)
 	}
 }
+
+// TestDisassembleWordsEmpty checks that an empty word slice returns an empty
+// map without invoking objdump (which rejects empty input files).
+func TestDisassembleWordsEmpty(t *testing.T) {
+	got, err := DisassembleWords(t.Context(), "/nonexistent-objdump", nil)
+	if err != nil {
+		t.Fatalf("empty input should not error: %v", err)
+	}
+	if len(got) != 0 {
+		t.Fatalf("expected empty map, got %v", got)
+	}
+}


### PR DESCRIPTION
Fixes #44.

## Problem

`golang.org/x/arch/arm64asm` cannot decode ARMv8.2 half-precision (`.8H`) SIMD instructions (every one returns "unknown instruction"). The WORD-encoding checker therefore exempted the 19 FP16 encodings in `f16/f16_arm64.s` via a static allow-list, which left them validated by neither the static checker nor x86 CI (which runs the pure-Go fallback, not the assembly), only by ARM64 hardware. Two of the encoding bugs found earlier were FP16 wrong-destination-register mistakes that reached hardware precisely because of this gap.

## Fix

Replace the allow-list with an `objdump` cross-check that disassembles the FP16 words and verifies them against their comments.

- **`internal/asmencoding/objdump.go`** (new): `FindObjdump()` locates an aarch64-capable objdump (`SIMD_OBJDUMP` override, then `aarch64-linux-gnu-objdump`, then native `objdump` on linux/arm64), probing each candidate on a known FP16 word so a wrong-architecture or non-GNU objdump (such as `llvm-objdump`) is rejected rather than trusted. `DisassembleWords()` decodes raw words with `objdump -D -b binary -m aarch64 -EL`.
- **`internal/asmencoding/asmencoding.go`**: extract `VerifyDecoded()` from `Verify()` so the objdump path reuses the exact same normalize + token-boundary-prefix comparison.
- **`asmcheck_test.go`**: route undecodable FP16 directives through the cross-check and drop the allow-list (`asmException`/`asmAllowlist`). When no objdump is present the directives are accepted unchecked so local runs stay green, unless `SIMD_REQUIRE_OBJDUMP` is set, which makes a missing tool fatal.
- **`f16/f16_arm64.s`**: add inline comments naming the 16 previously undocumented FP16 instructions (comment-only; instruction bytes unchanged).
- **`.github/workflows/ci.yml`**: install `binutils-aarch64-linux-gnu` and set `SIMD_REQUIRE_OBJDUMP=1` on the Linux job so the cross-check is mandatory there and cannot silently regress if the install ever breaks.

## Result

The FP16 allow-list shrinks to zero. Every WORD directive now self-documents and is validated, decodable ones by `arm64asm`, FP16 ones by objdump. Adding a new FP16 instruction is just `WORD $0x... // FXXX V.8H...`; CI validates it automatically, and an undocumented or mis-commented directive fails the build.

## Testing

- A deliberately wrong comment is caught: `claims="FADD V3.8H..." objdump="FADD V2.8H..."`.
- Absent objdump warns and passes locally; the `SIMD_REQUIRE_OBJDUMP` gate fails hard.
- `gofmt` / `go vet` / `golangci-lint` clean; race suite green on x86.
- Full suite plus the required cross-check pass on real arm64 hardware with both native and cross objdump (real NEON FP16 numerics included).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Enhanced validation for ARM64 floating-point instruction encodings with cross-verification capabilities.

* **Chores**
  * Improved CI/CD workflow for architecture-specific ARM64 testing support.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->