### PR TITLE
f32/f64: add InterleaveN/DeinterleaveN N-stream scatter/gather

### DIFF
--- a/README.md
+++ b/README.md
@@ -127,8 +127,8 @@ fmt.Println(cpu.HasFP16())     // true/false (ARM64 half-precision SIMD)
 |                 | `AccumulateAdd(dst, src, off)`      | Overlap-add: dst[off:] += src | 8x / 4x / 2x                        |
 | **Audio**       | `Interleave2(dst, a, b)`            | Pack stereo: [L,R,L,R,...]    | 4x / 2x                             |
 |                 | `Deinterleave2(a, b, src)`          | Unpack stereo to channels     | 4x / 2x                             |
-|                 | `InterleaveN(dst, srcs)`            | Pack N planar streams (N-stream Interleave2) | N=2,4 AVX / N=2,3,4 NEON |
-|                 | `DeinterleaveN(dsts, src)`          | Unpack N interleaved streams  | N=2,4 AVX / N=2,3,4 NEON            |
+|                 | `InterleaveN(dst, srcs)`            | Pack N planar streams (any N; N-stream Interleave2) | N=2,4 AVX / N=2,3,4 NEON; else Go |
+|                 | `DeinterleaveN(dsts, src)`          | Unpack N interleaved streams (any N) | N=2,4 AVX / N=2,3,4 NEON; else Go |
 |                 | `CubicInterpDot(hist,a,b,c,d,x)`    | Fused cubic interp dot product| 4x / 2x                             |
 |                 | `Int32ToFloat32Scale(dst,src,s)`    | PCM int32 to normalized float | 8x / 4x                             |
 |                 | `Int16ToFloat32Scale(dst,src,s)`    | PCM int16 to normalized float | 8x (AVX2) / 4x (NEON)               |

--- a/README.md
+++ b/README.md
@@ -127,6 +127,8 @@ fmt.Println(cpu.HasFP16())     // true/false (ARM64 half-precision SIMD)
 |                 | `AccumulateAdd(dst, src, off)`      | Overlap-add: dst[off:] += src | 8x / 4x / 2x                        |
 | **Audio**       | `Interleave2(dst, a, b)`            | Pack stereo: [L,R,L,R,...]    | 4x / 2x                             |
 |                 | `Deinterleave2(a, b, src)`          | Unpack stereo to channels     | 4x / 2x                             |
+|                 | `InterleaveN(dst, srcs)`            | Pack N planar streams (N-stream Interleave2) | N=2,4 AVX / N=2,3,4 NEON |
+|                 | `DeinterleaveN(dsts, src)`          | Unpack N interleaved streams  | N=2,4 AVX / N=2,3,4 NEON            |
 |                 | `CubicInterpDot(hist,a,b,c,d,x)`    | Fused cubic interp dot product| 4x / 2x                             |
 |                 | `Int32ToFloat32Scale(dst,src,s)`    | PCM int32 to normalized float | 8x / 4x                             |
 |                 | `Int16ToFloat32Scale(dst,src,s)`    | PCM int16 to normalized float | 8x (AVX2) / 4x (NEON)               |
@@ -142,6 +144,10 @@ Same API as `f64` but for `float32` with wider SIMD:
 | AMD64 (AVX+FMA) | 8x float32  |
 | AMD64 (SSE2)    | 4x float32  |
 | ARM64 (NEON)    | 4x float32  |
+
+`InterleaveN`/`DeinterleaveN` add an 8-stream AVX path (8x8 register transpose) on
+top of the shared N=2/4 (AVX) and N=2/3/4 (NEON) kernels; all other stream counts
+use the allocation-free generic path.
 
 **Additional split-format complex operations** (for FFT pipelines with separate real/imag arrays):
 

