### PR TITLE
f32: add row-major batch dot product APIs (DotProductIndexed/DotProductStrided)

### DIFF
--- a/README.md
+++ b/README.md
@@ -149,6 +149,15 @@ Same API as `f64` but for `float32` with wider SIMD:
 top of the shared N=2/4 (AVX) and N=2/3/4 (NEON) kernels; all other stream counts
 use the allocation-free generic path.
 
+**Row-major batch dot products** (for flat vector stores):
+
+| Function | Description |
+| --- | --- |
+| `DotProductIndexed(dst, base, query, rowIDs, dims) bool` | Scores selected row-major rows by `uint32` row ID without building `[][]float32`; returns whether an optimized SIMD batch kernel handled at least one batch. |
+| `DotProductStrided(dst, base, query, rowCount, dims, stride) bool` | Scores contiguous or fixed-stride row-major rows; returns whether an optimized SIMD batch kernel handled at least one batch. |
+
+Both APIs are allocation-free and include per-row fallback semantics for unsupported CPUs, tiny shapes, tails, and ragged inputs.
+
 **Additional split-format complex operations** (for FFT pipelines with separate real/imag arrays):
 
 | Category   | Function                              | Description                        | SIMD Width       |

--- a/doc.go
+++ b/doc.go
@@ -42,7 +42,7 @@
 //
 // Core arithmetic: Add, Sub, Mul, Div, Scale, AddScalar, AddScaled, FMA
 //
-// Reductions: Sum, DotProduct, DotProductBatch, Min, Max, MinIdx, MaxIdx
+// Reductions: Sum, DotProduct, DotProductBatch, DotProductIndexed, DotProductStrided, Min, Max, MinIdx, MaxIdx
 //
 // Statistics: Mean, Variance, StdDev, EuclideanDistance, Normalize
 //

--- a/f32/dot_product_batch4_test.go
+++ b/f32/dot_product_batch4_test.go
@@ -22,7 +22,10 @@ func TestDotProductBatchMatchesDotProductWideShapes(t *testing.T) {
 				got := make([]float32, rowCount)
 				DotProductBatch(got, rows, vec)
 				for i := range rows {
-					want := DotProduct(rows[i], vec)
+					// Anchor the oracle to the pure-scalar dotProductGo rather than the
+					// dispatched DotProduct, so on amd64 this checks the batched SIMD
+					// kernel against the scalar contract instead of SIMD-vs-SIMD.
+					want := dotProductGo(rows[i], vec)
 					if !closeFloat32(got[i], want) {
 						t.Fatalf("dim=%d rows=%d row=%d got=%g want=%g", dim, rowCount, i, got[i], want)
 					}
@@ -49,6 +52,23 @@ func TestDotProductBatchVariedRowLengths(t *testing.T) {
 		want := DotProduct(rows[i], vec)
 		if !closeFloat32(got[i], want) {
 			t.Fatalf("row=%d len=%d got=%g want=%g", i, len(rows[i]), got[i], want)
+		}
+	}
+}
+
+func TestDotProductBatchAllocs(t *testing.T) {
+	for _, rowCount := range []int{4, 8, 16, 128} {
+		vec := deterministicF32Vector(21, 768)
+		rows := make([][]float32, rowCount)
+		for i := range rows {
+			rows[i] = deterministicF32Vector(2000+i, 768)
+		}
+		results := make([]float32, rowCount)
+		allocs := testing.AllocsPerRun(100, func() {
+			DotProductBatch(results, rows, vec)
+		})
+		if allocs != 0 {
+			t.Fatalf("DotProductBatch rows=%d allocations = %v, want 0", rowCount, allocs)
 		}
 	}
 }

--- a/f32/dot_product_batch4_test.go
+++ b/f32/dot_product_batch4_test.go
@@ -1,0 +1,104 @@
+package f32
+
+import (
+	"fmt"
+	"math"
+	"testing"
+)
+
+var sinkBatch4Results []float32
+
+func TestDotProductBatchMatchesDotProductWideShapes(t *testing.T) {
+	dims := []int{0, 1, 2, 3, 4, 7, 8, 15, 16, 31, 32, 64, 127, 128, 255, 256, 768}
+	rowCounts := []int{0, 1, 2, 3, 4, 5, 7, 8, 16, 128}
+	for _, dim := range dims {
+		for _, rowCount := range rowCounts {
+			t.Run("shape", func(t *testing.T) {
+				vec := deterministicF32Vector(11, dim)
+				rows := make([][]float32, rowCount)
+				for i := range rows {
+					rows[i] = deterministicF32Vector(100+i, dim)
+				}
+				got := make([]float32, rowCount)
+				DotProductBatch(got, rows, vec)
+				for i := range rows {
+					want := DotProduct(rows[i], vec)
+					if !closeFloat32(got[i], want) {
+						t.Fatalf("dim=%d rows=%d row=%d got=%g want=%g", dim, rowCount, i, got[i], want)
+					}
+				}
+			})
+		}
+	}
+}
+
+func TestDotProductBatchVariedRowLengths(t *testing.T) {
+	vec := deterministicF32Vector(7, 768)
+	rows := [][]float32{
+		deterministicF32Vector(1, 0),
+		deterministicF32Vector(2, 1),
+		deterministicF32Vector(3, 15),
+		deterministicF32Vector(4, 16),
+		deterministicF32Vector(5, 255),
+		deterministicF32Vector(6, 768),
+		deterministicF32Vector(7, 769),
+	}
+	got := make([]float32, len(rows))
+	DotProductBatch(got, rows, vec)
+	for i := range rows {
+		want := DotProduct(rows[i], vec)
+		if !closeFloat32(got[i], want) {
+			t.Fatalf("row=%d len=%d got=%g want=%g", i, len(rows[i]), got[i], want)
+		}
+	}
+}
+
+func BenchmarkDotProductBatch768xRows(b *testing.B) {
+	for _, rowsN := range []int{4, 8, 16, 128} {
+		b.Run(fmt.Sprintf("batch_rows_%d", rowsN), func(b *testing.B) {
+			benchmarkDotProductBatch768Rows(b, rowsN, true)
+		})
+		b.Run(fmt.Sprintf("loop_rows_%d", rowsN), func(b *testing.B) {
+			benchmarkDotProductBatch768Rows(b, rowsN, false)
+		})
+	}
+}
+
+func benchmarkDotProductBatch768Rows(b *testing.B, rowsN int, batch bool) {
+	b.Helper()
+	const dim = 768
+	vec := deterministicF32Vector(17, dim)
+	rows := make([][]float32, rowsN)
+	for i := range rows {
+		rows[i] = deterministicF32Vector(1000+i, dim)
+	}
+	results := make([]float32, rowsN)
+	b.ReportAllocs()
+	b.ReportMetric(float64(rowsN), "dots/op")
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		if batch {
+			DotProductBatch(results, rows, vec)
+		} else {
+			for j, row := range rows {
+				results[j] = DotProduct(row, vec)
+			}
+		}
+	}
+	sinkBatch4Results = results
+}
+
+func deterministicF32Vector(seed, n int) []float32 {
+	out := make([]float32, n)
+	x := uint32(seed)*747796405 + 2891336453
+	for i := range out {
+		x = x*1664525 + 1013904223
+		out[i] = float32(int32(x>>9)%2000-1000) / 1000
+	}
+	return out
+}
+
+func closeFloat32(got, want float32) bool {
+	diff := math.Abs(float64(got - want))
+	return diff <= 1e-3*(1+math.Abs(float64(want)))
+}

