### PR TITLE
f32/f64: add ConvolveDecimate fused strided convolution

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,76 @@
+# simd - project notes for AI assistants
+
+High-performance SIMD library in pure Go assembly (no CGO). AMD64 (SSE2/AVX/AVX-512)
+and ARM64 (NEON), with a Go fallback. Cross-compiles cleanly because there is no C.
+
+## Hand-written assembly: reserved registers
+
+The single biggest footgun in this repo is clobbering a register the Go runtime
+reserves. The Go internal ABI fixes the meaning of a few registers across calls;
+hand-written `.s` files must respect that. Source of truth:
+https://go.googlesource.com/go/+/refs/heads/master/src/cmd/compile/abi-internal.md
+
+### AMD64
+
+| Register | Reserved meaning | Safe to clobber in a leaf `.s` function? |
+|----------|------------------|------------------------------------------|
+| `R14`    | Current goroutine `g` | No - treat as off-limits |
+| `R15`    | GOT temporary when dynamically linked | No |
+| `BP`     | Frame pointer | No (unless you save/restore it) |
+| `SP`     | Stack pointer | No |
+| `R12`, `R13`, `R15`(static) | Permanent scratch | Yes |
+| `RAX RBX RCX RDX RSI RDI R8 R9 R10 R11` | Args/results, general use | Yes |
+
+Prefer the legacy registers `RAX RBX RCX RDX RSI RDI` for scratch: they avoid the
+REX prefix that `R8`-`R15` require, so the encoding is one byte shorter.
+
+**Do not use `R14` as a scratch register.** `R14` holds the current goroutine
+pointer `g`. Use `BX` (or another general-purpose register) instead.
+
+Nuance worth knowing (verified empirically against go1.26 on amd64): a *leaf*
+`NOSPLIT` kernel that clobbers `R14` and returns does not actually crash today,
+because (1) the ABIInternal->ABI0 call wrapper restores `g` into `R14` from TLS on
+the way back, and (2) stackmap-less hand-written asm is never async-preempted, so
+the preemption handler never reads the clobbered `R14` mid-loop. That safety is an
+implementation detail, not a contract: the moment such a function gains a `CALL`
+into the runtime, or a stack map, the clobbered `g` becomes a live, GC-time crash.
+So follow the convention regardless and keep `R14` untouched. See PR #57 for the
+ConvolveDecimate kernels that originally used `R14` for the strided `pos` and were
+switched to `BX`.
+
+### ARM64
+
+| Register | Reserved meaning | Safe to clobber? |
+|----------|------------------|------------------|
+| `R28`    | Current goroutine `g` | No |
+| `R27`    | Assembler scratch (instruction expansion) | No |
+| `R18`    | Platform-reserved, never used | No |
+| `R29`    | Frame pointer | No |
+| `R30`    | Link register | Scratch in non-leaf bodies only |
+| `R16`, `R17` | Linker/trampoline scratch | No |
+| `R19`-`R25` | Permanent scratch | Yes |
+
+NEON instructions in this repo are hand-encoded as `WORD $0x...` with a decoded
+mnemonic in the trailing comment. The comment must match the encoding: the test
+suite cross-checks every `WORD` against `golang.org/x/arch/arm64asm` (see
+`asmcheck_test.go` / `internal/asmencoding`). When you add or change a `WORD`,
+verify the encoding with `aarch64-linux-gnu-as` + objdump or `arm64asm`.
+
+## Testing across architectures
+
+- AMD64 tests run natively here.
+- ARM64 is exercised on a native Raspberry Pi 5 host (`thakala@rpi5.local`,
+  aarch64, go installed). Cross-compile here, copy the test binary over, run it
+  there. No qemu emulation needed.
+- Each SIMD primitive ships a Go reference, parity tests against the active SIMD
+  path, a bit-exactness check vs the per-element scalar path where applicable, and
+  a `testing.AllocsPerRun == 0` allocation-free assertion.
+
+## Conventions
+
+- Zero allocations: every operation writes into caller-provided slices.
+- Public `XxxScale`/`Xxx` functions validate inputs and clamp `n := min(len(dst), ...)`;
+  the `Unsafe` variants skip bounds reconciliation.
+- `golangci-lint run ./...` runs with `new: false` (lints the whole tree), so
+  dupl/goconst/mnd/modernize all apply to new code.
+- Issues are tracked on GitHub (this repo), not elsewhere.

--- a/README.md
+++ b/README.md
@@ -123,6 +123,7 @@ fmt.Println(cpu.HasFP16())     // true/false (ARM64 half-precision SIMD)
 | **Batch**       | `DotProductBatch(r, rows, v)`       | Multiple dot products         | 8x / 4x / 2x                        |
 | **Signal**      | `ConvolveValid(dst, sig, k)`        | FIR filter / convolution      | 8x / 4x / 2x                        |
 |                 | `ConvolveValidMulti(dsts, sig, ks)` | Multi-kernel convolution      | 8x / 4x / 2x                        |
+|                 | `ConvolveDecimate(dst,sig,k,f,p)`   | Strided FIR downsample (decimate) | 8x / 4x / 2x                    |
 |                 | `AccumulateAdd(dst, src, off)`      | Overlap-add: dst[off:] += src | 8x / 4x / 2x                        |
 | **Audio**       | `Interleave2(dst, a, b)`            | Pack stereo: [L,R,L,R,...]    | 4x / 2x                             |
 |                 | `Deinterleave2(a, b, src)`          | Unpack stereo to channels     | 4x / 2x                             |
@@ -430,6 +431,24 @@ c64.Abs(magnitude, signalFFT)              // Extract magnitude
 | Deinterleave2 (f64)      | 1000 pairs            | 216 ns  | -       | -        |
 | Interleave2 (f32)        | 1000 pairs            | 109 ns  | -       | -        |
 | Deinterleave2 (f32)      | 1000 pairs            | 216 ns  | -       | -        |
+
+#### ConvolveDecimate (fused strided convolution)
+
+`ConvolveDecimate` fuses an FIR downsample loop into one call. The relevant
+baseline is what a consumer writes today: a Go loop calling `DotProductUnsafe`
+at each strided window (the inner dot is already SIMD). Both compute identical
+results; the fused kernel removes the per-output call, dispatch and slice-header
+overhead and keeps the kernel pointer resident, so the win is largest for short
+kernels. Signal length 4096, allocation-free. Measured (AVX2 on x86-64, NEON on
+a Raspberry Pi 5):
+
+| Config              | f32 x86 | f64 x86 | f32 NEON | f64 NEON |
+| ------------------- | ------- | ------- | -------- | -------- |
+| 20 taps, 2x decimate  | **2.0x** | **2.3x** | **1.7x** | **1.9x** |
+| 32 taps, 2x decimate  | **2.3x** | **1.7x** | **1.9x** | **1.7x** |
+| 64 taps, 2x decimate  | **2.0x** | **1.8x** | **1.7x** | **1.3x** |
+| 241 taps, 2x decimate | **1.5x** | **1.3x** | **1.2x** | **1.1x** |
+| 241 taps, 4x decimate | **1.4x** | **1.2x** | **1.2x** | **1.1x** |
 
 #### Performance Summary
 

--- a/doc.go
+++ b/doc.go
@@ -50,7 +50,7 @@
 //
 // Activation functions: Sigmoid, ReLU, Tanh, Exp, ClampScale
 //
-// Audio DSP: Interleave2, Deinterleave2, ConvolveValid, ConvolveValidMulti, AccumulateAdd, CumulativeSum, CubicInterpDot, Int32ToFloat32Scale, Int16ToFloat32Scale, Float32ToInt16Scale
+// Audio DSP: Interleave2, Deinterleave2, ConvolveValid, ConvolveValidMulti, ConvolveDecimate, AccumulateAdd, CumulativeSum, CubicInterpDot, Int32ToFloat32Scale, Int16ToFloat32Scale, Float32ToInt16Scale
 //
 // Complex (c128): Add, Sub, Mul, MulConj, Conj, Abs, AbsSq, Scale
 //

--- a/f32/convolve_decimate_amd64_test.go
+++ b/f32/convolve_decimate_amd64_test.go
@@ -1,0 +1,47 @@
+//go:build amd64
+
+package f32
+
+import (
+	"testing"
+
+	"github.com/tphakala/simd/cpu"
+)
+
+// TestConvolveDecimate_Backends validates every amd64 fused kernel this CPU can
+// execute by swapping the dispatch pointers, the same technique the existing
+// init tests use. SSE2 and the Go fallback always run here; AVX is the default
+// on this host; AVX-512 runs only on capable hardware/CI. Each backend is held
+// to the bit-exact oracle (fused kernel == per-window DotProductUnsafe loop),
+// which on amd64 means dotProduct uses the matching backend too.
+func TestConvolveDecimate_Backends(t *testing.T) {
+	savedConv := convolveDecimateImpl
+	savedDot := dotProductImpl
+	savedMin := minSIMDElements
+	t.Cleanup(func() {
+		convolveDecimateImpl = savedConv
+		dotProductImpl = savedDot
+		minSIMDElements = savedMin
+	})
+
+	backends := []struct {
+		name string
+		init func()
+		ok   bool
+	}{
+		{"Go", initGo, true},
+		{"SSE", initSSE, cpu.X86.SSE2},
+		{"AVX", initAVX, cpu.X86.AVX && cpu.X86.FMA},
+		{"AVX512", initAVX512, cpu.X86.AVX512F && cpu.X86.AVX512VL},
+	}
+
+	for _, be := range backends {
+		t.Run(be.name, func(t *testing.T) {
+			if !be.ok {
+				t.Skipf("%s not supported on this CPU", be.name)
+			}
+			be.init()
+			checkConvolveDecimateExact(t)
+		})
+	}
+}

--- a/f32/convolve_decimate_test.go
+++ b/f32/convolve_decimate_test.go
@@ -118,6 +118,16 @@ func TestConvolveDecimate_Edge(t *testing.T) {
 		t.Errorf("negative phase wrote to dst: %v", dst)
 	}
 
+	// phase >= factor: no-op (precondition phase in [0, factor)).
+	dst = []float32{99, 99}
+	ConvolveDecimate(dst, signal, []float32{1}, 2, 2)
+	if dst[0] != 99 || dst[1] != 99 {
+		t.Errorf("phase>=factor wrote to dst: %v", dst)
+	}
+
+	// empty dst: nothing to write (n == 0), must not panic.
+	ConvolveDecimate([]float32{}, signal, []float32{1}, 1, 0)
+
 	// kernel longer than signal: no valid output.
 	dst = []float32{99}
 	ConvolveDecimate(dst, []float32{1, 2}, []float32{1, 2, 3}, 1, 0)

