### PR TITLE
arm64: fix go vet asmdecl warnings in c64/c128/f16 NEON kernels

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,6 +10,11 @@ env:
   GO_VERSION: '1.25'
   GOLANGCI_LINT_VERSION: 'v2.6.1'
 
+# Least-privilege default token scope for all jobs. Every job here only checks
+# out code and runs build/test/lint/vet, so read-only contents is sufficient.
+permissions:
+  contents: read
+
 jobs:
   test:
     name: Test

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -76,6 +76,31 @@ jobs:
         with:
           version: ${{ env.GOLANGCI_LINT_VERSION }}
 
+  vet:
+    name: Vet
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        # Vet every supported arch, not just the host. go vet's asmdecl
+        # analyzer only checks the target arch's assembly, so an amd64-only
+        # vet silently skips the arm64 .s files. Cross-arch vet here is what
+        # catches frame-size / FP-offset mismatches in the NEON kernels.
+        goarch: [amd64, arm64]
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v6
+
+      - name: Set up Go
+        uses: actions/setup-go@v6
+        with:
+          go-version: ${{ env.GO_VERSION }}
+
+      - name: Run go vet
+        env:
+          GOARCH: ${{ matrix.goarch }}
+        run: go vet ./...
+
   build:
     name: Build
     runs-on: ubuntu-latest

--- a/c128/c128_arm64.s
+++ b/c128/c128_arm64.s
@@ -201,8 +201,8 @@ TEXT ·scaleNEON(SB), NOSPLIT, $0-64
     MOVD a_base+24(FP), R2
 
     // Load and broadcast scalar s to vectors
-    FMOVD s+48(FP), F20          // F20 = sr
-    FMOVD s+56(FP), F21          // F21 = si
+    FMOVD s_real+48(FP), F20     // F20 = sr
+    FMOVD s_imag+56(FP), F21     // F21 = si
 
     // Broadcast to vectors for SIMD ops
     VDUP V20.D[0], V20.D2        // V20 = [sr, sr]
@@ -372,7 +372,7 @@ sub_neon_done:
 // ============================================================================
 
 // func absNEON(dst []float64, a []complex128)
-TEXT ·absNEON(SB), NOSPLIT, $0-56
+TEXT ·absNEON(SB), NOSPLIT, $0-48
     MOVD dst_base+0(FP), R0
     MOVD dst_len+8(FP), R1
     MOVD a_base+24(FP), R2
@@ -441,7 +441,7 @@ abs_neon_done:
 // ============================================================================
 
 // func absSqNEON(dst []float64, a []complex128)
-TEXT ·absSqNEON(SB), NOSPLIT, $0-56
+TEXT ·absSqNEON(SB), NOSPLIT, $0-48
     MOVD dst_base+0(FP), R0
     MOVD dst_len+8(FP), R1
     MOVD a_base+24(FP), R2
@@ -501,7 +501,7 @@ abssq_neon_done:
 // ============================================================================
 
 // func conjNEON(dst, a []complex128)
-TEXT ·conjNEON(SB), NOSPLIT, $0-72
+TEXT ·conjNEON(SB), NOSPLIT, $0-48
     MOVD dst_base+0(FP), R0
     MOVD dst_len+8(FP), R1
     MOVD a_base+24(FP), R2

--- a/c64/c64_arm64.s
+++ b/c64/c64_arm64.s
@@ -200,8 +200,8 @@ TEXT ·scaleNEON(SB), NOSPLIT, $0-56
     MOVD a_base+24(FP), R2
 
     // Load scalar s and broadcast to vectors
-    FMOVS s+48(FP), F20          // F20 = sr
-    FMOVS s+52(FP), F21          // F21 = si
+    FMOVS s_real+48(FP), F20     // F20 = sr
+    FMOVS s_imag+52(FP), F21     // F21 = si
 
     // Broadcast to vectors
     VDUP V20.S[0], V20.S4        // V20 = [sr, sr, sr, sr]

--- a/f16/f16_arm64.s
+++ b/f16/f16_arm64.s
@@ -268,7 +268,7 @@ mul16_done:
 
 // func scaleNEON(dst, a []Float16, s Float16)
 // Length must be multiple of 8.
-TEXT ·scaleNEON(SB), NOSPLIT, $0-52
+TEXT ·scaleNEON(SB), NOSPLIT, $0-50
     MOVD dst_base+0(FP), R0
     MOVD dst_len+8(FP), R3
     MOVD a_base+24(FP), R1
@@ -545,7 +545,7 @@ div16_done:
 
 // func addScalarNEON(dst, a []Float16, s Float16)
 // Add scalar to each element. Length must be multiple of 8.
-TEXT ·addScalarNEON(SB), NOSPLIT, $0-52
+TEXT ·addScalarNEON(SB), NOSPLIT, $0-50
     MOVD dst_base+0(FP), R0
     MOVD dst_len+8(FP), R3
     MOVD a_base+24(FP), R1
@@ -576,7 +576,7 @@ addscalar16_done:
 
 // func clampNEON(dst, a []Float16, minVal, maxVal Float16)
 // Clamp each element to [minVal, maxVal]. Length must be multiple of 8.
-TEXT ·clampNEON(SB), NOSPLIT, $0-56
+TEXT ·clampNEON(SB), NOSPLIT, $0-52
     MOVD dst_base+0(FP), R0
     MOVD dst_len+8(FP), R3
     MOVD a_base+24(FP), R1


### PR DESCRIPTION
## Summary

`GOARCH=arm64 go vet ./...` reported 8 `asmdecl` warnings in the arm64 NEON
kernels of `c64`, `c128`, and `f16`. They persisted because `go vet`'s asmdecl
analyzer only checks the *host* arch's assembly, so an amd64 CI host silently
skips the arm64 `.s` files.

These are declaration-only fixes: the kernels already read their arguments at the
correct FP offsets, so emitted code is unchanged.

- **Six over-declared `TEXT` frame argsizes corrected** (the real declaration bugs):
  - `c128` `absNEON`/`absSqNEON` `$0-56` to `$0-48`, `conjNEON` `$0-72` to `$0-48`
  - `f16` `scaleNEON`/`addScalarNEON` `$0-52` to `$0-50`, `clampNEON` `$0-56` to `$0-52`
- **Two complex-scalar FP references renamed** to canonical `s_real`/`s_imag` field
  names in `scaleNEON` (`c64`, `c128`). Offsets were already correct.
- **CI hardening:** added a `vet` job running `go vet ./...` for `goarch: [amd64, arm64]`
  so a host-only vet can no longer skip the arm64 assembly. This is the root cause
  of the warnings going unnoticed.

## Related Issues

Fixes #62

## Test Plan

- [x] `GOARCH=arm64 go vet ./...` clean (was 8 warnings, now 0)
- [x] host `go vet ./...` clean
- [x] `go test ./...` passes on amd64
- [x] full test suite passes natively on arm64 (Raspberry Pi 5, go1.26.1), including
      the touched `c64`/`c128`/`f16` packages
- [x] `GOARCH=arm64 go build ./...` clean

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added cross-architecture code validation in CI pipeline for enhanced testing coverage

* **Bug Fixes**
  * Fixed ARM64 assembly stack frame configurations and operand handling in vectorized operations to improve compatibility

<!-- end of auto-generated comment: release notes by coderabbit.ai -->