--- a/f32/dot_product_rowmajor_amd64_test.go
+++ b/f32/dot_product_rowmajor_amd64_test.go
@@ -1,0 +1,122 @@
+//go:build amd64
+
+package f32
+
+import "testing"
+
+func TestDotProductRowMajorAMD64ThresholdPredicates(t *testing.T) {
+	// The SIMD-vs-fallback gate is monotone in (rows, dims): small shapes use
+	// the batched kernel, and shapes fall back once they cross a dim/row size.
+	// Boundaries: dims < 768 always SIMD; 768 <= dims < 2048 needs rows < 256;
+	// dims >= 2048 needs rows < 64. Plus rows >= 4, dims >= 64, queryLen >= dims,
+	// and (for strided) stride > 0.
+	indexedEnabled := []struct {
+		rows int
+		dims int
+	}{
+		{4, 64}, {256, 64}, {4, 128}, {256, 128}, {64, 768}, {255, 768}, {32, 2048}, {63, 2048},
+	}
+	for _, tc := range indexedEnabled {
+		if !batchDotIndexedSIMDEligible(tc.rows, tc.dims, tc.dims) {
+			t.Fatalf("indexed rows=%d dims=%d unexpectedly gated", tc.rows, tc.dims)
+		}
+	}
+
+	indexedGated := []struct {
+		rows int
+		dims int
+	}{
+		{1, 64}, {4, 63}, {256, 768}, {64, 2048}, {256, 2048},
+	}
+	for _, tc := range indexedGated {
+		if batchDotIndexedSIMDEligible(tc.rows, tc.dims, tc.dims) {
+			t.Fatalf("indexed rows=%d dims=%d unexpectedly enabled", tc.rows, tc.dims)
+		}
+	}
+	if batchDotIndexedSIMDEligible(4, 64, 63) {
+		t.Fatalf("indexed queryLen<dims unexpectedly enabled")
+	}
+
+	stridedEnabled := []struct {
+		rows   int
+		dims   int
+		stride int
+	}{
+		{4, 64, 64}, {256, 64, 80}, {13, 128, 128}, {13, 128, 144},
+		{255, 768, 768}, {255, 768, 784}, {32, 2048, 2048}, {63, 2048, 2064},
+	}
+	for _, tc := range stridedEnabled {
+		if !batchDotStridedSIMDEligible(tc.rows, tc.dims, tc.stride, tc.dims) {
+			t.Fatalf("strided rows=%d dims=%d stride=%d unexpectedly gated", tc.rows, tc.dims, tc.stride)
+		}
+	}
+
+	stridedGated := []struct {
+		rows   int
+		dims   int
+		stride int
+	}{
+		{1, 64, 64}, {4, 63, 63}, {256, 768, 768}, {256, 768, 784},
+		{64, 2048, 2048}, {64, 2048, 2064}, {256, 2048, 2064},
+	}
+	for _, tc := range stridedGated {
+		if batchDotStridedSIMDEligible(tc.rows, tc.dims, tc.stride, tc.dims) {
+			t.Fatalf("strided rows=%d dims=%d stride=%d unexpectedly enabled", tc.rows, tc.dims, tc.stride)
+		}
+	}
+	if batchDotStridedSIMDEligible(4, 64, 0, 64) {
+		t.Fatalf("strided stride=0 unexpectedly enabled")
+	}
+	if batchDotStridedSIMDEligible(4, 64, -1, 64) {
+		t.Fatalf("strided stride=-1 unexpectedly enabled")
+	}
+}
+
+func TestDotProductRowMajorAMD64FallbackUsesDotProductForValidRows(t *testing.T) {
+	const dims = 64
+	base := deterministicF32Vector(701, 3*dims)
+	query := deterministicF32Vector(702, dims)
+	savedDotProductImpl := dotProductImpl
+	defer func() { dotProductImpl = savedDotProductImpl }()
+
+	t.Run("indexed", func(t *testing.T) {
+		calls := 0
+		dotProductImpl = func(a, b []float32) float32 {
+			calls++
+			if len(a) != dims || len(b) != dims {
+				t.Fatalf("dotProduct len(a)=%d len(b)=%d, want %d", len(a), len(b), dims)
+			}
+			return float32(100 + calls)
+		}
+
+		rowIDs := []uint32{0, 99, 2}
+		got := make([]float32, len(rowIDs))
+		if DotProductIndexed(got, base, query, rowIDs, dims) {
+			t.Fatalf("indexed rows<4 unexpectedly reported optimized")
+		}
+		if calls != 2 {
+			t.Fatalf("indexed fallback dotProduct calls=%d, want 2", calls)
+		}
+		assertCloseSlice(t, got, []float32{101, 0, 102})
+	})
+
+	t.Run("strided", func(t *testing.T) {
+		calls := 0
+		dotProductImpl = func(a, b []float32) float32 {
+			calls++
+			if len(a) != dims || len(b) != dims {
+				t.Fatalf("dotProduct len(a)=%d len(b)=%d, want %d", len(a), len(b), dims)
+			}
+			return float32(200 + calls)
+		}
+
+		got := make([]float32, 3)
+		if DotProductStrided(got, base[:2*dims], query, 3, dims, dims) {
+			t.Fatalf("strided rows<4 unexpectedly reported optimized")
+		}
+		if calls != 2 {
+			t.Fatalf("strided fallback dotProduct calls=%d, want 2", calls)
+		}
+		assertCloseSlice(t, got, []float32{201, 202, 0})
+	})
+}

--- a/f32/dot_product_rowmajor_benchmark_test.go
+++ b/f32/dot_product_rowmajor_benchmark_test.go
@@ -1,0 +1,221 @@
+package f32
+
+import (
+	"fmt"
+	"testing"
+)
+
+var (
+	sinkRowMajorResults []float32
+	sinkRowMajorUsed    bool
+)
+
+var rowMajorBenchDims = []int{64, 128, 768, 2048}
+var rowMajorBenchRows = []int{1, 2, 4, 8, 13, 16, 32, 64, 256}
+
+func BenchmarkDotProductIndexedRowMajor(b *testing.B) {
+	for _, pattern := range []string{"contiguous", "scattered"} {
+		for _, dims := range rowMajorBenchDims {
+			for _, rows := range rowMajorBenchRows {
+				baseRows := rows + 257
+				if pattern == "contiguous" {
+					baseRows = rows
+				}
+				base := deterministicF32Vector(1000+dims+rows, baseRows*dims)
+				query := deterministicF32Vector(2000+dims, dims)
+				rowIDs := makeBenchRowIDs(rows, baseRows, pattern)
+				rowSlices := makeIndexedRowSlices(base, rowIDs, dims)
+
+				b.Run(fmt.Sprintf("pattern=%s/dim=%d/rows=%d/api=simd", pattern, dims, rows), func(b *testing.B) {
+					benchIndexedSIMD(b, base, query, rowIDs, dims)
+				})
+				b.Run(fmt.Sprintf("pattern=%s/dim=%d/rows=%d/api=loop", pattern, dims, rows), func(b *testing.B) {
+					benchIndexedLoop(b, base, query, rowIDs, dims)
+				})
+				b.Run(fmt.Sprintf("pattern=%s/dim=%d/rows=%d/api=scalar", pattern, dims, rows), func(b *testing.B) {
+					benchIndexedScalar(b, base, query, rowIDs, dims)
+				})
+				b.Run(fmt.Sprintf("pattern=%s/dim=%d/rows=%d/api=batch", pattern, dims, rows), func(b *testing.B) {
+					benchBatchRows(b, rowSlices, query)
+				})
+			}
+		}
+	}
+}
+
+func BenchmarkDotProductStridedRowMajor(b *testing.B) {
+	for _, pattern := range []string{"contiguous", "fixed_stride"} {
+		for _, dims := range rowMajorBenchDims {
+			stride := dims
+			if pattern == "fixed_stride" {
+				stride = dims + 16
+			}
+			for _, rows := range rowMajorBenchRows {
+				base := deterministicF32Vector(3000+dims+rows+stride, rows*stride)
+				query := deterministicF32Vector(4000+dims, dims)
+				rowSlices := makeStridedRowSlices(base, rows, dims, stride)
+
+				b.Run(fmt.Sprintf("pattern=%s/dim=%d/rows=%d/api=simd", pattern, dims, rows), func(b *testing.B) {
+					benchStridedSIMD(b, base, query, rows, dims, stride)
+				})
+				b.Run(fmt.Sprintf("pattern=%s/dim=%d/rows=%d/api=loop", pattern, dims, rows), func(b *testing.B) {
+					benchStridedLoop(b, base, query, rows, dims, stride)
+				})
+				b.Run(fmt.Sprintf("pattern=%s/dim=%d/rows=%d/api=scalar", pattern, dims, rows), func(b *testing.B) {
+					benchStridedScalar(b, base, query, rows, dims, stride)
+				})
+				b.Run(fmt.Sprintf("pattern=%s/dim=%d/rows=%d/api=batch", pattern, dims, rows), func(b *testing.B) {
+					benchBatchRows(b, rowSlices, query)
+				})
+			}
+		}
+	}
+}
+
+func benchIndexedSIMD(b *testing.B, base, query []float32, rowIDs []uint32, dims int) {
+	b.Helper()
+	dst := make([]float32, len(rowIDs))
+	reportRowMajorBench(b, len(rowIDs), dims)
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		sinkRowMajorUsed = DotProductIndexed(dst, base, query, rowIDs, dims)
+	}
+	reportOptimizedMetric(b, sinkRowMajorUsed)
+	reportRowMajorRate(b, len(rowIDs))
+	sinkRowMajorResults = dst
+}
+
+func benchIndexedLoop(b *testing.B, base, query []float32, rowIDs []uint32, dims int) {
+	b.Helper()
+	dst := make([]float32, len(rowIDs))
+	reportRowMajorBench(b, len(rowIDs), dims)
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		for j, rowID := range rowIDs {
+			off := int(rowID) * dims
+			dst[j] = DotProduct(base[off:off+dims], query[:dims])
+		}
+	}
+	reportRowMajorRate(b, len(rowIDs))
+	sinkRowMajorResults = dst
+}
+
+func benchIndexedScalar(b *testing.B, base, query []float32, rowIDs []uint32, dims int) {
+	b.Helper()
+	dst := make([]float32, len(rowIDs))
+	reportRowMajorBench(b, len(rowIDs), dims)
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		dotProductIndexedGo(dst, base, query, rowIDs, dims)
+	}
+	reportRowMajorRate(b, len(rowIDs))
+	sinkRowMajorResults = dst
+}
+
+func benchStridedSIMD(b *testing.B, base, query []float32, rows, dims, stride int) {
+	b.Helper()
+	dst := make([]float32, rows)
+	reportRowMajorBench(b, rows, dims)
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		sinkRowMajorUsed = DotProductStrided(dst, base, query, rows, dims, stride)
+	}
+	reportOptimizedMetric(b, sinkRowMajorUsed)
+	reportRowMajorRate(b, rows)
+	sinkRowMajorResults = dst
+}
+
+func benchStridedLoop(b *testing.B, base, query []float32, rows, dims, stride int) {
+	b.Helper()
+	dst := make([]float32, rows)
+	reportRowMajorBench(b, rows, dims)
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		for row := range rows {
+			off := row * stride
+			dst[row] = DotProduct(base[off:off+dims], query[:dims])
+		}
+	}
+	reportRowMajorRate(b, rows)
+	sinkRowMajorResults = dst
+}
+
+func benchStridedScalar(b *testing.B, base, query []float32, rows, dims, stride int) {
+	b.Helper()
+	dst := make([]float32, rows)
+	reportRowMajorBench(b, rows, dims)
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		dotProductStridedGo(dst, base, query, rows, dims, stride)
+	}
+	reportRowMajorRate(b, rows)
+	sinkRowMajorResults = dst
+}
+
+func benchBatchRows(b *testing.B, rows [][]float32, query []float32) {
+	b.Helper()
+	dst := make([]float32, len(rows))
+	dims := len(query)
+	reportRowMajorBench(b, len(rows), dims)
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		DotProductBatch(dst, rows, query)
+	}
+	reportRowMajorRate(b, len(rows))
+	sinkRowMajorResults = dst
+}
+
+func reportRowMajorBench(b *testing.B, rows, dims int) {
+	b.Helper()
+	b.ReportAllocs()
+	b.ReportMetric(float64(rows), "dots/op")
+	b.SetBytes(int64(rows * dims * 2 * 4))
+}
+
+func reportRowMajorRate(b *testing.B, rows int) {
+	b.Helper()
+	elapsed := b.Elapsed().Seconds()
+	if elapsed > 0 {
+		b.ReportMetric(float64(rows)*float64(b.N)/elapsed, "dots/s")
+	}
+}
+
+func reportOptimizedMetric(b *testing.B, optimized bool) {
+	b.Helper()
+	if optimized {
+		b.ReportMetric(1, "optimized")
+		return
+	}
+	b.ReportMetric(0, "optimized")
+}
+
+func makeBenchRowIDs(rows, baseRows int, pattern string) []uint32 {
+	ids := make([]uint32, rows)
+	for i := range ids {
+		switch pattern {
+		case "scattered":
+			ids[i] = uint32((i*131 + 17) % baseRows)
+		default:
+			ids[i] = uint32(i)
+		}
+	}
+	return ids
+}
+
+func makeIndexedRowSlices(base []float32, rowIDs []uint32, dims int) [][]float32 {
+	rows := make([][]float32, len(rowIDs))
+	for i, rowID := range rowIDs {
+		off := int(rowID) * dims
+		rows[i] = base[off : off+dims]
+	}
+	return rows
+}
+
+func makeStridedRowSlices(base []float32, rows, dims, stride int) [][]float32 {
+	out := make([][]float32, rows)
+	for i := range out {
+		off := i * stride
+		out[i] = base[off : off+dims]
+	}
+	return out
+}