--- a/f32/convolve_decimate_test.go
+++ b/f32/convolve_decimate_test.go
@@ -1,0 +1,315 @@
+package f32
+
+import (
+	"math"
+	"math/rand"
+	"testing"
+)
+
+// convolveDecimateRef is the scalar reference (correctness oracle) for
+// ConvolveDecimate. It computes the same strided valid-convolution outputs in
+// plain Go so the SIMD paths can be checked against it.
+func convolveDecimateRef(signal, kernel []float32, factor, phase int) []float32 {
+	kLen := len(kernel)
+	if kLen == 0 || factor < 1 || phase < 0 {
+		return nil
+	}
+	var out []float32
+	for pos := phase; pos+kLen <= len(signal); pos += factor {
+		var sum float32
+		for i := range kLen {
+			sum += signal[pos+i] * kernel[i]
+		}
+		out = append(out, sum)
+	}
+	return out
+}
+
+func TestConvolveDecimate_Basic(t *testing.T) {
+	tests := []struct {
+		name   string
+		signal []float32
+		kernel []float32
+		factor int
+		phase  int
+		want   []float32
+	}{
+		{
+			name:   "factor1 equals ConvolveValid",
+			signal: []float32{1, 2, 3, 4, 5},
+			kernel: []float32{1, 1, 1},
+			factor: 1,
+			phase:  0,
+			want:   []float32{6, 9, 12}, // 1+2+3, 2+3+4, 3+4+5
+		},
+		{
+			name:   "factor2 phase0",
+			signal: []float32{1, 2, 3, 4, 5, 6},
+			kernel: []float32{1, 1, 1},
+			factor: 2,
+			phase:  0,
+			want:   []float32{6, 12}, // pos 0 (1+2+3), pos 2 (3+4+5); pos 4 window 4,5,6 -> 15? check below
+		},
+		{
+			name:   "factor2 phase1",
+			signal: []float32{1, 2, 3, 4, 5, 6},
+			kernel: []float32{1, 1, 1},
+			factor: 2,
+			phase:  1,
+			want:   []float32{9, 15}, // pos 1 (2+3+4), pos 3 (4+5+6)
+		},
+		{
+			name:   "factor3 identity kernel",
+			signal: []float32{1, 2, 3, 4, 5, 6, 7, 8, 9},
+			kernel: []float32{1},
+			factor: 3,
+			phase:  0,
+			want:   []float32{1, 4, 7},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			dst := make([]float32, len(tt.want))
+			ConvolveDecimate(dst, tt.signal, tt.kernel, tt.factor, tt.phase)
+			for i, want := range tt.want {
+				if dst[i] != want {
+					t.Errorf("ConvolveDecimate()[%d] = %v, want %v", i, dst[i], want)
+				}
+			}
+		})
+	}
+}
+
+// TestConvolveDecimate_factor2Window verifies the "factor2 phase0" comment math
+// above is what we expect: with signal len 6, kernel len 3, factor 2, phase 0,
+// the valid strided positions are 0 and 2 (pos 4 would need indices 4,5,6 but 6
+// is out of range), so two outputs.
+func TestConvolveDecimate_OutputCount(t *testing.T) {
+	signal := make([]float32, 6)
+	kernel := []float32{1, 1, 1}
+	got := convolveDecimateRef(signal, kernel, 2, 0)
+	if len(got) != 2 {
+		t.Fatalf("reference output count = %d, want 2", len(got))
+	}
+}
+
+func TestConvolveDecimate_Edge(t *testing.T) {
+	signal := []float32{1, 2, 3, 4, 5}
+
+	// Empty kernel: nothing written.
+	dst := []float32{99, 99}
+	ConvolveDecimate(dst, signal, nil, 1, 0)
+	if dst[0] != 99 || dst[1] != 99 {
+		t.Errorf("empty kernel wrote to dst: %v", dst)
+	}
+
+	// factor < 1: treated as no-op (precondition factor >= 1).
+	dst = []float32{99, 99}
+	ConvolveDecimate(dst, signal, []float32{1}, 0, 0)
+	if dst[0] != 99 || dst[1] != 99 {
+		t.Errorf("factor<1 wrote to dst: %v", dst)
+	}
+
+	// negative phase: no-op (precondition phase >= 0).
+	dst = []float32{99, 99}
+	ConvolveDecimate(dst, signal, []float32{1}, 1, -1)
+	if dst[0] != 99 || dst[1] != 99 {
+		t.Errorf("negative phase wrote to dst: %v", dst)
+	}
+
+	// kernel longer than signal: no valid output.
+	dst = []float32{99}
+	ConvolveDecimate(dst, []float32{1, 2}, []float32{1, 2, 3}, 1, 0)
+	if dst[0] != 99 {
+		t.Errorf("kernel longer than signal wrote to dst: %v", dst)
+	}
+
+	// phase past end: no valid output.
+	dst = []float32{99}
+	ConvolveDecimate(dst, signal, []float32{1, 1}, 1, 10)
+	if dst[0] != 99 {
+		t.Errorf("phase past end wrote to dst: %v", dst)
+	}
+
+	// dst shorter than available outputs: only len(dst) written.
+	dst = []float32{0}
+	ConvolveDecimate(dst, signal, []float32{1}, 1, 0) // 5 outputs available
+	if dst[0] != 1 {
+		t.Errorf("dst[0] = %v, want 1", dst[0])
+	}
+}
+
+// TestConvolveDecimate_Parity checks the active SIMD path against the scalar
+// reference across the factor/phase/tap/length grid the issue calls for,
+// including ragged tails (lengths that are not multiples of the SIMD width).
+func TestConvolveDecimate_Parity(t *testing.T) {
+	rng := rand.New(rand.NewSource(0x5117D))
+	randSlice := func(n int) []float32 {
+		s := make([]float32, n)
+		for i := range s {
+			s[i] = rng.Float32()*2 - 1 // [-1, 1)
+		}
+		return s
+	}
+
+	taps := []int{1, 4, 7, 16, 20, 32, 64, 128, 241}
+	factors := []int{1, 2, 3, 4}
+	// Signal lengths chosen to exercise full-vector, partial-vector and scalar
+	// remainder paths plus ragged tails.
+	sigLens := []int{257, 480, 999, 4096, 8191}
+
+	for _, kLen := range taps {
+		for _, factor := range factors {
+			for phase := range factor {
+				for _, sigLen := range sigLens {
+					if sigLen < kLen {
+						continue
+					}
+					kernel := randSlice(kLen)
+					signal := randSlice(sigLen)
+					want := convolveDecimateRef(signal, kernel, factor, phase)
+					dst := make([]float32, len(want))
+					ConvolveDecimate(dst, signal, kernel, factor, phase)
+					for i := range want {
+						// The SIMD path may use FMA (single rounding) while the
+						// scalar reference uses separate mul+add, so near
+						// cancellations diverge in relative terms. Accept either a
+						// small relative error or a small absolute error; for
+						// signal/kernel in [-1,1] and <=241 taps the absolute
+						// accumulation error is bounded well under 1e-4.
+						absErr := math.Abs(float64(dst[i] - want[i]))
+						if relErrF32(dst[i], want[i]) > 1e-4 && absErr > 1e-4 {
+							t.Fatalf("taps=%d factor=%d phase=%d sigLen=%d: out[%d]=%v want %v (absErr %g)",
+								kLen, factor, phase, sigLen, i, dst[i], want[i], absErr)
+						}
+					}
+				}
+			}
+		}
+	}
+}
+
+// TestConvolveDecimate_MatchesDotProductUnsafe is the rigorous correctness
+// oracle. The fused kernel must produce bit-identical results to a loop calling
+// DotProductUnsafe at the same strided windows, because its inner dot replicates
+// the per-window dot exactly. This holds on every backend (asm vs asm, Go vs Go)
+// and proves the fusion changes nothing numerically versus the code it replaces.
+func TestConvolveDecimate_MatchesDotProductUnsafe(t *testing.T) {
+	checkConvolveDecimateExact(t)
+}
+
+// checkConvolveDecimateExact runs the bit-exact oracle against the currently
+// selected backend. It is shared with the amd64 per-backend test, which swaps
+// the dispatch pointers to exercise SSE / Go / AVX-512 on one machine.
+func checkConvolveDecimateExact(t *testing.T) {
+	t.Helper()
+	rng := rand.New(rand.NewSource(0xC0FFEE))
+	randSlice := func(n int) []float32 {
+		s := make([]float32, n)
+		for i := range s {
+			s[i] = rng.Float32()*2 - 1
+		}
+		return s
+	}
+
+	taps := []int{1, 4, 7, 16, 20, 32, 64, 128, 241}
+	factors := []int{1, 2, 3, 4}
+	sigLens := []int{257, 480, 999, 4096, 8191}
+
+	for _, kLen := range taps {
+		for _, factor := range factors {
+			for phase := range factor {
+				for _, sigLen := range sigLens {
+					if sigLen < kLen {
+						continue
+					}
+					kernel := randSlice(kLen)
+					signal := randSlice(sigLen)
+
+					var want []float32
+					for pos := phase; pos+kLen <= sigLen; pos += factor {
+						want = append(want, DotProductUnsafe(signal[pos:pos+kLen], kernel))
+					}
+					dst := make([]float32, len(want))
+					ConvolveDecimate(dst, signal, kernel, factor, phase)
+					for i := range want {
+						if dst[i] != want[i] {
+							t.Fatalf("taps=%d factor=%d phase=%d sigLen=%d: out[%d]=%v, DotProductUnsafe=%v (not bit-identical)",
+								kLen, factor, phase, sigLen, i, dst[i], want[i])
+						}
+					}
+				}
+			}
+		}
+	}
+}
+
+// BenchmarkConvolveDecimate compares the fused primitive against the status-quo
+// baseline a consumer writes today: a Go loop calling DotProductUnsafe at each
+// strided window. Both compute identical results; the fused path removes the
+// per-output call/dispatch overhead and keeps the kernel pointer resident.
+func BenchmarkConvolveDecimate(b *testing.B) {
+	cases := []struct {
+		name         string
+		kLen, factor int
+	}{
+		{"taps20_2x", 20, 2},
+		{"taps32_2x", 32, 2},
+		{"taps64_2x", 64, 2},
+		{"taps241_2x", 241, 2},
+		{"taps241_4x", 241, 4},
+	}
+	const sigLen = 4096
+	for _, c := range cases {
+		signal := make([]float32, sigLen)
+		for i := range signal {
+			signal[i] = float32(i%19) * 0.0517
+		}
+		kernel := make([]float32, c.kLen)
+		for i := range kernel {
+			kernel[i] = 1.0 / float32(c.kLen)
+		}
+		n := (sigLen-c.kLen)/c.factor + 1
+		dst := make([]float32, n)
+		bytes := int64(n * c.kLen * 4 * 2)
+
+		b.Run(c.name+"/Fused", func(b *testing.B) {
+			b.SetBytes(bytes)
+			for b.Loop() {
+				ConvolveDecimate(dst, signal, kernel, c.factor, 0)
+			}
+		})
+		b.Run(c.name+"/DotLoop", func(b *testing.B) {
+			b.SetBytes(bytes)
+			for b.Loop() {
+				pos := 0
+				for k := range dst {
+					dst[k] = DotProductUnsafe(signal[pos:pos+c.kLen], kernel)
+					pos += c.factor
+				}
+			}
+		})
+	}
+}
+
+// TestConvolveDecimate_AllocFree confirms the primitive allocates nothing when
+// the caller provides dst (the zero-alloc streaming contract).
+func TestConvolveDecimate_AllocFree(t *testing.T) {
+	signal := make([]float32, 4096)
+	kernel := make([]float32, 241)
+	for i := range signal {
+		signal[i] = float32(i%17) * 0.1
+	}
+	for i := range kernel {
+		kernel[i] = 1.0 / 241.0
+	}
+	dst := make([]float32, (len(signal)-len(kernel))/2+1)
+
+	allocs := testing.AllocsPerRun(50, func() {
+		ConvolveDecimate(dst, signal, kernel, 2, 0)
+	})
+	if allocs != 0 {
+		t.Errorf("ConvolveDecimate allocated %v times, want 0", allocs)
+	}
+}

