### PR TITLE
ci: make codecov project/patch coverage informational

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -1,0 +1,24 @@
+# codecov configuration
+#
+# This is a hand-written SIMD library: every primitive dispatches through
+# CPU-feature-gated branches (AVX-512 vs AVX vs scalar). On any single CI runner
+# only the branch matching that runner's CPU executes, so the other ISA arms are
+# permanently uncovered, and the hand-written .s kernels are not measured by Go
+# coverage at all. Patch coverage therefore cannot reach 100% for ISA-gated
+# dispatch on one CPU. Keep coverage visible and useful for the Go reference,
+# fallback, and validation code, but never let it block a PR: mark project and
+# patch status informational.
+coverage:
+  status:
+    project:
+      default:
+        informational: true
+    patch:
+      default:
+        informational: true
+
+ignore:
+  - "**/*_test.go"
+
+comment:
+  layout: "reach, diff, files"


### PR DESCRIPTION
## Summary

Add a `codecov.yml` that marks both `project` and `patch` coverage status as `informational: true`, and ignores `_test.go` files.

This is a hand-written SIMD library where every primitive dispatches through CPU-feature-gated branches (AVX-512 vs AVX vs scalar). On any single CI runner only the branch matching that runner's CPU executes, so the other ISA arms are permanently uncovered, and the hand-written `.s` kernels are not measured by Go coverage at all. Patch coverage therefore cannot structurally reach the default target for ISA-gated dispatch on a single CPU. PR #63 is a concrete example: every check passed except a red `codecov/patch` from the `useAVX512`/`useAVX` dispatch arms.

Making the statuses informational keeps the coverage signal visible and useful for the Go reference, fallback, and validation code without ever producing a false-red that blocks a PR.

## Test Plan
- [x] `codecov.yml` parses as valid YAML
- [x] Accepted by codecov's schema validator (`https://codecov.io/validate` returns "Valid!")