### PR TITLE
f32: Int16/Float32 PCM16 conversion primitives

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,6 +128,8 @@ fmt.Println(cpu.HasFP16())     // true/false (ARM64 half-precision SIMD)
 |                 | `Deinterleave2(a, b, src)`          | Unpack stereo to channels     | 4x / 2x                             |
 |                 | `CubicInterpDot(hist,a,b,c,d,x)`    | Fused cubic interp dot product| 4x / 2x                             |
 |                 | `Int32ToFloat32Scale(dst,src,s)`    | PCM int32 to normalized float | 8x / 4x                             |
+|                 | `Int16ToFloat32Scale(dst,src,s)`    | PCM int16 to normalized float | 8x (AVX2) / 4x (NEON)               |
+|                 | `Float32ToInt16Scale(dst,src,s)`    | Normalized float to PCM int16 | 8x (AVX2) / 4x (NEON)               |
 
 ### `f32` - float32 Operations
 

--- a/doc.go
+++ b/doc.go
@@ -50,7 +50,7 @@
 //
 // Activation functions: Sigmoid, ReLU, Tanh, Exp, ClampScale
 //
-// Audio DSP: Interleave2, Deinterleave2, ConvolveValid, ConvolveValidMulti, AccumulateAdd, CumulativeSum, CubicInterpDot, Int32ToFloat32Scale
+// Audio DSP: Interleave2, Deinterleave2, ConvolveValid, ConvolveValidMulti, AccumulateAdd, CumulativeSum, CubicInterpDot, Int32ToFloat32Scale, Int16ToFloat32Scale, Float32ToInt16Scale
 //
 // Complex (c128): Add, Sub, Mul, MulConj, Conj, Abs, AbsSq, Scale
 //

--- a/f32/benchmark_test.go
+++ b/f32/benchmark_test.go
@@ -610,6 +610,25 @@ func BenchmarkInt32ToFloat32Scale(b *testing.B) {
 // Int16ToFloat32Scale Benchmarks
 // =============================================================================
 
+// benchScalePair runs the SIMD and Go sub-benchmarks for one PCM conversion
+// primitive at a single size. bytesPerElem is the combined read+write width per
+// element, used for the throughput (MB/s) report.
+func benchScalePair(b *testing.B, size, bytesPerElem int, simd, gofb func()) {
+	b.Helper()
+	b.Run(fmt.Sprintf("SIMD_%d", size), func(b *testing.B) {
+		for i := 0; i < b.N; i++ {
+			simd()
+		}
+		b.SetBytes(int64(size * bytesPerElem))
+	})
+	b.Run(fmt.Sprintf("Go_%d", size), func(b *testing.B) {
+		for i := 0; i < b.N; i++ {
+			gofb()
+		}
+		b.SetBytes(int64(size * bytesPerElem))
+	})
+}
+
 func BenchmarkInt16ToFloat32Scale(b *testing.B) {
 	for _, size := range benchSizes {
 		src := make([]int16, size)
@@ -618,21 +637,10 @@ func BenchmarkInt16ToFloat32Scale(b *testing.B) {
 			src[i] = int16((i % 65536) - 32768)
 		}
 		scale := float32(1.0 / 32768.0)
-
-		b.Run(fmt.Sprintf("SIMD_%d", size), func(b *testing.B) {
-			for i := 0; i < b.N; i++ {
-				Int16ToFloat32Scale(dst, src, scale)
-			}
-			// Read int16 (2 bytes) + write float32 (4 bytes) = 6 bytes per element
-			b.SetBytes(int64(size * 6))
-		})
-
-		b.Run(fmt.Sprintf("Go_%d", size), func(b *testing.B) {
-			for i := 0; i < b.N; i++ {
-				int16ToFloat32ScaleGo(dst, src, scale)
-			}
-			b.SetBytes(int64(size * 6))
-		})
+		// Read int16 (2 bytes) + write float32 (4 bytes) = 6 bytes per element.
+		benchScalePair(b, size, 6,
+			func() { Int16ToFloat32Scale(dst, src, scale) },
+			func() { int16ToFloat32ScaleGo(dst, src, scale) })
 	}
 }
 
@@ -648,20 +656,9 @@ func BenchmarkFloat32ToInt16Scale(b *testing.B) {
 			src[i] = float32((i%65536)-32768) / 32768.0
 		}
 		scale := float32(32767.0)
-
-		b.Run(fmt.Sprintf("SIMD_%d", size), func(b *testing.B) {
-			for i := 0; i < b.N; i++ {
-				Float32ToInt16Scale(dst, src, scale)
-			}
-			// Read float32 (4 bytes) + write int16 (2 bytes) = 6 bytes per element
-			b.SetBytes(int64(size * 6))
-		})
-
-		b.Run(fmt.Sprintf("Go_%d", size), func(b *testing.B) {
-			for i := 0; i < b.N; i++ {
-				float32ToInt16ScaleGo(dst, src, scale)
-			}
-			b.SetBytes(int64(size * 6))
-		})
+		// Read float32 (4 bytes) + write int16 (2 bytes) = 6 bytes per element.
+		benchScalePair(b, size, 6,
+			func() { Float32ToInt16Scale(dst, src, scale) },
+			func() { float32ToInt16ScaleGo(dst, src, scale) })
 	}
 }

--- a/f32/benchmark_test.go
+++ b/f32/benchmark_test.go
@@ -605,3 +605,63 @@ func BenchmarkInt32ToFloat32Scale(b *testing.B) {
 		})
 	}
 }
+
+// =============================================================================
+// Int16ToFloat32Scale Benchmarks
+// =============================================================================
+
+func BenchmarkInt16ToFloat32Scale(b *testing.B) {
+	for _, size := range benchSizes {
+		src := make([]int16, size)
+		dst := make([]float32, size)
+		for i := range src {
+			src[i] = int16((i % 65536) - 32768)
+		}
+		scale := float32(1.0 / 32768.0)
+
+		b.Run(fmt.Sprintf("SIMD_%d", size), func(b *testing.B) {
+			for i := 0; i < b.N; i++ {
+				Int16ToFloat32Scale(dst, src, scale)
+			}
+			// Read int16 (2 bytes) + write float32 (4 bytes) = 6 bytes per element
+			b.SetBytes(int64(size * 6))
+		})
+
+		b.Run(fmt.Sprintf("Go_%d", size), func(b *testing.B) {
+			for i := 0; i < b.N; i++ {
+				int16ToFloat32ScaleGo(dst, src, scale)
+			}
+			b.SetBytes(int64(size * 6))
+		})
+	}
+}
+
+// =============================================================================
+// Float32ToInt16Scale Benchmarks
+// =============================================================================
+
+func BenchmarkFloat32ToInt16Scale(b *testing.B) {
+	for _, size := range benchSizes {
+		src := make([]float32, size)
+		dst := make([]int16, size)
+		for i := range src {
+			src[i] = float32((i%65536)-32768) / 32768.0
+		}
+		scale := float32(32767.0)
+
+		b.Run(fmt.Sprintf("SIMD_%d", size), func(b *testing.B) {
+			for i := 0; i < b.N; i++ {
+				Float32ToInt16Scale(dst, src, scale)
+			}
+			// Read float32 (4 bytes) + write int16 (2 bytes) = 6 bytes per element
+			b.SetBytes(int64(size * 6))
+		})
+
+		b.Run(fmt.Sprintf("Go_%d", size), func(b *testing.B) {
+			for i := 0; i < b.N; i++ {
+				float32ToInt16ScaleGo(dst, src, scale)
+			}
+			b.SetBytes(int64(size * 6))
+		})
+	}
+}

