### PR TITLE
f32/f64/c64: drop latent AVX512DQ deps in AVX-512 kernels

### DIFF
--- a/c64/c64_amd64.s
+++ b/c64/c64_amd64.s
@@ -1113,7 +1113,7 @@ TEXT ·conjAVX512(SB), NOSPLIT, $0-48
 
 conj_avx512_loop8:
     VMOVUPS (SI), Z0
-    VXORPS Z15, Z0, Z0       // Negate imag parts via sign bit XOR
+    VPXORD Z15, Z0, Z0       // Negate imag parts via sign-bit XOR (VPXORD: AVX512F, avoids VXORPS AVX512DQ dep)
     VMOVUPS Z0, (DX)
 
     ADDQ $64, SI

--- a/f32/f32_amd64.s
+++ b/f32/f32_amd64.s
@@ -728,10 +728,10 @@ TEXT ·dotProductAVX512(SB), NOSPLIT, $0-52
     MOVQ b_base+24(FP), DI
 
     // Initialize 4 independent accumulators
-    VXORPS Z0, Z0, Z0          // acc0
-    VXORPS Z3, Z3, Z3          // acc1
-    VXORPS Z4, Z4, Z4          // acc2
-    VXORPS Z5, Z5, Z5          // acc3
+    VPXORD Z0, Z0, Z0          // acc0
+    VPXORD Z3, Z3, Z3          // acc1
+    VPXORD Z4, Z4, Z4          // acc2
+    VPXORD Z5, Z5, Z5          // acc3
 
     // Process 64 elements per iteration (4 vectors × 16 floats)
     MOVQ CX, AX
@@ -788,7 +788,8 @@ dot32_512_loop16:
     JNZ  dot32_512_loop16
 
 dot32_512_remainder:
-    VEXTRACTF32X8 $1, Z0, Y1
+    // VEXTRACTF64X4 (AVX512F): same upper-256 extract as VEXTRACTF32X8, no AVX512DQ dep.
+    VEXTRACTF64X4 $1, Z0, Y1
     VADDPS Y1, Y0, Y0
     VEXTRACTF128 $1, Y0, X1
     VADDPS X1, X0, X0
@@ -1091,10 +1092,10 @@ TEXT ·sumAVX512(SB), NOSPLIT, $0-28
     MOVQ a_len+8(FP), CX
 
     // Initialize 4 independent accumulators
-    VXORPS Z0, Z0, Z0          // acc0
-    VXORPS Z3, Z3, Z3          // acc1
-    VXORPS Z4, Z4, Z4          // acc2
-    VXORPS Z5, Z5, Z5          // acc3
+    VPXORD Z0, Z0, Z0          // acc0
+    VPXORD Z3, Z3, Z3          // acc1
+    VPXORD Z4, Z4, Z4          // acc2
+    VPXORD Z5, Z5, Z5          // acc3
 
     // Process 64 elements per iteration (4 vectors × 16 floats)
     MOVQ CX, AX
@@ -1128,7 +1129,8 @@ sum32_512_loop16:
     JNZ  sum32_512_loop16
 
 sum32_512_remainder:
-    VEXTRACTF32X8 $1, Z0, Y1
+    // VEXTRACTF64X4 (AVX512F): same upper-256 extract as VEXTRACTF32X8, no AVX512DQ dep.
+    VEXTRACTF64X4 $1, Z0, Y1
     VADDPS Y1, Y0, Y0
     VEXTRACTF128 $1, Y0, X1
     VADDPS X1, X0, X0
@@ -1171,7 +1173,8 @@ min32_512_loop16:
     JNZ  min32_512_loop16
 
 min32_512_reduce:
-    VEXTRACTF32X8 $1, Z0, Y1
+    // VEXTRACTF64X4 (AVX512F): same upper-256 extract as VEXTRACTF32X8, no AVX512DQ dep.
+    VEXTRACTF64X4 $1, Z0, Y1
     VMINPS Y0, Y1, Y0
     VEXTRACTF128 $1, Y0, X1
     VMINPS X0, X1, X0
@@ -1216,7 +1219,8 @@ max32_512_loop16:
     JNZ  max32_512_loop16
 
 max32_512_reduce:
-    VEXTRACTF32X8 $1, Z0, Y1
+    // VEXTRACTF64X4 (AVX512F): same upper-256 extract as VEXTRACTF32X8, no AVX512DQ dep.
+    VEXTRACTF64X4 $1, Z0, Y1
     VMAXPS Y0, Y1, Y0
     VEXTRACTF128 $1, Y0, X1
     VMAXPS X0, X1, X0
@@ -1284,7 +1288,7 @@ TEXT ·negAVX512(SB), NOSPLIT, $0-48
     MOVQ dst_len+8(FP), CX
     MOVQ a_base+24(FP), SI
 
-    VXORPS Z2, Z2, Z2
+    VPXORD Z2, Z2, Z2
 
     MOVQ CX, AX
     SHRQ $4, AX