--- a/f32/dot_product_rowmajor_test.go
+++ b/f32/dot_product_rowmajor_test.go
@@ -1,0 +1,160 @@
+package f32
+
+import (
+	"runtime"
+	"testing"
+
+	"github.com/tphakala/simd/cpu"
+)
+
+func TestDotProductIndexedRowMajorParity(t *testing.T) {
+	dimsList := []int{1, 2, 7, 8, 15, 16, 31, 64, 65, 128, 768}
+	rowCounts := []int{0, 1, 2, 4, 5, 8, 13, 16}
+	for _, dims := range dimsList {
+		for _, rows := range rowCounts {
+			t.Run("shape", func(t *testing.T) {
+				baseRows := rows + 11
+				base := deterministicF32Vector(100+dims+rows, baseRows*dims)
+				query := deterministicF32Vector(200+dims, dims)
+				rowIDs := make([]uint32, rows)
+				for i := range rowIDs {
+					rowIDs[i] = uint32((i*7 + 3) % baseRows)
+				}
+
+				got := make([]float32, rows)
+				want := make([]float32, rows)
+				dotProductIndexedGo(want, base, query, rowIDs, dims)
+				DotProductIndexed(got, base, query, rowIDs, dims)
+				assertCloseSlice(t, got, want)
+			})
+		}
+	}
+}
+
+func TestDotProductStridedRowMajorParity(t *testing.T) {
+	dimsList := []int{1, 2, 7, 8, 15, 16, 31, 64, 65, 128, 768}
+	rowCounts := []int{0, 1, 2, 4, 5, 8, 13, 16}
+	for _, dims := range dimsList {
+		for _, rows := range rowCounts {
+			t.Run("shape", func(t *testing.T) {
+				stride := dims + 3
+				base := deterministicF32Vector(300+dims+rows, rows*stride)
+				query := deterministicF32Vector(400+dims, dims)
+
+				got := make([]float32, rows)
+				want := make([]float32, rows)
+				dotProductStridedGo(want, base, query, rows, dims, stride)
+				DotProductStrided(got, base, query, rows, dims, stride)
+				assertCloseSlice(t, got, want)
+			})
+		}
+	}
+}
+
+func TestDotProductRowMajorRaggedAndTails(t *testing.T) {
+	base := []float32{
+		1, 2, 3, 4,
+		5, 6, 7, 8,
+		9, 10, // truncated row 2
+	}
+	query := []float32{1, 10, 100}
+
+	t.Run("indexed", func(t *testing.T) {
+		rowIDs := []uint32{0, 1, 2, 99}
+		got := []float32{-1, -1, -1, -1, 123}
+		used := DotProductIndexed(got[:4], base, query, rowIDs, 4)
+		if used {
+			t.Fatalf("ragged indexed shape should use fallback")
+		}
+		want := []float32{321, 765, 109, 0, 123}
+		assertCloseSlice(t, got, want)
+	})
+
+	t.Run("strided", func(t *testing.T) {
+		got := []float32{-1, -1, -1, -1, 123}
+		used := DotProductStrided(got[:4], base, query, 4, 4, 4)
+		if used {
+			t.Fatalf("ragged strided shape should use fallback")
+		}
+		want := []float32{321, 765, 109, 0, 123}
+		assertCloseSlice(t, got, want)
+	})
+
+	t.Run("dst shorter", func(t *testing.T) {
+		got := []float32{-1, -1}
+		DotProductIndexed(got, base, query, []uint32{0, 1, 2}, 4)
+		assertCloseSlice(t, got, []float32{321, 765})
+	})
+
+	t.Run("invalid shape zeros processed dst", func(t *testing.T) {
+		got := []float32{7, 8, 9}
+		DotProductStrided(got, base, query, 3, 0, 4)
+		assertCloseSlice(t, got, []float32{0, 0, 0})
+
+		got = []float32{7, 8, 9}
+		DotProductStrided(got, base, query, 3, 4, 0)
+		assertCloseSlice(t, got, []float32{0, 0, 0})
+	})
+}
+
+func TestDotProductRowMajorOptimizedStatus(t *testing.T) {
+	const dims = 64
+	const rows = 8
+	base := deterministicF32Vector(501, rows*dims)
+	query := deterministicF32Vector(502, dims)
+	rowIDs := []uint32{7, 0, 5, 2, 6, 1, 4, 3}
+	indexedDst := make([]float32, rows)
+	stridedDst := make([]float32, rows)
+
+	indexedUsed := DotProductIndexed(indexedDst, base, query, rowIDs, dims)
+	stridedUsed := DotProductStrided(stridedDst, base, query, rows, dims, dims)
+	wantOptimized := runtime.GOARCH == "amd64" && ((cpu.X86.AVX512F && cpu.X86.AVX512VL) || (cpu.X86.AVX2 && cpu.X86.FMA))
+	if indexedUsed != wantOptimized {
+		t.Fatalf("indexed optimized status = %v, want %v (cpu=%s)", indexedUsed, wantOptimized, cpu.Info())
+	}
+	if stridedUsed != wantOptimized {
+		t.Fatalf("strided optimized status = %v, want %v (cpu=%s)", stridedUsed, wantOptimized, cpu.Info())
+	}
+
+	if DotProductIndexed(make([]float32, 2), base, query, rowIDs[:2], dims) {
+		t.Fatalf("rows<4 should not report optimized")
+	}
+	if DotProductStrided(make([]float32, rows), base, query[:32], rows, dims, dims) {
+		t.Fatalf("query shorter than dims should not report optimized")
+	}
+}
+
+func TestDotProductRowMajorAllocs(t *testing.T) {
+	const dims = 64
+	const rows = 8
+	base := deterministicF32Vector(601, rows*dims)
+	query := deterministicF32Vector(602, dims)
+	rowIDs := []uint32{7, 0, 5, 2, 6, 1, 4, 3}
+	dst := make([]float32, rows)
+
+	indexedAllocs := testing.AllocsPerRun(1000, func() {
+		DotProductIndexed(dst, base, query, rowIDs, dims)
+	})
+	if indexedAllocs != 0 {
+		t.Fatalf("DotProductIndexed allocations = %v, want 0", indexedAllocs)
+	}
+
+	stridedAllocs := testing.AllocsPerRun(1000, func() {
+		DotProductStrided(dst, base, query, rows, dims, dims)
+	})
+	if stridedAllocs != 0 {
+		t.Fatalf("DotProductStrided allocations = %v, want 0", stridedAllocs)
+	}
+}
+
+func assertCloseSlice(t *testing.T, got, want []float32) {
+	t.Helper()
+	if len(got) != len(want) {
+		t.Fatalf("len(got)=%d len(want)=%d", len(got), len(want))
+	}
+	for i := range got {
+		if !closeFloat32(got[i], want[i]) {
+			t.Fatalf("[%d] got=%g want=%g", i, got[i], want[i])
+		}
+	}
+}