--- a/f32/f32.go
+++ b/f32/f32.go
@@ -587,6 +587,74 @@ func Int32ToFloat32ScaleUnsafe(dst []float32, src []int32, scale float32) {
 	int32ToFloat32Scale(dst[:len(src)], src, scale)
 }
 
+// Int16ToFloat32Scale converts int16 samples to float32 and scales in one pass.
+// dst[i] = float32(src[i]) * scale
+//
+// This fuses the 16-bit PCM audio boundary: 16-bit audio normalizes with
+// scale = 1.0/32768.0 to map [-32768, 32767] into [-1, 1). int16 values are
+// exactly representable in float32, so the only rounding is the multiply.
+//
+// Processes min(len(dst), len(src)) elements.
+//
+// Uses AVX2 on AMD64 (8x int16), NEON on ARM64 (4x int16).
+func Int16ToFloat32Scale(dst []float32, src []int16, scale float32) {
+	n := min(len(dst), len(src))
+	if n == 0 {
+		return
+	}
+	int16ToFloat32Scale(dst[:n], src[:n], scale)
+}
+
+// Int16ToFloat32ScaleUnsafe converts int16 samples to float32 and scales without
+// length validation. This is a low-overhead variant for performance-critical code paths.
+//
+// PRECONDITIONS (caller must ensure):
+//   - len(dst) >= len(src)
+//   - len(src) > 0
+//
+// Violating these preconditions results in undefined behavior.
+// Use Int16ToFloat32Scale for safe operation with automatic length handling.
+func Int16ToFloat32ScaleUnsafe(dst []float32, src []int16, scale float32) {
+	// Slice dst to len(src) to ensure SIMD implementations don't read past src
+	int16ToFloat32Scale(dst[:len(src)], src, scale)
+}
+
+// Float32ToInt16Scale scales float32 samples and converts to int16 PCM in one pass.
+// dst[i] = clamp(roundTiesToEven(src[i]*scale), -32768, 32767)
+//
+// This fuses the float -> 16-bit PCM boundary: normalized audio in [-1, 1] is
+// written back to 16-bit with scale = 32767.0. Behavior is fully specified and
+// identical on every architecture:
+//   - rounding is round-to-nearest, ties to even (one LSB tighter than the
+//     common truncating int16(f*scale) cast);
+//   - out-of-range values saturate to the int16 range rather than wrapping;
+//   - +Inf -> 32767, -Inf -> -32768, NaN -> 0.
+//
+// Processes min(len(dst), len(src)) elements.
+//
+// Uses AVX2 on AMD64 (8x float32), NEON on ARM64 (4x float32).
+func Float32ToInt16Scale(dst []int16, src []float32, scale float32) {
+	n := min(len(dst), len(src))
+	if n == 0 {
+		return
+	}
+	float32ToInt16Scale(dst[:n], src[:n], scale)
+}
+
+// Float32ToInt16ScaleUnsafe scales float32 samples and converts to int16 without
+// length validation. This is a low-overhead variant for performance-critical code paths.
+//
+// PRECONDITIONS (caller must ensure):
+//   - len(dst) >= len(src)
+//   - len(src) > 0
+//
+// Violating these preconditions results in undefined behavior.
+// Use Float32ToInt16Scale for safe operation with automatic length handling.
+func Float32ToInt16ScaleUnsafe(dst []int16, src []float32, scale float32) {
+	// Slice dst to len(src) to ensure SIMD implementations don't write past dst
+	float32ToInt16Scale(dst[:len(src)], src, scale)
+}
+
 // ============================================================================
 // SPLIT-FORMAT COMPLEX OPERATIONS
 // ============================================================================

