### PR TITLE
f32: extend dotProductBatch32 4x query-load reuse to AVX2/FMA

### DIFF
--- a/README.md
+++ b/README.md
@@ -158,6 +158,12 @@ use the allocation-free generic path.
 
 Both APIs are allocation-free and include per-row fallback semantics for unsupported CPUs, tiny shapes, tails, and ragged inputs.
 
+`DotProductBatch` scores its `[][]float32` rows in groups of four, keeping the
+query vector resident in registers across each group instead of re-loading it
+for every row. The fused 4-row kernel runs on both AVX-512 and AVX2/FMA; short,
+ragged, or sub-SIMD-width rows fall back to the per-row dot product. Results are
+identical to the per-row path either way.
+
 **Additional split-format complex operations** (for FFT pipelines with separate real/imag arrays):
 
 | Category   | Function                              | Description                        | SIMD Width       |

--- a/README.md
+++ b/README.md
@@ -160,7 +160,7 @@ Both APIs are allocation-free and include per-row fallback semantics for unsuppo
 
 `DotProductBatch` scores its `[][]float32` rows in groups of four, keeping the
 query vector resident in registers across each group instead of re-loading it
-for every row. The fused 4-row kernel runs on both AVX-512 and AVX2/FMA; short,
+for every row. The fused 4-row kernel runs on both AVX-512 and AVX+FMA; short,
 ragged, or sub-SIMD-width rows fall back to the per-row dot product. Results are
 identical to the per-row path either way.
 

--- a/f32/dot_product_batch4_amd64_test.go
+++ b/f32/dot_product_batch4_amd64_test.go
@@ -1,0 +1,88 @@
+//go:build amd64
+
+package f32
+
+import (
+	"testing"
+
+	"github.com/tphakala/simd/cpu"
+)
+
+// kernelBatchModes returns the SIMD batch-of-4 modes that the current CPU can
+// actually execute. dotProductBatchKernel(false, ...) runs the AVX2/FMA kernel
+// and dotProductBatchKernel(true, ...) the AVX-512 one, so calling either on a
+// CPU without the matching ISA would fault. Tests use this to exercise every
+// kernel the host supports, including the AVX2 path that issue #64 adds.
+func kernelBatchModes() []bool {
+	var modes []bool
+	if cpu.X86.AVX2 && cpu.X86.FMA {
+		modes = append(modes, false)
+	}
+	if cpu.X86.AVX512F && cpu.X86.AVX512VL {
+		modes = append(modes, true)
+	}
+	return modes
+}
+
+func TestDotProductBatchKernelMatchesScalar(t *testing.T) {
+	modes := kernelBatchModes()
+	if len(modes) == 0 {
+		t.Skip("no AVX2/FMA or AVX-512 batch kernel available on this CPU")
+	}
+	// dims span the per-vector body plus assorted tails; rowCounts cross the
+	// batch-of-4 boundary so both the fused kernel and the scalar remainder run.
+	dims := []int{8, 15, 16, 31, 32, 64, 127, 128, 255, 256, 768}
+	rowCounts := []int{4, 5, 7, 8, 16, 17}
+	for _, useAVX512 := range modes {
+		for _, dim := range dims {
+			for _, rowCount := range rowCounts {
+				vec := deterministicF32Vector(11, dim)
+				rows := make([][]float32, rowCount)
+				for i := range rows {
+					rows[i] = deterministicF32Vector(100+i, dim)
+				}
+				got := make([]float32, rowCount)
+				dotProductBatchKernel(useAVX512, got, rows, vec, dim)
+				for i := range rows {
+					want := dotProductGo(rows[i], vec)
+					if !closeFloat32(got[i], want) {
+						t.Fatalf("avx512=%t dim=%d rows=%d row=%d got=%g want=%g",
+							useAVX512, dim, rowCount, i, got[i], want)
+					}
+				}
+			}
+		}
+	}
+}
+
+func TestDotProductBatchKernelShortRowsFallBack(t *testing.T) {
+	modes := kernelBatchModes()
+	if len(modes) == 0 {
+		t.Skip("no AVX2/FMA or AVX-512 batch kernel available on this CPU")
+	}
+	const vecLen = 64
+	vec := deterministicF32Vector(7, vecLen)
+	// A batch-of-4 group with rows shorter than vecLen must take the per-row
+	// fallback inside the group, never the fused full-row kernel. Length 0 rows
+	// must score 0. The trailing group exercises the post-loop remainder.
+	rowLens := []int{vecLen, 0, vecLen - 1, 3, vecLen, vecLen, vecLen + 8, 1}
+	for _, useAVX512 := range modes {
+		rows := make([][]float32, len(rowLens))
+		for i, l := range rowLens {
+			rows[i] = deterministicF32Vector(200+i, l)
+		}
+		got := make([]float32, len(rows))
+		dotProductBatchKernel(useAVX512, got, rows, vec, vecLen)
+		for i, row := range rows {
+			n := min(len(row), vecLen)
+			var want float32
+			if n > 0 {
+				want = dotProductGo(row[:n], vec[:n])
+			}
+			if !closeFloat32(got[i], want) {
+				t.Fatalf("avx512=%t row=%d len=%d got=%g want=%g",
+					useAVX512, i, len(row), got[i], want)
+			}
+		}
+	}
+}