--- a/f32/convolve_decimate_test.go
+++ b/f32/convolve_decimate_test.go
@@ -11,10 +11,10 @@ import (
 // plain Go so the SIMD paths can be checked against it.
 func convolveDecimateRef(signal, kernel []float32, factor, phase int) []float32 {
 	kLen := len(kernel)
-	if kLen == 0 || factor < 1 || phase < 0 {
+	if kLen == 0 || factor < 1 || phase < 0 || len(signal)-kLen-phase < 0 {
 		return nil
 	}
-	var out []float32
+	out := make([]float32, 0, (len(signal)-kLen-phase)/factor+1)
 	for pos := phase; pos+kLen <= len(signal); pos += factor {
 		var sum float32
 		for i := range kLen {
@@ -227,7 +227,7 @@ func checkConvolveDecimateExact(t *testing.T) {
 					kernel := randSlice(kLen)
 					signal := randSlice(sigLen)
 
-					var want []float32
+					want := make([]float32, 0, (sigLen-kLen-phase)/factor+1)
 					for pos := phase; pos+kLen <= sigLen; pos += factor {
 						want = append(want, DotProductUnsafe(signal[pos:pos+kLen], kernel))
 					}

--- a/f32/f32.go
+++ b/f32/f32.go
@@ -203,8 +203,8 @@ func ConvolveValid(dst, signal, kernel []float32) {
 // The kernel is applied as a plain dot product; pre-reverse it for true
 // convolution (matching DotProductUnsafe and ConvolveValid usage). factor must
 // be >= 1 (factor == 1 is valid convolution at every position) and phase must be
-// in [0, factor); factor < 1 or phase < 0 are treated as no-ops. With factor == 1
-// and phase == 0 this is exactly ConvolveValid.
+// in [0, factor); factor < 1, phase < 0, or phase >= factor are treated as
+// no-ops. With factor == 1 and phase == 0 this is exactly ConvolveValid.
 //
 // The number of outputs is the count of strided positions whose full kernel
 // window fits in signal; ConvolveDecimate writes min(len(dst), that count) and
@@ -212,7 +212,7 @@ func ConvolveValid(dst, signal, kernel []float32) {
 // the caller-provided buffers.
 func ConvolveDecimate(dst, signal, kernel []float32, factor, phase int) {
 	kLen := len(kernel)
-	if kLen == 0 || factor < 1 || phase < 0 {
+	if kLen == 0 || factor < 1 || phase < 0 || phase >= factor {
 		return
 	}
 	span := len(signal) - kLen - phase

--- a/f32/f32.go
+++ b/f32/f32.go
@@ -195,6 +195,37 @@ func ConvolveValid(dst, signal, kernel []float32) {
 	convolveValid32(dst[:n], signal, kernel)
 }
 
+// ConvolveDecimate computes a decimating (strided) valid convolution: it keeps
+// only every factor-th valid-convolution output, starting at phase.
+//
+//	dst[k] = sum_{i=0}^{len(kernel)-1} signal[phase + k*factor + i] * kernel[i]
+//
+// The kernel is applied as a plain dot product; pre-reverse it for true
+// convolution (matching DotProductUnsafe and ConvolveValid usage). factor must
+// be >= 1 (factor == 1 is valid convolution at every position) and phase must be
+// in [0, factor); factor < 1 or phase < 0 are treated as no-ops. With factor == 1
+// and phase == 0 this is exactly ConvolveValid.
+//
+// The number of outputs is the count of strided positions whose full kernel
+// window fits in signal; ConvolveDecimate writes min(len(dst), that count) and
+// leaves the remainder of dst untouched. It allocates nothing and operates on
+// the caller-provided buffers.
+func ConvolveDecimate(dst, signal, kernel []float32, factor, phase int) {
+	kLen := len(kernel)
+	if kLen == 0 || factor < 1 || phase < 0 {
+		return
+	}
+	span := len(signal) - kLen - phase
+	if span < 0 {
+		return
+	}
+	n := min(len(dst), span/factor+1)
+	if n == 0 {
+		return
+	}
+	convolveDecimate32(dst[:n], signal, kernel, factor, phase)
+}
+
 // AccumulateAdd adds src to dst starting at offset: dst[offset:offset+len(src)] += src.
 // This is a key primitive for overlap-add in FFT-based convolution.
 //

--- a/f32/f32_amd64.go
+++ b/f32/f32_amd64.go
@@ -18,38 +18,40 @@ var minSIMDElements = minAVXElements
 
 // Function pointer types for SIMD operations
 type (
-	dotProductFunc func(a, b []float32) float32
-	binaryOpFunc   func(dst, a, b []float32)
-	scaleFunc      func(dst, a []float32, s float32)
-	unaryOpFunc    func(dst, a []float32)
-	reduceFunc     func(a []float32) float32
-	reduceIdxFunc  func(a []float32) int
-	fmaFunc        func(dst, a, b, c []float32)
-	clampFunc      func(dst, a []float32, minVal, maxVal float32)
-	addScaledFunc  func(dst []float32, alpha float32, s []float32)
+	dotProductFunc       func(a, b []float32) float32
+	binaryOpFunc         func(dst, a, b []float32)
+	scaleFunc            func(dst, a []float32, s float32)
+	unaryOpFunc          func(dst, a []float32)
+	reduceFunc           func(a []float32) float32
+	reduceIdxFunc        func(a []float32) int
+	fmaFunc              func(dst, a, b, c []float32)
+	clampFunc            func(dst, a []float32, minVal, maxVal float32)
+	addScaledFunc        func(dst []float32, alpha float32, s []float32)
+	convolveDecimateFunc func(dst, signal, kernel []float32, factor, phase int)
 )
 
 // Function pointers - assigned at init time based on CPU features
 var (
-	dotProductImpl dotProductFunc
-	addImpl        binaryOpFunc
-	subImpl        binaryOpFunc
-	mulImpl        binaryOpFunc
-	divImpl        binaryOpFunc
-	scaleImpl      scaleFunc
-	addScalarImpl  scaleFunc
-	sumImpl        reduceFunc
-	minImpl        reduceFunc
-	maxImpl        reduceFunc
-	absImpl        unaryOpFunc
-	negImpl        unaryOpFunc
-	sqrtImpl       unaryOpFunc
-	reciprocalImpl unaryOpFunc
-	fmaImpl        fmaFunc
-	clampImpl      clampFunc
-	minIdxImpl     reduceIdxFunc
-	maxIdxImpl     reduceIdxFunc
-	addScaledImpl  addScaledFunc
+	dotProductImpl       dotProductFunc
+	addImpl              binaryOpFunc
+	subImpl              binaryOpFunc
+	mulImpl              binaryOpFunc
+	divImpl              binaryOpFunc
+	scaleImpl            scaleFunc
+	addScalarImpl        scaleFunc
+	sumImpl              reduceFunc
+	minImpl              reduceFunc
+	maxImpl              reduceFunc
+	absImpl              unaryOpFunc
+	negImpl              unaryOpFunc
+	sqrtImpl             unaryOpFunc
+	reciprocalImpl       unaryOpFunc
+	fmaImpl              fmaFunc
+	clampImpl            clampFunc
+	minIdxImpl           reduceIdxFunc
+	maxIdxImpl           reduceIdxFunc
+	addScaledImpl        addScaledFunc
+	convolveDecimateImpl convolveDecimateFunc
 )
 
 func init() {
@@ -88,6 +90,7 @@ func initAVX512() {
 	minIdxImpl = minIdxGo
 	maxIdxImpl = maxIdxGo
 	addScaledImpl = addScaledAVX512
+	convolveDecimateImpl = convolveDecimateAVX512
 }
 
 func initAVX() {
@@ -110,6 +113,7 @@ func initAVX() {
 	minIdxImpl = minIdxGo
 	maxIdxImpl = maxIdxGo
 	addScaledImpl = addScaledAVX
+	convolveDecimateImpl = convolveDecimateAVX
 }
 
 func initSSE() {
@@ -132,6 +136,7 @@ func initSSE() {
 	minIdxImpl = minIdxGo
 	maxIdxImpl = maxIdxGo
 	addScaledImpl = addScaledSSE
+	convolveDecimateImpl = convolveDecimateSSE
 }
 
 func initGo() {
@@ -154,6 +159,7 @@ func initGo() {
 	minIdxImpl = minIdxGo
 	maxIdxImpl = maxIdxGo
 	addScaledImpl = addScaledGo
+	convolveDecimateImpl = convolveDecimate32Go
 }
 
 // Dispatch functions - call function pointers (zero overhead after init)
@@ -268,6 +274,10 @@ func convolveValid32(dst, signal, kernel []float32) {
 	}
 }
 
+func convolveDecimate32(dst, signal, kernel []float32, factor, phase int) {
+	convolveDecimateImpl(dst, signal, kernel, factor, phase)
+}
+
 func accumulateAdd32(dst, src []float32) {
 	// AccumulateAdd is dst += src, which is the same as add(dst, dst, src)
 	addImpl(dst, dst, src)
@@ -301,6 +311,15 @@ func convolveValidMulti32(dsts [][]float32, signal []float32, kernels [][]float3
 //
 //go:noescape
 func dotProductAVX(a, b []float32) float32
+
+//go:noescape
+func convolveDecimateAVX(dst, signal, kernel []float32, factor, phase int)
+
+//go:noescape
+func convolveDecimateAVX512(dst, signal, kernel []float32, factor, phase int)
+
+//go:noescape
+func convolveDecimateSSE(dst, signal, kernel []float32, factor, phase int)
 
 //go:noescape
 func addAVX(dst, a, b []float32)

--- a/f32/f32_amd64.s
+++ b/f32/f32_amd64.s
@@ -4439,3 +4439,275 @@ addsub_scalar:
 addsub_done:
     VZEROUPPER
     RET
+
+// func convolveDecimateAVX(dst, signal, kernel []float32, factor, phase int)
+//
+// Fused decimating valid convolution: for each output k it computes the dot
+// product of signal[pos:pos+kLen] with kernel, then advances pos by factor.
+// The inner dot replicates dotProductAVX exactly (4 accumulators, 32/8/scalar
+// reduction) so results are bit-identical to a per-window DotProductUnsafe.
+// Outer state lives in R8-R14; the inner dot uses SI/DI/CX/AX and Y0-Y5.
+TEXT ·convolveDecimateAVX(SB), NOSPLIT, $0-88
+    MOVQ dst_base+0(FP), R8        // output pointer
+    MOVQ dst_len+8(FP), R9         // n outputs
+    MOVQ signal_base+24(FP), R10   // signal base
+    MOVQ kernel_base+48(FP), R11   // kernel base
+    MOVQ kernel_len+56(FP), R12    // kLen
+    MOVQ factor+72(FP), R13        // factor (elements)
+    MOVQ phase+80(FP), R14         // pos (elements)
+
+    TESTQ R9, R9
+    JZ    cd_avx_ret
+
+cd_avx_outer:
+    LEAQ (R10)(R14*4), SI          // SI = &signal[pos]
+    MOVQ R11, DI                   // DI = &kernel[0]
+
+    VXORPS Y0, Y0, Y0
+    VXORPS Y3, Y3, Y3
+    VXORPS Y4, Y4, Y4
+    VXORPS Y5, Y5, Y5
+
+    MOVQ R12, CX                   // CX = kLen
+    MOVQ CX, AX
+    SHRQ $5, AX                    // kLen / 32
+    JZ   cd_avx_loop8_check
+
+cd_avx_loop32:
+    VMOVUPS (SI), Y1
+    VMOVUPS (DI), Y2
+    VFMADD231PS Y1, Y2, Y0
+    VMOVUPS 32(SI), Y1
+    VMOVUPS 32(DI), Y2
+    VFMADD231PS Y1, Y2, Y3
+    VMOVUPS 64(SI), Y1
+    VMOVUPS 64(DI), Y2
+    VFMADD231PS Y1, Y2, Y4
+    VMOVUPS 96(SI), Y1
+    VMOVUPS 96(DI), Y2
+    VFMADD231PS Y1, Y2, Y5
+    ADDQ $128, SI
+    ADDQ $128, DI
+    DECQ AX
+    JNZ  cd_avx_loop32
+
+    VADDPS Y3, Y0, Y0
+    VADDPS Y4, Y0, Y0
+    VADDPS Y5, Y0, Y0
+
+cd_avx_loop8_check:
+    MOVQ R12, CX
+    ANDQ $31, CX
+    MOVQ CX, AX
+    SHRQ $3, AX
+    JZ   cd_avx_reduce
+
+cd_avx_loop8:
+    VMOVUPS (SI), Y1
+    VMOVUPS (DI), Y2
+    VFMADD231PS Y1, Y2, Y0
+    ADDQ $32, SI
+    ADDQ $32, DI
+    DECQ AX
+    JNZ  cd_avx_loop8
+
+cd_avx_reduce:
+    // Reduce Y0 to X0 before scalar ops (VEX scalar ops zero upper YMM).
+    VEXTRACTF128 $1, Y0, X1
+    VADDPS X1, X0, X0
+    VHADDPS X0, X0, X0
+    VHADDPS X0, X0, X0
+
+    MOVQ R12, CX
+    ANDQ $7, CX
+    JZ   cd_avx_store
+
+cd_avx_scalar:
+    VMOVSS (SI), X1
+    VMOVSS (DI), X2
+    VFMADD231SS X1, X2, X0
+    ADDQ $4, SI
+    ADDQ $4, DI
+    DECQ CX
+    JNZ  cd_avx_scalar
+
+cd_avx_store:
+    VMOVSS X0, (R8)
+    ADDQ $4, R8
+    ADDQ R13, R14                  // pos += factor
+    DECQ R9
+    JNZ  cd_avx_outer
+
+cd_avx_ret:
+    VZEROUPPER
+    RET
+
+// func convolveDecimateAVX512(dst, signal, kernel []float32, factor, phase int)
+//
+// AVX-512 fused decimating valid convolution. Inner dot replicates
+// dotProductAVX512 (4 Z accumulators, 64/16/scalar reduction) for bit-identical
+// results vs a per-window DotProductUnsafe on the AVX-512 path.
+TEXT ·convolveDecimateAVX512(SB), NOSPLIT, $0-88
+    MOVQ dst_base+0(FP), R8
+    MOVQ dst_len+8(FP), R9
+    MOVQ signal_base+24(FP), R10
+    MOVQ kernel_base+48(FP), R11
+    MOVQ kernel_len+56(FP), R12
+    MOVQ factor+72(FP), R13
+    MOVQ phase+80(FP), R14
+
+    TESTQ R9, R9
+    JZ    cd_avx512_ret
+
+cd_avx512_outer:
+    LEAQ (R10)(R14*4), SI
+    MOVQ R11, DI
+
+    VXORPS Z0, Z0, Z0
+    VXORPS Z3, Z3, Z3
+    VXORPS Z4, Z4, Z4
+    VXORPS Z5, Z5, Z5
+
+    MOVQ R12, CX
+    MOVQ CX, AX
+    SHRQ $6, AX                    // kLen / 64
+    JZ   cd_avx512_loop16_check
+
+cd_avx512_loop64:
+    VMOVUPS (SI), Z1
+    VMOVUPS (DI), Z2
+    VFMADD231PS Z1, Z2, Z0
+    VMOVUPS 64(SI), Z1
+    VMOVUPS 64(DI), Z2
+    VFMADD231PS Z1, Z2, Z3
+    VMOVUPS 128(SI), Z1
+    VMOVUPS 128(DI), Z2
+    VFMADD231PS Z1, Z2, Z4
+    VMOVUPS 192(SI), Z1
+    VMOVUPS 192(DI), Z2
+    VFMADD231PS Z1, Z2, Z5
+    ADDQ $256, SI
+    ADDQ $256, DI
+    DECQ AX
+    JNZ  cd_avx512_loop64
+
+    VADDPS Z3, Z0, Z0
+    VADDPS Z4, Z0, Z0
+    VADDPS Z5, Z0, Z0
+
+cd_avx512_loop16_check:
+    MOVQ R12, CX
+    ANDQ $63, CX
+    MOVQ CX, AX
+    SHRQ $4, AX
+    JZ   cd_avx512_reduce
+
+cd_avx512_loop16:
+    VMOVUPS (SI), Z1
+    VMOVUPS (DI), Z2
+    VFMADD231PS Z1, Z2, Z0
+    ADDQ $64, SI
+    ADDQ $64, DI
+    DECQ AX
+    JNZ  cd_avx512_loop16
+
+cd_avx512_reduce:
+    VEXTRACTF32X8 $1, Z0, Y1
+    VADDPS Y1, Y0, Y0
+    VEXTRACTF128 $1, Y0, X1
+    VADDPS X1, X0, X0
+    VHADDPS X0, X0, X0
+    VHADDPS X0, X0, X0
+
+    MOVQ R12, CX
+    ANDQ $15, CX
+    JZ   cd_avx512_store
+
+cd_avx512_scalar:
+    VMOVSS (SI), X1
+    VMOVSS (DI), X2
+    VFMADD231SS X1, X2, X0
+    ADDQ $4, SI
+    ADDQ $4, DI
+    DECQ CX
+    JNZ  cd_avx512_scalar
+
+cd_avx512_store:
+    VMOVSS X0, (R8)
+    ADDQ $4, R8
+    ADDQ R13, R14
+    DECQ R9
+    JNZ  cd_avx512_outer
+
+cd_avx512_ret:
+    VZEROUPPER
+    RET
+
+// func convolveDecimateSSE(dst, signal, kernel []float32, factor, phase int)
+//
+// SSE2 fused decimating valid convolution. Inner dot replicates dotProductSSE
+// (single accumulator, 4-wide loop, SHUFPS horizontal sum) for bit-identical
+// results vs a per-window DotProductUnsafe on the SSE path.
+TEXT ·convolveDecimateSSE(SB), NOSPLIT, $0-88
+    MOVQ dst_base+0(FP), R8
+    MOVQ dst_len+8(FP), R9
+    MOVQ signal_base+24(FP), R10
+    MOVQ kernel_base+48(FP), R11
+    MOVQ kernel_len+56(FP), R12
+    MOVQ factor+72(FP), R13
+    MOVQ phase+80(FP), R14
+
+    TESTQ R9, R9
+    JZ    cd_sse_ret
+
+cd_sse_outer:
+    LEAQ (R10)(R14*4), SI
+    MOVQ R11, DI
+    XORPS X0, X0
+
+    MOVQ R12, CX
+    MOVQ CX, AX
+    SHRQ $2, AX                    // kLen / 4
+    JZ   cd_sse_reduce
+
+cd_sse_loop4:
+    MOVUPS (SI), X1
+    MOVUPS (DI), X2
+    MULPS X2, X1
+    ADDPS X1, X0
+    ADDQ $16, SI
+    ADDQ $16, DI
+    DECQ AX
+    JNZ  cd_sse_loop4
+
+cd_sse_reduce:
+    MOVAPS X0, X1
+    SHUFPS $0x0E, X1, X1
+    ADDPS X1, X0
+    MOVAPS X0, X1
+    SHUFPS $0x01, X1, X1
+    ADDSS X1, X0
+
+    MOVQ R12, CX
+    ANDQ $3, CX
+    JZ   cd_sse_store
+
+cd_sse_scalar:
+    MOVSS (SI), X1
+    MOVSS (DI), X2
+    MULSS X2, X1
+    ADDSS X1, X0
+    ADDQ $4, SI
+    ADDQ $4, DI
+    DECQ CX
+    JNZ  cd_sse_scalar
+
+cd_sse_store:
+    MOVSS X0, (R8)
+    ADDQ $4, R8
+    ADDQ R13, R14
+    DECQ R9
+    JNZ  cd_sse_outer
+
+cd_sse_ret:
+    RET

--- a/f32/f32_amd64.s
+++ b/f32/f32_amd64.s
@@ -4446,7 +4446,9 @@ addsub_done:
 // product of signal[pos:pos+kLen] with kernel, then advances pos by factor.
 // The inner dot replicates dotProductAVX exactly (4 accumulators, 32/8/scalar
 // reduction) so results are bit-identical to a per-window DotProductUnsafe.
-// Outer state lives in R8-R14; the inner dot uses SI/DI/CX/AX and Y0-Y5.
+// Outer state lives in R8-R13 plus BX (pos); the inner dot uses SI/DI/CX/AX and
+// Y0-Y5. BX (not R14) holds pos: R14 is the goroutine g pointer in Go's amd64
+// ABI and must not be clobbered.
 TEXT ·convolveDecimateAVX(SB), NOSPLIT, $0-88
     MOVQ dst_base+0(FP), R8        // output pointer
     MOVQ dst_len+8(FP), R9         // n outputs
@@ -4454,13 +4456,13 @@ TEXT ·convolveDecimateAVX(SB), NOSPLIT, $0-88
     MOVQ kernel_base+48(FP), R11   // kernel base
     MOVQ kernel_len+56(FP), R12    // kLen
     MOVQ factor+72(FP), R13        // factor (elements)
-    MOVQ phase+80(FP), R14         // pos (elements)
+    MOVQ phase+80(FP), BX         // pos (elements)
 
     TESTQ R9, R9
     JZ    cd_avx_ret
 
 cd_avx_outer:
-    LEAQ (R10)(R14*4), SI          // SI = &signal[pos]
+    LEAQ (R10)(BX*4), SI          // SI = &signal[pos]
     MOVQ R11, DI                   // DI = &kernel[0]
 
     VXORPS Y0, Y0, Y0
@@ -4534,7 +4536,7 @@ cd_avx_scalar:
 cd_avx_store:
     VMOVSS X0, (R8)
     ADDQ $4, R8
-    ADDQ R13, R14                  // pos += factor
+    ADDQ R13, BX                  // pos += factor
     DECQ R9
     JNZ  cd_avx_outer
 
@@ -4554,13 +4556,13 @@ TEXT ·convolveDecimateAVX512(SB), NOSPLIT, $0-88
     MOVQ kernel_base+48(FP), R11
     MOVQ kernel_len+56(FP), R12
     MOVQ factor+72(FP), R13
-    MOVQ phase+80(FP), R14
+    MOVQ phase+80(FP), BX
 
     TESTQ R9, R9
     JZ    cd_avx512_ret
 
 cd_avx512_outer:
-    LEAQ (R10)(R14*4), SI
+    LEAQ (R10)(BX*4), SI
     MOVQ R11, DI
 
     VXORPS Z0, Z0, Z0
@@ -4635,7 +4637,7 @@ cd_avx512_scalar:
 cd_avx512_store:
     VMOVSS X0, (R8)
     ADDQ $4, R8
-    ADDQ R13, R14
+    ADDQ R13, BX
     DECQ R9
     JNZ  cd_avx512_outer
 
@@ -4655,13 +4657,13 @@ TEXT ·convolveDecimateSSE(SB), NOSPLIT, $0-88
     MOVQ kernel_base+48(FP), R11
     MOVQ kernel_len+56(FP), R12
     MOVQ factor+72(FP), R13
-    MOVQ phase+80(FP), R14
+    MOVQ phase+80(FP), BX
 
     TESTQ R9, R9
     JZ    cd_sse_ret
 
 cd_sse_outer:
-    LEAQ (R10)(R14*4), SI
+    LEAQ (R10)(BX*4), SI
     MOVQ R11, DI
     XORPS X0, X0
 
@@ -4705,7 +4707,7 @@ cd_sse_scalar:
 cd_sse_store:
     MOVSS X0, (R8)
     ADDQ $4, R8
-    ADDQ R13, R14
+    ADDQ R13, BX
     DECQ R9
     JNZ  cd_sse_outer
 

--- a/f32/f32_arm64.go
+++ b/f32/f32_arm64.go
@@ -135,6 +135,19 @@ func convolveValid32(dst, signal, kernel []float32) {
 	}
 }
 
+func convolveDecimate32(dst, signal, kernel []float32, factor, phase int) {
+	// Mirror dotProduct's NEON length threshold (>= 4) so the fused kernel and a
+	// per-window DotProductUnsafe pick the same backend, keeping results identical.
+	if hasNEON && len(kernel) >= 4 {
+		convolveDecimateNEON(dst, signal, kernel, factor, phase)
+		return
+	}
+	convolveDecimate32Go(dst, signal, kernel, factor, phase)
+}
+
+//go:noescape
+func convolveDecimateNEON(dst, signal, kernel []float32, factor, phase int)
+
 func accumulateAdd32(dst, src []float32) {
 	// AccumulateAdd is dst += src, use add with dst as both operands
 	if hasNEON && len(dst) >= 4 {

--- a/f32/f32_arm64.s
+++ b/f32/f32_arm64.s
@@ -2460,3 +2460,88 @@ addsub_neon_scalar:
 
 addsub_neon_done:
     RET
+
+// func convolveDecimateNEON(dst, signal, kernel []float32, factor, phase int)
+//
+// Fused decimating valid convolution. For each output it computes the dot
+// product of signal[pos:pos+kLen] with kernel, then advances pos by factor.
+// The inner dot replicates dotProductNEON exactly (dual accumulators, 8/4/scalar
+// reduction) so results are bit-identical to a per-window DotProductUnsafe when
+// the kernel is long enough to take the NEON path (the Go dispatcher only calls
+// this for len(kernel) >= 4). Outer state lives in R9-R15; the inner dot uses
+// R0-R4 and V0-V5.
+TEXT ·convolveDecimateNEON(SB), NOSPLIT, $0-88
+    MOVD dst_base+0(FP), R9        // output pointer
+    MOVD dst_len+8(FP), R10        // n outputs
+    MOVD signal_base+24(FP), R11   // signal base
+    MOVD kernel_base+48(FP), R12   // kernel base
+    MOVD kernel_len+56(FP), R13    // kLen
+    MOVD factor+72(FP), R14        // factor (elements)
+    MOVD phase+80(FP), R15         // pos (elements)
+
+    CBZ R10, cd_neon_done
+
+cd_neon_outer:
+    ADD R15<<2, R11, R0            // R0 = &signal[pos]
+    MOVD R12, R1                   // R1 = &kernel[0]
+    MOVD R13, R2                   // R2 = kLen (dot length)
+
+    VEOR V0.B16, V0.B16, V0.B16
+    VEOR V1.B16, V1.B16, V1.B16
+
+    LSR $3, R2, R3                 // kLen / 8
+    CBZ R3, cd_neon_rem4
+
+cd_neon_loop8:
+    VLD1.P 16(R0), [V2.S4]
+    VLD1.P 16(R0), [V3.S4]
+    VLD1.P 16(R1), [V4.S4]
+    VLD1.P 16(R1), [V5.S4]
+    WORD $0x4E24CC40              // FMLA V0.4S, V2.4S, V4.4S
+    WORD $0x4E25CC61              // FMLA V1.4S, V3.4S, V5.4S
+    SUB $1, R3
+    CBNZ R3, cd_neon_loop8
+
+    WORD $0x4E21D400             // FADD V0.4S, V0.4S, V1.4S
+
+cd_neon_rem4:
+    AND $7, R2, R3
+    LSR $2, R3, R4
+    CBZ R4, cd_neon_rem
+
+    VLD1.P 16(R0), [V2.S4]
+    VLD1.P 16(R1), [V4.S4]
+    WORD $0x4E24CC40              // FMLA V0.4S, V2.4S, V4.4S
+
+cd_neon_rem:
+    AND $3, R3, R4
+    CBZ R4, cd_neon_reduce
+
+    // Reduce vector FIRST before scalar ops (scalar ops zero upper V bits).
+    WORD $0x6E20D400             // FADDP V0.4S, V0.4S, V0.4S
+    WORD $0x7E30D800             // FADDP S0, V0.2S
+
+cd_neon_scalar:
+    FMOVS (R0), F2
+    FMOVS (R1), F4
+    FMADDS F4, F0, F2, F0         // F0 = F2 * F4 + F0
+    ADD $4, R0
+    ADD $4, R1
+    SUB $1, R4
+    CBNZ R4, cd_neon_scalar
+
+    B cd_neon_store
+
+cd_neon_reduce:
+    WORD $0x6E20D400             // FADDP V0.4S, V0.4S, V0.4S
+    WORD $0x7E30D800             // FADDP S0, V0.2S
+
+cd_neon_store:
+    FMOVS F0, (R9)
+    ADD $4, R9
+    ADD R14, R15                  // pos += factor
+    SUB $1, R10
+    CBNZ R10, cd_neon_outer
+
+cd_neon_done:
+    RET

--- a/f32/f32_go.go
+++ b/f32/f32_go.go
@@ -205,6 +205,17 @@ func convolveValid32Go(dst, signal, kernel []float32) {
 	}
 }
 
+// convolveDecimate32Go is the pure-Go decimating valid convolution. It is the
+// correctness oracle for the SIMD paths and the fallback on non-asm platforms.
+func convolveDecimate32Go(dst, signal, kernel []float32, factor, phase int) {
+	kLen := len(kernel)
+	pos := phase
+	for k := range dst {
+		dst[k] = dotProductGo(signal[pos:pos+kLen], kernel)
+		pos += factor
+	}
+}
+
 func accumulateAdd32Go(dst, src []float32) {
 	for i := range dst {
 		dst[i] += src[i]

--- a/f32/f32_other.go
+++ b/f32/f32_other.go
@@ -19,7 +19,10 @@ func clamp32(dst, a []float32, minVal, maxVal float32) { clampGo(dst, a, minVal,
 func dotProductBatch32(results []float32, rows [][]float32, vec []float32) {
 	dotProductBatch32Go(results, rows, vec)
 }
-func convolveValid32(dst, signal, kernel []float32)         { convolveValid32Go(dst, signal, kernel) }
+func convolveValid32(dst, signal, kernel []float32) { convolveValid32Go(dst, signal, kernel) }
+func convolveDecimate32(dst, signal, kernel []float32, factor, phase int) {
+	convolveDecimate32Go(dst, signal, kernel, factor, phase)
+}
 func accumulateAdd32(dst, src []float32)                    { accumulateAdd32Go(dst, src) }
 func interleave2_32(dst, a, b []float32)                    { interleave2Go(dst, a, b) }
 func deinterleave2_32(a, b, src []float32)                  { deinterleave2Go(a, b, src) }

--- a/f64/convolve_decimate_amd64_test.go
+++ b/f64/convolve_decimate_amd64_test.go
@@ -1,0 +1,47 @@
+//go:build amd64
+
+package f64
+
+import (
+	"testing"
+
+	"github.com/tphakala/simd/cpu"
+)
+
+// TestConvolveDecimate_Backends validates every amd64 fused kernel this CPU can
+// execute by swapping the dispatch pointers. SSE2 and the Go fallback always run
+// here; AVX is the default on this host; AVX-512 runs only on capable
+// hardware/CI. The AVX-without-FMA path shares the SSE2 dot, matching its
+// convolveDecimateImpl, so it is held to the same bit-exact oracle.
+func TestConvolveDecimate_Backends(t *testing.T) {
+	savedConv := convolveDecimateImpl
+	savedDot := dotProductImpl
+	savedMin := minSIMDElements
+	t.Cleanup(func() {
+		convolveDecimateImpl = savedConv
+		dotProductImpl = savedDot
+		minSIMDElements = savedMin
+	})
+
+	backends := []struct {
+		name string
+		init func()
+		ok   bool
+	}{
+		{"Go", initGo, true},
+		{"SSE2", initSSE2, cpu.X86.SSE2},
+		{"AVXNoFMA", initAVXNoFMA, cpu.X86.AVX},
+		{"AVX", initAVX, cpu.X86.AVX && cpu.X86.FMA},
+		{"AVX512", initAVX512, cpu.X86.AVX512F && cpu.X86.AVX512VL},
+	}
+
+	for _, be := range backends {
+		t.Run(be.name, func(t *testing.T) {
+			if !be.ok {
+				t.Skipf("%s not supported on this CPU", be.name)
+			}
+			be.init()
+			checkConvolveDecimateExact(t)
+		})
+	}
+}

--- a/f64/convolve_decimate_test.go
+++ b/f64/convolve_decimate_test.go
@@ -11,10 +11,10 @@ import (
 // plain Go so the SIMD paths can be checked against it.
 func convolveDecimateRef(signal, kernel []float64, factor, phase int) []float64 {
 	kLen := len(kernel)
-	if kLen == 0 || factor < 1 || phase < 0 {
+	if kLen == 0 || factor < 1 || phase < 0 || len(signal)-kLen-phase < 0 {
 		return nil
 	}
-	var out []float64
+	out := make([]float64, 0, (len(signal)-kLen-phase)/factor+1)
 	for pos := phase; pos+kLen <= len(signal); pos += factor {
 		var sum float64
 		for i := range kLen {
@@ -201,7 +201,7 @@ func checkConvolveDecimateExact(t *testing.T) {
 					kernel := randSlice(kLen)
 					signal := randSlice(sigLen)
 
-					var want []float64
+					want := make([]float64, 0, (sigLen-kLen-phase)/factor+1)
 					for pos := phase; pos+kLen <= sigLen; pos += factor {
 						want = append(want, DotProductUnsafe(signal[pos:pos+kLen], kernel))
 					}

--- a/f64/convolve_decimate_test.go
+++ b/f64/convolve_decimate_test.go
@@ -1,0 +1,285 @@
+package f64
+
+import (
+	"math"
+	"math/rand"
+	"testing"
+)
+
+// convolveDecimateRef is the scalar reference (correctness oracle) for
+// ConvolveDecimate. It computes the same strided valid-convolution outputs in
+// plain Go so the SIMD paths can be checked against it.
+func convolveDecimateRef(signal, kernel []float64, factor, phase int) []float64 {
+	kLen := len(kernel)
+	if kLen == 0 || factor < 1 || phase < 0 {
+		return nil
+	}
+	var out []float64
+	for pos := phase; pos+kLen <= len(signal); pos += factor {
+		var sum float64
+		for i := range kLen {
+			sum += signal[pos+i] * kernel[i]
+		}
+		out = append(out, sum)
+	}
+	return out
+}
+
+func TestConvolveDecimate_Basic(t *testing.T) {
+	tests := []struct {
+		name   string
+		signal []float64
+		kernel []float64
+		factor int
+		phase  int
+		want   []float64
+	}{
+		{
+			name:   "factor1 equals ConvolveValid",
+			signal: []float64{1, 2, 3, 4, 5},
+			kernel: []float64{1, 1, 1},
+			factor: 1,
+			phase:  0,
+			want:   []float64{6, 9, 12},
+		},
+		{
+			name:   "factor2 phase0",
+			signal: []float64{1, 2, 3, 4, 5, 6},
+			kernel: []float64{1, 1, 1},
+			factor: 2,
+			phase:  0,
+			want:   []float64{6, 12},
+		},
+		{
+			name:   "factor2 phase1",
+			signal: []float64{1, 2, 3, 4, 5, 6},
+			kernel: []float64{1, 1, 1},
+			factor: 2,
+			phase:  1,
+			want:   []float64{9, 15},
+		},
+		{
+			name:   "factor3 identity kernel",
+			signal: []float64{1, 2, 3, 4, 5, 6, 7, 8, 9},
+			kernel: []float64{1},
+			factor: 3,
+			phase:  0,
+			want:   []float64{1, 4, 7},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			dst := make([]float64, len(tt.want))
+			ConvolveDecimate(dst, tt.signal, tt.kernel, tt.factor, tt.phase)
+			for i, want := range tt.want {
+				if dst[i] != want {
+					t.Errorf("ConvolveDecimate()[%d] = %v, want %v", i, dst[i], want)
+				}
+			}
+		})
+	}
+}
+
+func TestConvolveDecimate_Edge(t *testing.T) {
+	signal := []float64{1, 2, 3, 4, 5}
+
+	dst := []float64{99, 99}
+	ConvolveDecimate(dst, signal, nil, 1, 0)
+	if dst[0] != 99 || dst[1] != 99 {
+		t.Errorf("empty kernel wrote to dst: %v", dst)
+	}
+
+	dst = []float64{99, 99}
+	ConvolveDecimate(dst, signal, []float64{1}, 0, 0)
+	if dst[0] != 99 || dst[1] != 99 {
+		t.Errorf("factor<1 wrote to dst: %v", dst)
+	}
+
+	dst = []float64{99, 99}
+	ConvolveDecimate(dst, signal, []float64{1}, 1, -1)
+	if dst[0] != 99 || dst[1] != 99 {
+		t.Errorf("negative phase wrote to dst: %v", dst)
+	}
+
+	dst = []float64{99}
+	ConvolveDecimate(dst, []float64{1, 2}, []float64{1, 2, 3}, 1, 0)
+	if dst[0] != 99 {
+		t.Errorf("kernel longer than signal wrote to dst: %v", dst)
+	}
+
+	dst = []float64{99}
+	ConvolveDecimate(dst, signal, []float64{1, 1}, 1, 10)
+	if dst[0] != 99 {
+		t.Errorf("phase past end wrote to dst: %v", dst)
+	}
+
+	dst = []float64{0}
+	ConvolveDecimate(dst, signal, []float64{1}, 1, 0)
+	if dst[0] != 1 {
+		t.Errorf("dst[0] = %v, want 1", dst[0])
+	}
+}
+
+// TestConvolveDecimate_Parity checks the active SIMD path against the scalar
+// reference across the factor/phase/tap/length grid, including ragged tails.
+func TestConvolveDecimate_Parity(t *testing.T) {
+	rng := rand.New(rand.NewSource(0x5117D))
+	randSlice := func(n int) []float64 {
+		s := make([]float64, n)
+		for i := range s {
+			s[i] = rng.Float64()*2 - 1
+		}
+		return s
+	}
+
+	taps := []int{1, 3, 5, 8, 16, 20, 32, 64, 128, 241}
+	factors := []int{1, 2, 3, 4}
+	sigLens := []int{257, 480, 999, 4096, 8191}
+
+	for _, kLen := range taps {
+		for _, factor := range factors {
+			for phase := range factor {
+				for _, sigLen := range sigLens {
+					if sigLen < kLen {
+						continue
+					}
+					kernel := randSlice(kLen)
+					signal := randSlice(sigLen)
+					want := convolveDecimateRef(signal, kernel, factor, phase)
+					dst := make([]float64, len(want))
+					ConvolveDecimate(dst, signal, kernel, factor, phase)
+					for i := range want {
+						// FMA (single rounding) vs scalar mul+add diverge near
+						// cancellations in relative terms; accept small relative
+						// or absolute error.
+						absErr := math.Abs(dst[i] - want[i])
+						relErr := absErr
+						if math.Abs(want[i]) > 1e-12 {
+							relErr = absErr / math.Abs(want[i])
+						}
+						if relErr > 1e-12 && absErr > 1e-12 {
+							t.Fatalf("taps=%d factor=%d phase=%d sigLen=%d: out[%d]=%v want %v (absErr %g)",
+								kLen, factor, phase, sigLen, i, dst[i], want[i], absErr)
+						}
+					}
+				}
+			}
+		}
+	}
+}
+
+// TestConvolveDecimate_MatchesDotProductUnsafe is the rigorous oracle: the fused
+// kernel must produce bit-identical results to a loop calling DotProductUnsafe at
+// the same strided windows on every backend.
+func TestConvolveDecimate_MatchesDotProductUnsafe(t *testing.T) {
+	checkConvolveDecimateExact(t)
+}
+
+func checkConvolveDecimateExact(t *testing.T) {
+	t.Helper()
+	rng := rand.New(rand.NewSource(0xC0FFEE))
+	randSlice := func(n int) []float64 {
+		s := make([]float64, n)
+		for i := range s {
+			s[i] = rng.Float64()*2 - 1
+		}
+		return s
+	}
+
+	taps := []int{1, 3, 5, 8, 16, 20, 32, 64, 128, 241}
+	factors := []int{1, 2, 3, 4}
+	sigLens := []int{257, 480, 999, 4096, 8191}
+
+	for _, kLen := range taps {
+		for _, factor := range factors {
+			for phase := range factor {
+				for _, sigLen := range sigLens {
+					if sigLen < kLen {
+						continue
+					}
+					kernel := randSlice(kLen)
+					signal := randSlice(sigLen)
+
+					var want []float64
+					for pos := phase; pos+kLen <= sigLen; pos += factor {
+						want = append(want, DotProductUnsafe(signal[pos:pos+kLen], kernel))
+					}
+					dst := make([]float64, len(want))
+					ConvolveDecimate(dst, signal, kernel, factor, phase)
+					for i := range want {
+						if dst[i] != want[i] {
+							t.Fatalf("taps=%d factor=%d phase=%d sigLen=%d: out[%d]=%v, DotProductUnsafe=%v (not bit-identical)",
+								kLen, factor, phase, sigLen, i, dst[i], want[i])
+						}
+					}
+				}
+			}
+		}
+	}
+}
+
+func TestConvolveDecimate_AllocFree(t *testing.T) {
+	signal := make([]float64, 4096)
+	kernel := make([]float64, 241)
+	for i := range signal {
+		signal[i] = float64(i%17) * 0.1
+	}
+	for i := range kernel {
+		kernel[i] = 1.0 / 241.0
+	}
+	dst := make([]float64, (len(signal)-len(kernel))/2+1)
+
+	allocs := testing.AllocsPerRun(50, func() {
+		ConvolveDecimate(dst, signal, kernel, 2, 0)
+	})
+	if allocs != 0 {
+		t.Errorf("ConvolveDecimate allocated %v times, want 0", allocs)
+	}
+}
+
+// BenchmarkConvolveDecimate compares the fused primitive against a Go loop
+// calling DotProductUnsafe at each strided window (the status-quo baseline).
+func BenchmarkConvolveDecimate(b *testing.B) {
+	cases := []struct {
+		name         string
+		kLen, factor int
+	}{
+		{"taps20_2x", 20, 2},
+		{"taps32_2x", 32, 2},
+		{"taps64_2x", 64, 2},
+		{"taps241_2x", 241, 2},
+		{"taps241_4x", 241, 4},
+	}
+	const sigLen = 4096
+	for _, c := range cases {
+		signal := make([]float64, sigLen)
+		for i := range signal {
+			signal[i] = float64(i%19) * 0.0517
+		}
+		kernel := make([]float64, c.kLen)
+		for i := range kernel {
+			kernel[i] = 1.0 / float64(c.kLen)
+		}
+		n := (sigLen-c.kLen)/c.factor + 1
+		dst := make([]float64, n)
+		bytes := int64(n * c.kLen * 8 * 2)
+
+		b.Run(c.name+"/Fused", func(b *testing.B) {
+			b.SetBytes(bytes)
+			for b.Loop() {
+				ConvolveDecimate(dst, signal, kernel, c.factor, 0)
+			}
+		})
+		b.Run(c.name+"/DotLoop", func(b *testing.B) {
+			b.SetBytes(bytes)
+			for b.Loop() {
+				pos := 0
+				for k := range dst {
+					dst[k] = DotProductUnsafe(signal[pos:pos+c.kLen], kernel)
+					pos += c.factor
+				}
+			}
+		})
+	}
+}

--- a/f64/convolve_decimate_test.go
+++ b/f64/convolve_decimate_test.go
@@ -102,6 +102,16 @@ func TestConvolveDecimate_Edge(t *testing.T) {
 		t.Errorf("negative phase wrote to dst: %v", dst)
 	}
 
+	// phase >= factor: no-op (precondition phase in [0, factor)).
+	dst = []float64{99, 99}
+	ConvolveDecimate(dst, signal, []float64{1}, 2, 2)
+	if dst[0] != 99 || dst[1] != 99 {
+		t.Errorf("phase>=factor wrote to dst: %v", dst)
+	}
+
+	// empty dst: nothing to write (n == 0), must not panic.
+	ConvolveDecimate([]float64{}, signal, []float64{1}, 1, 0)
+
 	dst = []float64{99}
 	ConvolveDecimate(dst, []float64{1, 2}, []float64{1, 2, 3}, 1, 0)
 	if dst[0] != 99 {
@@ -133,7 +143,7 @@ func TestConvolveDecimate_Parity(t *testing.T) {
 		return s
 	}
 
-	taps := []int{1, 3, 5, 8, 16, 20, 32, 64, 128, 241}
+	taps := []int{1, 4, 7, 16, 20, 32, 64, 128, 241}
 	factors := []int{1, 2, 3, 4}
 	sigLens := []int{257, 480, 999, 4096, 8191}
 
@@ -187,7 +197,7 @@ func checkConvolveDecimateExact(t *testing.T) {
 		return s
 	}
 
-	taps := []int{1, 3, 5, 8, 16, 20, 32, 64, 128, 241}
+	taps := []int{1, 4, 7, 16, 20, 32, 64, 128, 241}
 	factors := []int{1, 2, 3, 4}
 	sigLens := []int{257, 480, 999, 4096, 8191}
 

--- a/f64/f64.go
+++ b/f64/f64.go
@@ -339,6 +339,37 @@ func ConvolveValid(dst, signal, kernel []float64) {
 	convolveValid64(dst[:n], signal, kernel)
 }
 
+// ConvolveDecimate computes a decimating (strided) valid convolution: it keeps
+// only every factor-th valid-convolution output, starting at phase.
+//
+//	dst[k] = sum_{i=0}^{len(kernel)-1} signal[phase + k*factor + i] * kernel[i]
+//
+// The kernel is applied as a plain dot product; pre-reverse it for true
+// convolution (matching DotProductUnsafe and ConvolveValid usage). factor must
+// be >= 1 (factor == 1 is valid convolution at every position) and phase must be
+// in [0, factor); factor < 1 or phase < 0 are treated as no-ops. With factor == 1
+// and phase == 0 this is exactly ConvolveValid.
+//
+// The number of outputs is the count of strided positions whose full kernel
+// window fits in signal; ConvolveDecimate writes min(len(dst), that count) and
+// leaves the remainder of dst untouched. It allocates nothing and operates on
+// the caller-provided buffers.
+func ConvolveDecimate(dst, signal, kernel []float64, factor, phase int) {
+	kLen := len(kernel)
+	if kLen == 0 || factor < 1 || phase < 0 {
+		return
+	}
+	span := len(signal) - kLen - phase
+	if span < 0 {
+		return
+	}
+	n := min(len(dst), span/factor+1)
+	if n == 0 {
+		return
+	}
+	convolveDecimate64(dst[:n], signal, kernel, factor, phase)
+}
+
 // AccumulateAdd adds src to dst starting at offset: dst[offset:offset+len(src)] += src.
 // This is a key primitive for overlap-add in FFT-based convolution.
 //

--- a/f64/f64.go
+++ b/f64/f64.go
@@ -347,8 +347,8 @@ func ConvolveValid(dst, signal, kernel []float64) {
 // The kernel is applied as a plain dot product; pre-reverse it for true
 // convolution (matching DotProductUnsafe and ConvolveValid usage). factor must
 // be >= 1 (factor == 1 is valid convolution at every position) and phase must be
-// in [0, factor); factor < 1 or phase < 0 are treated as no-ops. With factor == 1
-// and phase == 0 this is exactly ConvolveValid.
+// in [0, factor); factor < 1, phase < 0, or phase >= factor are treated as
+// no-ops. With factor == 1 and phase == 0 this is exactly ConvolveValid.
 //
 // The number of outputs is the count of strided positions whose full kernel
 // window fits in signal; ConvolveDecimate writes min(len(dst), that count) and
@@ -356,7 +356,7 @@ func ConvolveValid(dst, signal, kernel []float64) {
 // the caller-provided buffers.
 func ConvolveDecimate(dst, signal, kernel []float64, factor, phase int) {
 	kLen := len(kernel)
-	if kLen == 0 || factor < 1 || phase < 0 {
+	if kLen == 0 || factor < 1 || phase < 0 || phase >= factor {
 		return
 	}
 	span := len(signal) - kLen - phase

--- a/f64/f64_amd64.go
+++ b/f64/f64_amd64.go
@@ -30,6 +30,7 @@ type (
 	interleave2Func       func(dst, a, b []float64)
 	deinterleave2Func     func(a, b, src []float64)
 	addScaledFunc         func(dst []float64, alpha float64, s []float64)
+	convolveDecimateFunc  func(dst, signal, kernel []float64, factor, phase int)
 )
 
 // Function pointers - assigned at init time based on CPU features
@@ -56,6 +57,7 @@ var (
 	interleave2Impl       interleave2Func
 	deinterleave2Impl     deinterleave2Func
 	addScaledImpl         addScaledFunc
+	convolveDecimateImpl  convolveDecimateFunc
 )
 
 func init() {
@@ -99,6 +101,7 @@ func initAVX512() {
 	interleave2Impl = interleave2AVX
 	deinterleave2Impl = deinterleave2AVX
 	addScaledImpl = addScaledAVX512
+	convolveDecimateImpl = convolveDecimateAVX512
 }
 
 func initAVX() {
@@ -125,6 +128,7 @@ func initAVX() {
 	interleave2Impl = interleave2AVX
 	deinterleave2Impl = deinterleave2AVX
 	addScaledImpl = addScaledAVX
+	convolveDecimateImpl = convolveDecimateAVX
 }
 
 // initAVXNoFMA runs on AVX-capable CPUs that lack FMA (rare but possible:
@@ -155,6 +159,7 @@ func initAVXNoFMA() {
 	interleave2Impl = interleave2AVX
 	deinterleave2Impl = deinterleave2AVX
 	addScaledImpl = addScaledSSE2
+	convolveDecimateImpl = convolveDecimateSSE2
 }
 
 func initSSE2() {
@@ -180,6 +185,7 @@ func initSSE2() {
 	interleave2Impl = interleave2SSE2
 	deinterleave2Impl = deinterleave2SSE2
 	addScaledImpl = addScaledSSE2
+	convolveDecimateImpl = convolveDecimateSSE2
 }
 
 func initGo() {
@@ -205,6 +211,7 @@ func initGo() {
 	interleave2Impl = interleave2Go
 	deinterleave2Impl = deinterleave2Go
 	addScaledImpl = addScaledGo64
+	convolveDecimateImpl = convolveDecimate64Go
 }
 
 // Dispatch functions - call function pointers (zero overhead after init)
@@ -327,6 +334,10 @@ func convolveValid64(dst, signal, kernel []float64) {
 	}
 }
 
+func convolveDecimate64(dst, signal, kernel []float64, factor, phase int) {
+	convolveDecimateImpl(dst, signal, kernel, factor, phase)
+}
+
 func accumulateAdd64(dst, src []float64) {
 	// AccumulateAdd is dst += src, which is the same as add(dst, dst, src)
 	addImpl(dst, dst, src)
@@ -447,6 +458,15 @@ func sigmoidAVX(dst, src []float64)
 //
 //go:noescape
 func dotProductAVX(a, b []float64) float64
+
+//go:noescape
+func convolveDecimateAVX(dst, signal, kernel []float64, factor, phase int)
+
+//go:noescape
+func convolveDecimateAVX512(dst, signal, kernel []float64, factor, phase int)
+
+//go:noescape
+func convolveDecimateSSE2(dst, signal, kernel []float64, factor, phase int)
 
 //go:noescape
 func addAVX(dst, a, b []float64)

--- a/f64/f64_amd64.s
+++ b/f64/f64_amd64.s
@@ -3928,7 +3928,9 @@ round_avx_done:
 // product of signal[pos:pos+kLen] with kernel, then advances pos by factor.
 // The inner dot replicates dotProductAVX exactly (4 accumulators, 16/4/scalar
 // reduction) so results are bit-identical to a per-window DotProductUnsafe.
-// Outer state lives in R8-R14; the inner dot uses SI/DI/CX/AX and Y0-Y5.
+// Outer state lives in R8-R13 plus BX (pos); the inner dot uses SI/DI/CX/AX and
+// Y0-Y5. BX (not R14) holds pos: R14 is the goroutine g pointer in Go's amd64
+// ABI and must not be clobbered.
 TEXT ·convolveDecimateAVX(SB), NOSPLIT, $0-88
     MOVQ dst_base+0(FP), R8        // output pointer
     MOVQ dst_len+8(FP), R9         // n outputs
@@ -3936,13 +3938,13 @@ TEXT ·convolveDecimateAVX(SB), NOSPLIT, $0-88
     MOVQ kernel_base+48(FP), R11   // kernel base
     MOVQ kernel_len+56(FP), R12    // kLen
     MOVQ factor+72(FP), R13        // factor (elements)
-    MOVQ phase+80(FP), R14         // pos (elements)
+    MOVQ phase+80(FP), BX         // pos (elements)
 
     TESTQ R9, R9
     JZ    cd_avx_ret
 
 cd_avx_outer:
-    LEAQ (R10)(R14*8), SI          // SI = &signal[pos]
+    LEAQ (R10)(BX*8), SI          // SI = &signal[pos]
     MOVQ R11, DI                   // DI = &kernel[0]
 
     VXORPD Y0, Y0, Y0
@@ -4014,7 +4016,7 @@ cd_avx_scalar:
 cd_avx_store:
     VMOVSD X0, (R8)
     ADDQ $8, R8
-    ADDQ R13, R14                  // pos += factor
+    ADDQ R13, BX                  // pos += factor
     DECQ R9
     JNZ  cd_avx_outer
 
@@ -4034,13 +4036,13 @@ TEXT ·convolveDecimateAVX512(SB), NOSPLIT, $0-88
     MOVQ kernel_base+48(FP), R11
     MOVQ kernel_len+56(FP), R12
     MOVQ factor+72(FP), R13
-    MOVQ phase+80(FP), R14
+    MOVQ phase+80(FP), BX
 
     TESTQ R9, R9
     JZ    cd_avx512_ret
 
 cd_avx512_outer:
-    LEAQ (R10)(R14*8), SI
+    LEAQ (R10)(BX*8), SI
     MOVQ R11, DI
 
     VXORPD Z0, Z0, Z0
@@ -4114,7 +4116,7 @@ cd_avx512_scalar:
 cd_avx512_store:
     VMOVSD X0, (R8)
     ADDQ $8, R8
-    ADDQ R13, R14
+    ADDQ R13, BX
     DECQ R9
     JNZ  cd_avx512_outer
 
@@ -4135,13 +4137,13 @@ TEXT ·convolveDecimateSSE2(SB), NOSPLIT, $0-88
     MOVQ kernel_base+48(FP), R11
     MOVQ kernel_len+56(FP), R12
     MOVQ factor+72(FP), R13
-    MOVQ phase+80(FP), R14
+    MOVQ phase+80(FP), BX
 
     TESTQ R9, R9
     JZ    cd_sse2_ret
 
 cd_sse2_outer:
-    LEAQ (R10)(R14*8), SI
+    LEAQ (R10)(BX*8), SI
     MOVQ R11, DI
     XORPD X0, X0
 
@@ -4177,7 +4179,7 @@ cd_sse2_reduce:
 cd_sse2_store:
     MOVSD X0, (R8)
     ADDQ $8, R8
-    ADDQ R13, R14
+    ADDQ R13, BX
     DECQ R9
     JNZ  cd_sse2_outer
 

--- a/f64/f64_amd64.s
+++ b/f64/f64_amd64.s
@@ -3921,3 +3921,265 @@ round_avx_scalar:
 round_avx_done:
     VZEROUPPER
     RET
+
+// func convolveDecimateAVX(dst, signal, kernel []float64, factor, phase int)
+//
+// Fused decimating valid convolution. For each output k it computes the dot
+// product of signal[pos:pos+kLen] with kernel, then advances pos by factor.
+// The inner dot replicates dotProductAVX exactly (4 accumulators, 16/4/scalar
+// reduction) so results are bit-identical to a per-window DotProductUnsafe.
+// Outer state lives in R8-R14; the inner dot uses SI/DI/CX/AX and Y0-Y5.
+TEXT ·convolveDecimateAVX(SB), NOSPLIT, $0-88
+    MOVQ dst_base+0(FP), R8        // output pointer
+    MOVQ dst_len+8(FP), R9         // n outputs
+    MOVQ signal_base+24(FP), R10   // signal base
+    MOVQ kernel_base+48(FP), R11   // kernel base
+    MOVQ kernel_len+56(FP), R12    // kLen
+    MOVQ factor+72(FP), R13        // factor (elements)
+    MOVQ phase+80(FP), R14         // pos (elements)
+
+    TESTQ R9, R9
+    JZ    cd_avx_ret
+
+cd_avx_outer:
+    LEAQ (R10)(R14*8), SI          // SI = &signal[pos]
+    MOVQ R11, DI                   // DI = &kernel[0]
+
+    VXORPD Y0, Y0, Y0
+    VXORPD Y3, Y3, Y3
+    VXORPD Y4, Y4, Y4
+    VXORPD Y5, Y5, Y5
+
+    MOVQ R12, CX                   // CX = kLen
+    MOVQ CX, AX
+    SHRQ $4, AX                    // kLen / 16
+    JZ   cd_avx_loop4_check
+
+cd_avx_loop16:
+    VMOVUPD (SI), Y1
+    VMOVUPD (DI), Y2
+    VFMADD231PD Y1, Y2, Y0
+    VMOVUPD 32(SI), Y1
+    VMOVUPD 32(DI), Y2
+    VFMADD231PD Y1, Y2, Y3
+    VMOVUPD 64(SI), Y1
+    VMOVUPD 64(DI), Y2
+    VFMADD231PD Y1, Y2, Y4
+    VMOVUPD 96(SI), Y1
+    VMOVUPD 96(DI), Y2
+    VFMADD231PD Y1, Y2, Y5
+    ADDQ $128, SI
+    ADDQ $128, DI
+    DECQ AX
+    JNZ  cd_avx_loop16
+
+    VADDPD Y3, Y0, Y0
+    VADDPD Y4, Y0, Y0
+    VADDPD Y5, Y0, Y0
+
+cd_avx_loop4_check:
+    MOVQ R12, CX
+    ANDQ $15, CX
+    MOVQ CX, AX
+    SHRQ $2, AX
+    JZ   cd_avx_reduce
+
+cd_avx_loop4:
+    VMOVUPD (SI), Y1
+    VMOVUPD (DI), Y2
+    VFMADD231PD Y1, Y2, Y0
+    ADDQ $32, SI
+    ADDQ $32, DI
+    DECQ AX
+    JNZ  cd_avx_loop4
+
+cd_avx_reduce:
+    VEXTRACTF128 $1, Y0, X1
+    VADDPD X1, X0, X0
+    VHADDPD X0, X0, X0
+
+    MOVQ R12, CX
+    ANDQ $3, CX
+    JZ   cd_avx_store
+
+cd_avx_scalar:
+    VMOVSD (SI), X1
+    VMOVSD (DI), X2
+    VFMADD231SD X1, X2, X0
+    ADDQ $8, SI
+    ADDQ $8, DI
+    DECQ CX
+    JNZ  cd_avx_scalar
+
+cd_avx_store:
+    VMOVSD X0, (R8)
+    ADDQ $8, R8
+    ADDQ R13, R14                  // pos += factor
+    DECQ R9
+    JNZ  cd_avx_outer
+
+cd_avx_ret:
+    VZEROUPPER
+    RET
+
+// func convolveDecimateAVX512(dst, signal, kernel []float64, factor, phase int)
+//
+// AVX-512 fused decimating valid convolution. Inner dot replicates
+// dotProductAVX512 (4 Z accumulators, 32/8/scalar reduction) for bit-identical
+// results vs a per-window DotProductUnsafe on the AVX-512 path.
+TEXT ·convolveDecimateAVX512(SB), NOSPLIT, $0-88
+    MOVQ dst_base+0(FP), R8
+    MOVQ dst_len+8(FP), R9
+    MOVQ signal_base+24(FP), R10
+    MOVQ kernel_base+48(FP), R11
+    MOVQ kernel_len+56(FP), R12
+    MOVQ factor+72(FP), R13
+    MOVQ phase+80(FP), R14
+
+    TESTQ R9, R9
+    JZ    cd_avx512_ret
+
+cd_avx512_outer:
+    LEAQ (R10)(R14*8), SI
+    MOVQ R11, DI
+
+    VXORPD Z0, Z0, Z0
+    VXORPD Z3, Z3, Z3
+    VXORPD Z4, Z4, Z4
+    VXORPD Z5, Z5, Z5
+
+    MOVQ R12, CX
+    MOVQ CX, AX
+    SHRQ $5, AX                    // kLen / 32
+    JZ   cd_avx512_loop8_check
+
+cd_avx512_loop32:
+    VMOVUPD (SI), Z1
+    VMOVUPD (DI), Z2
+    VFMADD231PD Z1, Z2, Z0
+    VMOVUPD 64(SI), Z1
+    VMOVUPD 64(DI), Z2
+    VFMADD231PD Z1, Z2, Z3
+    VMOVUPD 128(SI), Z1
+    VMOVUPD 128(DI), Z2
+    VFMADD231PD Z1, Z2, Z4
+    VMOVUPD 192(SI), Z1
+    VMOVUPD 192(DI), Z2
+    VFMADD231PD Z1, Z2, Z5
+    ADDQ $256, SI
+    ADDQ $256, DI
+    DECQ AX
+    JNZ  cd_avx512_loop32
+
+    VADDPD Z3, Z0, Z0
+    VADDPD Z4, Z0, Z0
+    VADDPD Z5, Z0, Z0
+
+cd_avx512_loop8_check:
+    MOVQ R12, CX
+    ANDQ $31, CX
+    MOVQ CX, AX
+    SHRQ $3, AX
+    JZ   cd_avx512_reduce
+
+cd_avx512_loop8:
+    VMOVUPD (SI), Z1
+    VMOVUPD (DI), Z2
+    VFMADD231PD Z1, Z2, Z0
+    ADDQ $64, SI
+    ADDQ $64, DI
+    DECQ AX
+    JNZ  cd_avx512_loop8
+
+cd_avx512_reduce:
+    VEXTRACTF64X4 $1, Z0, Y1
+    VADDPD Y1, Y0, Y0
+    VEXTRACTF128 $1, Y0, X1
+    VADDPD X1, X0, X0
+    VHADDPD X0, X0, X0
+
+    MOVQ R12, CX
+    ANDQ $7, CX
+    JZ   cd_avx512_store
+
+cd_avx512_scalar:
+    VMOVSD (SI), X1
+    VMOVSD (DI), X2
+    VFMADD231SD X1, X2, X0
+    ADDQ $8, SI
+    ADDQ $8, DI
+    DECQ CX
+    JNZ  cd_avx512_scalar
+
+cd_avx512_store:
+    VMOVSD X0, (R8)
+    ADDQ $8, R8
+    ADDQ R13, R14
+    DECQ R9
+    JNZ  cd_avx512_outer
+
+cd_avx512_ret:
+    VZEROUPPER
+    RET
+
+// func convolveDecimateSSE2(dst, signal, kernel []float64, factor, phase int)
+//
+// SSE2 fused decimating valid convolution (also used on the AVX-without-FMA
+// path, which selects the SSE2 dot). Inner dot replicates dotProductSSE2
+// (single accumulator, 2-wide loop, SHUFPD horizontal sum) for bit-identical
+// results vs a per-window DotProductUnsafe on those paths.
+TEXT ·convolveDecimateSSE2(SB), NOSPLIT, $0-88
+    MOVQ dst_base+0(FP), R8
+    MOVQ dst_len+8(FP), R9
+    MOVQ signal_base+24(FP), R10
+    MOVQ kernel_base+48(FP), R11
+    MOVQ kernel_len+56(FP), R12
+    MOVQ factor+72(FP), R13
+    MOVQ phase+80(FP), R14
+
+    TESTQ R9, R9
+    JZ    cd_sse2_ret
+
+cd_sse2_outer:
+    LEAQ (R10)(R14*8), SI
+    MOVQ R11, DI
+    XORPD X0, X0
+
+    MOVQ R12, CX
+    MOVQ CX, AX
+    SHRQ $1, AX                    // kLen / 2
+    JZ   cd_sse2_reduce
+
+cd_sse2_loop2:
+    MOVUPD (SI), X1
+    MOVUPD (DI), X2
+    MULPD X2, X1
+    ADDPD X1, X0
+    ADDQ $16, SI
+    ADDQ $16, DI
+    DECQ AX
+    JNZ  cd_sse2_loop2
+
+cd_sse2_reduce:
+    MOVAPD X0, X1
+    SHUFPD $1, X1, X1
+    ADDSD X1, X0
+
+    MOVQ R12, CX
+    ANDQ $1, CX
+    JZ   cd_sse2_store
+
+    MOVSD (SI), X1
+    MOVSD (DI), X2
+    MULSD X2, X1
+    ADDSD X1, X0
+
+cd_sse2_store:
+    MOVSD X0, (R8)
+    ADDQ $8, R8
+    ADDQ R13, R14
+    DECQ R9
+    JNZ  cd_sse2_outer
+
+cd_sse2_ret:
+    RET

--- a/f64/f64_arm64.go
+++ b/f64/f64_arm64.go
@@ -188,6 +188,19 @@ func convolveValid64(dst, signal, kernel []float64) {
 	}
 }
 
+func convolveDecimate64(dst, signal, kernel []float64, factor, phase int) {
+	// Mirror dotProduct's NEON length threshold (>= 2) so the fused kernel and a
+	// per-window DotProductUnsafe pick the same backend, keeping results identical.
+	if hasNEON && len(kernel) >= 2 {
+		convolveDecimateNEON(dst, signal, kernel, factor, phase)
+		return
+	}
+	convolveDecimate64Go(dst, signal, kernel, factor, phase)
+}
+
+//go:noescape
+func convolveDecimateNEON(dst, signal, kernel []float64, factor, phase int)
+
 func accumulateAdd64(dst, src []float64) {
 	// AccumulateAdd is dst += src, use add with dst as both operands
 	if hasNEON && len(dst) >= 2 {

--- a/f64/f64_arm64.s
+++ b/f64/f64_arm64.s
@@ -1465,3 +1465,80 @@ round_scalar:
 
 round_done:
     RET
+
+// func convolveDecimateNEON(dst, signal, kernel []float64, factor, phase int)
+//
+// Fused decimating valid convolution. For each output it computes the dot
+// product of signal[pos:pos+kLen] with kernel, then advances pos by factor.
+// The inner dot replicates dotProductNEON exactly (dual accumulators, 4/2/scalar
+// reduction) so results are bit-identical to a per-window DotProductUnsafe when
+// the kernel takes the NEON path (the Go dispatcher only calls this for
+// len(kernel) >= 2). Outer state lives in R9-R15; the inner dot uses R0-R4 and
+// V0-V5.
+TEXT ·convolveDecimateNEON(SB), NOSPLIT, $0-88
+    MOVD dst_base+0(FP), R9
+    MOVD dst_len+8(FP), R10
+    MOVD signal_base+24(FP), R11
+    MOVD kernel_base+48(FP), R12
+    MOVD kernel_len+56(FP), R13
+    MOVD factor+72(FP), R14
+    MOVD phase+80(FP), R15
+
+    CBZ R10, cd_neon_done
+
+cd_neon_outer:
+    ADD R15<<3, R11, R0           // R0 = &signal[pos]
+    MOVD R12, R1
+    MOVD R13, R2                  // R2 = kLen
+
+    VEOR V0.B16, V0.B16, V0.B16
+    VEOR V1.B16, V1.B16, V1.B16
+
+    LSR $2, R2, R3                // kLen / 4
+    CBZ R3, cd_neon_rem2
+
+cd_neon_loop4:
+    VLD1.P 16(R0), [V2.D2]
+    VLD1.P 16(R0), [V3.D2]
+    VLD1.P 16(R1), [V4.D2]
+    VLD1.P 16(R1), [V5.D2]
+    WORD $0x4E64CC40             // FMLA V0.2D, V2.2D, V4.2D
+    WORD $0x4E65CC61             // FMLA V1.2D, V3.2D, V5.2D
+    SUB $1, R3
+    CBNZ R3, cd_neon_loop4
+
+    WORD $0x4E61D400            // FADD V0.2D, V0.2D, V1.2D
+
+cd_neon_rem2:
+    AND $3, R2, R3
+    LSR $1, R3, R4
+    CBZ R4, cd_neon_rem1
+
+    VLD1.P 16(R0), [V2.D2]
+    VLD1.P 16(R1), [V4.D2]
+    WORD $0x4E64CC40            // FMLA V0.2D, V2.2D, V4.2D
+
+cd_neon_rem1:
+    AND $1, R3, R4
+    CBZ R4, cd_neon_reduce
+
+    // Reduce vector FIRST before scalar op (scalar ops zero upper V bits).
+    WORD $0x7E70D800           // FADDP D0, V0.2D
+    FMOVD (R0), F2
+    FMOVD (R1), F4
+    FMADDD F4, F0, F2, F0        // F0 = F2 * F4 + F0
+
+    B cd_neon_store
+
+cd_neon_reduce:
+    WORD $0x7E70D800           // FADDP D0, V0.2D
+
+cd_neon_store:
+    FMOVD F0, (R9)
+    ADD $8, R9
+    ADD R14, R15
+    SUB $1, R10
+    CBNZ R10, cd_neon_outer
+
+cd_neon_done:
+    RET

--- a/f64/f64_go.go
+++ b/f64/f64_go.go
@@ -303,6 +303,17 @@ func convolveValid64Go(dst, signal, kernel []float64) {
 	}
 }
 
+// convolveDecimate64Go is the pure-Go decimating valid convolution. It is the
+// correctness oracle for the SIMD paths and the fallback on non-asm platforms.
+func convolveDecimate64Go(dst, signal, kernel []float64, factor, phase int) {
+	kLen := len(kernel)
+	pos := phase
+	for k := range dst {
+		dst[k] = dotProductGo(signal[pos:pos+kLen], kernel)
+		pos += factor
+	}
+}
+
 func accumulateAdd64Go(dst, src []float64) {
 	for i := range dst {
 		dst[i] += src[i]

--- a/f64/f64_other.go
+++ b/f64/f64_other.go
@@ -29,9 +29,12 @@ func dotProductBatch64(results []float64, rows [][]float64, vec []float64) {
 	dotProductBatch64Go(results, rows, vec)
 }
 func convolveValid64(dst, signal, kernel []float64) { convolveValid64Go(dst, signal, kernel) }
-func accumulateAdd64(dst, src []float64)            { accumulateAdd64Go(dst, src) }
-func interleave2_64(dst, a, b []float64)            { interleave2Go(dst, a, b) }
-func deinterleave2_64(a, b, src []float64)          { deinterleave2Go(a, b, src) }
+func convolveDecimate64(dst, signal, kernel []float64, factor, phase int) {
+	convolveDecimate64Go(dst, signal, kernel, factor, phase)
+}
+func accumulateAdd64(dst, src []float64)   { accumulateAdd64Go(dst, src) }
+func interleave2_64(dst, a, b []float64)   { interleave2Go(dst, a, b) }
+func deinterleave2_64(a, b, src []float64) { deinterleave2Go(a, b, src) }
 func convolveValidMulti64(dsts [][]float64, signal []float64, kernels [][]float64, n, kLen int) {
 	convolveValidMultiGo(dsts, signal, kernels, n, kLen)
 }


### PR DESCRIPTION
## What

Adds `ConvolveDecimate(dst, signal, kernel []T, factor, phase int)` to `f32` and `f64`, a decimating (strided) valid convolution that keeps every `factor`-th valid-convolution output starting at `phase`:

```
dst[k] = sum_{i} signal[phase + k*factor + i] * kernel[i]
```

With `factor == 1, phase == 0` it is exactly `ConvolveValid`. This implements the first PR-sized item from the resampling tracking issue (#54): the integer-ratio FIR downsample path (96k/192k -> 48k) that go-audio-resampler runs today as a Go loop of per-window `DotProductUnsafe` calls. The fused primitive collapses that loop into one allocation-free call.

## How

The outer stride loop lives in assembly, holding the kernel pointer/length and the signal offset in registers across outputs. The inner dot product replicates the existing `dotProduct` kernels exactly, so every output is **bit-identical** to a per-window `DotProductUnsafe`.

- Backends: **AVX-512, AVX+FMA, SSE2** (amd64) and **NEON** (arm64), plus a pure-Go fallback.
- Allocation-free; operates on caller-provided buffers (preserves the zero-alloc streaming contract).
- The arm64 dispatch mirrors `dotProduct`'s NEON length threshold (>= 4 for f32, >= 2 for f64) so the fused kernel and a per-window dot select the same backend, keeping results identical.

## Performance

Speedup over the per-window `DotProductUnsafe` loop (the realistic consumer baseline; signal length 4096, allocation-free). The win is largest for short kernels, where the baseline's per-output call, dispatch and `VZEROUPPER` overhead dominates.

| Config | f32 x86 (AVX2) | f64 x86 (AVX2) | f32 NEON (Pi 5) | f64 NEON (Pi 5) |
|--------|------|------|------|------|
| 20 taps, 2x | 2.0x | 2.3x | 1.7x | 1.9x |
| 32 taps, 2x | 2.3x | 1.7x | 1.9x | 1.7x |
| 64 taps, 2x | 2.0x | 1.8x | 1.7x | 1.3x |
| 241 taps, 2x | 1.5x | 1.3x | 1.2x | 1.1x |
| 241 taps, 4x | 1.4x | 1.2x | 1.2x | 1.1x |

## Validation

- **Bit-exact oracle**: output is bit-identical to a `DotProductUnsafe` loop at the same strided windows, checked across factors {1..4}, every phase, tap counts {1,4,7,16,20,32,64,128,241} and ragged signal lengths.
- **Per-backend**: a pointer-swap test exercises every kernel the host CPU can run: Go/SSE/AVX (f32) and Go/SSE2/AVXNoFMA/AVX (f64) on this x86-64 host. The **NEON f32 and f64 kernels were run and validated bit-exact on real aarch64 hardware** (Raspberry Pi 5).
- **AVX-512** is build- and `go vet` (asmdecl) checked; it will run on capable CI.
- Scalar-reference parity, edge cases (empty kernel, `factor < 1`, negative/past-end phase, short dst), allocation-free, and `-race` all pass.

Closes #51. Part of #54.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added ConvolveDecimate: decimating (strided) valid convolution API with optimized implementations and fallbacks.

* **Documentation**
  * Added docs and a performance subsection with benchmarks comparing SIMD backends across kernel sizes and decimation factors.

* **Tests**
  * Added extensive cross-ISA tests and benchmarks validating correctness, edge cases, bit-identical backends, allocation behavior, and performance.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->