--- a/f32/f32_amd64.go
+++ b/f32/f32_amd64.go
@@ -565,6 +565,30 @@ func int32ToFloat32Scale(dst []float32, src []int32, scale float32) {
 //go:noescape
 func int32ToFloat32ScaleAVX(dst []float32, src []int32, scale float32)
 
+func int16ToFloat32Scale(dst []float32, src []int16, scale float32) {
+	// AVX2 is required because widening int16 to int32 uses VPMOVSXWD (ymm form).
+	if cpu.X86.AVX2 && len(dst) >= minAVXElements {
+		int16ToFloat32ScaleAVX(dst, src, scale)
+		return
+	}
+	int16ToFloat32ScaleGo(dst, src, scale)
+}
+
+//go:noescape
+func int16ToFloat32ScaleAVX(dst []float32, src []int16, scale float32)
+
+func float32ToInt16Scale(dst []int16, src []float32, scale float32) {
+	// AVX2 path; the saturating pack (VPACKSSDW) needs AVX2's VEXTRACTF128 split.
+	if cpu.X86.AVX2 && len(dst) >= minAVXElements {
+		float32ToInt16ScaleAVX(dst, src, scale)
+		return
+	}
+	float32ToInt16ScaleGo(dst, src, scale)
+}
+
+//go:noescape
+func float32ToInt16ScaleAVX(dst []int16, src []float32, scale float32)
+
 // ============================================================================
 // SPLIT-FORMAT COMPLEX OPERATIONS
 // ============================================================================

--- a/f32/f32_amd64.s
+++ b/f32/f32_amd64.s
@@ -3628,12 +3628,12 @@ f32toi16_tail:
     // Back up to the final aligned block of 8 and reprocess it (overlap).
     MOVQ $8, BX
     SUBQ CX, BX                    // BX = 8 - (len % 8)  (1..7)
-    MOVQ BX, R8
-    SHLQ $2, R8                    // (8 - rem) * 4 src bytes
-    SUBQ R8, SI
-    MOVQ BX, R8
-    SHLQ $1, R8                    // (8 - rem) * 2 dst bytes
-    SUBQ R8, DX
+    MOVQ BX, AX
+    SHLQ $2, AX                    // (8 - rem) * 4 src bytes
+    SUBQ AX, SI
+    MOVQ BX, AX
+    SHLQ $1, AX                    // (8 - rem) * 2 dst bytes
+    SUBQ AX, DX
 
     VMOVUPS (SI), Y0               // final 8 x float32
     VMULPS Y3, Y0, Y0

--- a/f32/f32_amd64.s
+++ b/f32/f32_amd64.s
@@ -3521,6 +3521,135 @@ i32tof32_done:
     VZEROUPPER
     RET
 
+// func int16ToFloat32ScaleAVX(dst []float32, src []int16, scale float32)
+// Converts int16 samples to float32 and multiplies by scale in one pass.
+// dst[i] = float32(src[i]) * scale
+// Optimized for 16-bit PCM audio (e.g., scale = 1.0/32768 to normalize to [-1, 1)).
+// Requires AVX2 (VPMOVSXWD ymm form to widen 8 int16 to 8 int32).
+// Frame: dst(24) + src(24) + scale(4) = 52 bytes
+TEXT ·int16ToFloat32ScaleAVX(SB), NOSPLIT, $0-52
+    MOVQ dst_base+0(FP), DX        // DX = dst pointer (float32 out)
+    MOVQ dst_len+8(FP), CX         // CX = length (len(dst) == len(src))
+    MOVQ src_base+24(FP), SI       // SI = src pointer (int16 in)
+
+    // Broadcast scale to all 8 lanes
+    VBROADCASTSS scale+48(FP), Y2  // Y2 = {scale, scale, ..., scale}
+
+    // Process 8 int16 elements per iteration
+    MOVQ CX, AX
+    SHRQ $3, AX                    // len / 8
+    JZ   i16tof32_remainder
+
+i16tof32_loop8:
+    VPMOVSXWD (SI), Y0             // load 8 int16, sign-extend to 8 x int32
+    VCVTDQ2PS Y0, Y1              // convert int32 to float32
+    VMULPS Y2, Y1, Y1            // multiply by scale
+    VMOVUPS Y1, (DX)            // store 8 x float32
+    ADDQ $16, SI               // advance src by 8 x int16 = 16 bytes
+    ADDQ $32, DX               // advance dst by 8 x float32 = 32 bytes
+    DECQ AX
+    JNZ  i16tof32_loop8
+
+i16tof32_remainder:
+    ANDQ $7, CX                    // remainder = len % 8
+    JZ   i16tof32_done
+
+i16tof32_scalar:
+    MOVWLSX (SI), AX               // load int16, sign-extend to 32-bit
+    VCVTSI2SSL AX, X0, X0         // convert int32 to float32
+    VMULSS X2, X0, X0            // multiply by scale (X2 = scale lane 0)
+    VMOVSS X0, (DX)            // store float32
+    ADDQ $2, SI
+    ADDQ $4, DX
+    DECQ CX
+    JNZ  i16tof32_scalar
+
+i16tof32_done:
+    VZEROUPPER
+    RET
+
+// Clamp constants for float32 -> int16 saturation (broadcast per lane).
+DATA f32toi16max<>+0(SB)/4, $0x46FFFE00  // 32767.0
+GLOBL f32toi16max<>(SB), RODATA|NOPTR, $4
+DATA f32toi16min<>+0(SB)/4, $0xC7000000  // -32768.0
+GLOBL f32toi16min<>(SB), RODATA|NOPTR, $4
+
+// func float32ToInt16ScaleAVX(dst []int16, src []float32, scale float32)
+// Scales float32 samples and converts to int16 PCM in one pass.
+// dst[i] = clamp(roundTiesToEven(src[i]*scale), -32768, 32767), NaN -> 0.
+// Requires AVX2.
+//
+// Matches ARM64 FCVTNS+SQXTN bit-for-bit. The hardware VCVTPS2DQ+VPACKSSDW path
+// alone would map NaN and +Inf to -32768, so NaN and the saturation bounds are
+// handled explicitly before the convert:
+//   1. multiply by scale
+//   2. self-compare (VCMPPS EQ) and AND: NaN lanes -> 0
+//   3. VMINPS 32767.0 / VMAXPS -32768.0: clamp, mapping +Inf -> 32767, -Inf -> -32768
+//   4. VCVTPS2DQ: round to nearest-even (in range, so exact)
+//   5. VPACKSSDW (via VEXTRACTF128): pack 8 int32 to 8 int16 in order
+//
+// The 1-7 element tail reprocesses the final aligned block of 8 (an overlapping
+// store of identical values); the dispatcher guarantees len >= 8.
+//
+// Frame: dst(24) + src(24) + scale(4) = 52 bytes
+TEXT ·float32ToInt16ScaleAVX(SB), NOSPLIT, $0-52
+    MOVQ dst_base+0(FP), DX        // DX = dst pointer (int16 out)
+    MOVQ dst_len+8(FP), CX         // CX = length (len(dst) == len(src))
+    MOVQ src_base+24(FP), SI       // SI = src pointer (float32 in)
+
+    VBROADCASTSS scale+48(FP), Y3      // Y3 = scale x8
+    VBROADCASTSS f32toi16max<>(SB), Y4 // Y4 = 32767.0 x8
+    VBROADCASTSS f32toi16min<>(SB), Y5 // Y5 = -32768.0 x8
+
+    MOVQ CX, AX
+    SHRQ $3, AX                    // len / 8
+    JZ   f32toi16_tail
+
+f32toi16_loop8:
+    VMOVUPS (SI), Y0               // 8 x float32
+    VMULPS Y3, Y0, Y0            // * scale
+    VCMPPS $0, Y0, Y0, Y1       // Y1 = (Y0 == Y0) ? ones : 0  (0 for NaN)
+    VANDPS Y1, Y0, Y0          // NaN lanes -> 0
+    VMINPS Y4, Y0, Y0         // clamp high (+Inf -> 32767)
+    VMAXPS Y5, Y0, Y0        // clamp low (-Inf -> -32768)
+    VCVTPS2DQ Y0, Y0         // 8 x int32, round nearest-even
+    VEXTRACTF128 $1, Y0, X1  // high 4 int32 -> X1
+    VPACKSSDW X1, X0, X0     // pack to 8 x int16 (in order)
+    VMOVDQU X0, (DX)         // store 8 x int16 (16 bytes)
+    ADDQ $32, SI            // advance src by 8 x float32
+    ADDQ $16, DX           // advance dst by 8 x int16
+    DECQ AX
+    JNZ  f32toi16_loop8
+
+f32toi16_tail:
+    ANDQ $7, CX                    // remainder = len % 8
+    JZ   f32toi16_done
+
+    // Back up to the final aligned block of 8 and reprocess it (overlap).
+    MOVQ $8, BX
+    SUBQ CX, BX                    // BX = 8 - (len % 8)  (1..7)
+    MOVQ BX, R8
+    SHLQ $2, R8                    // (8 - rem) * 4 src bytes
+    SUBQ R8, SI
+    MOVQ BX, R8
+    SHLQ $1, R8                    // (8 - rem) * 2 dst bytes
+    SUBQ R8, DX
+
+    VMOVUPS (SI), Y0               // final 8 x float32
+    VMULPS Y3, Y0, Y0
+    VCMPPS $0, Y0, Y0, Y1
+    VANDPS Y1, Y0, Y0
+    VMINPS Y4, Y0, Y0
+    VMAXPS Y5, Y0, Y0
+    VCVTPS2DQ Y0, Y0
+    VEXTRACTF128 $1, Y0, X1
+    VPACKSSDW X1, X0, X0
+    VMOVDQU X0, (DX)               // store final 8 x int16
+
+f32toi16_done:
+    VZEROUPPER
+    RET
+
 // ============================================================================
 // SPLIT-FORMAT COMPLEX OPERATIONS
 // ============================================================================

--- a/f32/f32_arm64.go
+++ b/f32/f32_arm64.go
@@ -361,6 +361,28 @@ func int32ToFloat32Scale(dst []float32, src []int32, scale float32) {
 //go:noescape
 func int32ToFloat32ScaleNEON(dst []float32, src []int32, scale float32)
 
+func int16ToFloat32Scale(dst []float32, src []int16, scale float32) {
+	if hasNEON && len(dst) >= 4 {
+		int16ToFloat32ScaleNEON(dst, src, scale)
+		return
+	}
+	int16ToFloat32ScaleGo(dst, src, scale)
+}
+
+//go:noescape
+func int16ToFloat32ScaleNEON(dst []float32, src []int16, scale float32)
+
+func float32ToInt16Scale(dst []int16, src []float32, scale float32) {
+	if hasNEON && len(dst) >= 4 {
+		float32ToInt16ScaleNEON(dst, src, scale)
+		return
+	}
+	float32ToInt16ScaleGo(dst, src, scale)
+}
+
+//go:noescape
+func float32ToInt16ScaleNEON(dst []int16, src []float32, scale float32)
+
 // ============================================================================
 // SPLIT-FORMAT COMPLEX OPERATIONS
 // ============================================================================

--- a/f32/f32_arm64.s
+++ b/f32/f32_arm64.s
@@ -1643,6 +1643,117 @@ i32tof32_neon_scalar_loop:
 i32tof32_neon_done:
     RET
 
+// func int16ToFloat32ScaleNEON(dst []float32, src []int16, scale float32)
+// Converts int16 samples to float32 and multiplies by scale in one pass.
+// dst[i] = float32(src[i]) * scale
+// Optimized for 16-bit PCM audio (e.g., scale = 1.0/32768 to normalize to [-1, 1)).
+//
+// NEON opcodes (hand-encoded; the Go assembler lacks these vector forms):
+// SXTL Vd.4S, Vn.4H:        widen 4 signed int16 to 4 int32
+// SCVTF Vd.4S, Vn.4S:       signed int32 to float32
+// FMUL Vd.4S, Vn.4S, Vm.4S: multiply
+// DUP Vd.4S, Vn.S[0]:       broadcast lane 0
+//
+// Frame: dst(24) + src(24) + scale(4) = 52 bytes
+TEXT ·int16ToFloat32ScaleNEON(SB), NOSPLIT, $0-52
+    MOVD dst_base+0(FP), R0        // R0 = dst pointer (float32 out)
+    MOVD dst_len+8(FP), R3         // R3 = length (len(dst) == len(src))
+    MOVD src_base+24(FP), R1       // R1 = src pointer (int16 in)
+    FMOVS scale+48(FP), F2         // F2 = scale
+
+    // Broadcast scale to all 4 lanes
+    WORD $0x4E040442               // DUP V2.4S, V2.S[0]
+
+    // Process 4 int16 elements per iteration
+    LSR $2, R3, R4                 // R4 = len / 4
+    CBZ R4, i16tof32_neon_scalar
+
+i16tof32_neon_loop4:
+    VLD1.P 8(R1), [V0.H4]          // V0 = 4 x int16 (low 4 halfwords)
+    WORD $0x0F10A401               // SXTL V1.4S, V0.4H
+    WORD $0x4E21D821               // SCVTF V1.4S, V1.4S
+    WORD $0x6E22DC21               // FMUL V1.4S, V1.4S, V2.4S
+    VST1.P [V1.S4], 16(R0)         // store 4 x float32
+    SUB $1, R4
+    CBNZ R4, i16tof32_neon_loop4
+
+i16tof32_neon_scalar:
+    AND $3, R3                     // remainder = len % 4
+    CBZ R3, i16tof32_neon_done
+
+i16tof32_neon_scalar_loop:
+    MOVH (R1), R5                  // load int16, sign-extended
+    SCVTFWS R5, F0                 // convert int32 to float32
+    FMULS F2, F0, F0               // F0 = F0 * scale
+    FMOVS F0, (R0)                 // store float32
+    ADD $4, R0
+    ADD $2, R1
+    SUB $1, R3
+    CBNZ R3, i16tof32_neon_scalar_loop
+
+i16tof32_neon_done:
+    RET
+
+// func float32ToInt16ScaleNEON(dst []int16, src []float32, scale float32)
+// Scales float32 samples and converts to int16 PCM in one pass.
+// dst[i] = clamp(roundTiesToEven(src[i]*scale), -32768, 32767), NaN -> 0.
+// The hardware defines the semantics: FCVTNS rounds to nearest-even and
+// saturates to int32 (NaN -> 0, +-Inf -> int32 min/max); SQXTN then saturates
+// int32 to int16, yielding +Inf -> 32767, -Inf -> -32768.
+//
+// NEON opcodes (hand-encoded; the Go assembler lacks these vector forms):
+// FMUL Vd.4S, Vn.4S, Vm.4S: multiply
+// FCVTNS Vd.4S, Vn.4S:      float32 to signed int32, round to nearest-even, saturating
+// SQXTN Vd.4H, Vn.4S:       signed saturating narrow int32 to int16
+// DUP Vd.4S, Vn.S[0]:       broadcast lane 0
+//
+// The 1-3 element tail reprocesses the final aligned block of 4 (an overlapping
+// store of identical values) so every element goes through the same vector path;
+// the dispatcher guarantees len >= 4.
+//
+// Frame: dst(24) + src(24) + scale(4) = 52 bytes
+TEXT ·float32ToInt16ScaleNEON(SB), NOSPLIT, $0-52
+    MOVD dst_base+0(FP), R0        // R0 = dst pointer (int16 out)
+    MOVD dst_len+8(FP), R3         // R3 = length (len(dst) == len(src))
+    MOVD src_base+24(FP), R1       // R1 = src pointer (float32 in)
+    FMOVS scale+48(FP), F2         // F2 = scale
+
+    // Broadcast scale to all 4 lanes
+    WORD $0x4E040442               // DUP V2.4S, V2.S[0]
+
+    // Process 4 float32 elements per iteration
+    LSR $2, R3, R4                 // R4 = len / 4
+    CBZ R4, f32toi16_neon_tail
+
+f32toi16_neon_loop4:
+    VLD1.P 16(R1), [V0.S4]         // V0 = 4 x float32
+    WORD $0x6E22DC01               // FMUL V1.4S, V0.4S, V2.4S
+    WORD $0x4E21A821               // FCVTNS V1.4S, V1.4S
+    WORD $0x0E614821               // SQXTN V1.4H, V1.4S
+    VST1.P [V1.H4], 8(R0)          // store 4 x int16 (8 bytes)
+    SUB $1, R4
+    CBNZ R4, f32toi16_neon_loop4
+
+f32toi16_neon_tail:
+    AND $3, R3, R5                 // R5 = len % 4
+    CBZ R5, f32toi16_neon_done
+
+    // Back up to the final aligned block of 4 and reprocess it (overlap).
+    MOVD $4, R6
+    SUB R5, R6, R6                 // R6 = 4 - (len % 4)  (1..3)
+    LSL $2, R6, R7                 // R7 = (4 - rem) * 4 src bytes
+    SUB R7, R1, R1                 // R1 -= that many bytes
+    LSL $1, R6, R7                 // R7 = (4 - rem) * 2 dst bytes
+    SUB R7, R0, R0                 // R0 -= that many bytes
+    VLD1 (R1), [V0.S4]            // V0 = final 4 x float32
+    WORD $0x6E22DC01               // FMUL V1.4S, V0.4S, V2.4S
+    WORD $0x4E21A821               // FCVTNS V1.4S, V1.4S
+    WORD $0x0E614821               // SQXTN V1.4H, V1.4S
+    VST1 [V1.H4], (R0)            // store final 4 x int16
+
+f32toi16_neon_done:
+    RET
+
 // ============================================================================
 // SPLIT-FORMAT COMPLEX OPERATIONS
 // ============================================================================

--- a/f32/f32_go.go
+++ b/f32/f32_go.go
@@ -464,23 +464,7 @@ func int32ToFloat32ScaleGo(dst []float32, src []int32, scale float32) {
 // int16 values are exactly representable in float32, so this is a single
 // rounding (the multiply); the SIMD paths produce bit-identical results.
 func int16ToFloat32ScaleGo(dst []float32, src []int16, scale float32) {
-	n := len(src)
-	n8 := n &^ unrollMask // Round down to multiple of 8
-
-	// Unrolled loop: 8 elements per iteration
-	for i := 0; i < n8; i += 8 {
-		dst[i] = float32(src[i]) * scale
-		dst[i+1] = float32(src[i+1]) * scale
-		dst[i+2] = float32(src[i+2]) * scale
-		dst[i+3] = float32(src[i+3]) * scale
-		dst[i+4] = float32(src[i+4]) * scale
-		dst[i+5] = float32(src[i+5]) * scale
-		dst[i+6] = float32(src[i+6]) * scale
-		dst[i+7] = float32(src[i+7]) * scale
-	}
-
-	// Handle remainder
-	for i := n8; i < n; i++ {
+	for i := range src {
 		dst[i] = float32(src[i]) * scale
 	}
 }
@@ -494,15 +478,15 @@ func int16ToFloat32ScaleGo(dst []float32, src []int16, scale float32) {
 // architectures. Rounding is round-to-nearest, ties to even (one LSB tighter
 // than a truncating int16(f*scale) cast).
 func float32ToInt16ScaleGo(dst []int16, src []float32, scale float32) {
-	for i := 0; i < len(src); i++ {
+	for i := range src {
 		v := src[i] * scale
 		switch {
 		case v != v: // NaN
 			dst[i] = 0
-		case v >= 32767: // includes +Inf
-			dst[i] = 32767
-		case v <= -32768: // includes -Inf
-			dst[i] = -32768
+		case v >= math.MaxInt16: // includes +Inf
+			dst[i] = math.MaxInt16
+		case v <= math.MinInt16: // includes -Inf
+			dst[i] = math.MinInt16
 		default:
 			dst[i] = int16(math.RoundToEven(float64(v)))
 		}

--- a/f32/f32_go.go
+++ b/f32/f32_go.go
@@ -459,6 +459,56 @@ func int32ToFloat32ScaleGo(dst []float32, src []int32, scale float32) {
 	}
 }
 
+// int16ToFloat32ScaleGo converts int16 samples to float32 and scales.
+// dst[i] = float32(src[i]) * scale
+// int16 values are exactly representable in float32, so this is a single
+// rounding (the multiply); the SIMD paths produce bit-identical results.
+func int16ToFloat32ScaleGo(dst []float32, src []int16, scale float32) {
+	n := len(src)
+	n8 := n &^ unrollMask // Round down to multiple of 8
+
+	// Unrolled loop: 8 elements per iteration
+	for i := 0; i < n8; i += 8 {
+		dst[i] = float32(src[i]) * scale
+		dst[i+1] = float32(src[i+1]) * scale
+		dst[i+2] = float32(src[i+2]) * scale
+		dst[i+3] = float32(src[i+3]) * scale
+		dst[i+4] = float32(src[i+4]) * scale
+		dst[i+5] = float32(src[i+5]) * scale
+		dst[i+6] = float32(src[i+6]) * scale
+		dst[i+7] = float32(src[i+7]) * scale
+	}
+
+	// Handle remainder
+	for i := n8; i < n; i++ {
+		dst[i] = float32(src[i]) * scale
+	}
+}
+
+// float32ToInt16ScaleGo scales float32 samples and converts to int16 PCM.
+// dst[i] = clamp(roundTiesToEven(src[i]*scale), -32768, 32767), with
+// NaN -> 0, +Inf -> 32767, -Inf -> -32768.
+//
+// These are exactly the results of ARM64 FCVTNS + SQXTN; the AVX2 path and this
+// fallback are written to match that bit-for-bit so output is identical across
+// architectures. Rounding is round-to-nearest, ties to even (one LSB tighter
+// than a truncating int16(f*scale) cast).
+func float32ToInt16ScaleGo(dst []int16, src []float32, scale float32) {
+	for i := 0; i < len(src); i++ {
+		v := src[i] * scale
+		switch {
+		case v != v: // NaN
+			dst[i] = 0
+		case v >= 32767: // includes +Inf
+			dst[i] = 32767
+		case v <= -32768: // includes -Inf
+			dst[i] = -32768
+		default:
+			dst[i] = int16(math.RoundToEven(float64(v)))
+		}
+	}
+}
+
 // ============================================================================
 // SPLIT-FORMAT COMPLEX OPERATIONS (Pure Go)
 // ============================================================================

--- a/f32/f32_other.go
+++ b/f32/f32_other.go
@@ -46,6 +46,10 @@ func tanh32(dst, src []float32)                                 { tanh32Go(dst, 
 func exp32(dst, src []float32)                                  { exp32Go(dst, src) }
 func int32ToFloat32Scale(dst []float32, src []int32, s float32) { int32ToFloat32ScaleGo(dst, src, s) }
 
+func int16ToFloat32Scale(dst []float32, src []int16, s float32) { int16ToFloat32ScaleGo(dst, src, s) }
+
+func float32ToInt16Scale(dst []int16, src []float32, s float32) { float32ToInt16ScaleGo(dst, src, s) }
+
 // Split-format complex operations
 func mulComplex32(dstRe, dstIm, aRe, aIm, bRe, bIm []float32) {
 	mulComplex32Go(dstRe, dstIm, aRe, aIm, bRe, bIm)

--- a/f32/f32_test.go
+++ b/f32/f32_test.go
@@ -1830,6 +1830,347 @@ func TestInt32ToFloat32ScaleUnsafe(t *testing.T) {
 }
 
 // =============================================================================
+// Int16ToFloat32Scale Tests
+// =============================================================================
+
+// int16ToFloat32ScaleRef is the scalar reference: dst[i] = float32(src[i]) * scale.
+// int16 values are exactly representable in float32, so a single multiply with
+// the same rounding as the SIMD paths makes results bit-identical.
+func int16ToFloat32ScaleRef(dst []float32, src []int16, scale float32) {
+	n := min(len(dst), len(src))
+	for i := 0; i < n; i++ {
+		dst[i] = float32(src[i]) * scale
+	}
+}
+
+func TestInt16ToFloat32Scale(t *testing.T) {
+	testCases := []struct {
+		name  string
+		src   []int16
+		scale float32
+	}{
+		{"empty", nil, 1.0},
+		{"single", []int16{32767}, 1.0 / 32768.0},
+		{"four", []int16{-32768, -16384, 0, 32767}, 1.0 / 32768.0},
+		{"seven", []int16{-32768, -16384, -8192, 0, 8192, 16384, 32767}, 1.0 / 32768.0},
+		{"eight", []int16{-32768, -16384, -8192, 0, 8192, 16384, 32767, -1}, 1.0 / 32768.0},
+		{"nine", []int16{-32768, -16384, -8192, 0, 8192, 16384, 32767, -1, 100}, 1.0 / 32768.0},
+		{"sixteen", make([]int16, 16), 1.0 / 32768.0},
+		{"seventeen", make([]int16, 17), 1.0 / 32768.0},
+		{"boundaries", []int16{-32768, -1, 0, 1, 32767}, 1.0 / 32768.0},
+		{"unit_scale", []int16{-32768, -100, 0, 100, 32767}, 1.0},
+	}
+
+	for i := range testCases {
+		if testCases[i].name == "sixteen" || testCases[i].name == "seventeen" {
+			for j := range testCases[i].src {
+				testCases[i].src[j] = int16((j - len(testCases[i].src)/2) * 1000)
+			}
+		}
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			dst := make([]float32, len(tc.src))
+			Int16ToFloat32Scale(dst, tc.src, tc.scale)
+
+			want := make([]float32, len(tc.src))
+			int16ToFloat32ScaleRef(want, tc.src, tc.scale)
+
+			for i := range dst {
+				if dst[i] != want[i] {
+					t.Errorf("Int16ToFloat32Scale()[%d] = %v, want %v (src=%d)", i, dst[i], want[i], tc.src[i])
+				}
+			}
+		})
+	}
+}
+
+func TestInt16ToFloat32Scale_Large(t *testing.T) {
+	for _, size := range []int{63, 100, 1000, 10000} {
+		t.Run(fmt.Sprintf("size_%d", size), func(t *testing.T) {
+			src := make([]int16, size)
+			for i := range src {
+				src[i] = int16(i%65536 - 32768)
+			}
+			dst := make([]float32, size)
+			want := make([]float32, size)
+			scale := float32(1.0 / 32768.0)
+
+			Int16ToFloat32Scale(dst, src, scale)
+			int16ToFloat32ScaleRef(want, src, scale)
+
+			for i := range dst {
+				if dst[i] != want[i] {
+					t.Fatalf("Int16ToFloat32Scale()[%d] = %v, want %v", i, dst[i], want[i])
+				}
+			}
+		})
+	}
+}
+
+func TestInt16ToFloat32Scale_LengthMismatch(t *testing.T) {
+	src := []int16{1, 2, 3, 4, 5, 6, 7, 8, 9, 10}
+	scale := float32(1.0 / 32768.0)
+
+	// dst shorter than src: only len(dst) processed.
+	dst := make([]float32, 6)
+	Int16ToFloat32Scale(dst, src, scale)
+	for i := range dst {
+		if want := float32(src[i]) * scale; dst[i] != want {
+			t.Errorf("short dst [%d] = %v, want %v", i, dst[i], want)
+		}
+	}
+
+	// src shorter than dst: only len(src) written, tail untouched.
+	dst2 := make([]float32, 12)
+	for i := range dst2 {
+		dst2[i] = -999
+	}
+	Int16ToFloat32Scale(dst2, src, scale)
+	for i := 0; i < len(src); i++ {
+		if want := float32(src[i]) * scale; dst2[i] != want {
+			t.Errorf("short src [%d] = %v, want %v", i, dst2[i], want)
+		}
+	}
+	for i := len(src); i < len(dst2); i++ {
+		if dst2[i] != -999 {
+			t.Errorf("tail [%d] was modified: %v", i, dst2[i])
+		}
+	}
+}
+
+func TestInt16ToFloat32ScaleUnsafe(t *testing.T) {
+	src := []int16{-32768, 0, 32767, -16384, 16384, -8192, 8192, 0, 1}
+	dst := make([]float32, len(src))
+	scale := float32(1.0 / 32768.0)
+
+	Int16ToFloat32ScaleUnsafe(dst, src, scale)
+
+	for i := range dst {
+		if want := float32(src[i]) * scale; dst[i] != want {
+			t.Errorf("Int16ToFloat32ScaleUnsafe()[%d] = %v, want %v", i, dst[i], want)
+		}
+	}
+}
+
+// =============================================================================
+// Float32ToInt16Scale Tests
+// =============================================================================
+
+// float32ToInt16ScaleRef is the canonical scalar reference that defines the
+// semantics every backend (Go fallback, AVX2, NEON) must match bit-for-bit:
+//
+//	dst[i] = clamp(roundTiesToEven(src[i]*scale), -32768, 32767)
+//
+// with NaN -> 0, +Inf -> 32767, -Inf -> -32768. These are exactly the results
+// of ARM64 FCVTNS + SQXTN.
+func float32ToInt16ScaleRef(dst []int16, src []float32, scale float32) {
+	n := min(len(dst), len(src))
+	for i := 0; i < n; i++ {
+		v := src[i] * scale
+		switch {
+		case v != v: // NaN
+			dst[i] = 0
+		case v >= 32767: // includes +Inf
+			dst[i] = 32767
+		case v <= -32768: // includes -Inf
+			dst[i] = -32768
+		default:
+			dst[i] = int16(math.RoundToEven(float64(v)))
+		}
+	}
+}
+
+func TestFloat32ToInt16Scale(t *testing.T) {
+	inf := float32(math.Inf(1))
+	nan := float32(math.NaN())
+	testCases := []struct {
+		name  string
+		src   []float32
+		scale float32
+	}{
+		{"empty", nil, 32767.0},
+		{"single", []float32{0.5}, 32767.0},
+		{"four", []float32{-1.0, -0.5, 0.0, 1.0}, 32767.0},
+		{"eight", []float32{-1.0, -0.5, -0.25, 0.0, 0.25, 0.5, 1.0, 0.999}, 32767.0},
+		{"nine", []float32{-1.0, -0.5, -0.25, 0.0, 0.25, 0.5, 1.0, 0.999, -0.001}, 32767.0},
+		{"sixteen", make([]float32, 16), 32767.0},
+		{"seventeen", make([]float32, 17), 32767.0},
+		// Out-of-range inputs must clamp, not wrap.
+		{"overrange", []float32{2.0, -2.0, 1.5, -1.5, 100.0, -100.0, 5e9, -5e9}, 32767.0},
+		// Infinities and NaN.
+		{"inf_nan", []float32{inf, -inf, nan, 0.5, -0.5, nan, inf, -inf}, 32767.0},
+		// Rounding ties-to-even around .5 boundaries (scale 1.0 so src == product).
+		{"ties", []float32{0.5, 1.5, 2.5, 3.5, -0.5, -1.5, -2.5, -3.5}, 1.0},
+		// Exact integer products.
+		{"exact", []float32{-32768, -16384, 0, 16384, 32767}, 1.0},
+	}
+
+	for i := range testCases {
+		if testCases[i].name == "sixteen" || testCases[i].name == "seventeen" {
+			for j := range testCases[i].src {
+				testCases[i].src[j] = float32(j-len(testCases[i].src)/2) / 32768.0
+			}
+		}
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			dst := make([]int16, len(tc.src))
+			Float32ToInt16Scale(dst, tc.src, tc.scale)
+
+			want := make([]int16, len(tc.src))
+			float32ToInt16ScaleRef(want, tc.src, tc.scale)
+
+			for i := range dst {
+				if dst[i] != want[i] {
+					t.Errorf("Float32ToInt16Scale()[%d] = %d, want %d (src=%g, prod=%g)",
+						i, dst[i], want[i], tc.src[i], tc.src[i]*tc.scale)
+				}
+			}
+		})
+	}
+}
+
+func TestFloat32ToInt16Scale_Boundaries(t *testing.T) {
+	// scale = 32767: -1.0 -> -32767, +1.0 -> +32767 (the documented PCM16 output).
+	src := []float32{-1.0, 1.0, 0.0}
+	dst := make([]int16, len(src))
+	Float32ToInt16Scale(dst, src, 32767.0)
+	wantVals := []int16{-32767, 32767, 0}
+	for i := range dst {
+		if dst[i] != wantVals[i] {
+			t.Errorf("[%d] = %d, want %d", i, dst[i], wantVals[i])
+		}
+	}
+}
+
+func TestFloat32ToInt16Scale_NaNInfClamp(t *testing.T) {
+	inf := float32(math.Inf(1))
+	src := []float32{float32(math.NaN()), inf, -inf, 2.0, -2.0}
+	dst := make([]int16, len(src))
+	Float32ToInt16Scale(dst, src, 32767.0)
+	want := []int16{0, 32767, -32768, 32767, -32768}
+	for i := range dst {
+		if dst[i] != want[i] {
+			t.Errorf("[%d] (src=%g) = %d, want %d", i, src[i], dst[i], want[i])
+		}
+	}
+}
+
+func TestFloat32ToInt16Scale_Large(t *testing.T) {
+	for _, size := range []int{63, 100, 1000, 10000} {
+		t.Run(fmt.Sprintf("size_%d", size), func(t *testing.T) {
+			src := make([]float32, size)
+			for i := range src {
+				// Sweep [-1.2, 1.2) so some values clamp.
+				src[i] = float32(i%2400-1200) / 1000.0
+			}
+			dst := make([]int16, size)
+			want := make([]int16, size)
+			Float32ToInt16Scale(dst, src, 32767.0)
+			float32ToInt16ScaleRef(want, src, 32767.0)
+			for i := range dst {
+				if dst[i] != want[i] {
+					t.Fatalf("[%d] (src=%g) = %d, want %d", i, src[i], dst[i], want[i])
+				}
+			}
+		})
+	}
+}
+
+func TestFloat32ToInt16Scale_RoundTrip(t *testing.T) {
+	// int16 -> float32 -> int16 must come back within 1 LSB.
+	src16 := make([]int16, 0, 65536)
+	for v := -32768; v <= 32767; v++ {
+		src16 = append(src16, int16(v))
+	}
+	f := make([]float32, len(src16))
+	Int16ToFloat32Scale(f, src16, 1.0/32768.0)
+	back := make([]int16, len(src16))
+	Float32ToInt16Scale(back, f, 32767.0)
+	for i := range src16 {
+		d := int(back[i]) - int(src16[i])
+		if d < -1 || d > 1 {
+			t.Fatalf("round-trip [%d]: %d -> %g -> %d (diff %d)", i, src16[i], f[i], back[i], d)
+		}
+	}
+}
+
+func TestFloat32ToInt16Scale_LengthMismatch(t *testing.T) {
+	src := []float32{0.1, 0.2, 0.3, 0.4, 0.5, 0.6, 0.7, 0.8, 0.9, 1.0}
+	scale := float32(32767.0)
+
+	dst := make([]int16, 6)
+	Float32ToInt16Scale(dst, src, scale)
+	want := make([]int16, 6)
+	float32ToInt16ScaleRef(want, src, scale)
+	for i := range dst {
+		if dst[i] != want[i] {
+			t.Errorf("short dst [%d] = %d, want %d", i, dst[i], want[i])
+		}
+	}
+
+	dst2 := make([]int16, 12)
+	for i := range dst2 {
+		dst2[i] = -999
+	}
+	Float32ToInt16Scale(dst2, src, scale)
+	want2 := make([]int16, len(src))
+	float32ToInt16ScaleRef(want2, src, scale)
+	for i := 0; i < len(src); i++ {
+		if dst2[i] != want2[i] {
+			t.Errorf("short src [%d] = %d, want %d", i, dst2[i], want2[i])
+		}
+	}
+	for i := len(src); i < len(dst2); i++ {
+		if dst2[i] != -999 {
+			t.Errorf("tail [%d] modified: %d", i, dst2[i])
+		}
+	}
+}
+
+func TestFloat32ToInt16ScaleUnsafe(t *testing.T) {
+	src := []float32{-1.0, -0.5, 0.0, 0.5, 1.0, 2.0, -2.0, 0.25, -0.25}
+	dst := make([]int16, len(src))
+	scale := float32(32767.0)
+	Float32ToInt16ScaleUnsafe(dst, src, scale)
+	want := make([]int16, len(src))
+	float32ToInt16ScaleRef(want, src, scale)
+	for i := range dst {
+		if dst[i] != want[i] {
+			t.Errorf("Float32ToInt16ScaleUnsafe()[%d] = %d, want %d", i, dst[i], want[i])
+		}
+	}
+}
+
+// TestPCM16Conversion_AllocFree asserts the PCM16 conversion primitives operate
+// purely on caller-provided buffers (the zero-alloc streaming contract).
+func TestPCM16Conversion_AllocFree(t *testing.T) {
+	i16 := make([]int16, 1024)
+	f := make([]float32, 1024)
+	for i := range i16 {
+		i16[i] = int16(i%65536 - 32768)
+		f[i] = float32(i%2400-1200) / 1000.0
+	}
+	cases := []struct {
+		name string
+		fn   func()
+	}{
+		{"Int16ToFloat32Scale", func() { Int16ToFloat32Scale(f, i16, 1.0/32768.0) }},
+		{"Int16ToFloat32ScaleUnsafe", func() { Int16ToFloat32ScaleUnsafe(f, i16, 1.0/32768.0) }},
+		{"Float32ToInt16Scale", func() { Float32ToInt16Scale(i16, f, 32767.0) }},
+		{"Float32ToInt16ScaleUnsafe", func() { Float32ToInt16ScaleUnsafe(i16, f, 32767.0) }},
+	}
+	for _, c := range cases {
+		if a := testing.AllocsPerRun(50, c.fn); a != 0 {
+			t.Errorf("%s allocated %v times per run, want 0", c.name, a)
+		}
+	}
+}
+
+// =============================================================================
 // Split-Format Complex Operations Tests
 // =============================================================================
 

--- a/f32/f32_test.go
+++ b/f32/f32_test.go
@@ -1836,9 +1836,28 @@ func TestInt32ToFloat32ScaleUnsafe(t *testing.T) {
 // int16ToFloat32ScaleRef is the scalar reference: dst[i] = float32(src[i]) * scale.
 // int16 values are exactly representable in float32, so a single multiply with
 // the same rounding as the SIMD paths makes results bit-identical.
+// int16Ramp builds an n-element int16 ramp spanning negative and positive values
+// so sized test cases exercise full SIMD blocks plus a scalar remainder.
+func int16Ramp(n int) []int16 {
+	s := make([]int16, n)
+	for i := range s {
+		s[i] = int16((i - n/2) * 1000)
+	}
+	return s
+}
+
+// float32Ramp builds an n-element float32 ramp roughly in [-1, 1).
+func float32Ramp(n int) []float32 {
+	s := make([]float32, n)
+	for i := range s {
+		s[i] = float32(i-n/2) / float32(n/2+1)
+	}
+	return s
+}
+
 func int16ToFloat32ScaleRef(dst []float32, src []int16, scale float32) {
 	n := min(len(dst), len(src))
-	for i := 0; i < n; i++ {
+	for i := range n {
 		dst[i] = float32(src[i]) * scale
 	}
 }
@@ -1855,18 +1874,10 @@ func TestInt16ToFloat32Scale(t *testing.T) {
 		{"seven", []int16{-32768, -16384, -8192, 0, 8192, 16384, 32767}, 1.0 / 32768.0},
 		{"eight", []int16{-32768, -16384, -8192, 0, 8192, 16384, 32767, -1}, 1.0 / 32768.0},
 		{"nine", []int16{-32768, -16384, -8192, 0, 8192, 16384, 32767, -1, 100}, 1.0 / 32768.0},
-		{"sixteen", make([]int16, 16), 1.0 / 32768.0},
-		{"seventeen", make([]int16, 17), 1.0 / 32768.0},
+		{"block16", int16Ramp(16), 1.0 / 32768.0},
+		{"block17", int16Ramp(17), 1.0 / 32768.0},
 		{"boundaries", []int16{-32768, -1, 0, 1, 32767}, 1.0 / 32768.0},
 		{"unit_scale", []int16{-32768, -100, 0, 100, 32767}, 1.0},
-	}
-
-	for i := range testCases {
-		if testCases[i].name == "sixteen" || testCases[i].name == "seventeen" {
-			for j := range testCases[i].src {
-				testCases[i].src[j] = int16((j - len(testCases[i].src)/2) * 1000)
-			}
-		}
 	}
 
 	for _, tc := range testCases {
@@ -1928,7 +1939,7 @@ func TestInt16ToFloat32Scale_LengthMismatch(t *testing.T) {
 		dst2[i] = -999
 	}
 	Int16ToFloat32Scale(dst2, src, scale)
-	for i := 0; i < len(src); i++ {
+	for i := range src {
 		if want := float32(src[i]) * scale; dst2[i] != want {
 			t.Errorf("short src [%d] = %v, want %v", i, dst2[i], want)
 		}
@@ -1967,15 +1978,15 @@ func TestInt16ToFloat32ScaleUnsafe(t *testing.T) {
 // of ARM64 FCVTNS + SQXTN.
 func float32ToInt16ScaleRef(dst []int16, src []float32, scale float32) {
 	n := min(len(dst), len(src))
-	for i := 0; i < n; i++ {
+	for i := range n {
 		v := src[i] * scale
 		switch {
 		case v != v: // NaN
 			dst[i] = 0
-		case v >= 32767: // includes +Inf
-			dst[i] = 32767
-		case v <= -32768: // includes -Inf
-			dst[i] = -32768
+		case v >= math.MaxInt16: // includes +Inf
+			dst[i] = math.MaxInt16
+		case v <= math.MinInt16: // includes -Inf
+			dst[i] = math.MinInt16
 		default:
 			dst[i] = int16(math.RoundToEven(float64(v)))
 		}
@@ -1995,8 +2006,8 @@ func TestFloat32ToInt16Scale(t *testing.T) {
 		{"four", []float32{-1.0, -0.5, 0.0, 1.0}, 32767.0},
 		{"eight", []float32{-1.0, -0.5, -0.25, 0.0, 0.25, 0.5, 1.0, 0.999}, 32767.0},
 		{"nine", []float32{-1.0, -0.5, -0.25, 0.0, 0.25, 0.5, 1.0, 0.999, -0.001}, 32767.0},
-		{"sixteen", make([]float32, 16), 32767.0},
-		{"seventeen", make([]float32, 17), 32767.0},
+		{"block16", float32Ramp(16), 32767.0},
+		{"block17", float32Ramp(17), 32767.0},
 		// Out-of-range inputs must clamp, not wrap.
 		{"overrange", []float32{2.0, -2.0, 1.5, -1.5, 100.0, -100.0, 5e9, -5e9}, 32767.0},
 		// Infinities and NaN.
@@ -2005,14 +2016,6 @@ func TestFloat32ToInt16Scale(t *testing.T) {
 		{"ties", []float32{0.5, 1.5, 2.5, 3.5, -0.5, -1.5, -2.5, -3.5}, 1.0},
 		// Exact integer products.
 		{"exact", []float32{-32768, -16384, 0, 16384, 32767}, 1.0},
-	}
-
-	for i := range testCases {
-		if testCases[i].name == "sixteen" || testCases[i].name == "seventeen" {
-			for j := range testCases[i].src {
-				testCases[i].src[j] = float32(j-len(testCases[i].src)/2) / 32768.0
-			}
-		}
 	}
 
 	for _, tc := range testCases {
@@ -2119,7 +2122,7 @@ func TestFloat32ToInt16Scale_LengthMismatch(t *testing.T) {
 	Float32ToInt16Scale(dst2, src, scale)
 	want2 := make([]int16, len(src))
 	float32ToInt16ScaleRef(want2, src, scale)
-	for i := 0; i < len(src); i++ {
+	for i := range src {
 		if dst2[i] != want2[i] {
 			t.Errorf("short src [%d] = %d, want %d", i, dst2[i], want2[i])
 		}

--- a/f32/go_impl_test.go
+++ b/f32/go_impl_test.go
@@ -466,3 +466,50 @@ func TestMaxIdxGo(t *testing.T) {
 		})
 	}
 }
+
+func TestInt16ToFloat32ScaleGo(t *testing.T) {
+	srcs := [][]int16{
+		{},
+		{0},
+		{-32768, -1, 0, 1, 32767},
+		{-32768, -16384, -8192, 0, 8192, 16384, 32767, -1, 100},
+	}
+	for _, src := range srcs {
+		dst := make([]float32, len(src))
+		want := make([]float32, len(src))
+		int16ToFloat32ScaleGo(dst, src, 1.0/32768.0)
+		int16ToFloat32ScaleRef(want, src, 1.0/32768.0)
+		for i := range dst {
+			if dst[i] != want[i] {
+				t.Errorf("int16ToFloat32ScaleGo[%d] = %v, want %v (src=%d)", i, dst[i], want[i], src[i])
+			}
+		}
+	}
+}
+
+func TestFloat32ToInt16ScaleGo(t *testing.T) {
+	inf := float32(math.Inf(1))
+
+	// scale 32767: in-range, clamp, and inf/nan handling.
+	src := []float32{-1, -0.5, 0, 0.5, 1, 2, -2, 100, -100, inf, -inf, float32(math.NaN())}
+	dst := make([]int16, len(src))
+	want := make([]int16, len(src))
+	float32ToInt16ScaleGo(dst, src, 32767)
+	float32ToInt16ScaleRef(want, src, 32767)
+	for i := range dst {
+		if dst[i] != want[i] {
+			t.Errorf("float32ToInt16ScaleGo[%d] (src=%g) = %d, want %d", i, src[i], dst[i], want[i])
+		}
+	}
+
+	// scale 1.0 so the product lands exactly on .5 ties: must round to even.
+	ties := []float32{0.5, 1.5, 2.5, 3.5, -0.5, -1.5, -2.5, -3.5}
+	tdst := make([]int16, len(ties))
+	twant := []int16{0, 2, 2, 4, 0, -2, -2, -4} // ties to even
+	float32ToInt16ScaleGo(tdst, ties, 1.0)
+	for i := range tdst {
+		if tdst[i] != twant[i] {
+			t.Errorf("float32ToInt16ScaleGo ties[%d] (src=%g) = %d, want %d", i, ties[i], tdst[i], twant[i])
+		}
+	}
+}


### PR DESCRIPTION
Implements #50 (the first PR-sized item from the #54 tracking issue): SIMD int16 <-> float32 conversion for the 16-bit PCM audio boundary. This fuses the per-call scalar conversion that wraps the float32 resampler hot path (birdnet-go's `SimpleResamplerFloat32.ProcessInto`).

## API

Mirrors the existing `Int32ToFloat32Scale` (safe + `Unsafe` variants, `min(len(dst), len(src))` handling, allocation-free):

```go
func Int16ToFloat32Scale(dst []float32, src []int16, scale float32)
func Int16ToFloat32ScaleUnsafe(dst []float32, src []int16, scale float32)
func Float32ToInt16Scale(dst []int16, src []float32, scale float32)
func Float32ToInt16ScaleUnsafe(dst []int16, src []float32, scale float32)
```

## Semantics

- `Int16ToFloat32Scale`: `dst[i] = float32(src[i]) * scale`. int16 is exactly representable in float32, so the only rounding is the multiply.
- `Float32ToInt16Scale`: `clamp(roundTiesToEven(src[i]*scale), -32768, 32767)`, with `NaN -> 0`, `+Inf -> 32767`, `-Inf -> -32768`. Rounding is round-to-nearest, ties-to-even (one LSB tighter than the common truncating `int16(f*scale)` cast).

The ARM64 path (`FCVTNS`+`SQXTN`) defines the float->int16 semantics natively; the AVX2 path (NaN self-compare mask + `VMINPS`/`VMAXPS` clamp + `VCVTPS2DQ` + `VPACKSSDW`) and the Go fallback are written to match it bit-for-bit, so output is identical across architectures. (A naive `VCVTPS2DQ`+`VPACKSSDW` alone would map NaN and +Inf to -32768, so those are handled explicitly.)

## Backends

- amd64: AVX2, 8-wide (`VPMOVSXWD` for the int16 widen).
- arm64: NEON, 4-wide. New `WORD`-encoded vector ops (`SXTL`, `SCVTF`, `FMUL`, `FCVTNS`, `SQXTN`, `DUP`) all carry comments and pass the encoding validator (cross-checked against aarch64 objdump).
- Go fallback otherwise (unrolled).

## Tests

- Parity vs an independent scalar reference: sizes through SIMD widths + remainders, boundaries (+-1.0, +-32767, -32768), out-of-range clamp, NaN/Inf, ties-to-even.
- int16 -> float32 -> int16 round trip over the full int16 range, within 1 LSB.
- Length-mismatch / tail-untouched, zero-length, allocation-free, explicit Go-fallback tests.
- Benchmarks vs scalar.

Verified on amd64 (incl. `-race` and the WORD-encoding validator with `SIMD_REQUIRE_OBJDUMP=1`) and natively on arm64.

Measured speedups over the Go fallback (amd64 AVX2, 1024 elements): int16->float32 ~11x, float32->int16 ~12x.

Closes #50. Part of #54.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added `Int16ToFloat32Scale` and `Float32ToInt16Scale` audio PCM conversion functions with optional scaling.
  * Optimized SIMD implementations for AMD64 (AVX/AVX2) and ARM64 (NEON) architectures with Go fallbacks.

* **Documentation**
  * Updated README and package documentation with newly supported audio conversion operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->