--- a/f32/dot_product_rowmajor_test.go
+++ b/f32/dot_product_rowmajor_test.go
@@ -22,10 +22,11 @@ func TestDotProductIndexedRowMajorParity(t *testing.T) {
 				}
 
 				got := make([]float32, rows)
-				want := make([]float32, rows)
-				dotProductIndexedGo(want, base, query, rowIDs, dims)
 				DotProductIndexed(got, base, query, rowIDs, dims)
-				assertCloseSlice(t, got, want)
+				// Compare against a pure-scalar oracle that never touches the
+				// SIMD dispatch path, so a bug shared by the batched and
+				// single-row SIMD kernels cannot slip through.
+				assertCloseSlice(t, got, scalarIndexedOracle(base, query, rowIDs, dims))
 			})
 		}
 	}
@@ -42,10 +43,8 @@ func TestDotProductStridedRowMajorParity(t *testing.T) {
 				query := deterministicF32Vector(400+dims, dims)
 
 				got := make([]float32, rows)
-				want := make([]float32, rows)
-				dotProductStridedGo(want, base, query, rows, dims, stride)
 				DotProductStrided(got, base, query, rows, dims, stride)
-				assertCloseSlice(t, got, want)
+				assertCloseSlice(t, got, scalarStridedOracle(base, query, rows, dims, stride))
 			})
 		}
 	}
@@ -108,7 +107,7 @@ func TestDotProductRowMajorOptimizedStatus(t *testing.T) {
 
 	indexedUsed := DotProductIndexed(indexedDst, base, query, rowIDs, dims)
 	stridedUsed := DotProductStrided(stridedDst, base, query, rows, dims, dims)
-	wantOptimized := runtime.GOARCH == "amd64" && ((cpu.X86.AVX512F && cpu.X86.AVX512VL) || (cpu.X86.AVX2 && cpu.X86.FMA))
+	wantOptimized := runtime.GOARCH == "amd64" && ((cpu.X86.AVX512F && cpu.X86.AVX512VL) || (cpu.X86.AVX && cpu.X86.FMA))
 	if indexedUsed != wantOptimized {
 		t.Fatalf("indexed optimized status = %v, want %v (cpu=%s)", indexedUsed, wantOptimized, cpu.Info())
 	}
@@ -157,4 +156,53 @@ func assertCloseSlice(t *testing.T, got, want []float32) {
 			t.Fatalf("[%d] got=%g want=%g", i, got[i], want[i])
 		}
 	}
+}
+
+// scalarIndexedOracle and scalarStridedOracle recompute the expected scores
+// with the pure-scalar dotProductGo, mirroring the public APIs' row selection,
+// ragged-input clamping, and out-of-range zeroing. They never call the
+// dispatched dotProduct, so they stay independent of the SIMD kernels under
+// test.
+func scalarIndexedOracle(base, query []float32, rowIDs []uint32, dims int) []float32 {
+	dst := make([]float32, len(rowIDs))
+	if dims <= 0 || len(query) == 0 {
+		return dst
+	}
+	for i, id := range rowIDs {
+		off := int(id) * dims
+		if off < 0 || off >= len(base) {
+			continue
+		}
+		n := min(dims, len(query))
+		if rem := len(base) - off; rem < n {
+			n = rem
+		}
+		if n <= 0 {
+			continue
+		}
+		dst[i] = dotProductGo(base[off:off+n], query[:n])
+	}
+	return dst
+}
+
+func scalarStridedOracle(base, query []float32, rowCount, dims, stride int) []float32 {
+	dst := make([]float32, rowCount)
+	if dims <= 0 || stride <= 0 || len(query) == 0 {
+		return dst
+	}
+	for i := range rowCount {
+		off := i * stride
+		if off < 0 || off >= len(base) {
+			continue
+		}
+		n := min(dims, len(query))
+		if rem := len(base) - off; rem < n {
+			n = rem
+		}
+		if n <= 0 {
+			continue
+		}
+		dst[i] = dotProductGo(base[off:off+n], query[:n])
+	}
+	return dst
 }

--- a/f32/f32.go
+++ b/f32/f32.go
@@ -178,6 +178,42 @@ func DotProductBatch(results []float32, rows [][]float32, vec []float32) {
 	dotProductBatch32(results[:n], rows[:n], vec)
 }
 
+// DotProductIndexed computes dot products between query and selected rows in a
+// flat row-major base slice. For each processed row i:
+//
+//	dst[i] = dot(base[rowIDs[i]*dims : rowIDs[i]*dims+dims], query[:dims])
+//
+// The number of processed rows is min(len(dst), len(rowIDs)). Ragged inputs are
+// safe: if query is shorter than dims or a row extends past base, the dot uses
+// the available common prefix; out-of-range row IDs, non-positive dims, or an
+// empty query produce a zero score for that row. The function returns true when
+// at least one optimized platform SIMD batch kernel was used; false means the
+// per-row fallback handled the call.
+func DotProductIndexed(dst, base, query []float32, rowIDs []uint32, dims int) bool {
+	n := min(len(dst), len(rowIDs))
+	if n == 0 {
+		return false
+	}
+	return dotProductIndexed(dst[:n], base, query, rowIDs[:n], dims)
+}
+
+// DotProductStrided computes dot products between query and rowCount rows in a
+// flat base slice where row i starts at base[i*stride]. dims and stride are in
+// float32 elements, not bytes; use stride >= dims for non-overlapping rows.
+// The number of processed rows is
+// min(len(dst), rowCount). Ragged inputs are safe: if query is shorter than dims
+// or a row extends past base, the dot uses the available common prefix;
+// non-positive rowCount/dims/stride or an empty query produce zero scores for
+// processed rows. The function returns true when at least one optimized platform
+// SIMD batch kernel was used; false means the per-row fallback handled the call.
+func DotProductStrided(dst, base, query []float32, rowCount, dims, stride int) bool {
+	if rowCount <= 0 || len(dst) == 0 {
+		return false
+	}
+	n := min(len(dst), rowCount)
+	return dotProductStrided(dst[:n], base, query, n, dims, stride)
+}
+
 // ConvolveValid computes valid convolution of signal with kernel.
 // dst[i] = sum(signal[i+j] * kernel[j]) for j in 0..len(kernel)-1.
 // Output length is len(signal) - len(kernel) + 1.

--- a/f32/f32_amd64.go
+++ b/f32/f32_amd64.go
@@ -2,7 +2,11 @@
 
 package f32
 
-import "github.com/tphakala/simd/cpu"
+import (
+	"unsafe"
+
+	"github.com/tphakala/simd/cpu"
+)
 
 // Minimum number of float32 elements required for SIMD operations.
 // AVX processes 8 float32 values per 256-bit register.