@@ -4788,10 +4792,10 @@ cd_avx512_outer:
     LEAQ (R10)(BX*4), SI
     MOVQ R11, DI
 
-    VXORPS Z0, Z0, Z0
-    VXORPS Z3, Z3, Z3
-    VXORPS Z4, Z4, Z4
-    VXORPS Z5, Z5, Z5
+    VPXORD Z0, Z0, Z0
+    VPXORD Z3, Z3, Z3
+    VPXORD Z4, Z4, Z4
+    VPXORD Z5, Z5, Z5
 
     MOVQ R12, CX
     MOVQ CX, AX
@@ -4837,7 +4841,8 @@ cd_avx512_loop16:
     JNZ  cd_avx512_loop16
 
 cd_avx512_reduce:
-    VEXTRACTF32X8 $1, Z0, Y1
+    // VEXTRACTF64X4 (AVX512F): same upper-256 extract as VEXTRACTF32X8, no AVX512DQ dep.
+    VEXTRACTF64X4 $1, Z0, Y1
     VADDPS Y1, Y0, Y0
     VEXTRACTF128 $1, Y0, X1
     VADDPS X1, X0, X0
@@ -5104,14 +5109,14 @@ TEXT ·dotProduct4AVX512(SB), NOSPLIT, $0-56
     MOVQ vec+40(FP), DI
     MOVQ n+48(FP), CX
 
-    VXORPS Z0, Z0, Z0          // acc0a
-    VXORPS Z3, Z3, Z3          // acc1a
-    VXORPS Z4, Z4, Z4          // acc2a
-    VXORPS Z5, Z5, Z5          // acc3a
-    VXORPS Z6, Z6, Z6          // acc0b
-    VXORPS Z7, Z7, Z7          // acc1b
-    VXORPS Z8, Z8, Z8          // acc2b
-    VXORPS Z9, Z9, Z9          // acc3b
+    VPXORD Z0, Z0, Z0          // acc0a
+    VPXORD Z3, Z3, Z3          // acc1a
+    VPXORD Z4, Z4, Z4          // acc2a
+    VPXORD Z5, Z5, Z5          // acc3a
+    VPXORD Z6, Z6, Z6          // acc0b
+    VPXORD Z7, Z7, Z7          // acc1b
+    VPXORD Z8, Z8, Z8          // acc2b
+    VPXORD Z9, Z9, Z9          // acc3b
 
     MOVQ CX, AX
     SHRQ $6, AX                // n / 64

--- a/f64/f64_amd64.s
+++ b/f64/f64_amd64.s
@@ -1094,10 +1094,10 @@ TEXT ·dotProductAVX512(SB), NOSPLIT, $0-56
     MOVQ b_base+24(FP), DI
 
     // Initialize 4 independent accumulators
-    VXORPD Z0, Z0, Z0          // acc0
-    VXORPD Z3, Z3, Z3          // acc1
-    VXORPD Z4, Z4, Z4          // acc2
-    VXORPD Z5, Z5, Z5          // acc3
+    VPXORQ Z0, Z0, Z0          // acc0
+    VPXORQ Z3, Z3, Z3          // acc1
+    VPXORQ Z4, Z4, Z4          // acc2
+    VPXORQ Z5, Z5, Z5          // acc3
 
     // Process 32 elements per iteration (4 vectors × 8 doubles)
     MOVQ CX, AX
@@ -1455,10 +1455,10 @@ TEXT ·sumAVX512(SB), NOSPLIT, $0-32
     MOVQ a_len+8(FP), CX
 
     // Initialize 4 independent accumulators
-    VXORPD Z0, Z0, Z0          // acc0
-    VXORPD Z3, Z3, Z3          // acc1
-    VXORPD Z4, Z4, Z4          // acc2
-    VXORPD Z5, Z5, Z5          // acc3
+    VPXORQ Z0, Z0, Z0          // acc0
+    VPXORQ Z3, Z3, Z3          // acc1
+    VPXORQ Z4, Z4, Z4          // acc2
+    VPXORQ Z5, Z5, Z5          // acc3
 
     // Process 32 elements per iteration (4 vectors × 8 doubles)
     MOVQ CX, AX
@@ -1613,7 +1613,8 @@ TEXT ·absAVX512(SB), NOSPLIT, $0-48
 
 abs_512_loop8:
     VMOVUPD (SI), Z0
-    VANDPD Z0, Z2, Z1
+    // VPANDQ (AVX512F) integer-domain AND: identical bits to VANDPD (AVX512DQ), no DQ dep.
+    VPANDQ Z0, Z2, Z1
     VMOVUPD Z1, (DX)
     ADDQ $64, SI
     ADDQ $64, DX
@@ -1643,7 +1644,7 @@ TEXT ·negAVX512(SB), NOSPLIT, $0-48
     MOVQ dst_len+8(FP), CX
     MOVQ a_base+24(FP), SI
 