--- a/f32/f32.go
+++ b/f32/f32.go
@@ -273,6 +273,62 @@ func Deinterleave2(a, b, src []float32) {
 
 const interleave2Channels = 2
 
+// InterleaveN interleaves N planar streams into a single interleaved buffer:
+//
+//	dst[i*N + c] = srcs[c][i],   N = len(srcs)
+//
+// It is the N-stream generalization of Interleave2. N == 1 copies srcs[0] into
+// dst; N == 2 produces the same result as Interleave2. The number of frames
+// written is min(len(dst)/N, min over c of len(srcs[c])); dst beyond n*N and any
+// ragged source tails are left untouched. An empty srcs is a no-op.
+//
+// This is the planar -> interleaved direction for multichannel audio (for
+// example combining per-phase polyphase outputs into one stream). It allocates
+// nothing and operates on the caller-provided buffers.
+func InterleaveN(dst []float32, srcs [][]float32) {
+	nc := len(srcs)
+	if nc == 0 {
+		return
+	}
+	n := len(dst) / nc
+	for _, s := range srcs {
+		if len(s) < n {
+			n = len(s)
+		}
+	}
+	if n == 0 {
+		return
+	}
+	interleaveN32(dst, srcs, n)
+}
+
+// DeinterleaveN splits one interleaved buffer into N planar streams:
+//
+//	dsts[c][i] = src[i*N + c],   N = len(dsts)
+//
+// It is the inverse of InterleaveN and the N-stream generalization of
+// Deinterleave2. N == 1 copies src into dsts[0]; N == 2 produces the same result
+// as Deinterleave2. The number of frames written is min(len(src)/N, min over c
+// of len(dsts[c])); any ragged destination tails are left untouched. An empty
+// dsts is a no-op. It allocates nothing and operates on the caller-provided
+// buffers.
+func DeinterleaveN(dsts [][]float32, src []float32) {
+	nc := len(dsts)
+	if nc == 0 {
+		return
+	}
+	n := len(src) / nc
+	for _, d := range dsts {
+		if len(d) < n {
+			n = len(d)
+		}
+	}
+	if n == 0 {
+		return
+	}
+	deinterleaveN32(dsts, src, n)
+}
+
 // Sqrt computes element-wise square root: dst[i] = sqrt(a[i]).
 // Processes min(len(dst), len(a)) elements.
 func Sqrt(dst, a []float32) {

--- a/f32/f32_amd64.go
+++ b/f32/f32_amd64.go
@@ -300,6 +300,96 @@ func deinterleave2_32(a, b, src []float32) {
 	deinterleave2Go(a, b, src)
 }
 
+// interleaveN32 interleaves nc = len(srcs) planar streams into dst. N == 2
+// reuses the existing Interleave2 SIMD; other small N use shuffle-based
+// transposes (added incrementally); the rest fall back to the generic Go path.
+// Stream counts with dedicated AMD64 SIMD interleave/deinterleave kernels (the
+// 2-stream path reuses interleave2Channels). interleave4BlockMask/8 align a
+// frame count down to a whole SIMD block; the caller handles the remainder.
+const (
+	interleave4Streams   = 4
+	interleave8Streams   = 8
+	interleave4BlockMask = interleave4Streams - 1
+	interleave8BlockMask = interleave8Streams - 1
+)
+
+func interleaveN32(dst []float32, srcs [][]float32, n int) {
+	switch len(srcs) {
+	case interleave2Channels:
+		interleave2_32(dst[:n*interleave2Channels], srcs[0][:n], srcs[1][:n])
+	case interleave4Streams:
+		if cpu.X86.AVX && n >= interleave4Streams {
+			blk := n &^ interleave4BlockMask
+			interleave4AVX(dst, srcs[0], srcs[1], srcs[2], srcs[3], blk)
+			interleaveNTailGo(dst, srcs, blk, n)
+			return
+		}
+		interleaveNGo(dst, srcs, n)
+	case interleave8Streams:
+		if cpu.X86.AVX && n >= interleave8Streams {
+			blk := n &^ interleave8BlockMask
+			interleave8AVX(dst, srcs, blk)
+			interleaveNTailGo(dst, srcs, blk, n)
+			return
+		}
+		interleaveNGo(dst, srcs, n)
+	default:
+		interleaveNGo(dst, srcs, n)
+	}
+}
+
+// interleaveNTailGo writes the trailing frames [from, n) of an N-stream
+// interleave that an asm kernel left after processing whole SIMD blocks. It
+// reslices nothing in srcs, so it stays allocation-free.
+func interleaveNTailGo(dst []float32, srcs [][]float32, from, n int) {
+	nc := len(srcs)
+	for i := from; i < n; i++ {
+		base := i * nc
+		for c := range nc {
+			dst[base+c] = srcs[c][i]
+		}
+	}
+}
+
+// deinterleaveNTailGo writes the trailing frames [from, n) of an N-stream
+// deinterleave, allocation-free.
+func deinterleaveNTailGo(dsts [][]float32, src []float32, from, n int) {
+	nc := len(dsts)
+	for i := from; i < n; i++ {
+		base := i * nc
+		for c := range nc {
+			dsts[c][i] = src[base+c]
+		}
+	}
+}
+
+// deinterleaveN32 splits src into nc = len(dsts) planar streams. N == 2 reuses
+// the existing Deinterleave2 SIMD; the rest fall back to the generic Go path.
+func deinterleaveN32(dsts [][]float32, src []float32, n int) {
+	switch len(dsts) {
+	case interleave2Channels:
+		deinterleave2_32(dsts[0][:n], dsts[1][:n], src[:n*interleave2Channels])
+	case interleave4Streams:
+		if cpu.X86.AVX && n >= interleave4Streams {
+			blk := n &^ interleave4BlockMask
+			deinterleave4AVX(dsts[0], dsts[1], dsts[2], dsts[3], src, blk)
+			deinterleaveNTailGo(dsts, src, blk, n)
+			return
+		}
+		deinterleaveNGo(dsts, src, n)
+	case interleave8Streams:
+		if cpu.X86.AVX && n >= interleave8Streams {
+			blk := n &^ interleave8BlockMask
+			deinterleave8AVX(dsts, src, blk)
+			deinterleaveNTailGo(dsts, src, blk, n)
+			return
+		}
+		deinterleaveNGo(dsts, src, n)
+	default:
+		deinterleaveNGo(dsts, src, n)
+	}
+}
+
 func convolveValidMulti32(dsts [][]float32, signal []float32, kernels [][]float32, n, _ int) {
 	// Kernel-major loop order: each kernel stays hot in cache for entire signal pass
 	for k, kernel := range kernels {
@@ -485,6 +575,18 @@ func interleave2AVX(dst, a, b []float32)
 
 //go:noescape
 func deinterleave2AVX(a, b, src []float32)
+
+//go:noescape
+func interleave4AVX(dst, s0, s1, s2, s3 []float32, n int)
+
+//go:noescape
+func deinterleave4AVX(d0, d1, d2, d3, src []float32, n int)
+
+//go:noescape
+func interleave8AVX(dst []float32, srcs [][]float32, n int)
+
+//go:noescape
+func deinterleave8AVX(dsts [][]float32, src []float32, n int)
 
 func variance32(a []float32, mean float32) float32 {
 	return variance32Go(a, mean)

--- a/f32/f32_amd64.s
+++ b/f32/f32_amd64.s
@@ -2117,6 +2117,247 @@ deinterleave2_avx32_done:
     VZEROUPPER
     RET
 
+// func interleave4AVX(dst, s0, s1, s2, s3 []float32, n int)
+// Interleaves 4 planar streams (dst[i*4+c] = s_c[i]) via a 4x4 transpose of
+// XMM registers, 4 frames per iteration. n is a multiple of 4 (the caller
+// handles the tail).
+TEXT ·interleave4AVX(SB), NOSPLIT, $0-128
+    MOVQ dst_base+0(FP), DI
+    MOVQ s0_base+24(FP), AX
+    MOVQ s1_base+48(FP), BX
+    MOVQ s2_base+72(FP), CX
+    MOVQ s3_base+96(FP), DX
+    MOVQ n+120(FP), SI
+    SHRQ $2, SI                // SI = n/4 blocks
+    TESTQ SI, SI
+    JZ interleave4_avx_done
+
+interleave4_avx_loop:
+    VMOVUPS (AX), X0           // r0 = s0[i:i+4]
+    VMOVUPS (BX), X1           // r1 = s1[i:i+4]
+    VMOVUPS (CX), X2           // r2 = s2[i:i+4]
+    VMOVUPS (DX), X3           // r3 = s3[i:i+4]
+    VUNPCKLPS X1, X0, X4       // [r0.0,r1.0,r0.1,r1.1]
+    VUNPCKHPS X1, X0, X5       // [r0.2,r1.2,r0.3,r1.3]
+    VUNPCKLPS X3, X2, X6       // [r2.0,r3.0,r2.1,r3.1]
+    VUNPCKHPS X3, X2, X7       // [r2.2,r3.2,r2.3,r3.3]
+    VSHUFPS $0x44, X6, X4, X8  // frame0 = [r0.0,r1.0,r2.0,r3.0]
+    VSHUFPS $0xEE, X6, X4, X9  // frame1 = [r0.1,r1.1,r2.1,r3.1]
+    VSHUFPS $0x44, X7, X5, X10 // frame2 = [r0.2,r1.2,r2.2,r3.2]
+    VSHUFPS $0xEE, X7, X5, X11 // frame3 = [r0.3,r1.3,r2.3,r3.3]
+    VMOVUPS X8, (DI)
+    VMOVUPS X9, 16(DI)
+    VMOVUPS X10, 32(DI)
+    VMOVUPS X11, 48(DI)
+    ADDQ $16, AX
+    ADDQ $16, BX
+    ADDQ $16, CX
+    ADDQ $16, DX
+    ADDQ $64, DI
+    DECQ SI
+    JNZ interleave4_avx_loop
+
+interleave4_avx_done:
+    VZEROUPPER
+    RET
+
+// func deinterleave4AVX(d0, d1, d2, d3, src []float32, n int)
+// Splits an interleaved 4-stream buffer (d_c[i] = src[i*4+c]) via a 4x4
+// transpose, 4 frames per iteration. n is a multiple of 4.
+TEXT ·deinterleave4AVX(SB), NOSPLIT, $0-128
+    MOVQ d0_base+0(FP), AX
+    MOVQ d1_base+24(FP), BX
+    MOVQ d2_base+48(FP), CX
+    MOVQ d3_base+72(FP), DX
+    MOVQ src_base+96(FP), SI
+    MOVQ n+120(FP), DI
+    SHRQ $2, DI                // DI = n/4 blocks
+    TESTQ DI, DI
+    JZ deinterleave4_avx_done
+
+deinterleave4_avx_loop:
+    VMOVUPS (SI), X0           // frame0 = src[0:4]
+    VMOVUPS 16(SI), X1         // frame1
+    VMOVUPS 32(SI), X2         // frame2
+    VMOVUPS 48(SI), X3         // frame3
+    VUNPCKLPS X1, X0, X4       // [f0c0,f1c0,f0c1,f1c1]
+    VUNPCKHPS X1, X0, X5       // [f0c2,f1c2,f0c3,f1c3]
+    VUNPCKLPS X3, X2, X6       // [f2c0,f3c0,f2c1,f3c1]
+    VUNPCKHPS X3, X2, X7       // [f2c2,f3c2,f2c3,f3c3]
+    VSHUFPS $0x44, X6, X4, X8  // chan0 = [f0c0,f1c0,f2c0,f3c0]
+    VSHUFPS $0xEE, X6, X4, X9  // chan1
+    VSHUFPS $0x44, X7, X5, X10 // chan2
+    VSHUFPS $0xEE, X7, X5, X11 // chan3
+    VMOVUPS X8, (AX)
+    VMOVUPS X9, (BX)
+    VMOVUPS X10, (CX)
+    VMOVUPS X11, (DX)
+    ADDQ $16, AX
+    ADDQ $16, BX
+    ADDQ $16, CX
+    ADDQ $16, DX
+    ADDQ $64, SI
+    DECQ DI
+    JNZ deinterleave4_avx_loop
+
+deinterleave4_avx_done:
+    VZEROUPPER
+    RET
+
+// func interleave8AVX(dst []float32, srcs [][]float32, n int)
+// Interleaves 8 planar streams (dst[i*8+c] = srcs[c][i]) via an 8x8 transpose
+// of YMM registers, 8 frames per iteration. n is a multiple of 8 (the caller
+// handles the tail). srcs must have exactly 8 elements.
+TEXT ·interleave8AVX(SB), NOSPLIT, $0-56
+    MOVQ srcs_base+24(FP), R12   // R12 = &srcs[0] (array of slice headers)
+    MOVQ 0(R12), AX              // srcs[0].ptr
+    MOVQ 24(R12), BX             // srcs[1].ptr
+    MOVQ 48(R12), CX             // srcs[2].ptr
+    MOVQ 72(R12), DX             // srcs[3].ptr
+    MOVQ 96(R12), R8             // srcs[4].ptr
+    MOVQ 120(R12), R9            // srcs[5].ptr
+    MOVQ 144(R12), R10           // srcs[6].ptr
+    MOVQ 168(R12), R11           // srcs[7].ptr
+    MOVQ dst_base+0(FP), DI
+    MOVQ n+48(FP), SI
+    SHRQ $3, SI                  // SI = n/8 blocks
+    TESTQ SI, SI
+    JZ interleave8_avx_done
+
+interleave8_avx_loop:
+    VMOVUPS (AX), Y0             // row k = srcs[k][i:i+8]
+    VMOVUPS (BX), Y1
+    VMOVUPS (CX), Y2
+    VMOVUPS (DX), Y3
+    VMOVUPS (R8), Y4
+    VMOVUPS (R9), Y5
+    VMOVUPS (R10), Y6
+    VMOVUPS (R11), Y7
+    VUNPCKLPS Y1, Y0, Y8
+    VUNPCKHPS Y1, Y0, Y9
+    VUNPCKLPS Y3, Y2, Y10
+    VUNPCKHPS Y3, Y2, Y11
+    VUNPCKLPS Y5, Y4, Y12
+    VUNPCKHPS Y5, Y4, Y13
+    VUNPCKLPS Y7, Y6, Y14
+    VUNPCKHPS Y7, Y6, Y15
+    VSHUFPS $0x44, Y10, Y8, Y0
+    VSHUFPS $0xEE, Y10, Y8, Y1
+    VSHUFPS $0x44, Y11, Y9, Y2
+    VSHUFPS $0xEE, Y11, Y9, Y3
+    VSHUFPS $0x44, Y14, Y12, Y4
+    VSHUFPS $0xEE, Y14, Y12, Y5
+    VSHUFPS $0x44, Y15, Y13, Y6
+    VSHUFPS $0xEE, Y15, Y13, Y7
+    VPERM2F128 $0x20, Y4, Y0, Y8   // frame0
+    VPERM2F128 $0x20, Y5, Y1, Y9   // frame1
+    VPERM2F128 $0x20, Y6, Y2, Y10  // frame2
+    VPERM2F128 $0x20, Y7, Y3, Y11  // frame3
+    VPERM2F128 $0x31, Y4, Y0, Y12  // frame4
+    VPERM2F128 $0x31, Y5, Y1, Y13  // frame5
+    VPERM2F128 $0x31, Y6, Y2, Y14  // frame6
+    VPERM2F128 $0x31, Y7, Y3, Y15  // frame7
+    VMOVUPS Y8, (DI)
+    VMOVUPS Y9, 32(DI)
+    VMOVUPS Y10, 64(DI)
+    VMOVUPS Y11, 96(DI)
+    VMOVUPS Y12, 128(DI)
+    VMOVUPS Y13, 160(DI)
+    VMOVUPS Y14, 192(DI)
+    VMOVUPS Y15, 224(DI)
+    ADDQ $32, AX
+    ADDQ $32, BX
+    ADDQ $32, CX
+    ADDQ $32, DX
+    ADDQ $32, R8
+    ADDQ $32, R9
+    ADDQ $32, R10
+    ADDQ $32, R11
+    ADDQ $256, DI
+    DECQ SI
+    JNZ interleave8_avx_loop
+
+interleave8_avx_done:
+    VZEROUPPER
+    RET
+
+// func deinterleave8AVX(dsts [][]float32, src []float32, n int)
+// Splits an interleaved 8-stream buffer (dsts[c][i] = src[i*8+c]) via an 8x8
+// transpose, 8 frames per iteration. n is a multiple of 8. dsts must have
+// exactly 8 elements.
+TEXT ·deinterleave8AVX(SB), NOSPLIT, $0-56
+    MOVQ dsts_base+0(FP), R12    // R12 = &dsts[0] (array of slice headers)
+    MOVQ 0(R12), AX             // dsts[0].ptr
+    MOVQ 24(R12), BX            // dsts[1].ptr
+    MOVQ 48(R12), CX            // dsts[2].ptr
+    MOVQ 72(R12), DX            // dsts[3].ptr
+    MOVQ 96(R12), R8            // dsts[4].ptr
+    MOVQ 120(R12), R9           // dsts[5].ptr
+    MOVQ 144(R12), R10          // dsts[6].ptr
+    MOVQ 168(R12), R11          // dsts[7].ptr
+    MOVQ src_base+24(FP), SI
+    MOVQ n+48(FP), DI
+    SHRQ $3, DI                 // DI = n/8 blocks
+    TESTQ DI, DI
+    JZ deinterleave8_avx_done
+
+deinterleave8_avx_loop:
+    VMOVUPS (SI), Y0            // frame k = src[k*8:k*8+8]
+    VMOVUPS 32(SI), Y1
+    VMOVUPS 64(SI), Y2
+    VMOVUPS 96(SI), Y3
+    VMOVUPS 128(SI), Y4
+    VMOVUPS 160(SI), Y5
+    VMOVUPS 192(SI), Y6
+    VMOVUPS 224(SI), Y7
+    VUNPCKLPS Y1, Y0, Y8
+    VUNPCKHPS Y1, Y0, Y9
+    VUNPCKLPS Y3, Y2, Y10
+    VUNPCKHPS Y3, Y2, Y11
+    VUNPCKLPS Y5, Y4, Y12
+    VUNPCKHPS Y5, Y4, Y13
+    VUNPCKLPS Y7, Y6, Y14
+    VUNPCKHPS Y7, Y6, Y15
+    VSHUFPS $0x44, Y10, Y8, Y0
+    VSHUFPS $0xEE, Y10, Y8, Y1
+    VSHUFPS $0x44, Y11, Y9, Y2
+    VSHUFPS $0xEE, Y11, Y9, Y3
+    VSHUFPS $0x44, Y14, Y12, Y4
+    VSHUFPS $0xEE, Y14, Y12, Y5
+    VSHUFPS $0x44, Y15, Y13, Y6
+    VSHUFPS $0xEE, Y15, Y13, Y7
+    VPERM2F128 $0x20, Y4, Y0, Y8   // chan0
+    VPERM2F128 $0x20, Y5, Y1, Y9   // chan1
+    VPERM2F128 $0x20, Y6, Y2, Y10  // chan2
+    VPERM2F128 $0x20, Y7, Y3, Y11  // chan3
+    VPERM2F128 $0x31, Y4, Y0, Y12  // chan4
+    VPERM2F128 $0x31, Y5, Y1, Y13  // chan5
+    VPERM2F128 $0x31, Y6, Y2, Y14  // chan6
+    VPERM2F128 $0x31, Y7, Y3, Y15  // chan7
+    VMOVUPS Y8, (AX)
+    VMOVUPS Y9, (BX)
+    VMOVUPS Y10, (CX)
+    VMOVUPS Y11, (DX)
+    VMOVUPS Y12, (R8)
+    VMOVUPS Y13, (R9)
+    VMOVUPS Y14, (R10)
+    VMOVUPS Y15, (R11)
+    ADDQ $32, AX
+    ADDQ $32, BX
+    ADDQ $32, CX
+    ADDQ $32, DX
+    ADDQ $32, R8
+    ADDQ $32, R9
+    ADDQ $32, R10
+    ADDQ $32, R11
+    ADDQ $256, SI
+    DECQ DI
+    JNZ deinterleave8_avx_loop
+
+deinterleave8_avx_done:
+    VZEROUPPER
+    RET
+
 // ============================================================================
 // SQRT, RECIPROCAL, ADDSCALED IMPLEMENTATIONS
 // ============================================================================

--- a/f32/f32_arm64.go
+++ b/f32/f32_arm64.go
@@ -215,6 +215,63 @@ func deinterleave2_32(a, b, src []float32) {
 	deinterleave2Go(a, b, src)
 }
 
+// interleaveN32 interleaves nc = len(srcs) planar streams into dst. N == 2
+// reuses the existing Interleave2 NEON; N in {3,4} use the NEON ST3/ST4
+// structured stores (added incrementally); the rest fall back to generic Go.
+// Stream counts with dedicated ARM64 NEON interleave/deinterleave kernels (the
+// 2-stream path reuses interleave2Channels). neonInterleaveBlock is the NEON
+// structured load/store block size in frames (4 float32 per .4S register).
+const (
+	interleave3Streams  = 3
+	interleave4Streams  = 4
+	neonInterleaveBlock = 4
+)
+
+func interleaveN32(dst []float32, srcs [][]float32, n int) {
+	switch len(srcs) {
+	case interleave2Channels:
+		interleave2_32(dst[:n*interleave2Channels], srcs[0][:n], srcs[1][:n])
+	case interleave3Streams:
+		if hasNEON && n >= neonInterleaveBlock {
+			interleave3NEON(dst, srcs[0], srcs[1], srcs[2], n)
+			return
+		}
+		interleaveNGo(dst, srcs, n)
+	case interleave4Streams:
+		if hasNEON && n >= neonInterleaveBlock {
+			interleave4NEON(dst, srcs[0], srcs[1], srcs[2], srcs[3], n)
+			return
+		}
+		interleaveNGo(dst, srcs, n)
+	default:
+		interleaveNGo(dst, srcs, n)
+	}
+}
+
+// deinterleaveN32 splits src into nc = len(dsts) planar streams. N == 2 reuses
+// the existing Deinterleave2 NEON; N in {3,4} use the NEON LD3/LD4 structured
+// loads (added incrementally); the rest fall back to generic Go.
+func deinterleaveN32(dsts [][]float32, src []float32, n int) {
+	switch len(dsts) {
+	case interleave2Channels:
+		deinterleave2_32(dsts[0][:n], dsts[1][:n], src[:n*interleave2Channels])
+	case interleave3Streams:
+		if hasNEON && n >= neonInterleaveBlock {
+			deinterleave3NEON(dsts[0], dsts[1], dsts[2], src, n)
+			return
+		}
+		deinterleaveNGo(dsts, src, n)
+	case interleave4Streams:
+		if hasNEON && n >= neonInterleaveBlock {
+			deinterleave4NEON(dsts[0], dsts[1], dsts[2], dsts[3], src, n)
+			return
+		}
+		deinterleaveNGo(dsts, src, n)
+	default:
+		deinterleaveNGo(dsts, src, n)
+	}
+}
+
 func convolveValidMulti32(dsts [][]float32, signal []float32, kernels [][]float32, n, _ int) {
 	// Kernel-major loop order: each kernel stays hot in cache for entire signal pass
 	for k, kernel := range kernels {
@@ -227,6 +284,18 @@ func interleave2NEON(dst, a, b []float32)
 
 //go:noescape
 func deinterleave2NEON(a, b, src []float32)
+
+//go:noescape
+func interleave3NEON(dst, s0, s1, s2 []float32, n int)
+
+//go:noescape
+func deinterleave3NEON(d0, d1, d2, src []float32, n int)
+
+//go:noescape
+func interleave4NEON(dst, s0, s1, s2, s3 []float32, n int)
+
+//go:noescape
+func deinterleave4NEON(d0, d1, d2, d3, src []float32, n int)
 
 func sqrt32(dst, a []float32) {
 	if hasNEON && len(dst) >= 4 {

--- a/f32/f32_arm64.s
+++ b/f32/f32_arm64.s
@@ -649,6 +649,184 @@ deinterleave2_neon32_loop1:
 deinterleave2_neon32_done:
     RET
 
+// func interleave3NEON(dst, s0, s1, s2 []float32, n int)
+// Interleaves 3 planar streams (dst[i*3+c] = s_c[i]) with the NEON ST3
+// structured store, 4 frames per iteration, then a scalar tail.
+TEXT ·interleave3NEON(SB), NOSPLIT, $0-104
+    MOVD dst_base+0(FP), R0
+    MOVD s0_base+24(FP), R1
+    MOVD s1_base+48(FP), R2
+    MOVD s2_base+72(FP), R3
+    MOVD n+96(FP), R4
+
+    LSR $2, R4, R5             // R5 = n / 4
+    CBZ R5, interleave3_neon_tail
+
+interleave3_neon_loop4:
+    VLD1.P 16(R1), [V0.S4]     // V0 = s0[i:i+4]
+    VLD1.P 16(R2), [V1.S4]     // V1 = s1[i:i+4]
+    VLD1.P 16(R3), [V2.S4]     // V2 = s2[i:i+4]
+    VST3.P [V0.S4, V1.S4, V2.S4], 48(R0)  // interleaved store of 12 floats
+    SUB $1, R5
+    CBNZ R5, interleave3_neon_loop4
+
+interleave3_neon_tail:
+    AND $3, R4
+    CBZ R4, interleave3_neon_done
+
+interleave3_neon_tail1:
+    FMOVS (R1), F0
+    FMOVS (R2), F1
+    FMOVS (R3), F2
+    FMOVS F0, (R0)
+    FMOVS F1, 4(R0)
+    FMOVS F2, 8(R0)
+    ADD $4, R1
+    ADD $4, R2
+    ADD $4, R3
+    ADD $12, R0
+    SUB $1, R4
+    CBNZ R4, interleave3_neon_tail1
+
+interleave3_neon_done:
+    RET
+
+// func deinterleave3NEON(d0, d1, d2, src []float32, n int)
+// Splits an interleaved 3-stream buffer (d_c[i] = src[i*3+c]) with the NEON LD3
+// structured load, 4 frames per iteration, then a scalar tail.
+TEXT ·deinterleave3NEON(SB), NOSPLIT, $0-104
+    MOVD d0_base+0(FP), R0
+    MOVD d1_base+24(FP), R1
+    MOVD d2_base+48(FP), R2
+    MOVD src_base+72(FP), R3
+    MOVD n+96(FP), R4
+
+    LSR $2, R4, R5             // R5 = n / 4
+    CBZ R5, deinterleave3_neon_tail
+
+deinterleave3_neon_loop4:
+    VLD3.P 48(R3), [V0.S4, V1.S4, V2.S4]  // de-interleave 12 floats
+    VST1.P [V0.S4], 16(R0)     // d0[i:i+4]
+    VST1.P [V1.S4], 16(R1)     // d1[i:i+4]
+    VST1.P [V2.S4], 16(R2)     // d2[i:i+4]
+    SUB $1, R5
+    CBNZ R5, deinterleave3_neon_loop4
+
+deinterleave3_neon_tail:
+    AND $3, R4
+    CBZ R4, deinterleave3_neon_done
+
+deinterleave3_neon_tail1:
+    FMOVS (R3), F0
+    FMOVS 4(R3), F1
+    FMOVS 8(R3), F2
+    FMOVS F0, (R0)
+    FMOVS F1, (R1)
+    FMOVS F2, (R2)
+    ADD $12, R3
+    ADD $4, R0
+    ADD $4, R1
+    ADD $4, R2
+    SUB $1, R4
+    CBNZ R4, deinterleave3_neon_tail1
+
+deinterleave3_neon_done:
+    RET
+
+// func interleave4NEON(dst, s0, s1, s2, s3 []float32, n int)
+// Interleaves 4 planar streams (dst[i*4+c] = s_c[i]) with the NEON ST4
+// structured store, 4 frames per iteration, then a scalar tail.
+TEXT ·interleave4NEON(SB), NOSPLIT, $0-128
+    MOVD dst_base+0(FP), R0
+    MOVD s0_base+24(FP), R1
+    MOVD s1_base+48(FP), R2
+    MOVD s2_base+72(FP), R3
+    MOVD s3_base+96(FP), R4
+    MOVD n+120(FP), R5
+
+    LSR $2, R5, R6             // R6 = n / 4
+    CBZ R6, interleave4_neon_tail
+
+interleave4_neon_loop4:
+    VLD1.P 16(R1), [V0.S4]
+    VLD1.P 16(R2), [V1.S4]
+    VLD1.P 16(R3), [V2.S4]
+    VLD1.P 16(R4), [V3.S4]
+    VST4.P [V0.S4, V1.S4, V2.S4, V3.S4], 64(R0)  // interleaved store of 16 floats
+    SUB $1, R6
+    CBNZ R6, interleave4_neon_loop4
+
+interleave4_neon_tail:
+    AND $3, R5
+    CBZ R5, interleave4_neon_done
+
+interleave4_neon_tail1:
+    FMOVS (R1), F0
+    FMOVS (R2), F1
+    FMOVS (R3), F2
+    FMOVS (R4), F3
+    FMOVS F0, (R0)
+    FMOVS F1, 4(R0)
+    FMOVS F2, 8(R0)
+    FMOVS F3, 12(R0)
+    ADD $4, R1
+    ADD $4, R2
+    ADD $4, R3
+    ADD $4, R4
+    ADD $16, R0
+    SUB $1, R5
+    CBNZ R5, interleave4_neon_tail1
+
+interleave4_neon_done:
+    RET
+
+// func deinterleave4NEON(d0, d1, d2, d3, src []float32, n int)
+// Splits an interleaved 4-stream buffer (d_c[i] = src[i*4+c]) with the NEON LD4
+// structured load, 4 frames per iteration, then a scalar tail.
+TEXT ·deinterleave4NEON(SB), NOSPLIT, $0-128
+    MOVD d0_base+0(FP), R0
+    MOVD d1_base+24(FP), R1
+    MOVD d2_base+48(FP), R2
+    MOVD d3_base+72(FP), R3
+    MOVD src_base+96(FP), R4
+    MOVD n+120(FP), R5
+
+    LSR $2, R5, R6             // R6 = n / 4
+    CBZ R6, deinterleave4_neon_tail
+
+deinterleave4_neon_loop4:
+    VLD4.P 64(R4), [V0.S4, V1.S4, V2.S4, V3.S4]  // de-interleave 16 floats
+    VST1.P [V0.S4], 16(R0)
+    VST1.P [V1.S4], 16(R1)
+    VST1.P [V2.S4], 16(R2)
+    VST1.P [V3.S4], 16(R3)
+    SUB $1, R6
+    CBNZ R6, deinterleave4_neon_loop4
+
+deinterleave4_neon_tail:
+    AND $3, R5
+    CBZ R5, deinterleave4_neon_done
+
+deinterleave4_neon_tail1:
+    FMOVS (R4), F0
+    FMOVS 4(R4), F1
+    FMOVS 8(R4), F2
+    FMOVS 12(R4), F3
+    FMOVS F0, (R0)
+    FMOVS F1, (R1)
+    FMOVS F2, (R2)
+    FMOVS F3, (R3)
+    ADD $16, R4
+    ADD $4, R0
+    ADD $4, R1
+    ADD $4, R2
+    ADD $4, R3
+    SUB $1, R5
+    CBNZ R5, deinterleave4_neon_tail1
+
+deinterleave4_neon_done:
+    RET
+
 // Additional NEON operations for f32
 
 // FSQRT Vd.4S, Vn.4S: 0x6EA1F800 | (Vn << 5) | Vd

--- a/f32/f32_go.go
+++ b/f32/f32_go.go
@@ -236,6 +236,39 @@ func deinterleave2Go(a, b, src []float32) {
 	}
 }
 
+// interleaveNGo is the generic strided interleave: dst[i*nc+c] = srcs[c][i] for
+// nc = len(srcs) streams and n frames. It is the portable fallback and the
+// correctness reference for the SIMD specializations. The caller guarantees
+// len(dst) >= n*nc and len(srcs[c]) >= n for every c.
+func interleaveNGo(dst []float32, srcs [][]float32, n int) {
+	nc := len(srcs)
+	dst = dst[:n*nc]
+	for c := range nc {
+		s := srcs[c][:n]
+		di := c
+		for i := range n {
+			dst[di] = s[i]
+			di += nc
+		}
+	}
+}
+
+// deinterleaveNGo is the generic strided deinterleave: dsts[c][i] = src[i*nc+c]
+// for nc = len(dsts) streams and n frames. The caller guarantees
+// len(src) >= n*nc and len(dsts[c]) >= n for every c.
+func deinterleaveNGo(dsts [][]float32, src []float32, n int) {
+	nc := len(dsts)
+	src = src[:n*nc]
+	for c := range nc {
+		d := dsts[c][:n]
+		si := c
+		for i := range n {
+			d[i] = src[si]
+			si += nc
+		}
+	}
+}
+
 func convolveValidMultiGo(dsts [][]float32, signal []float32, kernels [][]float32, n, _ int) {
 	// Kernel-major loop order: each kernel stays hot in cache for entire signal pass
 	for k, kernel := range kernels {

--- a/f32/f32_other.go
+++ b/f32/f32_other.go
@@ -23,9 +23,13 @@ func convolveValid32(dst, signal, kernel []float32) { convolveValid32Go(dst, sig
 func convolveDecimate32(dst, signal, kernel []float32, factor, phase int) {
 	convolveDecimate32Go(dst, signal, kernel, factor, phase)
 }
-func accumulateAdd32(dst, src []float32)                    { accumulateAdd32Go(dst, src) }
-func interleave2_32(dst, a, b []float32)                    { interleave2Go(dst, a, b) }
-func deinterleave2_32(a, b, src []float32)                  { deinterleave2Go(a, b, src) }
+func accumulateAdd32(dst, src []float32)                   { accumulateAdd32Go(dst, src) }
+func interleave2_32(dst, a, b []float32)                   { interleave2Go(dst, a, b) }
+func deinterleave2_32(a, b, src []float32)                 { deinterleave2Go(a, b, src) }
+func interleaveN32(dst []float32, srcs [][]float32, n int) { interleaveNGo(dst, srcs, n) }
+func deinterleaveN32(dsts [][]float32, src []float32, n int) {
+	deinterleaveNGo(dsts, src, n)
+}
 func sqrt32(dst, a []float32)                               { sqrt32Go(dst, a) }
 func reciprocal32(dst, a []float32)                         { reciprocal32Go(dst, a) }
 func minIdx32(a []float32) int                              { return minIdxGo(a) }

--- a/f32/interleave_n_test.go
+++ b/f32/interleave_n_test.go
@@ -1,0 +1,357 @@
+package f32
+
+import (
+	"fmt"
+	"testing"
+)
+
+// interleaveNRef is the independent scalar oracle for InterleaveN:
+// dst[i*nc+c] = srcs[c][i]. It is intentionally the most literal possible
+// transcription of the contract so it cannot share a bug with the production
+// generic path (interleaveNGo).
+func interleaveNRef(dst []float32, srcs [][]float32, n int) {
+	nc := len(srcs)
+	for i := range n {
+		for c := range nc {
+			dst[i*nc+c] = srcs[c][i]
+		}
+	}
+}
+
+// deinterleaveNRef is the independent scalar oracle for DeinterleaveN:
+// dsts[c][i] = src[i*nc+c].
+func deinterleaveNRef(dsts [][]float32, src []float32, n int) {
+	nc := len(dsts)
+	for i := range n {
+		for c := range nc {
+			dsts[c][i] = src[i*nc+c]
+		}
+	}
+}
+
+// chanVal returns a value unique to (channel, frame) so any lane that lands in
+// the wrong slot is caught: a transpose bug cannot accidentally produce a
+// matching value.
+func chanVal(c, i int) float32 { return float32(c*100000 + i) }
+
+// interleaveNFrameCounts spans the SIMD block boundaries of every kernel
+// (NEON ST3/ST4 and AMD64 4x4/8x8 process 4 or 8 frames per iteration) plus
+// their +-1 tails and some larger sizes.
+var interleaveNFrameCounts = []int{0, 1, 2, 3, 4, 5, 7, 8, 9, 15, 16, 17, 31, 33, 64, 100, 255, 1000}
+
+// interleaveNStreamCounts covers the SIMD-specialized N and unspecialized N
+// (1, 5) that must fall back to the generic path.
+var interleaveNStreamCounts = []int{1, 2, 3, 4, 5, 6, 8}
+
+func TestInterleaveN_Parity(t *testing.T) {
+	const pad = 5 // extra dst frames that must stay untouched
+	const sentinel = float32(-7777)
+	for _, nc := range interleaveNStreamCounts {
+		for _, n := range interleaveNFrameCounts {
+			t.Run(fmt.Sprintf("N=%d/n=%d", nc, n), func(t *testing.T) {
+				srcs := make([][]float32, nc)
+				for c := range srcs {
+					srcs[c] = make([]float32, n)
+					for i := range srcs[c] {
+						srcs[c][i] = chanVal(c, i)
+					}
+				}
+				dst := make([]float32, (n+pad)*nc)
+				for i := range dst {
+					dst[i] = sentinel
+				}
+				InterleaveN(dst, srcs)
+
+				want := make([]float32, (n+pad)*nc)
+				for i := range want {
+					want[i] = sentinel
+				}
+				interleaveNRef(want, srcs, n)
+
+				for i := range dst {
+					if dst[i] != want[i] {
+						t.Fatalf("dst[%d] = %v, want %v (n=%d nc=%d)", i, dst[i], want[i], n, nc)
+					}
+				}
+			})
+		}
+	}
+}
+
+func TestDeinterleaveN_Parity(t *testing.T) {
+	const pad = 5
+	const sentinel = float32(-7777)
+	for _, nc := range interleaveNStreamCounts {
+		for _, n := range interleaveNFrameCounts {
+			t.Run(fmt.Sprintf("N=%d/n=%d", nc, n), func(t *testing.T) {
+				src := make([]float32, n*nc)
+				for i := range src {
+					src[i] = float32(i + 1)
+				}
+				dsts := make([][]float32, nc)
+				want := make([][]float32, nc)
+				for c := range dsts {
+					dsts[c] = make([]float32, n+pad)
+					want[c] = make([]float32, n+pad)
+					for i := range dsts[c] {
+						dsts[c][i] = sentinel
+						want[c][i] = sentinel
+					}
+				}
+				DeinterleaveN(dsts, src)
+				deinterleaveNRef(want, src, n)
+
+				for c := range dsts {
+					for i := range dsts[c] {
+						if dsts[c][i] != want[c][i] {
+							t.Fatalf("dsts[%d][%d] = %v, want %v (n=%d nc=%d)", c, i, dsts[c][i], want[c][i], n, nc)
+						}
+					}
+				}
+			})
+		}
+	}
+}
+
+// TestInterleaveN_MatchesInterleave2 pins the N==2 path to the existing
+// Interleave2 result exactly (the contract requires bit-identical output).
+func TestInterleaveN_MatchesInterleave2(t *testing.T) {
+	for _, n := range interleaveNFrameCounts {
+		a := make([]float32, n)
+		b := make([]float32, n)
+		for i := range n {
+			a[i] = float32(i) * 1.5
+			b[i] = float32(i)*-2.25 + 0.5
+		}
+		got := make([]float32, n*2)
+		want := make([]float32, n*2)
+		InterleaveN(got, [][]float32{a, b})
+		Interleave2(want, a, b)
+		for i := range want {
+			if got[i] != want[i] {
+				t.Fatalf("n=%d: InterleaveN[%d]=%v, Interleave2=%v", n, i, got[i], want[i])
+			}
+		}
+	}
+}
+
+// TestDeinterleaveN_MatchesDeinterleave2 pins the N==2 path to Deinterleave2.
+func TestDeinterleaveN_MatchesDeinterleave2(t *testing.T) {
+	for _, n := range interleaveNFrameCounts {
+		src := make([]float32, n*2)
+		for i := range src {
+			src[i] = float32(i)*0.75 - 3
+		}
+		gotA := make([]float32, n)
+		gotB := make([]float32, n)
+		wantA := make([]float32, n)
+		wantB := make([]float32, n)
+		DeinterleaveN([][]float32{gotA, gotB}, src)
+		Deinterleave2(wantA, wantB, src)
+		for i := range n {
+			if gotA[i] != wantA[i] || gotB[i] != wantB[i] {
+				t.Fatalf("n=%d: i=%d got (%v,%v) want (%v,%v)", n, i, gotA[i], gotB[i], wantA[i], wantB[i])
+			}
+		}
+	}
+}
+
+// TestInterleaveN_RaggedClamp checks that the frame count clamps to the shortest
+// source and to len(dst)/N, and that nothing past the clamped region is written.
+func TestInterleaveN_RaggedClamp(t *testing.T) {
+	srcs := [][]float32{
+		{1, 2, 3, 4, 5},
+		{10, 20, 30}, // shortest -> clamps n to 3
+		{100, 200, 300, 400},
+	}
+	const sentinel = float32(-1)
+	dst := make([]float32, 20)
+	for i := range dst {
+		dst[i] = sentinel
+	}
+	InterleaveN(dst, srcs)
+	// n clamps to 3, nc=3 -> 9 written.
+	want := []float32{1, 10, 100, 2, 20, 200, 3, 30, 300}
+	for i, w := range want {
+		if dst[i] != w {
+			t.Fatalf("dst[%d]=%v want %v", i, dst[i], w)
+		}
+	}
+	for i := len(want); i < len(dst); i++ {
+		if dst[i] != sentinel {
+			t.Fatalf("dst[%d]=%v modified past clamp", i, dst[i])
+		}
+	}
+}
+
+// TestInterleaveN_ShortDst clamps on len(dst)/N when dst is the limiting factor.
+func TestInterleaveN_ShortDst(t *testing.T) {
+	srcs := [][]float32{{1, 2, 3, 4}, {5, 6, 7, 8}, {9, 10, 11, 12}}
+	dst := make([]float32, 7) // 7/3 = 2 frames
+	InterleaveN(dst, srcs)
+	want := []float32{1, 5, 9, 2, 6, 10, 0} // last element untouched (was 0)
+	for i, w := range want {
+		if dst[i] != w {
+			t.Fatalf("dst[%d]=%v want %v", i, dst[i], w)
+		}
+	}
+}
+
+// TestDeinterleaveN_RaggedClamp mirrors the clamp behavior for the split path.
+func TestDeinterleaveN_RaggedClamp(t *testing.T) {
+	src := []float32{1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12}
+	const sentinel = float32(-1)
+	dsts := [][]float32{
+		make([]float32, 5),
+		make([]float32, 2), // shortest -> clamps n to 2
+		make([]float32, 4),
+	}
+	for c := range dsts {
+		for i := range dsts[c] {
+			dsts[c][i] = sentinel
+		}
+	}
+	DeinterleaveN(dsts, src)
+	// n = min(12/3, 5, 2, 4) = 2
+	wantPrefix := [][]float32{{1, 4}, {2, 5}, {3, 6}}
+	for c := range wantPrefix {
+		for i := range wantPrefix[c] {
+			if dsts[c][i] != wantPrefix[c][i] {
+				t.Fatalf("dsts[%d][%d]=%v want %v", c, i, dsts[c][i], wantPrefix[c][i])
+			}
+		}
+		for i := len(wantPrefix[c]); i < len(dsts[c]); i++ {
+			if dsts[c][i] != sentinel {
+				t.Fatalf("dsts[%d][%d]=%v modified past clamp", c, i, dsts[c][i])
+			}
+		}
+	}
+}
+
+// TestInterleaveN_RoundTrip interleaves then deinterleaves and expects identity.
+func TestInterleaveN_RoundTrip(t *testing.T) {
+	for _, nc := range interleaveNStreamCounts {
+		for _, n := range []int{1, 3, 4, 8, 17, 100} {
+			srcs := make([][]float32, nc)
+			for c := range srcs {
+				srcs[c] = make([]float32, n)
+				for i := range srcs[c] {
+					srcs[c][i] = chanVal(c, i)
+				}
+			}
+			inter := make([]float32, n*nc)
+			InterleaveN(inter, srcs)
+			out := make([][]float32, nc)
+			for c := range out {
+				out[c] = make([]float32, n)
+			}
+			DeinterleaveN(out, inter)
+			for c := range nc {
+				for i := range n {
+					if out[c][i] != srcs[c][i] {
+						t.Fatalf("nc=%d n=%d round-trip out[%d][%d]=%v want %v", nc, n, c, i, out[c][i], srcs[c][i])
+					}
+				}
+			}
+		}
+	}
+}
+
+// TestInterleaveN_Empty exercises the no-op guards (empty srcs/dsts, zero frames).
+func TestInterleaveN_Empty(_ *testing.T) {
+	InterleaveN(nil, nil)
+	InterleaveN([]float32{1, 2, 3}, nil)
+	InterleaveN(nil, [][]float32{{1}, {2}})
+	DeinterleaveN(nil, nil)
+	DeinterleaveN(nil, []float32{1, 2, 3})
+	DeinterleaveN([][]float32{{0}, {0}}, nil)
+	// A single empty source: nc=1, n=0 -> no-op.
+	InterleaveN([]float32{9}, [][]float32{{}})
+}
+
+// TestInterleaveN_AllocFree asserts the streaming contract: no per-call allocs.
+func TestInterleaveN_AllocFree(t *testing.T) {
+	for _, nc := range interleaveNStreamCounts {
+		const n = 512
+		srcs := make([][]float32, nc)
+		for c := range srcs {
+			srcs[c] = make([]float32, n)
+		}
+		dst := make([]float32, n*nc)
+		dsts := make([][]float32, nc)
+		for c := range dsts {
+			dsts[c] = make([]float32, n)
+		}
+		src := make([]float32, n*nc)
+
+		if a := testing.AllocsPerRun(50, func() { InterleaveN(dst, srcs) }); a != 0 {
+			t.Errorf("InterleaveN N=%d allocated %v times per run, want 0", nc, a)
+		}
+		if a := testing.AllocsPerRun(50, func() { DeinterleaveN(dsts, src) }); a != 0 {
+			t.Errorf("DeinterleaveN N=%d allocated %v times per run, want 0", nc, a)
+		}
+	}
+}
+
+func benchInterleaveN(b *testing.B, nc int) {
+	b.Helper()
+	const n = 1024
+	srcs := make([][]float32, nc)
+	for c := range srcs {
+		srcs[c] = make([]float32, n)
+		for i := range srcs[c] {
+			srcs[c][i] = chanVal(c, i)
+		}
+	}
+	dst := make([]float32, n*nc)
+	b.SetBytes(int64(n * nc * 4))
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		InterleaveN(dst, srcs)
+	}
+}
+
+func benchInterleaveNScalar(b *testing.B, nc int) {
+	b.Helper()
+	const n = 1024
+	srcs := make([][]float32, nc)
+	for c := range srcs {
+		srcs[c] = make([]float32, n)
+	}
+	dst := make([]float32, n*nc)
+	b.SetBytes(int64(n * nc * 4))
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		interleaveNRef(dst, srcs, n)
+	}
+}
+
+func BenchmarkInterleaveN_N3(b *testing.B)       { benchInterleaveN(b, 3) }
+func BenchmarkInterleaveN_N4(b *testing.B)       { benchInterleaveN(b, 4) }
+func BenchmarkInterleaveN_N6(b *testing.B)       { benchInterleaveN(b, 6) }
+func BenchmarkInterleaveN_N8(b *testing.B)       { benchInterleaveN(b, 8) }
+func BenchmarkInterleaveNScalar_N3(b *testing.B) { benchInterleaveNScalar(b, 3) }
+func BenchmarkInterleaveNScalar_N6(b *testing.B) { benchInterleaveNScalar(b, 6) }
+
+func benchDeinterleaveN(b *testing.B, nc int) {
+	b.Helper()
+	const n = 1024
+	src := make([]float32, n*nc)
+	for i := range src {
+		src[i] = float32(i)
+	}
+	dsts := make([][]float32, nc)
+	for c := range dsts {
+		dsts[c] = make([]float32, n)
+	}
+	b.SetBytes(int64(n * nc * 4))
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		DeinterleaveN(dsts, src)
+	}
+}
+
+func BenchmarkDeinterleaveN_N3(b *testing.B) { benchDeinterleaveN(b, 3) }
+func BenchmarkDeinterleaveN_N4(b *testing.B) { benchDeinterleaveN(b, 4) }
+func BenchmarkDeinterleaveN_N6(b *testing.B) { benchDeinterleaveN(b, 6) }
+func BenchmarkDeinterleaveN_N8(b *testing.B) { benchDeinterleaveN(b, 8) }

--- a/f64/f64.go
+++ b/f64/f64.go
@@ -452,6 +452,59 @@ func Deinterleave2(a, b, src []float64) {
 
 const interleave2Channels = 2
 
+// InterleaveN interleaves N planar streams into a single interleaved buffer:
+//
+//	dst[i*N + c] = srcs[c][i],   N = len(srcs)
+//
+// It is the N-stream generalization of Interleave2. N == 1 copies srcs[0] into
+// dst; N == 2 produces the same result as Interleave2. The number of frames
+// written is min(len(dst)/N, min over c of len(srcs[c])); dst beyond n*N and any
+// ragged source tails are left untouched. An empty srcs is a no-op. It allocates
+// nothing and operates on the caller-provided buffers.
+func InterleaveN(dst []float64, srcs [][]float64) {
+	nc := len(srcs)
+	if nc == 0 {
+		return
+	}
+	n := len(dst) / nc
+	for _, s := range srcs {
+		if len(s) < n {
+			n = len(s)
+		}
+	}
+	if n == 0 {
+		return
+	}
+	interleaveN64(dst, srcs, n)
+}
+
+// DeinterleaveN splits one interleaved buffer into N planar streams:
+//
+//	dsts[c][i] = src[i*N + c],   N = len(dsts)
+//
+// It is the inverse of InterleaveN and the N-stream generalization of
+// Deinterleave2. N == 1 copies src into dsts[0]; N == 2 produces the same result
+// as Deinterleave2. The number of frames written is min(len(src)/N, min over c
+// of len(dsts[c])); any ragged destination tails are left untouched. An empty
+// dsts is a no-op. It allocates nothing and operates on the caller-provided
+// buffers.
+func DeinterleaveN(dsts [][]float64, src []float64) {
+	nc := len(dsts)
+	if nc == 0 {
+		return
+	}
+	n := len(src) / nc
+	for _, d := range dsts {
+		if len(d) < n {
+			n = len(d)
+		}
+	}
+	if n == 0 {
+		return
+	}
+	deinterleaveN64(dsts, src, n)
+}
+
 // CubicInterpDot computes the fused cubic interpolation dot product:
 //
 //	Σ hist[i] * (a[i] + x*(b[i] + x*(c[i] + x*d[i])))

--- a/f64/f64_amd64.go
+++ b/f64/f64_amd64.go
@@ -361,6 +361,78 @@ func deinterleave2_64(a, b, src []float64) {
 	deinterleave2Go(a, b, src)
 }
 
+// interleaveN64 interleaves nc = len(srcs) planar streams into dst. N == 2
+// reuses the existing Interleave2 SIMD; other small N use shuffle-based
+// transposes (added incrementally); the rest fall back to the generic Go path.
+// Stream counts with dedicated AMD64 SIMD interleave/deinterleave kernels (the
+// 2-stream path reuses interleave2Channels). interleave4BlockMask aligns a
+// frame count down to a whole 4-frame SIMD block; the caller handles the tail.
+const (
+	interleave4Streams   = 4
+	interleave4BlockMask = interleave4Streams - 1
+)
+
+func interleaveN64(dst []float64, srcs [][]float64, n int) {
+	switch len(srcs) {
+	case interleave2Channels:
+		interleave2_64(dst[:n*interleave2Channels], srcs[0][:n], srcs[1][:n])
+	case interleave4Streams:
+		if cpu.X86.AVX && n >= interleave4Streams {
+			blk := n &^ interleave4BlockMask
+			interleave4AVX(dst, srcs[0], srcs[1], srcs[2], srcs[3], blk)
+			interleaveNTailGo(dst, srcs, blk, n)
+			return
+		}
+		interleaveNGo(dst, srcs, n)
+	default:
+		interleaveNGo(dst, srcs, n)
+	}
+}
+
+// interleaveNTailGo writes the trailing frames [from, n) of an N-stream
+// interleave that an asm kernel left after processing whole SIMD blocks,
+// allocation-free.
+func interleaveNTailGo(dst []float64, srcs [][]float64, from, n int) {
+	nc := len(srcs)
+	for i := from; i < n; i++ {
+		base := i * nc
+		for c := range nc {
+			dst[base+c] = srcs[c][i]
+		}
+	}
+}
+
+// deinterleaveNTailGo writes the trailing frames [from, n) of an N-stream
+// deinterleave, allocation-free.
+func deinterleaveNTailGo(dsts [][]float64, src []float64, from, n int) {
+	nc := len(dsts)
+	for i := from; i < n; i++ {
+		base := i * nc
+		for c := range nc {
+			dsts[c][i] = src[base+c]
+		}
+	}
+}
+
+// deinterleaveN64 splits src into nc = len(dsts) planar streams. N == 2 reuses
+// the existing Deinterleave2 SIMD; the rest fall back to the generic Go path.
+func deinterleaveN64(dsts [][]float64, src []float64, n int) {
+	switch len(dsts) {
+	case interleave2Channels:
+		deinterleave2_64(dsts[0][:n], dsts[1][:n], src[:n*interleave2Channels])
+	case interleave4Streams:
+		if cpu.X86.AVX && n >= interleave4Streams {
+			blk := n &^ interleave4BlockMask
+			deinterleave4AVX(dsts[0], dsts[1], dsts[2], dsts[3], src, blk)
+			deinterleaveNTailGo(dsts, src, blk, n)
+			return
+		}
+		deinterleaveNGo(dsts, src, n)
+	default:
+		deinterleaveNGo(dsts, src, n)
+	}
+}
+
 func convolveValidMulti64(dsts [][]float64, signal []float64, kernels [][]float64, n, _ int) {
 	// Kernel-major loop order: each kernel stays hot in cache for entire signal pass
 	for k, kernel := range kernels {
@@ -653,6 +725,12 @@ func interleave2AVX(dst, a, b []float64)
 
 //go:noescape
 func deinterleave2AVX(a, b, src []float64)
+
+//go:noescape
+func interleave4AVX(dst, s0, s1, s2, s3 []float64, n int)
+
+//go:noescape
+func deinterleave4AVX(d0, d1, d2, d3, src []float64, n int)
 
 //go:noescape
 func interleave2SSE2(dst, a, b []float64)

--- a/f64/f64_amd64.s
+++ b/f64/f64_amd64.s
@@ -2978,6 +2978,93 @@ deinterleave2_sse2_remainder:
 deinterleave2_sse2_done:
     RET
 
+// func interleave4AVX(dst, s0, s1, s2, s3 []float64, n int)
+// Interleaves 4 planar streams (dst[i*4+c] = s_c[i]) via a 4x4 transpose of
+// YMM registers (4 doubles each), 4 frames per iteration. n is a multiple of 4
+// (the caller handles the tail).
+TEXT ·interleave4AVX(SB), NOSPLIT, $0-128
+    MOVQ dst_base+0(FP), DI
+    MOVQ s0_base+24(FP), AX
+    MOVQ s1_base+48(FP), BX
+    MOVQ s2_base+72(FP), CX
+    MOVQ s3_base+96(FP), DX
+    MOVQ n+120(FP), SI
+    SHRQ $2, SI                // SI = n/4 blocks
+    TESTQ SI, SI
+    JZ interleave4_avx_done
+
+interleave4_avx_loop:
+    VMOVUPD (AX), Y0           // r0 = s0[i:i+4]
+    VMOVUPD (BX), Y1           // r1 = s1[i:i+4]
+    VMOVUPD (CX), Y2           // r2 = s2[i:i+4]
+    VMOVUPD (DX), Y3           // r3 = s3[i:i+4]
+    VUNPCKLPD Y1, Y0, Y4       // [r0.0,r1.0,r0.2,r1.2]
+    VUNPCKHPD Y1, Y0, Y5       // [r0.1,r1.1,r0.3,r1.3]
+    VUNPCKLPD Y3, Y2, Y6       // [r2.0,r3.0,r2.2,r3.2]
+    VUNPCKHPD Y3, Y2, Y7       // [r2.1,r3.1,r2.3,r3.3]
+    VPERM2F128 $0x20, Y6, Y4, Y8   // frame0 = [r0.0,r1.0,r2.0,r3.0]
+    VPERM2F128 $0x20, Y7, Y5, Y9   // frame1 = [r0.1,r1.1,r2.1,r3.1]
+    VPERM2F128 $0x31, Y6, Y4, Y10  // frame2 = [r0.2,r1.2,r2.2,r3.2]
+    VPERM2F128 $0x31, Y7, Y5, Y11  // frame3 = [r0.3,r1.3,r2.3,r3.3]
+    VMOVUPD Y8, (DI)
+    VMOVUPD Y9, 32(DI)
+    VMOVUPD Y10, 64(DI)
+    VMOVUPD Y11, 96(DI)
+    ADDQ $32, AX
+    ADDQ $32, BX
+    ADDQ $32, CX
+    ADDQ $32, DX
+    ADDQ $128, DI
+    DECQ SI
+    JNZ interleave4_avx_loop
+
+interleave4_avx_done:
+    VZEROUPPER
+    RET
+
+// func deinterleave4AVX(d0, d1, d2, d3, src []float64, n int)
+// Splits an interleaved 4-stream buffer (d_c[i] = src[i*4+c]) via a 4x4
+// transpose, 4 frames per iteration. n is a multiple of 4.
+TEXT ·deinterleave4AVX(SB), NOSPLIT, $0-128
+    MOVQ d0_base+0(FP), AX
+    MOVQ d1_base+24(FP), BX
+    MOVQ d2_base+48(FP), CX
+    MOVQ d3_base+72(FP), DX
+    MOVQ src_base+96(FP), SI
+    MOVQ n+120(FP), DI
+    SHRQ $2, DI                // DI = n/4 blocks
+    TESTQ DI, DI
+    JZ deinterleave4_avx_done
+
+deinterleave4_avx_loop:
+    VMOVUPD (SI), Y0           // frame0 = src[0:4]
+    VMOVUPD 32(SI), Y1         // frame1
+    VMOVUPD 64(SI), Y2         // frame2
+    VMOVUPD 96(SI), Y3         // frame3
+    VUNPCKLPD Y1, Y0, Y4       // [f0c0,f1c0,f0c2,f1c2]
+    VUNPCKHPD Y1, Y0, Y5       // [f0c1,f1c1,f0c3,f1c3]
+    VUNPCKLPD Y3, Y2, Y6       // [f2c0,f3c0,f2c2,f3c2]
+    VUNPCKHPD Y3, Y2, Y7       // [f2c1,f3c1,f2c3,f3c3]
+    VPERM2F128 $0x20, Y6, Y4, Y8   // chan0 = [f0c0,f1c0,f2c0,f3c0]
+    VPERM2F128 $0x20, Y7, Y5, Y9   // chan1
+    VPERM2F128 $0x31, Y6, Y4, Y10  // chan2
+    VPERM2F128 $0x31, Y7, Y5, Y11  // chan3
+    VMOVUPD Y8, (AX)
+    VMOVUPD Y9, (BX)
+    VMOVUPD Y10, (CX)
+    VMOVUPD Y11, (DX)
+    ADDQ $32, AX
+    ADDQ $32, BX
+    ADDQ $32, CX
+    ADDQ $32, DX
+    ADDQ $128, SI
+    DECQ DI
+    JNZ deinterleave4_avx_loop
+
+deinterleave4_avx_done:
+    VZEROUPPER
+    RET
+
 // ============================================================================
 // ADDSCALED - dst[i] += alpha * s[i] (AXPY operation)
 // ============================================================================

--- a/f64/f64_arm64.go
+++ b/f64/f64_arm64.go
@@ -283,6 +283,63 @@ func deinterleave2_64(a, b, src []float64) {
 	deinterleave2Go(a, b, src)
 }
 
+// interleaveN64 interleaves nc = len(srcs) planar streams into dst. N == 2
+// reuses the existing Interleave2 NEON; N in {3,4} use the NEON ST3/ST4
+// structured stores (added incrementally); the rest fall back to generic Go.
+// Stream counts with dedicated ARM64 NEON interleave/deinterleave kernels (the
+// 2-stream path reuses interleave2Channels). neonInterleaveBlock is the NEON
+// structured load/store block size in frames (2 float64 per .2D register).
+const (
+	interleave3Streams  = 3
+	interleave4Streams  = 4
+	neonInterleaveBlock = 2
+)
+
+func interleaveN64(dst []float64, srcs [][]float64, n int) {
+	switch len(srcs) {
+	case interleave2Channels:
+		interleave2_64(dst[:n*interleave2Channels], srcs[0][:n], srcs[1][:n])
+	case interleave3Streams:
+		if hasNEON && n >= neonInterleaveBlock {
+			interleave3NEON(dst, srcs[0], srcs[1], srcs[2], n)
+			return
+		}
+		interleaveNGo(dst, srcs, n)
+	case interleave4Streams:
+		if hasNEON && n >= neonInterleaveBlock {
+			interleave4NEON(dst, srcs[0], srcs[1], srcs[2], srcs[3], n)
+			return
+		}
+		interleaveNGo(dst, srcs, n)
+	default:
+		interleaveNGo(dst, srcs, n)
+	}
+}
+
+// deinterleaveN64 splits src into nc = len(dsts) planar streams. N == 2 reuses
+// the existing Deinterleave2 NEON; N in {3,4} use the NEON LD3/LD4 structured
+// loads (added incrementally); the rest fall back to generic Go.
+func deinterleaveN64(dsts [][]float64, src []float64, n int) {
+	switch len(dsts) {
+	case interleave2Channels:
+		deinterleave2_64(dsts[0][:n], dsts[1][:n], src[:n*interleave2Channels])
+	case interleave3Streams:
+		if hasNEON && n >= neonInterleaveBlock {
+			deinterleave3NEON(dsts[0], dsts[1], dsts[2], src, n)
+			return
+		}
+		deinterleaveNGo(dsts, src, n)
+	case interleave4Streams:
+		if hasNEON && n >= neonInterleaveBlock {
+			deinterleave4NEON(dsts[0], dsts[1], dsts[2], dsts[3], src, n)
+			return
+		}
+		deinterleaveNGo(dsts, src, n)
+	default:
+		deinterleaveNGo(dsts, src, n)
+	}
+}
+
 func convolveValidMulti64(dsts [][]float64, signal []float64, kernels [][]float64, n, _ int) {
 	// Kernel-major loop order: each kernel stays hot in cache for entire signal pass
 	for k, kernel := range kernels {
@@ -295,6 +352,18 @@ func interleave2NEON(dst, a, b []float64)
 
 //go:noescape
 func deinterleave2NEON(a, b, src []float64)
+
+//go:noescape
+func interleave3NEON(dst, s0, s1, s2 []float64, n int)
+
+//go:noescape
+func deinterleave3NEON(d0, d1, d2, src []float64, n int)
+
+//go:noescape
+func interleave4NEON(dst, s0, s1, s2, s3 []float64, n int)
+
+//go:noescape
+func deinterleave4NEON(d0, d1, d2, d3, src []float64, n int)
 
 func minIdx64(a []float64) int {
 	return minIdxGo64(a)

--- a/f64/f64_arm64.s
+++ b/f64/f64_arm64.s
@@ -726,6 +726,150 @@ deinterleave2_neon_remainder:
 deinterleave2_neon_done:
     RET
 
+// func interleave3NEON(dst, s0, s1, s2 []float64, n int)
+// Interleaves 3 planar streams (dst[i*3+c] = s_c[i]) with the NEON ST3
+// structured store, 2 frames per iteration, then a single scalar tail frame.
+TEXT ·interleave3NEON(SB), NOSPLIT, $0-104
+    MOVD dst_base+0(FP), R0
+    MOVD s0_base+24(FP), R1
+    MOVD s1_base+48(FP), R2
+    MOVD s2_base+72(FP), R3
+    MOVD n+96(FP), R4
+
+    LSR $1, R4, R5             // R5 = n / 2
+    CBZ R5, interleave3_neon_tail
+
+interleave3_neon_loop2:
+    VLD1.P 16(R1), [V0.D2]     // V0 = s0[i:i+2]
+    VLD1.P 16(R2), [V1.D2]     // V1 = s1[i:i+2]
+    VLD1.P 16(R3), [V2.D2]     // V2 = s2[i:i+2]
+    VST3.P [V0.D2, V1.D2, V2.D2], 48(R0)  // interleaved store of 6 doubles
+    SUB $1, R5
+    CBNZ R5, interleave3_neon_loop2
+
+interleave3_neon_tail:
+    AND $1, R4
+    CBZ R4, interleave3_neon_done
+    FMOVD (R1), F0
+    FMOVD (R2), F1
+    FMOVD (R3), F2
+    FMOVD F0, (R0)
+    FMOVD F1, 8(R0)
+    FMOVD F2, 16(R0)
+
+interleave3_neon_done:
+    RET
+
+// func deinterleave3NEON(d0, d1, d2, src []float64, n int)
+// Splits an interleaved 3-stream buffer (d_c[i] = src[i*3+c]) with the NEON LD3
+// structured load, 2 frames per iteration, then a single scalar tail frame.
+TEXT ·deinterleave3NEON(SB), NOSPLIT, $0-104
+    MOVD d0_base+0(FP), R0
+    MOVD d1_base+24(FP), R1
+    MOVD d2_base+48(FP), R2
+    MOVD src_base+72(FP), R3
+    MOVD n+96(FP), R4
+
+    LSR $1, R4, R5             // R5 = n / 2
+    CBZ R5, deinterleave3_neon_tail
+
+deinterleave3_neon_loop2:
+    VLD3.P 48(R3), [V0.D2, V1.D2, V2.D2]  // de-interleave 6 doubles
+    VST1.P [V0.D2], 16(R0)     // d0[i:i+2]
+    VST1.P [V1.D2], 16(R1)     // d1[i:i+2]
+    VST1.P [V2.D2], 16(R2)     // d2[i:i+2]
+    SUB $1, R5
+    CBNZ R5, deinterleave3_neon_loop2
+
+deinterleave3_neon_tail:
+    AND $1, R4
+    CBZ R4, deinterleave3_neon_done
+    FMOVD (R3), F0
+    FMOVD 8(R3), F1
+    FMOVD 16(R3), F2
+    FMOVD F0, (R0)
+    FMOVD F1, (R1)
+    FMOVD F2, (R2)
+
+deinterleave3_neon_done:
+    RET
+
+// func interleave4NEON(dst, s0, s1, s2, s3 []float64, n int)
+// Interleaves 4 planar streams (dst[i*4+c] = s_c[i]) with the NEON ST4
+// structured store, 2 frames per iteration, then a single scalar tail frame.
+TEXT ·interleave4NEON(SB), NOSPLIT, $0-128
+    MOVD dst_base+0(FP), R0
+    MOVD s0_base+24(FP), R1
+    MOVD s1_base+48(FP), R2
+    MOVD s2_base+72(FP), R3
+    MOVD s3_base+96(FP), R4
+    MOVD n+120(FP), R5
+
+    LSR $1, R5, R6             // R6 = n / 2
+    CBZ R6, interleave4_neon_tail
+
+interleave4_neon_loop2:
+    VLD1.P 16(R1), [V0.D2]
+    VLD1.P 16(R2), [V1.D2]
+    VLD1.P 16(R3), [V2.D2]
+    VLD1.P 16(R4), [V3.D2]
+    VST4.P [V0.D2, V1.D2, V2.D2, V3.D2], 64(R0)  // interleaved store of 8 doubles
+    SUB $1, R6
+    CBNZ R6, interleave4_neon_loop2
+
+interleave4_neon_tail:
+    AND $1, R5
+    CBZ R5, interleave4_neon_done
+    FMOVD (R1), F0
+    FMOVD (R2), F1
+    FMOVD (R3), F2
+    FMOVD (R4), F3
+    FMOVD F0, (R0)
+    FMOVD F1, 8(R0)
+    FMOVD F2, 16(R0)
+    FMOVD F3, 24(R0)
+
+interleave4_neon_done:
+    RET
+
+// func deinterleave4NEON(d0, d1, d2, d3, src []float64, n int)
+// Splits an interleaved 4-stream buffer (d_c[i] = src[i*4+c]) with the NEON LD4
+// structured load, 2 frames per iteration, then a single scalar tail frame.
+TEXT ·deinterleave4NEON(SB), NOSPLIT, $0-128
+    MOVD d0_base+0(FP), R0
+    MOVD d1_base+24(FP), R1
+    MOVD d2_base+48(FP), R2
+    MOVD d3_base+72(FP), R3
+    MOVD src_base+96(FP), R4
+    MOVD n+120(FP), R5
+
+    LSR $1, R5, R6             // R6 = n / 2
+    CBZ R6, deinterleave4_neon_tail
+
+deinterleave4_neon_loop2:
+    VLD4.P 64(R4), [V0.D2, V1.D2, V2.D2, V3.D2]  // de-interleave 8 doubles
+    VST1.P [V0.D2], 16(R0)
+    VST1.P [V1.D2], 16(R1)
+    VST1.P [V2.D2], 16(R2)
+    VST1.P [V3.D2], 16(R3)
+    SUB $1, R6
+    CBNZ R6, deinterleave4_neon_loop2
+
+deinterleave4_neon_tail:
+    AND $1, R5
+    CBZ R5, deinterleave4_neon_done
+    FMOVD (R4), F0
+    FMOVD 8(R4), F1
+    FMOVD 16(R4), F2
+    FMOVD 24(R4), F3
+    FMOVD F0, (R0)
+    FMOVD F1, (R1)
+    FMOVD F2, (R2)
+    FMOVD F3, (R3)
+
+deinterleave4_neon_done:
+    RET
+
 // ============================================================================
 // CUBIC INTERPOLATION DOT PRODUCT
 // ============================================================================

--- a/f64/f64_go.go
+++ b/f64/f64_go.go
@@ -334,6 +334,39 @@ func deinterleave2Go(a, b, src []float64) {
 	}
 }
 
+// interleaveNGo is the generic strided interleave: dst[i*nc+c] = srcs[c][i] for
+// nc = len(srcs) streams and n frames. It is the portable fallback and the
+// correctness reference for the SIMD specializations. The caller guarantees
+// len(dst) >= n*nc and len(srcs[c]) >= n for every c.
+func interleaveNGo(dst []float64, srcs [][]float64, n int) {
+	nc := len(srcs)
+	dst = dst[:n*nc]
+	for c := range nc {
+		s := srcs[c][:n]
+		di := c
+		for i := range n {
+			dst[di] = s[i]
+			di += nc
+		}
+	}
+}
+
+// deinterleaveNGo is the generic strided deinterleave: dsts[c][i] = src[i*nc+c]
+// for nc = len(dsts) streams and n frames. The caller guarantees
+// len(src) >= n*nc and len(dsts[c]) >= n for every c.
+func deinterleaveNGo(dsts [][]float64, src []float64, n int) {
+	nc := len(dsts)
+	src = src[:n*nc]
+	for c := range nc {
+		d := dsts[c][:n]
+		si := c
+		for i := range n {
+			d[i] = src[si]
+			si += nc
+		}
+	}
+}
+
 // cubicInterpDotGo computes: Σ hist[i] * (a[i] + x*(b[i] + x*(c[i] + x*d[i])))
 // Uses Horner's method for numerical stability.
 func cubicInterpDotGo(hist, a, b, c, d []float64, x float64) float64 {

--- a/f64/f64_other.go
+++ b/f64/f64_other.go
@@ -35,6 +35,12 @@ func convolveDecimate64(dst, signal, kernel []float64, factor, phase int) {
 func accumulateAdd64(dst, src []float64)   { accumulateAdd64Go(dst, src) }
 func interleave2_64(dst, a, b []float64)   { interleave2Go(dst, a, b) }
 func deinterleave2_64(a, b, src []float64) { deinterleave2Go(a, b, src) }
+func interleaveN64(dst []float64, srcs [][]float64, n int) {
+	interleaveNGo(dst, srcs, n)
+}
+func deinterleaveN64(dsts [][]float64, src []float64, n int) {
+	deinterleaveNGo(dsts, src, n)
+}
 func convolveValidMulti64(dsts [][]float64, signal []float64, kernels [][]float64, n, kLen int) {
 	convolveValidMultiGo(dsts, signal, kernels, n, kLen)
 }

--- a/f64/interleave_n_test.go
+++ b/f64/interleave_n_test.go
@@ -1,0 +1,337 @@
+package f64
+
+import (
+	"fmt"
+	"testing"
+)
+
+// interleaveNRef is the independent scalar oracle for InterleaveN:
+// dst[i*nc+c] = srcs[c][i]. It is the most literal transcription of the
+// contract so it cannot share a bug with the production generic path.
+func interleaveNRef(dst []float64, srcs [][]float64, n int) {
+	nc := len(srcs)
+	for i := range n {
+		for c := range nc {
+			dst[i*nc+c] = srcs[c][i]
+		}
+	}
+}
+
+// deinterleaveNRef is the independent scalar oracle for DeinterleaveN:
+// dsts[c][i] = src[i*nc+c].
+func deinterleaveNRef(dsts [][]float64, src []float64, n int) {
+	nc := len(dsts)
+	for i := range n {
+		for c := range nc {
+			dsts[c][i] = src[i*nc+c]
+		}
+	}
+}
+
+// chanVal returns a value unique to (channel, frame) so a misplaced lane is
+// always caught.
+func chanVal(c, i int) float64 { return float64(c*100000 + i) }
+
+var interleaveNFrameCounts = []int{0, 1, 2, 3, 4, 5, 7, 8, 9, 15, 16, 17, 31, 33, 64, 100, 255, 1000}
+
+var interleaveNStreamCounts = []int{1, 2, 3, 4, 5, 6, 8}
+
+func TestInterleaveN_Parity(t *testing.T) {
+	const pad = 5
+	const sentinel = float64(-7777)
+	for _, nc := range interleaveNStreamCounts {
+		for _, n := range interleaveNFrameCounts {
+			t.Run(fmt.Sprintf("N=%d/n=%d", nc, n), func(t *testing.T) {
+				srcs := make([][]float64, nc)
+				for c := range srcs {
+					srcs[c] = make([]float64, n)
+					for i := range srcs[c] {
+						srcs[c][i] = chanVal(c, i)
+					}
+				}
+				dst := make([]float64, (n+pad)*nc)
+				for i := range dst {
+					dst[i] = sentinel
+				}
+				InterleaveN(dst, srcs)
+
+				want := make([]float64, (n+pad)*nc)
+				for i := range want {
+					want[i] = sentinel
+				}
+				interleaveNRef(want, srcs, n)
+
+				for i := range dst {
+					if dst[i] != want[i] {
+						t.Fatalf("dst[%d] = %v, want %v (n=%d nc=%d)", i, dst[i], want[i], n, nc)
+					}
+				}
+			})
+		}
+	}
+}
+
+func TestDeinterleaveN_Parity(t *testing.T) {
+	const pad = 5
+	const sentinel = float64(-7777)
+	for _, nc := range interleaveNStreamCounts {
+		for _, n := range interleaveNFrameCounts {
+			t.Run(fmt.Sprintf("N=%d/n=%d", nc, n), func(t *testing.T) {
+				src := make([]float64, n*nc)
+				for i := range src {
+					src[i] = float64(i + 1)
+				}
+				dsts := make([][]float64, nc)
+				want := make([][]float64, nc)
+				for c := range dsts {
+					dsts[c] = make([]float64, n+pad)
+					want[c] = make([]float64, n+pad)
+					for i := range dsts[c] {
+						dsts[c][i] = sentinel
+						want[c][i] = sentinel
+					}
+				}
+				DeinterleaveN(dsts, src)
+				deinterleaveNRef(want, src, n)
+
+				for c := range dsts {
+					for i := range dsts[c] {
+						if dsts[c][i] != want[c][i] {
+							t.Fatalf("dsts[%d][%d] = %v, want %v (n=%d nc=%d)", c, i, dsts[c][i], want[c][i], n, nc)
+						}
+					}
+				}
+			})
+		}
+	}
+}
+
+func TestInterleaveN_MatchesInterleave2(t *testing.T) {
+	for _, n := range interleaveNFrameCounts {
+		a := make([]float64, n)
+		b := make([]float64, n)
+		for i := range n {
+			a[i] = float64(i) * 1.5
+			b[i] = float64(i)*-2.25 + 0.5
+		}
+		got := make([]float64, n*2)
+		want := make([]float64, n*2)
+		InterleaveN(got, [][]float64{a, b})
+		Interleave2(want, a, b)
+		for i := range want {
+			if got[i] != want[i] {
+				t.Fatalf("n=%d: InterleaveN[%d]=%v, Interleave2=%v", n, i, got[i], want[i])
+			}
+		}
+	}
+}
+
+func TestDeinterleaveN_MatchesDeinterleave2(t *testing.T) {
+	for _, n := range interleaveNFrameCounts {
+		src := make([]float64, n*2)
+		for i := range src {
+			src[i] = float64(i)*0.75 - 3
+		}
+		gotA := make([]float64, n)
+		gotB := make([]float64, n)
+		wantA := make([]float64, n)
+		wantB := make([]float64, n)
+		DeinterleaveN([][]float64{gotA, gotB}, src)
+		Deinterleave2(wantA, wantB, src)
+		for i := range n {
+			if gotA[i] != wantA[i] || gotB[i] != wantB[i] {
+				t.Fatalf("n=%d: i=%d got (%v,%v) want (%v,%v)", n, i, gotA[i], gotB[i], wantA[i], wantB[i])
+			}
+		}
+	}
+}
+
+func TestInterleaveN_RaggedClamp(t *testing.T) {
+	srcs := [][]float64{
+		{1, 2, 3, 4, 5},
+		{10, 20, 30},
+		{100, 200, 300, 400},
+	}
+	const sentinel = float64(-1)
+	dst := make([]float64, 20)
+	for i := range dst {
+		dst[i] = sentinel
+	}
+	InterleaveN(dst, srcs)
+	want := []float64{1, 10, 100, 2, 20, 200, 3, 30, 300}
+	for i, w := range want {
+		if dst[i] != w {
+			t.Fatalf("dst[%d]=%v want %v", i, dst[i], w)
+		}
+	}
+	for i := len(want); i < len(dst); i++ {
+		if dst[i] != sentinel {
+			t.Fatalf("dst[%d]=%v modified past clamp", i, dst[i])
+		}
+	}
+}
+
+func TestInterleaveN_ShortDst(t *testing.T) {
+	srcs := [][]float64{{1, 2, 3, 4}, {5, 6, 7, 8}, {9, 10, 11, 12}}
+	dst := make([]float64, 7)
+	InterleaveN(dst, srcs)
+	want := []float64{1, 5, 9, 2, 6, 10, 0}
+	for i, w := range want {
+		if dst[i] != w {
+			t.Fatalf("dst[%d]=%v want %v", i, dst[i], w)
+		}
+	}
+}
+
+func TestDeinterleaveN_RaggedClamp(t *testing.T) {
+	src := []float64{1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12}
+	const sentinel = float64(-1)
+	dsts := [][]float64{
+		make([]float64, 5),
+		make([]float64, 2),
+		make([]float64, 4),
+	}
+	for c := range dsts {
+		for i := range dsts[c] {
+			dsts[c][i] = sentinel
+		}
+	}
+	DeinterleaveN(dsts, src)
+	wantPrefix := [][]float64{{1, 4}, {2, 5}, {3, 6}}
+	for c := range wantPrefix {
+		for i := range wantPrefix[c] {
+			if dsts[c][i] != wantPrefix[c][i] {
+				t.Fatalf("dsts[%d][%d]=%v want %v", c, i, dsts[c][i], wantPrefix[c][i])
+			}
+		}
+		for i := len(wantPrefix[c]); i < len(dsts[c]); i++ {
+			if dsts[c][i] != sentinel {
+				t.Fatalf("dsts[%d][%d]=%v modified past clamp", c, i, dsts[c][i])
+			}
+		}
+	}
+}
+
+func TestInterleaveN_RoundTrip(t *testing.T) {
+	for _, nc := range interleaveNStreamCounts {
+		for _, n := range []int{1, 3, 4, 8, 17, 100} {
+			srcs := make([][]float64, nc)
+			for c := range srcs {
+				srcs[c] = make([]float64, n)
+				for i := range srcs[c] {
+					srcs[c][i] = chanVal(c, i)
+				}
+			}
+			inter := make([]float64, n*nc)
+			InterleaveN(inter, srcs)
+			out := make([][]float64, nc)
+			for c := range out {
+				out[c] = make([]float64, n)
+			}
+			DeinterleaveN(out, inter)
+			for c := range nc {
+				for i := range n {
+					if out[c][i] != srcs[c][i] {
+						t.Fatalf("nc=%d n=%d round-trip out[%d][%d]=%v want %v", nc, n, c, i, out[c][i], srcs[c][i])
+					}
+				}
+			}
+		}
+	}
+}
+
+func TestInterleaveN_Empty(_ *testing.T) {
+	InterleaveN(nil, nil)
+	InterleaveN([]float64{1, 2, 3}, nil)
+	InterleaveN(nil, [][]float64{{1}, {2}})
+	DeinterleaveN(nil, nil)
+	DeinterleaveN(nil, []float64{1, 2, 3})
+	DeinterleaveN([][]float64{{0}, {0}}, nil)
+	InterleaveN([]float64{9}, [][]float64{{}})
+}
+
+func TestInterleaveN_AllocFree(t *testing.T) {
+	for _, nc := range interleaveNStreamCounts {
+		const n = 512
+		srcs := make([][]float64, nc)
+		for c := range srcs {
+			srcs[c] = make([]float64, n)
+		}
+		dst := make([]float64, n*nc)
+		dsts := make([][]float64, nc)
+		for c := range dsts {
+			dsts[c] = make([]float64, n)
+		}
+		src := make([]float64, n*nc)
+
+		if a := testing.AllocsPerRun(50, func() { InterleaveN(dst, srcs) }); a != 0 {
+			t.Errorf("InterleaveN N=%d allocated %v times per run, want 0", nc, a)
+		}
+		if a := testing.AllocsPerRun(50, func() { DeinterleaveN(dsts, src) }); a != 0 {
+			t.Errorf("DeinterleaveN N=%d allocated %v times per run, want 0", nc, a)
+		}
+	}
+}
+
+func benchInterleaveN(b *testing.B, nc int) {
+	b.Helper()
+	const n = 1024
+	srcs := make([][]float64, nc)
+	for c := range srcs {
+		srcs[c] = make([]float64, n)
+		for i := range srcs[c] {
+			srcs[c][i] = chanVal(c, i)
+		}
+	}
+	dst := make([]float64, n*nc)
+	b.SetBytes(int64(n * nc * 8))
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		InterleaveN(dst, srcs)
+	}
+}
+
+func benchInterleaveNScalar(b *testing.B, nc int) {
+	b.Helper()
+	const n = 1024
+	srcs := make([][]float64, nc)
+	for c := range srcs {
+		srcs[c] = make([]float64, n)
+	}
+	dst := make([]float64, n*nc)
+	b.SetBytes(int64(n * nc * 8))
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		interleaveNRef(dst, srcs, n)
+	}
+}
+
+func BenchmarkInterleaveN_N3(b *testing.B)       { benchInterleaveN(b, 3) }
+func BenchmarkInterleaveN_N4(b *testing.B)       { benchInterleaveN(b, 4) }
+func BenchmarkInterleaveN_N6(b *testing.B)       { benchInterleaveN(b, 6) }
+func BenchmarkInterleaveN_N8(b *testing.B)       { benchInterleaveN(b, 8) }
+func BenchmarkInterleaveNScalar_N3(b *testing.B) { benchInterleaveNScalar(b, 3) }
+func BenchmarkInterleaveNScalar_N6(b *testing.B) { benchInterleaveNScalar(b, 6) }
+
+func benchDeinterleaveN(b *testing.B, nc int) {
+	b.Helper()
+	const n = 1024
+	src := make([]float64, n*nc)
+	for i := range src {
+		src[i] = float64(i)
+	}
+	dsts := make([][]float64, nc)
+	for c := range dsts {
+		dsts[c] = make([]float64, n)
+	}
+	b.SetBytes(int64(n * nc * 8))
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		DeinterleaveN(dsts, src)
+	}
+}
+
+func BenchmarkDeinterleaveN_N3(b *testing.B) { benchDeinterleaveN(b, 3) }
+func BenchmarkDeinterleaveN_N4(b *testing.B) { benchDeinterleaveN(b, 4) }
+func BenchmarkDeinterleaveN_N6(b *testing.B) { benchDeinterleaveN(b, 6) }
+func BenchmarkDeinterleaveN_N8(b *testing.B) { benchDeinterleaveN(b, 8) }


### PR DESCRIPTION
## Summary

Generalizes `Interleave2`/`Deinterleave2` to N planar streams in `f32` and `f64`, the planar <-> interleaved primitive that go-audio-resampler's factor > 2 integer upsample (16k -> 48k, 8k -> 48k) currently does in a scalar nested loop.

```go
func InterleaveN(dst []float32, srcs [][]float32)   // dst[i*N + c] = srcs[c][i]
func DeinterleaveN(dsts [][]float32, src []float32) // dsts[c][i] = src[i*N + c]
```

N is derived from `len(srcs)`/`len(dsts)`. N == 1 is a copy; N == 2 produces the same result as `Interleave2`/`Deinterleave2`. The frame count clamps to `min(len(dst)/N, shortest stream)`; ragged tails and `dst` past the clamp are left untouched. Allocation-free, caller-owned buffers, preserving the float32 zero-alloc streaming contract.

## SIMD coverage

| N | f32 AMD64 | f64 AMD64 | f32/f64 ARM64 |
|---|-----------|-----------|---------------|
| 2 | AVX (existing) | AVX (existing) | NEON ZIP/UZP (existing) |
| 3 | generic Go | generic Go | **NEON ST3/LD3** |
| 4 | **AVX 4x4 transpose** | **AVX 4x4 transpose** | **NEON ST4/LD4** |
| 8 | **AVX 8x8 transpose** | generic Go | generic Go |
| other | generic Go | generic Go | generic Go |

ARM64's structured load/store (ST3/LD3/ST4/LD4) maps 1:1 to the operation, so it covers the hot N=3 path directly. On a Raspberry Pi 5, N=3 interleave runs about 10x the scalar path (770 ns vs 8105 ns for 1024 frames) and deinterleave about 13x. On x86 the N=4/N=8 transposes run about 6-7x scalar. Everything not specialized uses the allocation-free generic Go path.

The remaining shuffle-based cells (AMD64 f32 N=3/N=6 and f64 N=3/N=6/N=8) need bespoke `VPERMPS`/`VPERMPD` gather-blend or multi-register transposes for a more modest x86 gain; they are tracked as a follow-up to be gated on x86 profiling rather than landed speculatively.

## Tests

`interleave_n_test.go` in each package: parity against an independent scalar oracle for N in {1,2,3,4,5,6,8} across assorted lengths and ragged tails (spanning every SIMD block boundary and its +-1 tail), N == 2 bit-equivalence with `Interleave2`/`Deinterleave2`, round-trip identity, length clamping, empty-input guards, and `AllocsPerRun == 0`. Benchmarks vs the scalar nested loop included.

Verified on amd64 and on a Raspberry Pi 5 (arm64). `golangci-lint` clean on both architectures; the ARM64 WORD-encoding cross-check still passes (the new structured load/stores use Go assembler mnemonics, not hand-encoded `WORD`s).

Closes #53. Part of #54.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added generalized multi-channel audio interleaving functions supporting arbitrary channel counts (3, 4, and beyond) for 32-bit and 64-bit floating-point data, complementing existing 2-channel support with allocation-free streaming behavior.

* **Tests**
  * Added comprehensive test suites and performance benchmarks validating multi-channel interleaving across various channel counts and edge cases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->