@@ -257,6 +261,51 @@ func cumulativeSum32(dst, a []float32) {
 
 func dotProductBatch32(results []float32, rows [][]float32, vec []float32) {
 	vecLen := len(vec)
+	if vecLen == 0 {
+		for i := range rows {
+			results[i] = 0
+		}
+		return
+	}
+	if cpu.X86.AVX512F && cpu.X86.AVX512VL && len(rows) >= 4 && vecLen >= minAVX512Elements {
+		i := 0
+		for i+3 < len(rows) {
+			row0, row1, row2, row3 := rows[i], rows[i+1], rows[i+2], rows[i+3]
+			if len(row0) >= vecLen && len(row1) >= vecLen && len(row2) >= vecLen && len(row3) >= vecLen {
+				dotProduct4AVX512(
+					(*float32)(unsafe.Pointer(&results[i])),
+					(*float32)(unsafe.Pointer(&row0[0])),
+					(*float32)(unsafe.Pointer(&row1[0])),
+					(*float32)(unsafe.Pointer(&row2[0])),
+					(*float32)(unsafe.Pointer(&row3[0])),
+					(*float32)(unsafe.Pointer(&vec[0])),
+					vecLen,
+				)
+				i += 4
+				continue
+			}
+			for j := range 4 {
+				row := rows[i+j]
+				n := min(len(row), vecLen)
+				if n == 0 {
+					results[i+j] = 0
+				} else {
+					results[i+j] = dotProduct(row[:n], vec[:n])
+				}
+			}
+			i += 4
+		}
+		for ; i < len(rows); i++ {
+			row := rows[i]
+			n := min(len(row), vecLen)
+			if n == 0 {
+				results[i] = 0
+			} else {
+				results[i] = dotProduct(row[:n], vec[:n])
+			}
+		}
+		return
+	}
 	for i, row := range rows {
 		n := min(len(row), vecLen)
 		if n == 0 {
@@ -264,6 +313,234 @@ func dotProductBatch32(results []float32, rows [][]float32, vec []float32) {
 			continue
 		}
 		results[i] = dotProduct(row[:n], vec[:n])
+	}
+}
+
+const (
+	batchDotRows    = 4
+	batchDotMinDims = 64
+
+	// SIMD-vs-fallback gate. Above these dim/row sizes the batched kernel stops
+	// beating the per-row fallback on the hardware measured so far, so very
+	// large shapes stay on the scalar path. These are deliberately conservative
+	// monotone thresholds, not per-machine tuned cliffs; re-tune against a
+	// benchmark matrix before enabling more shapes.
+	batchDotLargeDims    = 768
+	batchDotLargeMaxRows = 256
+	batchDotHugeDims     = 2048
+	batchDotHugeMaxRows  = 64
+)
+
+// dotProduct4Batch scores four full rows (base[off0..off3], each dims long)
+// against query and writes the four results starting at dst[di]. It centralizes
+// the unsafe pointer setup and the AVX-512/AVX kernel selection shared by the
+// indexed and strided batch loops.
+func dotProduct4Batch(useAVX512 bool, dst []float32, di int, base []float32, off0, off1, off2, off3 int, query []float32, dims int) {
+	results := (*float32)(unsafe.Pointer(&dst[di]))
+	r0 := (*float32)(unsafe.Pointer(&base[off0]))
+	r1 := (*float32)(unsafe.Pointer(&base[off1]))
+	r2 := (*float32)(unsafe.Pointer(&base[off2]))
+	r3 := (*float32)(unsafe.Pointer(&base[off3]))
+	q := (*float32)(unsafe.Pointer(&query[0]))
+	if useAVX512 {
+		dotProduct4AVX512(results, r0, r1, r2, r3, q, dims)
+	} else {
+		dotProduct4AVX(results, r0, r1, r2, r3, q, dims)
+	}
+}
+
+func dotProductIndexed(dst, base, query []float32, rowIDs []uint32, dims int) bool {
+	n := min(len(dst), len(rowIDs))
+	if n == 0 {
+		return false
+	}
+	if !batchDotIndexedSIMDEligible(n, dims, len(query)) {
+		dotProductIndexedFallback(dst[:n], base, query, rowIDs[:n], dims)
+		return false
+	}
+	maxRow := fullRowMaxIndex(len(base), dims, dims)
+	if maxRow < 0 {
+		dotProductIndexedFallback(dst[:n], base, query, rowIDs[:n], dims)
+		return false
+	}
+	useAVX512 := cpu.X86.AVX512F && cpu.X86.AVX512VL
+	useAVX := !useAVX512 && cpu.X86.AVX2 && cpu.X86.FMA
+	if !useAVX512 && !useAVX {
+		dotProductIndexedFallback(dst[:n], base, query, rowIDs[:n], dims)
+		return false
+	}
+
+	queryFull := query[:dims]
+	usedSIMD := false
+	i := 0
+	for ; i+batchDotRows-1 < n; i += batchDotRows {
+		id0, id1, id2, id3 := rowIDs[i], rowIDs[i+1], rowIDs[i+2], rowIDs[i+3]
+		if rowIDInFullRange(id0, maxRow) && rowIDInFullRange(id1, maxRow) && rowIDInFullRange(id2, maxRow) && rowIDInFullRange(id3, maxRow) {
+			off0 := int(id0) * dims
+			off1 := int(id1) * dims
+			off2 := int(id2) * dims
+			off3 := int(id3) * dims
+			dotProduct4Batch(useAVX512, dst, i, base, off0, off1, off2, off3, queryFull, dims)
+			usedSIMD = true
+			continue
+		}
+		for j := range batchDotRows {
+			dst[i+j] = dotProductIndexedTail(base, query, queryFull, rowIDs[i+j], dims, maxRow, usedSIMD)
+		}
+	}
+	for ; i < n; i++ {
+		dst[i] = dotProductIndexedTail(base, query, queryFull, rowIDs[i], dims, maxRow, usedSIMD)
+	}
+	return usedSIMD
+}
+
+func dotProductStrided(dst, base, query []float32, rowCount, dims, stride int) bool {
+	if rowCount <= 0 || len(dst) == 0 {
+		return false
+	}
+	n := min(len(dst), rowCount)
+	if !batchDotStridedSIMDEligible(n, dims, stride, len(query)) {
+		dotProductStridedFallback(dst[:n], base, query, n, dims, stride)
+		return false
+	}
+	maxRow := fullRowMaxIndex(len(base), dims, stride)
+	if maxRow < 0 {
+		dotProductStridedFallback(dst[:n], base, query, n, dims, stride)
+		return false
+	}
+	useAVX512 := cpu.X86.AVX512F && cpu.X86.AVX512VL
+	useAVX := !useAVX512 && cpu.X86.AVX2 && cpu.X86.FMA
+	if !useAVX512 && !useAVX {
+		dotProductStridedFallback(dst[:n], base, query, n, dims, stride)
+		return false
+	}
+
+	queryFull := query[:dims]
+	usedSIMD := false
+	i := 0
+	for ; i+batchDotRows-1 < n; i += batchDotRows {
+		if i+batchDotRows-1 <= maxRow {
+			off0 := i * stride
+			off1 := off0 + stride
+			off2 := off1 + stride
+			off3 := off2 + stride
+			dotProduct4Batch(useAVX512, dst, i, base, off0, off1, off2, off3, queryFull, dims)
+			usedSIMD = true
+			continue
+		}
+		for j := range batchDotRows {
+			dst[i+j] = dotProductStridedTail(base, query, queryFull, i+j, dims, stride, maxRow, usedSIMD)
+		}
+	}
+	for ; i < n; i++ {
+		dst[i] = dotProductStridedTail(base, query, queryFull, i, dims, stride, maxRow, usedSIMD)
+	}
+	return usedSIMD
+}
+
+func fullRowMaxIndex(baseLen, dims, stride int) int {
+	if dims <= 0 || stride <= 0 || baseLen < dims {
+		return -1
+	}
+	return (baseLen - dims) / stride
+}
+
+func rowIDInFullRange(rowID uint32, maxRow int) bool {
+	return maxRow >= 0 && uint64(rowID) <= uint64(maxRow)
+}
+
+func dotProductIndexedFallback(dst, base, query []float32, rowIDs []uint32, dims int) {
+	n := min(len(dst), len(rowIDs))
+	if n == 0 {
+		return
+	}
+	if dims <= 0 || len(query) == 0 {
+		clear(dst[:n])
+		return
+	}
+	queryN := min(dims, len(query))
+	queryFull := query[:queryN]
+	maxRow := fullRowMaxIndex(len(base), queryN, dims)
+	for i := range n {
+		rowID := rowIDs[i]
+		if rowIDInFullRange(rowID, maxRow) {
+			off := int(rowID) * dims
+			dst[i] = dotProduct(base[off:off+queryN], queryFull)
+			continue
+		}
+		dst[i] = dotProductIndexedOneGo(base, query, rowID, dims)
+	}
+}
+
+func dotProductStridedFallback(dst, base, query []float32, rowCount, dims, stride int) {
+	if rowCount <= 0 || len(dst) == 0 {
+		return
+	}
+	n := min(len(dst), rowCount)
+	if dims <= 0 || stride <= 0 || len(query) == 0 {
+		clear(dst[:n])
+		return
+	}
+	queryN := min(dims, len(query))
+	queryFull := query[:queryN]
+	maxRow := fullRowMaxIndex(len(base), queryN, stride)
+	if n-1 <= maxRow {
+		for i, off := 0, 0; i < n; i, off = i+1, off+stride {
+			dst[i] = dotProduct(base[off:off+queryN], queryFull)
+		}
+		return
+	}
+	for i := range n {
+		if i <= maxRow {
+			off := i * stride
+			dst[i] = dotProduct(base[off:off+queryN], queryFull)
+			continue
+		}
+		dst[i] = dotProductStridedOneGo(base, query, i, dims, stride)
+	}
+}
+
+func dotProductIndexedTail(base, query, queryFull []float32, rowID uint32, dims, maxRow int, allowDotProduct bool) float32 {
+	if allowDotProduct && rowIDInFullRange(rowID, maxRow) {
+		off := int(rowID) * dims
+		return dotProduct(base[off:off+dims], queryFull)
+	}
+	return dotProductIndexedOneGo(base, query, rowID, dims)
+}
+
+func dotProductStridedTail(base, query, queryFull []float32, row, dims, stride, maxRow int, allowDotProduct bool) float32 {
+	if allowDotProduct && row >= 0 && row <= maxRow {
+		off := row * stride
+		return dotProduct(base[off:off+dims], queryFull)
+	}
+	return dotProductStridedOneGo(base, query, row, dims, stride)
+}
+
+func batchDotIndexedSIMDEligible(rows, dims, queryLen int) bool {
+	if rows < batchDotRows || dims < batchDotMinDims || queryLen < dims {
+		return false
+	}
+	return batchDotRowsWithinGate(rows, dims)
+}
+
+func batchDotStridedSIMDEligible(rows, dims, stride, queryLen int) bool {
+	if rows < batchDotRows || dims < batchDotMinDims || stride <= 0 || queryLen < dims {
+		return false
+	}
+	return batchDotRowsWithinGate(rows, dims)
+}
+
+// batchDotRowsWithinGate reports whether a (rows, dims) shape is small enough
+// that the batched SIMD kernel is expected to beat the per-row fallback. The
+// gate is monotone in both dimensions: larger shapes fall back first.
+func batchDotRowsWithinGate(rows, dims int) bool {
+	switch {
+	case dims >= batchDotHugeDims:
+		return rows < batchDotHugeMaxRows
+	case dims >= batchDotLargeDims:
+		return rows < batchDotLargeMaxRows
+	default:
+		return true
 	}
 }
 
@@ -412,6 +689,9 @@ func convolveDecimateAVX512(dst, signal, kernel []float32, factor, phase int)
 func convolveDecimateSSE(dst, signal, kernel []float32, factor, phase int)
 
 //go:noescape
+func dotProduct4AVX(results, row0, row1, row2, row3, vec *float32, n int)
+
+//go:noescape
 func addAVX(dst, a, b []float32)
 
 //go:noescape
@@ -466,6 +746,9 @@ func addScaledAVX(dst []float32, alpha float32, s []float32)
 //
 //go:noescape
 func dotProductAVX512(a, b []float32) float32
+
+//go:noescape
+func dotProduct4AVX512(results, row0, row1, row2, row3, vec *float32, n int)
 
 //go:noescape
 func addAVX512(dst, a, b []float32)

--- a/f32/f32_amd64.go
+++ b/f32/f32_amd64.go
@@ -364,7 +364,7 @@ func dotProductIndexed(dst, base, query []float32, rowIDs []uint32, dims int) bo
 		return false
 	}
 	useAVX512 := cpu.X86.AVX512F && cpu.X86.AVX512VL
-	useAVX := !useAVX512 && cpu.X86.AVX2 && cpu.X86.FMA
+	useAVX := !useAVX512 && cpu.X86.AVX && cpu.X86.FMA
 	if !useAVX512 && !useAVX {
 		dotProductIndexedFallback(dst[:n], base, query, rowIDs[:n], dims)
 		return false
@@ -409,7 +409,7 @@ func dotProductStrided(dst, base, query []float32, rowCount, dims, stride int) b
 		return false
 	}
 	useAVX512 := cpu.X86.AVX512F && cpu.X86.AVX512VL
-	useAVX := !useAVX512 && cpu.X86.AVX2 && cpu.X86.FMA
+	useAVX := !useAVX512 && cpu.X86.AVX && cpu.X86.FMA
 	if !useAVX512 && !useAVX {
 		dotProductStridedFallback(dst[:n], base, query, n, dims, stride)
 		return false

--- a/f32/f32_amd64.go
+++ b/f32/f32_amd64.go
@@ -385,11 +385,11 @@ func dotProductIndexed(dst, base, query []float32, rowIDs []uint32, dims int) bo
 			continue
 		}
 		for j := range batchDotRows {
-			dst[i+j] = dotProductIndexedTail(base, query, queryFull, rowIDs[i+j], dims, maxRow, usedSIMD)
+			dst[i+j] = dotProductIndexedTail(base, query, queryFull, rowIDs[i+j], dims, maxRow)
 		}
 	}
 	for ; i < n; i++ {
-		dst[i] = dotProductIndexedTail(base, query, queryFull, rowIDs[i], dims, maxRow, usedSIMD)
+		dst[i] = dotProductIndexedTail(base, query, queryFull, rowIDs[i], dims, maxRow)
 	}
 	return usedSIMD
 }