-    VXORPD Z2, Z2, Z2
+    VPXORQ Z2, Z2, Z2
 
     MOVQ CX, AX
     SHRQ $3, AX
@@ -1908,10 +1909,10 @@ TEXT ·varianceAVX512(SB), NOSPLIT, $0-40
     VBROADCASTSD mean+24(FP), Z2
 
     // Initialize 4 accumulators for parallel reduction
-    VXORPD Z0, Z0, Z0
-    VXORPD Z3, Z3, Z3
-    VXORPD Z4, Z4, Z4
-    VXORPD Z5, Z5, Z5
+    VPXORQ Z0, Z0, Z0
+    VPXORQ Z3, Z3, Z3
+    VPXORQ Z4, Z4, Z4
+    VPXORQ Z5, Z5, Z5
 
     // Process 32 elements (4 vectors of 8) per iteration
     MOVQ CX, AX
@@ -1994,10 +1995,10 @@ TEXT ·euclideanDistanceAVX512(SB), NOSPLIT, $0-56
     MOVQ b_base+24(FP), DI
 
     // Initialize 4 independent accumulators
-    VXORPD Z0, Z0, Z0          // acc0
-    VXORPD Z3, Z3, Z3          // acc1
-    VXORPD Z4, Z4, Z4          // acc2
-    VXORPD Z5, Z5, Z5          // acc3
+    VPXORQ Z0, Z0, Z0          // acc0
+    VPXORQ Z3, Z3, Z3          // acc1
+    VPXORQ Z4, Z4, Z4          // acc2
+    VPXORQ Z5, Z5, Z5          // acc3
 
     // Process 32 elements per iteration
     MOVQ CX, AX
@@ -4132,10 +4133,10 @@ cd_avx512_outer:
     LEAQ (R10)(BX*8), SI
     MOVQ R11, DI
 
-    VXORPD Z0, Z0, Z0
-    VXORPD Z3, Z3, Z3
-    VXORPD Z4, Z4, Z4
-    VXORPD Z5, Z5, Z5
+    VPXORQ Z0, Z0, Z0
+    VPXORQ Z3, Z3, Z3
+    VPXORQ Z4, Z4, Z4
+    VPXORQ Z5, Z5, Z5
 
     MOVQ R12, CX
     MOVQ CX, AX


### PR DESCRIPTION
## Summary

The AVX-512 kernels gate dispatch on `AVX512F + AVX512VL`, but several instructions had a CPUID feature flag of `AVX512DQ`, a latent dependency that does not match the dispatch gate. This converts them to `AVX512F` equivalents that produce bit-identical results.

**`VEXTRACTF32X8` -> `VEXTRACTF64X4` (the original #67 scope):**
Five reduction tails in `f32` (`dotProductAVX512`, the sum/min/max kernels, and the convolve-decimate kernel) extracted the upper 256 bits with `VEXTRACTF32X8` (`AVX512DQ`). `VEXTRACTF64X4` (`AVX512F`) extracts the identical `SRC1[511:256]` with no writemask, so results are bit-identical. Matches the prior conversion of `dotProduct4AVX512` in #63.

**Packed FP-logical ops on ZMM -> AVX512F integer domain:**
The EVEX forms of `VXORPS`/`VXORPD`/`VANDPD` on `ZMM` require `AVX512DQ`. The `AVX512F` integer-domain forms `VPXORD`/`VPXORQ`/`VPANDQ` perform the identical bitwise op:
- 42 zeroing idioms `VXORPS`/`VXORPD Zx,Zx,Zx` -> `VPXORD`/`VPXORQ` (f32 x21, f64 x21)
- f64 abs mask `VANDPD` -> `VPANDQ`
- c64 conjugate sign-flip `VXORPS` -> `VPXORD`

The repo already used `VPXORQ`/`VPANDD` elsewhere, so this also resolves an inconsistency. YMM/XMM `VXORPD` (VEX-encoded, no DQ requirement) is left untouched.

This is not reachable on shipping hardware: every `AVX512F+VL` CPU (Skylake-SP onward) also has `AVX512DQ`, and the only `F`-without-`DQ` parts (Knights Landing/Mill) also lack `VL`, so they never enter these paths. ISA hygiene/consistency, not a live fix.

## Related Issues

Fixes #67

## Test Plan

- [x] `go build ./...` and `go vet ./...` clean
- [x] `go test -count=1 ./...` passes across all packages
- [x] `golangci-lint run ./...` reports 0 issues
- [x] `objdump` confirms zero EVEX FP-logical or `VEXTRACTF32X8` ops remain on ZMM in f32/f64/c64/c128
- [x] Emitted `VEXTRACTF64X4` is the W1 (`AVX512F`) encoding `62 f3 fd 48 1b`; replacements are EVEX `AVX512F` (`vpxord`/`vpxorq`/`vpandq`)
- [ ] CI green on cross-arch matrix