--- a/f32/dot_product_batch4_amd64_test.go
+++ b/f32/dot_product_batch4_amd64_test.go
@@ -9,13 +9,13 @@ import (
 )
 
 // kernelBatchModes returns the SIMD batch-of-4 modes that the current CPU can
-// actually execute. dotProductBatchKernel(false, ...) runs the AVX2/FMA kernel
+// actually execute. dotProductBatchKernel(false, ...) runs the AVX+FMA kernel
 // and dotProductBatchKernel(true, ...) the AVX-512 one, so calling either on a
 // CPU without the matching ISA would fault. Tests use this to exercise every
-// kernel the host supports, including the AVX2 path that issue #64 adds.
+// kernel the host supports, including the AVX+FMA path that issue #64 adds.
 func kernelBatchModes() []bool {
 	var modes []bool
-	if cpu.X86.AVX2 && cpu.X86.FMA {
+	if cpu.X86.AVX && cpu.X86.FMA {
 		modes = append(modes, false)
 	}
 	if cpu.X86.AVX512F && cpu.X86.AVX512VL {

--- a/f32/f32_amd64.go
+++ b/f32/f32_amd64.go
@@ -267,52 +267,69 @@ func dotProductBatch32(results []float32, rows [][]float32, vec []float32) {
 		}
 		return
 	}
-	if cpu.X86.AVX512F && cpu.X86.AVX512VL && len(rows) >= 4 && vecLen >= minAVX512Elements {
-		i := 0
-		for i+3 < len(rows) {
-			row0, row1, row2, row3 := rows[i], rows[i+1], rows[i+2], rows[i+3]
-			if len(row0) >= vecLen && len(row1) >= vecLen && len(row2) >= vecLen && len(row3) >= vecLen {
-				dotProduct4AVX512(
-					(*float32)(unsafe.Pointer(&results[i])),
-					(*float32)(unsafe.Pointer(&row0[0])),
-					(*float32)(unsafe.Pointer(&row1[0])),
-					(*float32)(unsafe.Pointer(&row2[0])),
-					(*float32)(unsafe.Pointer(&row3[0])),
-					(*float32)(unsafe.Pointer(&vec[0])),
-					vecLen,
-				)
-				i += 4
-				continue
-			}
-			for j := range 4 {
-				row := rows[i+j]
-				n := min(len(row), vecLen)
-				if n == 0 {
-					results[i+j] = 0
-				} else {
-					results[i+j] = dotProduct(row[:n], vec[:n])
-				}
-			}
-			i += 4
-		}
-		for ; i < len(rows); i++ {
-			row := rows[i]
+	switch {
+	case cpu.X86.AVX512F && cpu.X86.AVX512VL && len(rows) >= 4 && vecLen >= minAVX512Elements:
+		dotProductBatchKernel(true, results, rows, vec, vecLen)
+	case cpu.X86.AVX2 && cpu.X86.FMA && len(rows) >= 4 && vecLen >= minAVXElements:
+		dotProductBatchKernel(false, results, rows, vec, vecLen)
+	default:
+		for i, row := range rows {
 			n := min(len(row), vecLen)
 			if n == 0 {
 				results[i] = 0
+				continue
+			}
+			results[i] = dotProduct(row[:n], vec[:n])
+		}
+	}
+}
+
+// dotProductBatchKernel scores every row in rows against vec, writing result i
+// to results[i]. Rows are processed in groups of four so the query vector stays
+// resident in registers across the group instead of being re-loaded per row;
+// useAVX512 selects the AVX-512 kernel over the AVX2/FMA one. A group whose four
+// rows are each at least vecLen long takes the fused 4-row kernel; any shorter
+// or trailing row falls back to the per-row dotProduct dispatch (scoring 0 when
+// empty). The caller guarantees the selected ISA is available, len(rows) >= 4,
+// and vecLen meets the kernel's minimum width.
+func dotProductBatchKernel(useAVX512 bool, results []float32, rows [][]float32, vec []float32, vecLen int) {
+	i := 0
+	for i+3 < len(rows) {
+		row0, row1, row2, row3 := rows[i], rows[i+1], rows[i+2], rows[i+3]
+		if len(row0) >= vecLen && len(row1) >= vecLen && len(row2) >= vecLen && len(row3) >= vecLen {
+			res := (*float32)(unsafe.Pointer(&results[i]))
+			r0 := (*float32)(unsafe.Pointer(&row0[0]))
+			r1 := (*float32)(unsafe.Pointer(&row1[0]))
+			r2 := (*float32)(unsafe.Pointer(&row2[0]))
+			r3 := (*float32)(unsafe.Pointer(&row3[0]))
+			q := (*float32)(unsafe.Pointer(&vec[0]))
+			if useAVX512 {
+				dotProduct4AVX512(res, r0, r1, r2, r3, q, vecLen)
 			} else {
-				results[i] = dotProduct(row[:n], vec[:n])
+				dotProduct4AVX(res, r0, r1, r2, r3, q, vecLen)
+			}
+			i += 4
+			continue
+		}
+		for j := range 4 {
+			row := rows[i+j]
+			n := min(len(row), vecLen)
+			if n == 0 {
+				results[i+j] = 0
+			} else {
+				results[i+j] = dotProduct(row[:n], vec[:n])
 			}
 		}
-		return
+		i += 4
 	}
-	for i, row := range rows {
+	for ; i < len(rows); i++ {
+		row := rows[i]
 		n := min(len(row), vecLen)
 		if n == 0 {
 			results[i] = 0
-			continue
+		} else {
+			results[i] = dotProduct(row[:n], vec[:n])
 		}
-		results[i] = dotProduct(row[:n], vec[:n])
 	}
 }
 

--- a/f32/f32_amd64.go
+++ b/f32/f32_amd64.go
@@ -270,7 +270,7 @@ func dotProductBatch32(results []float32, rows [][]float32, vec []float32) {
 	switch {
 	case cpu.X86.AVX512F && cpu.X86.AVX512VL && len(rows) >= 4 && vecLen >= minAVX512Elements:
 		dotProductBatchKernel(true, results, rows, vec, vecLen)
-	case cpu.X86.AVX2 && cpu.X86.FMA && len(rows) >= 4 && vecLen >= minAVXElements:
+	case cpu.X86.AVX && cpu.X86.FMA && len(rows) >= 4 && vecLen >= minAVXElements:
 		dotProductBatchKernel(false, results, rows, vec, vecLen)
 	default:
 		for i, row := range rows {
@@ -287,7 +287,7 @@ func dotProductBatch32(results []float32, rows [][]float32, vec []float32) {
 // dotProductBatchKernel scores every row in rows against vec, writing result i
 // to results[i]. Rows are processed in groups of four so the query vector stays
 // resident in registers across the group instead of being re-loaded per row;
-// useAVX512 selects the AVX-512 kernel over the AVX2/FMA one. A group whose four
+// useAVX512 selects the AVX-512 kernel over the AVX+FMA one. A group whose four
 // rows are each at least vecLen long takes the fused 4-row kernel; any shorter
 // or trailing row falls back to the per-row dotProduct dispatch (scoring 0 when
 // empty). The caller guarantees the selected ISA is available, len(rows) >= 4,


### PR DESCRIPTION
## Summary

`DotProductBatch` (backed by `dotProductBatch32`) gained a batch-of-4
query-load-reuse fast path in #63, but it was gated only on AVX-512. AVX2-only
CPUs (most CI runners and a lot of production hardware) fell back to the per-row
`dotProductAVX` loop and re-loaded the query vector for every row.

This brings the same reuse to the AVX2/FMA path:

- Extract the shared batch loop into `dotProductBatchKernel(useAVX512, ...)` so
  both ISA paths drive identical code. Keeping the loop in one helper avoids the
  `dupl`-tripping verbatim duplication a second copy-pasted branch would create
  (called out in the issue).
- Add an `AVX2 && FMA` branch that calls the existing, already-tested
  `dotProduct4AVX` kernel, gated on `minAVXElements` (8).

The AVX-512 path is unchanged (same kernel, same `minAVX512Elements` gate), and
results are identical to the per-row fallback either way (the gate only chooses
SIMD vs scalar dispatch).

On an AVX2-only host (no AVX-512), `DotProductBatch` at dims=768 now runs about
1.5x-1.8x faster than the per-row loop, still allocation-free.

## Related Issues

Closes #64

## Test Plan

- [x] New `dotProductBatchKernel` tests drive each available kernel directly
      (forcing the AVX2 path even where AVX-512 exists) and check parity against
      the scalar oracle across vector-width tails, the batch-of-4 remainder, and
      the in-group short-row fallback.
- [x] `go test ./f32/` and `go test -race ./f32/` pass.
- [x] `go build ./...`, `go vet ./...`, and `GOARCH=arm64 go build ./...` clean.
- [x] `golangci-lint run ./f32/...` reports 0 issues.
- [x] `BenchmarkDotProductBatch768xRows` shows ~1.5x-1.8x over the per-row loop
      on an AVX2/FMA host, 0 allocs.