@@ -429,11 +429,11 @@ func dotProductStrided(dst, base, query []float32, rowCount, dims, stride int) b
 			continue
 		}
 		for j := range batchDotRows {
-			dst[i+j] = dotProductStridedTail(base, query, queryFull, i+j, dims, stride, maxRow, usedSIMD)
+			dst[i+j] = dotProductStridedTail(base, query, queryFull, i+j, dims, stride, maxRow)
 		}
 	}
 	for ; i < n; i++ {
-		dst[i] = dotProductStridedTail(base, query, queryFull, i, dims, stride, maxRow, usedSIMD)
+		dst[i] = dotProductStridedTail(base, query, queryFull, i, dims, stride, maxRow)
 	}
 	return usedSIMD
 }
@@ -500,16 +500,20 @@ func dotProductStridedFallback(dst, base, query []float32, rowCount, dims, strid
 	}
 }
 
-func dotProductIndexedTail(base, query, queryFull []float32, rowID uint32, dims, maxRow int, allowDotProduct bool) float32 {
-	if allowDotProduct && rowIDInFullRange(rowID, maxRow) {
+// dotProductIndexedTail scores one row for the mixed-block and trailing-tail
+// paths. The CPU capability and queryLen >= dims are already verified by the
+// caller, so any in-range row can take the optimized single-row dotProduct;
+// out-of-range rows score zero via the ragged-safe Go path.
+func dotProductIndexedTail(base, query, queryFull []float32, rowID uint32, dims, maxRow int) float32 {
+	if rowIDInFullRange(rowID, maxRow) {
 		off := int(rowID) * dims
 		return dotProduct(base[off:off+dims], queryFull)
 	}
 	return dotProductIndexedOneGo(base, query, rowID, dims)
 }
 
-func dotProductStridedTail(base, query, queryFull []float32, row, dims, stride, maxRow int, allowDotProduct bool) float32 {
-	if allowDotProduct && row >= 0 && row <= maxRow {
+func dotProductStridedTail(base, query, queryFull []float32, row, dims, stride, maxRow int) float32 {
+	if row >= 0 && row <= maxRow {
 		off := row * stride
 		return dotProduct(base[off:off+dims], queryFull)
 	}

--- a/f32/f32_amd64.s
+++ b/f32/f32_amd64.s
@@ -5197,7 +5197,9 @@ dot4_512_reduce:
     VADDPS Z9, Z5, Z5
 
     // Reduce acc0 into X0.
-    VEXTRACTF32X8 $1, Z0, Y1
+    // VEXTRACTF64X4 (AVX512F) extracts the same upper 256 bits as VEXTRACTF32X8
+    // (AVX512DQ) but without requiring DQ, matching the AVX512F+VL dispatch gate.
+    VEXTRACTF64X4 $1, Z0, Y1
     VADDPS Y1, Y0, Y0
     VEXTRACTF128 $1, Y0, X1
     VADDPS X1, X0, X0
@@ -5205,7 +5207,7 @@ dot4_512_reduce:
     VHADDPS X0, X0, X0
 
     // Reduce acc1 into X3.
-    VEXTRACTF32X8 $1, Z3, Y1
+    VEXTRACTF64X4 $1, Z3, Y1
     VADDPS Y1, Y3, Y3
     VEXTRACTF128 $1, Y3, X1
     VADDPS X1, X3, X3
@@ -5213,7 +5215,7 @@ dot4_512_reduce:
     VHADDPS X3, X3, X3
 
     // Reduce acc2 into X4.
-    VEXTRACTF32X8 $1, Z4, Y1
+    VEXTRACTF64X4 $1, Z4, Y1
     VADDPS Y1, Y4, Y4
     VEXTRACTF128 $1, Y4, X1
     VADDPS X1, X4, X4
@@ -5221,7 +5223,7 @@ dot4_512_reduce:
     VHADDPS X4, X4, X4
 
     // Reduce acc3 into X5.
-    VEXTRACTF32X8 $1, Z5, Y1
+    VEXTRACTF64X4 $1, Z5, Y1
     VADDPS Y1, Y5, Y5
     VEXTRACTF128 $1, Y5, X1
     VADDPS X1, X5, X5

--- a/f32/f32_amd64.s
+++ b/f32/f32_amd64.s
@@ -738,6 +738,7 @@ TEXT ·dotProductAVX512(SB), NOSPLIT, $0-52
     SHRQ $6, AX                // len / 64
     JZ   dot32_512_loop16_check
 
+PCALIGN $64
 dot32_512_loop64:
     // Load and FMA for acc0
     VMOVUPS (SI), Z1
@@ -776,6 +777,7 @@ dot32_512_loop16_check:
     SHRQ $4, AX
     JZ   dot32_512_remainder
 
+PCALIGN $64
 dot32_512_loop16:
     VMOVUPS (SI), Z1
     VMOVUPS (DI), Z2
@@ -4933,4 +4935,324 @@ cd_sse_store:
     JNZ  cd_sse_outer
 
 cd_sse_ret:
+    RET
+
+// func dotProduct4AVX(results, row0, row1, row2, row3, vec *float32, n int)
+// Computes four dot products against the same vec, reusing each vec load.
+TEXT ·dotProduct4AVX(SB), NOSPLIT, $0-56
+    MOVQ results+0(FP), DX
+    MOVQ row0+8(FP), SI
+    MOVQ row1+16(FP), R8
+    MOVQ row2+24(FP), R9
+    MOVQ row3+32(FP), R10
+    MOVQ vec+40(FP), DI
+    MOVQ n+48(FP), CX
+
+    VXORPS Y0, Y0, Y0          // acc0a
+    VXORPS Y3, Y3, Y3          // acc1a
+    VXORPS Y4, Y4, Y4          // acc2a
+    VXORPS Y5, Y5, Y5          // acc3a
+    VXORPS Y6, Y6, Y6          // acc0b
+    VXORPS Y7, Y7, Y7          // acc1b
+    VXORPS Y8, Y8, Y8          // acc2b
+    VXORPS Y9, Y9, Y9          // acc3b
+
+    MOVQ CX, AX
+    SHRQ $5, AX                // n / 32
+    JZ   dot4_avx_loop8_check
+
+dot4_avx_loop32:
+    VMOVUPS (DI), Y1
+    VMOVUPS (SI), Y2
+    VFMADD231PS Y1, Y2, Y0
+    VMOVUPS (R8), Y2
+    VFMADD231PS Y1, Y2, Y3
+    VMOVUPS (R9), Y2
+    VFMADD231PS Y1, Y2, Y4
+    VMOVUPS (R10), Y2
+    VFMADD231PS Y1, Y2, Y5
+
+    VMOVUPS 32(DI), Y1
+    VMOVUPS 32(SI), Y2
+    VFMADD231PS Y1, Y2, Y6
+    VMOVUPS 32(R8), Y2
+    VFMADD231PS Y1, Y2, Y7
+    VMOVUPS 32(R9), Y2
+    VFMADD231PS Y1, Y2, Y8
+    VMOVUPS 32(R10), Y2
+    VFMADD231PS Y1, Y2, Y9
+
+    VMOVUPS 64(DI), Y1
+    VMOVUPS 64(SI), Y2
+    VFMADD231PS Y1, Y2, Y0
+    VMOVUPS 64(R8), Y2
+    VFMADD231PS Y1, Y2, Y3
+    VMOVUPS 64(R9), Y2
+    VFMADD231PS Y1, Y2, Y4
+    VMOVUPS 64(R10), Y2
+    VFMADD231PS Y1, Y2, Y5
+
+    VMOVUPS 96(DI), Y1
+    VMOVUPS 96(SI), Y2
+    VFMADD231PS Y1, Y2, Y6
+    VMOVUPS 96(R8), Y2
+    VFMADD231PS Y1, Y2, Y7
+    VMOVUPS 96(R9), Y2
+    VFMADD231PS Y1, Y2, Y8
+    VMOVUPS 96(R10), Y2
+    VFMADD231PS Y1, Y2, Y9
+
+    ADDQ $128, DI
+    ADDQ $128, SI
+    ADDQ $128, R8
+    ADDQ $128, R9
+    ADDQ $128, R10
+    DECQ AX
+    JNZ  dot4_avx_loop32
+
+dot4_avx_loop8_check:
+    ANDQ $31, CX
+    MOVQ CX, AX
+    SHRQ $3, AX
+    JZ   dot4_avx_reduce
+
+dot4_avx_loop8:
+    VMOVUPS (DI), Y1
+    VMOVUPS (SI), Y2
+    VFMADD231PS Y1, Y2, Y0
+    VMOVUPS (R8), Y2
+    VFMADD231PS Y1, Y2, Y3
+    VMOVUPS (R9), Y2
+    VFMADD231PS Y1, Y2, Y4
+    VMOVUPS (R10), Y2
+    VFMADD231PS Y1, Y2, Y5
+    ADDQ $32, DI
+    ADDQ $32, SI
+    ADDQ $32, R8
+    ADDQ $32, R9
+    ADDQ $32, R10
+    DECQ AX
+    JNZ  dot4_avx_loop8
+
+dot4_avx_reduce:
+    VADDPS Y6, Y0, Y0
+    VADDPS Y7, Y3, Y3
+    VADDPS Y8, Y4, Y4
+    VADDPS Y9, Y5, Y5
+
+    // Reduce acc0 into X0.
+    VEXTRACTF128 $1, Y0, X1
+    VADDPS X1, X0, X0
+    VHADDPS X0, X0, X0
+    VHADDPS X0, X0, X0
+
+    // Reduce acc1 into X3.
+    VEXTRACTF128 $1, Y3, X1
+    VADDPS X1, X3, X3
+    VHADDPS X3, X3, X3
+    VHADDPS X3, X3, X3
+
+    // Reduce acc2 into X4.
+    VEXTRACTF128 $1, Y4, X1
+    VADDPS X1, X4, X4
+    VHADDPS X4, X4, X4
+    VHADDPS X4, X4, X4
+
+    // Reduce acc3 into X5.
+    VEXTRACTF128 $1, Y5, X1
+    VADDPS X1, X5, X5
+    VHADDPS X5, X5, X5
+    VHADDPS X5, X5, X5
+
+    ANDQ $7, CX
+    JZ   dot4_avx_done
+
+dot4_avx_scalar:
+    VMOVSS (DI), X1
+    VMOVSS (SI), X2
+    VFMADD231SS X1, X2, X0
+    VMOVSS (R8), X2
+    VFMADD231SS X1, X2, X3
+    VMOVSS (R9), X2
+    VFMADD231SS X1, X2, X4
+    VMOVSS (R10), X2
+    VFMADD231SS X1, X2, X5
+    ADDQ $4, DI
+    ADDQ $4, SI
+    ADDQ $4, R8
+    ADDQ $4, R9
+    ADDQ $4, R10
+    DECQ CX
+    JNZ  dot4_avx_scalar
+
+dot4_avx_done:
+    VMOVSS X0, (DX)
+    VMOVSS X3, 4(DX)
+    VMOVSS X4, 8(DX)
+    VMOVSS X5, 12(DX)
+    VZEROUPPER
+    RET
+
+// func dotProduct4AVX512(results, row0, row1, row2, row3, vec *float32, n int)
+// Computes four dot products against the same vec, reusing each vec load.
+TEXT ·dotProduct4AVX512(SB), NOSPLIT, $0-56
+    MOVQ results+0(FP), DX
+    MOVQ row0+8(FP), SI
+    MOVQ row1+16(FP), R8
+    MOVQ row2+24(FP), R9
+    MOVQ row3+32(FP), R10
+    MOVQ vec+40(FP), DI
+    MOVQ n+48(FP), CX
+
+    VXORPS Z0, Z0, Z0          // acc0a
+    VXORPS Z3, Z3, Z3          // acc1a
+    VXORPS Z4, Z4, Z4          // acc2a
+    VXORPS Z5, Z5, Z5          // acc3a
+    VXORPS Z6, Z6, Z6          // acc0b
+    VXORPS Z7, Z7, Z7          // acc1b
+    VXORPS Z8, Z8, Z8          // acc2b
+    VXORPS Z9, Z9, Z9          // acc3b
+
+    MOVQ CX, AX
+    SHRQ $6, AX                // n / 64
+    JZ   dot4_512_loop16_check
+
+dot4_512_loop64:
+    VMOVUPS (DI), Z1
+    VMOVUPS (SI), Z2
+    VFMADD231PS Z1, Z2, Z0
+    VMOVUPS (R8), Z2
+    VFMADD231PS Z1, Z2, Z3
+    VMOVUPS (R9), Z2
+    VFMADD231PS Z1, Z2, Z4
+    VMOVUPS (R10), Z2
+    VFMADD231PS Z1, Z2, Z5
+
+    VMOVUPS 64(DI), Z1
+    VMOVUPS 64(SI), Z2
+    VFMADD231PS Z1, Z2, Z6
+    VMOVUPS 64(R8), Z2
+    VFMADD231PS Z1, Z2, Z7
+    VMOVUPS 64(R9), Z2
+    VFMADD231PS Z1, Z2, Z8
+    VMOVUPS 64(R10), Z2
+    VFMADD231PS Z1, Z2, Z9
+
+    VMOVUPS 128(DI), Z1
+    VMOVUPS 128(SI), Z2
+    VFMADD231PS Z1, Z2, Z0
+    VMOVUPS 128(R8), Z2
+    VFMADD231PS Z1, Z2, Z3
+    VMOVUPS 128(R9), Z2
+    VFMADD231PS Z1, Z2, Z4
+    VMOVUPS 128(R10), Z2
+    VFMADD231PS Z1, Z2, Z5
+
+    VMOVUPS 192(DI), Z1
+    VMOVUPS 192(SI), Z2
+    VFMADD231PS Z1, Z2, Z6
+    VMOVUPS 192(R8), Z2
+    VFMADD231PS Z1, Z2, Z7
+    VMOVUPS 192(R9), Z2
+    VFMADD231PS Z1, Z2, Z8
+    VMOVUPS 192(R10), Z2
+    VFMADD231PS Z1, Z2, Z9
+
+    ADDQ $256, DI
+    ADDQ $256, SI
+    ADDQ $256, R8
+    ADDQ $256, R9
+    ADDQ $256, R10
+    DECQ AX
+    JNZ  dot4_512_loop64
+
+dot4_512_loop16_check:
+    ANDQ $63, CX
+    MOVQ CX, AX
+    SHRQ $4, AX
+    JZ   dot4_512_reduce
+
+dot4_512_loop16:
+    VMOVUPS (DI), Z1
+    VMOVUPS (SI), Z2
+    VFMADD231PS Z1, Z2, Z0
+    VMOVUPS (R8), Z2
+    VFMADD231PS Z1, Z2, Z3
+    VMOVUPS (R9), Z2
+    VFMADD231PS Z1, Z2, Z4
+    VMOVUPS (R10), Z2
+    VFMADD231PS Z1, Z2, Z5
+    ADDQ $64, DI
+    ADDQ $64, SI
+    ADDQ $64, R8
+    ADDQ $64, R9
+    ADDQ $64, R10
+    DECQ AX
+    JNZ  dot4_512_loop16
+
+dot4_512_reduce:
+    VADDPS Z6, Z0, Z0
+    VADDPS Z7, Z3, Z3
+    VADDPS Z8, Z4, Z4
+    VADDPS Z9, Z5, Z5
+
+    // Reduce acc0 into X0.
+    VEXTRACTF32X8 $1, Z0, Y1
+    VADDPS Y1, Y0, Y0
+    VEXTRACTF128 $1, Y0, X1
+    VADDPS X1, X0, X0
+    VHADDPS X0, X0, X0
+    VHADDPS X0, X0, X0
+
+    // Reduce acc1 into X3.
+    VEXTRACTF32X8 $1, Z3, Y1
+    VADDPS Y1, Y3, Y3
+    VEXTRACTF128 $1, Y3, X1
+    VADDPS X1, X3, X3
+    VHADDPS X3, X3, X3
+    VHADDPS X3, X3, X3
+
+    // Reduce acc2 into X4.
+    VEXTRACTF32X8 $1, Z4, Y1
+    VADDPS Y1, Y4, Y4
+    VEXTRACTF128 $1, Y4, X1
+    VADDPS X1, X4, X4
+    VHADDPS X4, X4, X4
+    VHADDPS X4, X4, X4
+
+    // Reduce acc3 into X5.
+    VEXTRACTF32X8 $1, Z5, Y1
+    VADDPS Y1, Y5, Y5
+    VEXTRACTF128 $1, Y5, X1
+    VADDPS X1, X5, X5
+    VHADDPS X5, X5, X5
+    VHADDPS X5, X5, X5
+
+    ANDQ $15, CX
+    JZ   dot4_512_done
+
+dot4_512_scalar:
+    VMOVSS (DI), X1
+    VMOVSS (SI), X2
+    VFMADD231SS X1, X2, X0
+    VMOVSS (R8), X2
+    VFMADD231SS X1, X2, X3
+    VMOVSS (R9), X2
+    VFMADD231SS X1, X2, X4
+    VMOVSS (R10), X2
+    VFMADD231SS X1, X2, X5
+    ADDQ $4, DI
+    ADDQ $4, SI
+    ADDQ $4, R8
+    ADDQ $4, R9
+    ADDQ $4, R10
+    DECQ CX
+    JNZ  dot4_512_scalar
+
+dot4_512_done:
+    VMOVSS X0, (DX)
+    VMOVSS X3, 4(DX)
+    VMOVSS X4, 8(DX)
+    VMOVSS X5, 12(DX)
+    VZEROUPPER
     RET

--- a/f32/f32_arm64.go
+++ b/f32/f32_arm64.go
@@ -128,6 +128,16 @@ func dotProductBatch32(results []float32, rows [][]float32, vec []float32) {
 	}
 }
 
+func dotProductIndexed(dst, base, query []float32, rowIDs []uint32, dims int) bool {
+	dotProductIndexedGo(dst, base, query, rowIDs, dims)
+	return false
+}
+
+func dotProductStrided(dst, base, query []float32, rowCount, dims, stride int) bool {
+	dotProductStridedGo(dst, base, query, rowCount, dims, stride)
+	return false
+}
+
 func convolveValid32(dst, signal, kernel []float32) {
 	kLen := len(kernel)
 	for i := range dst {

--- a/f32/f32_go.go
+++ b/f32/f32_go.go
@@ -198,6 +198,99 @@ func dotProductBatch32Go(results []float32, rows [][]float32, vec []float32) {
 	}
 }
 
+func dotProductIndexedGo(dst, base, query []float32, rowIDs []uint32, dims int) {
+	n := min(len(dst), len(rowIDs))
+	if n == 0 {
+		return
+	}
+	if dims <= 0 || len(query) == 0 {
+		clear(dst[:n])
+		return
+	}
+	for i := range n {
+		dst[i] = dotProductIndexedOneGo(base, query, rowIDs[i], dims)
+	}
+}
+
+func dotProductIndexedOneGo(base, query []float32, rowID uint32, dims int) float32 {
+	if dims <= 0 || len(query) == 0 {
+		return 0
+	}
+	offset, ok := rowOffsetUint32InBase(rowID, dims, len(base))
+	if !ok {
+		return 0
+	}
+	n := min(dims, len(query))
+	if remaining := len(base) - offset; remaining < n {
+		n = remaining
+	}
+	if n <= 0 {
+		return 0
+	}
+	return dotProduct(base[offset:offset+n], query[:n])
+}
+
+func dotProductStridedGo(dst, base, query []float32, rowCount, dims, stride int) {
+	if rowCount <= 0 || len(dst) == 0 {
+		return
+	}
+	n := min(len(dst), rowCount)
+	if dims <= 0 || stride <= 0 || len(query) == 0 {
+		clear(dst[:n])
+		return
+	}
+	for i := range n {
+		dst[i] = dotProductStridedOneGo(base, query, i, dims, stride)
+	}
+}
+
+func dotProductStridedOneGo(base, query []float32, row, dims, stride int) float32 {
+	if row < 0 || dims <= 0 || stride <= 0 || len(query) == 0 {
+		return 0
+	}
+	offset, ok := rowOffsetStrideInBase(row, stride, len(base))
+	if !ok {
+		return 0
+	}
+	n := min(dims, len(query))
+	if remaining := len(base) - offset; remaining < n {
+		n = remaining
+	}
+	if n <= 0 {
+		return 0
+	}
+	return dotProduct(base[offset:offset+n], query[:n])
+}
+
+func rowOffsetUint32InBase(rowID uint32, stride, baseLen int) (int, bool) {
+	if stride <= 0 || baseLen <= 0 {
+		return 0, false
+	}
+	offset, ok := mulUint64(uint64(rowID), uint64(stride))
+	if !ok || offset >= uint64(baseLen) {
+		return 0, false
+	}
+	return int(offset), true
+}
+
+func rowOffsetStrideInBase(row, stride, baseLen int) (int, bool) {
+	if row < 0 || stride <= 0 || baseLen <= 0 {
+		return 0, false
+	}
+	offset, ok := mulUint64(uint64(row), uint64(stride))
+	if !ok || offset >= uint64(baseLen) {
+		return 0, false
+	}
+	return int(offset), true
+}
+
+func mulUint64(a, b uint64) (uint64, bool) {
+	if a != 0 && b > ^uint64(0)/a {
+		return 0, false
+	}
+	return a * b, true
+}
+
 func convolveValid32Go(dst, signal, kernel []float32) {
 	kLen := len(kernel)
 	for i := range dst {

--- a/f32/f32_other.go
+++ b/f32/f32_other.go
@@ -19,6 +19,14 @@ func clamp32(dst, a []float32, minVal, maxVal float32) { clampGo(dst, a, minVal,
 func dotProductBatch32(results []float32, rows [][]float32, vec []float32) {
 	dotProductBatch32Go(results, rows, vec)
 }
+func dotProductIndexed(dst, base, query []float32, rowIDs []uint32, dims int) bool {
+	dotProductIndexedGo(dst, base, query, rowIDs, dims)
+	return false
+}
+func dotProductStrided(dst, base, query []float32, rowCount, dims, stride int) bool {
+	dotProductStridedGo(dst, base, query, rowCount, dims, stride)
+	return false
+}
 func convolveValid32(dst, signal, kernel []float32) { convolveValid32Go(dst, signal, kernel) }
 func convolveDecimate32(dst, signal, kernel []float32, factor, phase int) {
 	convolveDecimate32Go(dst, signal, kernel, factor, phase)


### PR DESCRIPTION
## Summary

Adds two allocation-free public APIs for scoring rows of a flat row-major
`float32` store against a single query vector, without building `[][]float32`
(the embedding / vector-search shape):

- `DotProductIndexed(dst, base, query, rowIDs, dims) bool`: scores rows
  selected by `uint32` row ID.
- `DotProductStrided(dst, base, query, rowCount, dims, stride) bool`: scores
  contiguous or fixed-stride rows.

Both dispatch to two new kernels, `dotProduct4AVX` and `dotProduct4AVX512`,
that compute four dot products against the same query while reusing each
query load (the win is 4x fewer query loads, not just wider vectors). Ragged
inputs, tiny shapes, tails, unsupported CPUs, and out-of-range rows fall back
to a per-row scalar path; the functions return whether an optimized batch
kernel actually ran. Ships with a Go reference, ARM64/other fallbacks, parity
tests against the reference, an allocation-free assertion, threshold-predicate
tests, and benchmarks.

The two new assembly kernels use only caller-safe scratch registers
(`AX/CX/DX/SI/DI/R8-R10`); neither touches `R14` (the goroutine `g` pointer),
in line with the repo's reserved-register rules.

### Attribution

The feature originates from Mikers' fork (`github.com/snissn/simd`), credited
as co-author on the commit. Changes I made while upstreaming it: rebased onto
current `main` (preserving the InterleaveN and ConvolveDecimate work that
landed after the fork branched), replaced the per-machine SIMD-eligibility
cliffs with a conservative monotone gate (identical numeric results, the gate
only chooses SIMD vs fallback), removed two unused offset helpers, and applied
the repo's lint conventions.

## Test Plan

- [x] `go build ./...`, `go vet ./f32/`, `gofmt` clean
- [x] `golangci-lint run ./...` clean (amd64 and `GOARCH=arm64`)
- [x] `go test ./...` passes on amd64 (AVX / AVX-512 kernels exercised natively)
- [x] Cross-compiled `f32` test binary run on a native Raspberry Pi 5 (aarch64): full `f32` suite passes, including the new row-major parity/ragged/allocs tests on the Go fallback path
- [x] Allocation-free assertion (`testing.AllocsPerRun == 0`) for both new APIs

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

**New Features**
- Added `DotProductIndexed` and `DotProductStrided` functions for computing multiple dot products in row-major layout with zero allocations and automatic hardware optimization when available.

**Documentation**
- Updated README and package documentation with the new row-major batch dot product APIs and usage details.

**Tests**
- Added comprehensive test coverage including correctness validation, benchmarks, and allocation verification.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->