### PR TITLE
f32/f64: batch-of-4 query-load-reuse dot kernels (f64 AMD64, f32 ARM64 NEON)

### DIFF
--- a/README.md
+++ b/README.md
@@ -134,6 +134,11 @@ fmt.Println(cpu.HasFP16())     // true/false (ARM64 half-precision SIMD)
 |                 | `Int16ToFloat32Scale(dst,src,s)`    | PCM int16 to normalized float | 8x (AVX2) / 4x (NEON)               |
 |                 | `Float32ToInt16Scale(dst,src,s)`    | Normalized float to PCM int16 | 8x (AVX2) / 4x (NEON)               |
 
+`DotProductBatch` scores its `[][]float64` rows in groups of four, keeping the
+query vector resident in registers across each group via a fused 4-row kernel on
+AMD64 (AVX-512 and AVX+FMA) instead of re-loading it per row. Short, ragged, or
+sub-SIMD-width rows fall back to the per-row dot product, with identical results.
+
 ### `f32` - float32 Operations
 
 Same API as `f64` but for `float32` with wider SIMD:
@@ -156,13 +161,13 @@ use the allocation-free generic path.
 | `DotProductIndexed(dst, base, query, rowIDs, dims) bool` | Scores selected row-major rows by `uint32` row ID without building `[][]float32`; returns whether an optimized SIMD batch kernel handled at least one batch. |
 | `DotProductStrided(dst, base, query, rowCount, dims, stride) bool` | Scores contiguous or fixed-stride row-major rows; returns whether an optimized SIMD batch kernel handled at least one batch. |
 
-Both APIs are allocation-free and include per-row fallback semantics for unsupported CPUs, tiny shapes, tails, and ragged inputs.
+Both APIs are allocation-free. The batched SIMD kernel covers AMD64 (AVX-512 / AVX+FMA) and ARM64 (NEON); unsupported CPUs, tiny shapes, tails, and ragged inputs use the per-row fallback.
 
 `DotProductBatch` scores its `[][]float32` rows in groups of four, keeping the
 query vector resident in registers across each group instead of re-loading it
-for every row. The fused 4-row kernel runs on both AVX-512 and AVX+FMA; short,
-ragged, or sub-SIMD-width rows fall back to the per-row dot product. Results are
-identical to the per-row path either way.
+for every row. The fused 4-row kernel runs on AVX-512, AVX+FMA, and ARM64 NEON;
+short, ragged, or sub-SIMD-width rows fall back to the per-row dot product.
+Results are identical to the per-row path either way.
 
 **Additional split-format complex operations** (for FFT pipelines with separate real/imag arrays):
 

--- a/f32/dot_product_batch4_arm64_test.go
+++ b/f32/dot_product_batch4_arm64_test.go
@@ -1,0 +1,36 @@
+//go:build arm64
+
+package f32
+
+import "testing"
+
+// TestDotProduct4NEONKernel scores four deterministic rows against one query
+// with the NEON batch-of-4 kernel and compares each result to the pure-scalar
+// dotProductGo oracle, so a buggy hand-encoded kernel (wrong lane count, bad
+// horizontal reduction, mishandled 4-element or scalar tail) is caught rather
+// than passing by SIMD-vs-SIMD agreement.
+func TestDotProduct4NEONKernel(t *testing.T) {
+	if !hasNEON {
+		t.Skip("NEON required")
+	}
+	// Cover sub-vector, exact-multiple, and tail-bearing dims for the 8/iter
+	// main loop, the 4-element remainder, and the scalar tail.
+	dims := []int{1, 2, 3, 4, 5, 7, 8, 15, 16, 31, 32, 63, 64, 65, 127, 128, 256, 768}
+	for _, dim := range dims {
+		vec := deterministicF32Vector(11, dim)
+		rows := [4][]float32{
+			deterministicF32Vector(100, dim),
+			deterministicF32Vector(101, dim),
+			deterministicF32Vector(102, dim),
+			deterministicF32Vector(103, dim),
+		}
+		results := make([]float32, 4)
+		dotProduct4NEON(&results[0], &rows[0][0], &rows[1][0], &rows[2][0], &rows[3][0], &vec[0], dim)
+		for i, row := range rows {
+			want := dotProductGo(row, vec)
+			if !closeFloat32(results[i], want) {
+				t.Fatalf("dim=%d row=%d got=%g want=%g", dim, i, results[i], want)
+			}
+		}
+	}
+}

--- a/f32/dot_product_rowmajor.go
+++ b/f32/dot_product_rowmajor.go
@@ -1,0 +1,132 @@
+package f32
+
+// Shared scaffolding for the row-major batch dot APIs (DotProductIndexed /
+// DotProductStrided). The per-architecture dispatch (f32_amd64.go, f32_arm64.go)
+// owns the SIMD kernel selection and the batch-of-4 loop; everything here is the
+// portable glue both arches lean on: the SIMD-vs-fallback eligibility gate, the
+// full-row range math, and the ragged-safe scalar fallback/tail paths.
+
+const (
+	batchDotRows    = 4
+	batchDotMinDims = 64
+
+	// SIMD-vs-fallback gate. Above these dim/row sizes the batched kernel stops
+	// beating the per-row fallback on the hardware measured so far, so very
+	// large shapes stay on the scalar path. These are deliberately conservative
+	// monotone thresholds, not per-machine tuned cliffs; re-tune against a
+	// benchmark matrix before enabling more shapes.
+	batchDotLargeDims    = 768
+	batchDotLargeMaxRows = 256
+	batchDotHugeDims     = 2048
+	batchDotHugeMaxRows  = 64
+)
+
+func fullRowMaxIndex(baseLen, dims, stride int) int {
+	if dims <= 0 || stride <= 0 || baseLen < dims {
+		return -1
+	}
+	return (baseLen - dims) / stride
+}
+
+func rowIDInFullRange(rowID uint32, maxRow int) bool {
+	return maxRow >= 0 && uint64(rowID) <= uint64(maxRow)
+}
+
+func dotProductIndexedFallback(dst, base, query []float32, rowIDs []uint32, dims int) {
+	n := min(len(dst), len(rowIDs))
+	if n == 0 {
+		return
+	}
+	if dims <= 0 || len(query) == 0 {
+		clear(dst[:n])
+		return
+	}
+	queryN := min(dims, len(query))
+	queryFull := query[:queryN]
+	maxRow := fullRowMaxIndex(len(base), queryN, dims)
+	for i := range n {
+		rowID := rowIDs[i]
+		if rowIDInFullRange(rowID, maxRow) {
+			off := int(rowID) * dims
+			dst[i] = dotProduct(base[off:off+queryN], queryFull)
+			continue
+		}
+		dst[i] = dotProductIndexedOneGo(base, query, rowID, dims)
+	}
+}
+
+func dotProductStridedFallback(dst, base, query []float32, rowCount, dims, stride int) {
+	if rowCount <= 0 || len(dst) == 0 {
+		return
+	}
+	n := min(len(dst), rowCount)
+	if dims <= 0 || stride <= 0 || len(query) == 0 {
+		clear(dst[:n])
+		return
+	}
+	queryN := min(dims, len(query))
+	queryFull := query[:queryN]
+	maxRow := fullRowMaxIndex(len(base), queryN, stride)
+	if n-1 <= maxRow {
+		for i, off := 0, 0; i < n; i, off = i+1, off+stride {
+			dst[i] = dotProduct(base[off:off+queryN], queryFull)
+		}
+		return
+	}
+	for i := range n {
+		if i <= maxRow {
+			off := i * stride
+			dst[i] = dotProduct(base[off:off+queryN], queryFull)
+			continue
+		}
+		dst[i] = dotProductStridedOneGo(base, query, i, dims, stride)
+	}
+}
+
+// dotProductIndexedTail scores one row for the mixed-block and trailing-tail
+// paths. The CPU capability and queryLen >= dims are already verified by the
+// caller, so any in-range row can take the optimized single-row dotProduct;
+// out-of-range rows score zero via the ragged-safe Go path.
+func dotProductIndexedTail(base, query, queryFull []float32, rowID uint32, dims, maxRow int) float32 {
+	if rowIDInFullRange(rowID, maxRow) {
+		off := int(rowID) * dims
+		return dotProduct(base[off:off+dims], queryFull)
+	}
+	return dotProductIndexedOneGo(base, query, rowID, dims)
+}
+
+func dotProductStridedTail(base, query, queryFull []float32, row, dims, stride, maxRow int) float32 {
+	if row >= 0 && row <= maxRow {
+		off := row * stride
+		return dotProduct(base[off:off+dims], queryFull)
+	}
+	return dotProductStridedOneGo(base, query, row, dims, stride)
+}
+
+func batchDotIndexedSIMDEligible(rows, dims, queryLen int) bool {
+	if rows < batchDotRows || dims < batchDotMinDims || queryLen < dims {
+		return false
+	}
+	return batchDotRowsWithinGate(rows, dims)
+}
+
+func batchDotStridedSIMDEligible(rows, dims, stride, queryLen int) bool {
+	if rows < batchDotRows || dims < batchDotMinDims || stride <= 0 || queryLen < dims {
+		return false
+	}
+	return batchDotRowsWithinGate(rows, dims)
+}
+
+// batchDotRowsWithinGate reports whether a (rows, dims) shape is small enough
+// that the batched SIMD kernel is expected to beat the per-row fallback. The
+// gate is monotone in both dimensions: larger shapes fall back first.
+func batchDotRowsWithinGate(rows, dims int) bool {
+	switch {
+	case dims >= batchDotHugeDims:
+		return rows < batchDotHugeMaxRows
+	case dims >= batchDotLargeDims:
+		return rows < batchDotLargeMaxRows
+	default:
+		return true
+	}
+}

--- a/f32/dot_product_rowmajor_test.go
+++ b/f32/dot_product_rowmajor_test.go
@@ -107,7 +107,8 @@ func TestDotProductRowMajorOptimizedStatus(t *testing.T) {
 
 	indexedUsed := DotProductIndexed(indexedDst, base, query, rowIDs, dims)
 	stridedUsed := DotProductStrided(stridedDst, base, query, rows, dims, dims)
-	wantOptimized := runtime.GOARCH == "amd64" && ((cpu.X86.AVX512F && cpu.X86.AVX512VL) || (cpu.X86.AVX && cpu.X86.FMA))
+	wantOptimized := (runtime.GOARCH == "amd64" && ((cpu.X86.AVX512F && cpu.X86.AVX512VL) || (cpu.X86.AVX && cpu.X86.FMA))) ||
+		(runtime.GOARCH == "arm64" && cpu.HasNEON())
 	if indexedUsed != wantOptimized {
 		t.Fatalf("indexed optimized status = %v, want %v (cpu=%s)", indexedUsed, wantOptimized, cpu.Info())
 	}

--- a/f32/f32_amd64.go
+++ b/f32/f32_amd64.go
@@ -333,21 +333,6 @@ func dotProductBatchKernel(useAVX512 bool, results []float32, rows [][]float32, 
 	}
 }
 
-const (
-	batchDotRows    = 4
-	batchDotMinDims = 64
-
-	// SIMD-vs-fallback gate. Above these dim/row sizes the batched kernel stops
-	// beating the per-row fallback on the hardware measured so far, so very
-	// large shapes stay on the scalar path. These are deliberately conservative
-	// monotone thresholds, not per-machine tuned cliffs; re-tune against a
-	// benchmark matrix before enabling more shapes.
-	batchDotLargeDims    = 768
-	batchDotLargeMaxRows = 256
-	batchDotHugeDims     = 2048
-	batchDotHugeMaxRows  = 64
-)
-
 // dotProduct4Batch scores four full rows (base[off0..off3], each dims long)
 // against query and writes the four results starting at dst[di]. It centralizes
 // the unsafe pointer setup and the AVX-512/AVX kernel selection shared by the
@@ -453,116 +438,6 @@ func dotProductStrided(dst, base, query []float32, rowCount, dims, stride int) b
 		dst[i] = dotProductStridedTail(base, query, queryFull, i, dims, stride, maxRow)
 	}
 	return usedSIMD
-}
-
-func fullRowMaxIndex(baseLen, dims, stride int) int {
-	if dims <= 0 || stride <= 0 || baseLen < dims {
-		return -1
-	}
-	return (baseLen - dims) / stride
-}
-
-func rowIDInFullRange(rowID uint32, maxRow int) bool {
-	return maxRow >= 0 && uint64(rowID) <= uint64(maxRow)
-}
-
-func dotProductIndexedFallback(dst, base, query []float32, rowIDs []uint32, dims int) {
-	n := min(len(dst), len(rowIDs))
-	if n == 0 {
-		return
-	}
-	if dims <= 0 || len(query) == 0 {
-		clear(dst[:n])
-		return
-	}
-	queryN := min(dims, len(query))
-	queryFull := query[:queryN]
-	maxRow := fullRowMaxIndex(len(base), queryN, dims)
-	for i := range n {
-		rowID := rowIDs[i]
-		if rowIDInFullRange(rowID, maxRow) {
-			off := int(rowID) * dims
-			dst[i] = dotProduct(base[off:off+queryN], queryFull)
-			continue
-		}
-		dst[i] = dotProductIndexedOneGo(base, query, rowID, dims)
-	}
-}
-
-func dotProductStridedFallback(dst, base, query []float32, rowCount, dims, stride int) {
-	if rowCount <= 0 || len(dst) == 0 {
-		return
-	}
-	n := min(len(dst), rowCount)
-	if dims <= 0 || stride <= 0 || len(query) == 0 {
-		clear(dst[:n])
-		return
-	}
-	queryN := min(dims, len(query))
-	queryFull := query[:queryN]
-	maxRow := fullRowMaxIndex(len(base), queryN, stride)
-	if n-1 <= maxRow {
-		for i, off := 0, 0; i < n; i, off = i+1, off+stride {
-			dst[i] = dotProduct(base[off:off+queryN], queryFull)
-		}
-		return
-	}
-	for i := range n {
-		if i <= maxRow {
-			off := i * stride
-			dst[i] = dotProduct(base[off:off+queryN], queryFull)
-			continue
-		}
-		dst[i] = dotProductStridedOneGo(base, query, i, dims, stride)
-	}
-}
-
-// dotProductIndexedTail scores one row for the mixed-block and trailing-tail
-// paths. The CPU capability and queryLen >= dims are already verified by the
-// caller, so any in-range row can take the optimized single-row dotProduct;
-// out-of-range rows score zero via the ragged-safe Go path.
-func dotProductIndexedTail(base, query, queryFull []float32, rowID uint32, dims, maxRow int) float32 {
-	if rowIDInFullRange(rowID, maxRow) {
-		off := int(rowID) * dims
-		return dotProduct(base[off:off+dims], queryFull)
-	}
-	return dotProductIndexedOneGo(base, query, rowID, dims)
-}
-
-func dotProductStridedTail(base, query, queryFull []float32, row, dims, stride, maxRow int) float32 {
-	if row >= 0 && row <= maxRow {
-		off := row * stride
-		return dotProduct(base[off:off+dims], queryFull)
-	}
-	return dotProductStridedOneGo(base, query, row, dims, stride)
-}
-
-func batchDotIndexedSIMDEligible(rows, dims, queryLen int) bool {
-	if rows < batchDotRows || dims < batchDotMinDims || queryLen < dims {
-		return false
-	}
-	return batchDotRowsWithinGate(rows, dims)
-}
-
-func batchDotStridedSIMDEligible(rows, dims, stride, queryLen int) bool {
-	if rows < batchDotRows || dims < batchDotMinDims || stride <= 0 || queryLen < dims {
-		return false
-	}
-	return batchDotRowsWithinGate(rows, dims)
-}
-
-// batchDotRowsWithinGate reports whether a (rows, dims) shape is small enough
-// that the batched SIMD kernel is expected to beat the per-row fallback. The
-// gate is monotone in both dimensions: larger shapes fall back first.
-func batchDotRowsWithinGate(rows, dims int) bool {
-	switch {
-	case dims >= batchDotHugeDims:
-		return rows < batchDotHugeMaxRows
-	case dims >= batchDotLargeDims:
-		return rows < batchDotLargeMaxRows
-	default:
-		return true
-	}
 }
 
 func convolveValid32(dst, signal, kernel []float32) {

--- a/f32/f32_arm64.go
+++ b/f32/f32_arm64.go
@@ -2,7 +2,11 @@
 
 package f32
 
-import "github.com/tphakala/simd/cpu"
+import (
+	"unsafe"
+
+	"github.com/tphakala/simd/cpu"
+)
 
 var (
 	hasNEON = cpu.ARM64.NEON
@@ -118,6 +122,19 @@ func clamp32(dst, a []float32, minVal, maxVal float32) {
 
 func dotProductBatch32(results []float32, rows [][]float32, vec []float32) {
 	vecLen := len(vec)
+	if vecLen == 0 {
+		for i := range rows {
+			results[i] = 0
+		}
+		return
+	}
+	// Mirror dotProduct's NEON length threshold (>= 4): the batch-of-4 kernel
+	// keeps the query vector resident across the group instead of reloading it
+	// per row, which is the only win here since the per-row path is already NEON.
+	if hasNEON && len(rows) >= batchDotRows && vecLen >= 4 {
+		dotProductBatchKernel(results, rows, vec, vecLen)
+		return
+	}
 	for i, row := range rows {
 		n := min(len(row), vecLen)
 		if n == 0 {
@@ -128,14 +145,136 @@ func dotProductBatch32(results []float32, rows [][]float32, vec []float32) {
 	}
 }
 
+// dotProductBatchKernel scores rows against vec in groups of four, keeping the
+// query vector resident across each group via dotProduct4NEON instead of
+// reloading it per row. Rows shorter than vecLen (and any tail past the last
+// full group of four) fall back to the per-row dotProduct, so results stay
+// anchored to the scalar contract regardless of row shape.
+func dotProductBatchKernel(results []float32, rows [][]float32, vec []float32, vecLen int) {
+	i := 0
+	for i+3 < len(rows) {
+		row0, row1, row2, row3 := rows[i], rows[i+1], rows[i+2], rows[i+3]
+		if len(row0) >= vecLen && len(row1) >= vecLen && len(row2) >= vecLen && len(row3) >= vecLen {
+			res := (*float32)(unsafe.Pointer(&results[i]))
+			r0 := (*float32)(unsafe.Pointer(&row0[0]))
+			r1 := (*float32)(unsafe.Pointer(&row1[0]))
+			r2 := (*float32)(unsafe.Pointer(&row2[0]))
+			r3 := (*float32)(unsafe.Pointer(&row3[0]))
+			q := (*float32)(unsafe.Pointer(&vec[0]))
+			dotProduct4NEON(res, r0, r1, r2, r3, q, vecLen)
+			i += 4
+			continue
+		}
+		for j := range 4 {
+			row := rows[i+j]
+			n := min(len(row), vecLen)
+			if n == 0 {
+				results[i+j] = 0
+			} else {
+				results[i+j] = dotProduct(row[:n], vec[:n])
+			}
+		}
+		i += 4
+	}
+	for ; i < len(rows); i++ {
+		row := rows[i]
+		n := min(len(row), vecLen)
+		if n == 0 {
+			results[i] = 0
+		} else {
+			results[i] = dotProduct(row[:n], vec[:n])
+		}
+	}
+}
+
 func dotProductIndexed(dst, base, query []float32, rowIDs []uint32, dims int) bool {
-	dotProductIndexedGo(dst, base, query, rowIDs, dims)
-	return false
+	n := min(len(dst), len(rowIDs))
+	if n == 0 {
+		return false
+	}
+	if !hasNEON || !batchDotIndexedSIMDEligible(n, dims, len(query)) {
+		dotProductIndexedFallback(dst[:n], base, query, rowIDs[:n], dims)
+		return false
+	}
+	maxRow := fullRowMaxIndex(len(base), dims, dims)
+	if maxRow < 0 {
+		dotProductIndexedFallback(dst[:n], base, query, rowIDs[:n], dims)
+		return false
+	}
+
+	queryFull := query[:dims]
+	usedSIMD := false
+	i := 0
+	for ; i+batchDotRows-1 < n; i += batchDotRows {
+		id0, id1, id2, id3 := rowIDs[i], rowIDs[i+1], rowIDs[i+2], rowIDs[i+3]
+		if rowIDInFullRange(id0, maxRow) && rowIDInFullRange(id1, maxRow) && rowIDInFullRange(id2, maxRow) && rowIDInFullRange(id3, maxRow) {
+			off0 := int(id0) * dims
+			off1 := int(id1) * dims
+			off2 := int(id2) * dims
+			off3 := int(id3) * dims
+			dotProduct4Batch(dst, i, base, off0, off1, off2, off3, queryFull, dims)
+			usedSIMD = true
+			continue
+		}
+		for j := range batchDotRows {
+			dst[i+j] = dotProductIndexedTail(base, query, queryFull, rowIDs[i+j], dims, maxRow)
+		}
+	}
+	for ; i < n; i++ {
+		dst[i] = dotProductIndexedTail(base, query, queryFull, rowIDs[i], dims, maxRow)
+	}
+	return usedSIMD
 }
 
 func dotProductStrided(dst, base, query []float32, rowCount, dims, stride int) bool {
-	dotProductStridedGo(dst, base, query, rowCount, dims, stride)
-	return false
+	if rowCount <= 0 || len(dst) == 0 {
+		return false
+	}
+	n := min(len(dst), rowCount)
+	if !hasNEON || !batchDotStridedSIMDEligible(n, dims, stride, len(query)) {
+		dotProductStridedFallback(dst[:n], base, query, n, dims, stride)
+		return false
+	}
+	maxRow := fullRowMaxIndex(len(base), dims, stride)
+	if maxRow < 0 {
+		dotProductStridedFallback(dst[:n], base, query, n, dims, stride)
+		return false
+	}
+
+	queryFull := query[:dims]
+	usedSIMD := false
+	i := 0
+	for ; i+batchDotRows-1 < n; i += batchDotRows {
+		if i+batchDotRows-1 <= maxRow {
+			off0 := i * stride
+			off1 := off0 + stride
+			off2 := off1 + stride
+			off3 := off2 + stride
+			dotProduct4Batch(dst, i, base, off0, off1, off2, off3, queryFull, dims)
+			usedSIMD = true
+			continue
+		}
+		for j := range batchDotRows {
+			dst[i+j] = dotProductStridedTail(base, query, queryFull, i+j, dims, stride, maxRow)
+		}
+	}
+	for ; i < n; i++ {
+		dst[i] = dotProductStridedTail(base, query, queryFull, i, dims, stride, maxRow)
+	}
+	return usedSIMD
+}
+
+// dotProduct4Batch scores four full rows (base[off0..off3], each dims long)
+// against query and writes the four results starting at dst[di], centralizing
+// the unsafe pointer setup shared by the indexed and strided batch loops.
+func dotProduct4Batch(dst []float32, di int, base []float32, off0, off1, off2, off3 int, query []float32, dims int) {
+	results := (*float32)(unsafe.Pointer(&dst[di]))
+	r0 := (*float32)(unsafe.Pointer(&base[off0]))
+	r1 := (*float32)(unsafe.Pointer(&base[off1]))
+	r2 := (*float32)(unsafe.Pointer(&base[off2]))
+	r3 := (*float32)(unsafe.Pointer(&base[off3]))
+	q := (*float32)(unsafe.Pointer(&query[0]))
+	dotProduct4NEON(results, r0, r1, r2, r3, q, dims)
 }
 
 func convolveValid32(dst, signal, kernel []float32) {
@@ -169,6 +308,9 @@ func accumulateAdd32(dst, src []float32) {
 
 //go:noescape
 func dotProductNEON(a, b []float32) float32
+
+//go:noescape
+func dotProduct4NEON(results, row0, row1, row2, row3, vec *float32, n int)
 
 //go:noescape
 func addNEON(dst, a, b []float32)

--- a/f32/f32_arm64.s
+++ b/f32/f32_arm64.s
@@ -87,6 +87,119 @@ dot32_reduce:
     FMOVS F0, ret+48(FP)
     RET
 
+// func dotProduct4NEON(results, row0, row1, row2, row3, vec *float32, n int)
+// Scores four rows against the same vec, reusing each vec load across the
+// group instead of reloading the query per row. Two accumulator banks per row
+// (V0-V3 bank a, V4-V7 bank b) hide FMLA latency over an 8-element main loop;
+// V16/V17 hold the two query chunks, V18-V21 the four row chunks.
+TEXT ·dotProduct4NEON(SB), NOSPLIT, $0-56
+    MOVD results+0(FP), R0
+    MOVD row0+8(FP), R1
+    MOVD row1+16(FP), R2
+    MOVD row2+24(FP), R3
+    MOVD row3+32(FP), R4
+    MOVD vec+40(FP), R5
+    MOVD n+48(FP), R6
+
+    VEOR V0.B16, V0.B16, V0.B16
+    VEOR V1.B16, V1.B16, V1.B16
+    VEOR V2.B16, V2.B16, V2.B16
+    VEOR V3.B16, V3.B16, V3.B16
+    VEOR V4.B16, V4.B16, V4.B16
+    VEOR V5.B16, V5.B16, V5.B16
+    VEOR V6.B16, V6.B16, V6.B16
+    VEOR V7.B16, V7.B16, V7.B16
+
+    // Process 8 elements per row (2 NEON chunks) per iteration.
+    LSR $3, R6, R7             // R7 = n / 8
+    CBZ R7, dot4n_rem4_check
+
+dot4n_loop8:
+    // chunk a: vec[0:4] -> V16, accumulate into bank a (V0-V3)
+    VLD1.P 16(R5), [V16.S4]
+    VLD1.P 16(R1), [V18.S4]
+    WORD $0x4E30CE40           // FMLA V0.4S, V18.4S, V16.4S
+    VLD1.P 16(R2), [V19.S4]
+    WORD $0x4E30CE61           // FMLA V1.4S, V19.4S, V16.4S
+    VLD1.P 16(R3), [V20.S4]
+    WORD $0x4E30CE82           // FMLA V2.4S, V20.4S, V16.4S
+    VLD1.P 16(R4), [V21.S4]
+    WORD $0x4E30CEA3           // FMLA V3.4S, V21.4S, V16.4S
+    // chunk b: vec[4:8] -> V17, accumulate into bank b (V4-V7)
+    VLD1.P 16(R5), [V17.S4]
+    VLD1.P 16(R1), [V18.S4]
+    WORD $0x4E31CE44           // FMLA V4.4S, V18.4S, V17.4S
+    VLD1.P 16(R2), [V19.S4]
+    WORD $0x4E31CE65           // FMLA V5.4S, V19.4S, V17.4S
+    VLD1.P 16(R3), [V20.S4]
+    WORD $0x4E31CE86           // FMLA V6.4S, V20.4S, V17.4S
+    VLD1.P 16(R4), [V21.S4]
+    WORD $0x4E31CEA7           // FMLA V7.4S, V21.4S, V17.4S
+    SUB $1, R7
+    CBNZ R7, dot4n_loop8
+
+    // Fold bank b into bank a (only reached when the main loop ran).
+    WORD $0x4E24D400           // FADD V0.4S, V0.4S, V4.4S
+    WORD $0x4E25D421           // FADD V1.4S, V1.4S, V5.4S
+    WORD $0x4E26D442           // FADD V2.4S, V2.4S, V6.4S
+    WORD $0x4E27D463           // FADD V3.4S, V3.4S, V7.4S
+
+dot4n_rem4_check:
+    AND $7, R6, R8
+    LSR $2, R8, R9             // R9 = (n & 7) / 4
+    CBZ R9, dot4n_reduce
+
+    // One 4-element chunk into bank a.
+    VLD1.P 16(R5), [V16.S4]
+    VLD1.P 16(R1), [V18.S4]
+    WORD $0x4E30CE40           // FMLA V0.4S, V18.4S, V16.4S
+    VLD1.P 16(R2), [V19.S4]
+    WORD $0x4E30CE61           // FMLA V1.4S, V19.4S, V16.4S
+    VLD1.P 16(R3), [V20.S4]
+    WORD $0x4E30CE82           // FMLA V2.4S, V20.4S, V16.4S
+    VLD1.P 16(R4), [V21.S4]
+    WORD $0x4E30CEA3           // FMLA V3.4S, V21.4S, V16.4S
+
+dot4n_reduce:
+    // Reduce each bank-a accumulator to a scalar (S0..S3) BEFORE any scalar FMA,
+    // since scalar ops zero the upper lanes of the V register.
+    WORD $0x6E20D400           // FADDP V0.4S, V0.4S, V0.4S
+    WORD $0x7E30D800           // FADDP S0, V0.2S
+    WORD $0x6E21D421           // FADDP V1.4S, V1.4S, V1.4S
+    WORD $0x7E30D821           // FADDP S1, V1.2S
+    WORD $0x6E22D442           // FADDP V2.4S, V2.4S, V2.4S
+    WORD $0x7E30D842           // FADDP S2, V2.2S
+    WORD $0x6E23D463           // FADDP V3.4S, V3.4S, V3.4S
+    WORD $0x7E30D863           // FADDP S3, V3.2S
+
+    AND $3, R6, R8             // R8 = n & 3 (scalar tail count)
+    CBZ R8, dot4n_store
+
+dot4n_scalar:
+    FMOVS (R5), F18
+    FMOVS (R1), F19
+    FMADDS F18, F0, F19, F0    // F0 = F19 * F18 + F0
+    FMOVS (R2), F19
+    FMADDS F18, F1, F19, F1
+    FMOVS (R3), F19
+    FMADDS F18, F2, F19, F2
+    FMOVS (R4), F19
+    FMADDS F18, F3, F19, F3
+    ADD $4, R5
+    ADD $4, R1
+    ADD $4, R2
+    ADD $4, R3
+    ADD $4, R4
+    SUB $1, R8
+    CBNZ R8, dot4n_scalar
+
+dot4n_store:
+    FMOVS F0, (R0)
+    FMOVS F1, 4(R0)
+    FMOVS F2, 8(R0)
+    FMOVS F3, 12(R0)
+    RET
+
 // func addNEON(dst, a, b []float32)
 TEXT ·addNEON(SB), NOSPLIT, $0-72
     MOVD dst_base+0(FP), R0

--- a/f64/dot_product_batch4_amd64_test.go
+++ b/f64/dot_product_batch4_amd64_test.go
@@ -1,0 +1,56 @@
+//go:build amd64
+
+package f64
+
+import (
+	"math"
+	"testing"
+
+	"github.com/tphakala/simd/cpu"
+)
+
+// dotProduct4Kernel is the shared signature of the batch-of-4 query-load-reuse
+// kernels: four rows scored against one resident query vector.
+type dotProduct4Kernel func(results, row0, row1, row2, row3, vec *float64, n int)
+
+// checkDotProduct4Kernel scores four deterministic rows against one query with
+// the given kernel and compares each result to the pure-scalar dotProductGo
+// oracle, so a buggy hand-written kernel (wrong lane count, bad reduction,
+// mishandled tail) is caught rather than passing by SIMD-vs-SIMD agreement.
+func checkDotProduct4Kernel(t *testing.T, kernel dotProduct4Kernel) {
+	t.Helper()
+	// Cover sub-vector, exact-multiple, and tail-bearing dims for both the
+	// AVX (4-lane, 16/iter) and AVX-512 (8-lane, 64/iter) main loops.
+	dims := []int{1, 2, 3, 4, 7, 8, 15, 16, 31, 32, 63, 64, 65, 127, 128, 256, 768}
+	for _, dim := range dims {
+		vec := deterministicF64Vector(11, dim)
+		rows := [4][]float64{
+			deterministicF64Vector(100, dim),
+			deterministicF64Vector(101, dim),
+			deterministicF64Vector(102, dim),
+			deterministicF64Vector(103, dim),
+		}
+		results := make([]float64, 4)
+		kernel(&results[0], &rows[0][0], &rows[1][0], &rows[2][0], &rows[3][0], &vec[0], dim)
+		for i, row := range rows {
+			want := dotProductGo(row, vec)
+			if !almostEqual(results[i], want, 1e-9*(1+math.Abs(want))) {
+				t.Fatalf("dim=%d row=%d got=%g want=%g", dim, i, results[i], want)
+			}
+		}
+	}
+}
+
+func TestDotProduct4AVXKernel(t *testing.T) {
+	if !cpu.X86.AVX || !cpu.X86.FMA {
+		t.Skip("AVX+FMA required")
+	}
+	checkDotProduct4Kernel(t, dotProduct4AVX)
+}
+
+func TestDotProduct4AVX512Kernel(t *testing.T) {
+	if !cpu.X86.AVX512F || !cpu.X86.AVX512VL {
+		t.Skip("AVX-512F+VL required")
+	}
+	checkDotProduct4Kernel(t, dotProduct4AVX512)
+}

--- a/f64/dot_product_batch4_test.go
+++ b/f64/dot_product_batch4_test.go
@@ -1,0 +1,124 @@
+package f64
+
+import (
+	"fmt"
+	"math"
+	"testing"
+)
+
+var sinkBatch4Results64 []float64
+
+func TestDotProductBatchMatchesDotProductWideShapes(t *testing.T) {
+	dims := []int{0, 1, 2, 3, 4, 7, 8, 15, 16, 31, 32, 64, 127, 128, 255, 256, 768}
+	rowCounts := []int{0, 1, 2, 3, 4, 5, 7, 8, 16, 128}
+	for _, dim := range dims {
+		for _, rowCount := range rowCounts {
+			t.Run("shape", func(t *testing.T) {
+				vec := deterministicF64Vector(11, dim)
+				rows := make([][]float64, rowCount)
+				for i := range rows {
+					rows[i] = deterministicF64Vector(100+i, dim)
+				}
+				got := make([]float64, rowCount)
+				DotProductBatch(got, rows, vec)
+				for i := range rows {
+					// Anchor the oracle to the pure-scalar dotProductGo rather than the
+					// dispatched DotProduct, so on amd64 this checks the batched SIMD
+					// kernel against the scalar contract instead of SIMD-vs-SIMD.
+					want := dotProductGo(rows[i], vec)
+					if !closeFloat64(got[i], want) {
+						t.Fatalf("dim=%d rows=%d row=%d got=%g want=%g", dim, rowCount, i, got[i], want)
+					}
+				}
+			})
+		}
+	}
+}
+
+func TestDotProductBatchVariedRowLengths(t *testing.T) {
+	vec := deterministicF64Vector(7, 768)
+	rows := [][]float64{
+		deterministicF64Vector(1, 0),
+		deterministicF64Vector(2, 1),
+		deterministicF64Vector(3, 15),
+		deterministicF64Vector(4, 16),
+		deterministicF64Vector(5, 255),
+		deterministicF64Vector(6, 768),
+		deterministicF64Vector(7, 769),
+	}
+	got := make([]float64, len(rows))
+	DotProductBatch(got, rows, vec)
+	for i := range rows {
+		want := DotProduct(rows[i], vec)
+		if !closeFloat64(got[i], want) {
+			t.Fatalf("row=%d len=%d got=%g want=%g", i, len(rows[i]), got[i], want)
+		}
+	}
+}
+
+func TestDotProductBatchAllocs(t *testing.T) {
+	for _, rowCount := range []int{4, 8, 16, 128} {
+		vec := deterministicF64Vector(21, 768)
+		rows := make([][]float64, rowCount)
+		for i := range rows {
+			rows[i] = deterministicF64Vector(2000+i, 768)
+		}
+		results := make([]float64, rowCount)
+		allocs := testing.AllocsPerRun(100, func() {
+			DotProductBatch(results, rows, vec)
+		})
+		if allocs != 0 {
+			t.Fatalf("DotProductBatch rows=%d allocations = %v, want 0", rowCount, allocs)
+		}
+	}
+}
+
+func BenchmarkDotProductBatch768xRows(b *testing.B) {
+	for _, rowsN := range []int{4, 8, 16, 128} {
+		b.Run(fmt.Sprintf("batch_rows_%d", rowsN), func(b *testing.B) {
+			benchmarkDotProductBatch768Rows(b, rowsN, true)
+		})
+		b.Run(fmt.Sprintf("loop_rows_%d", rowsN), func(b *testing.B) {
+			benchmarkDotProductBatch768Rows(b, rowsN, false)
+		})
+	}
+}
+
+func benchmarkDotProductBatch768Rows(b *testing.B, rowsN int, batch bool) {
+	b.Helper()
+	const dim = 768
+	vec := deterministicF64Vector(17, dim)
+	rows := make([][]float64, rowsN)
+	for i := range rows {
+		rows[i] = deterministicF64Vector(1000+i, dim)
+	}
+	results := make([]float64, rowsN)
+	b.ReportAllocs()
+	b.ReportMetric(float64(rowsN), "dots/op")
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		if batch {
+			DotProductBatch(results, rows, vec)
+		} else {
+			for j, row := range rows {
+				results[j] = DotProduct(row, vec)
+			}
+		}
+	}
+	sinkBatch4Results64 = results
+}
+
+func deterministicF64Vector(seed, n int) []float64 {
+	out := make([]float64, n)
+	x := uint32(seed)*747796405 + 2891336453
+	for i := range out {
+		x = x*1664525 + 1013904223
+		out[i] = float64(int32(x>>9)%2000-1000) / 1000
+	}
+	return out
+}
+
+func closeFloat64(got, want float64) bool {
+	diff := math.Abs(got - want)
+	return diff <= 1e-9*(1+math.Abs(want))
+}

--- a/f64/f64_amd64.go
+++ b/f64/f64_amd64.go
@@ -2,7 +2,11 @@
 
 package f64
 
-import "github.com/tphakala/simd/cpu"
+import (
+	"unsafe"
+
+	"github.com/tphakala/simd/cpu"
+)
 
 // Minimum number of float64 elements required for SIMD operations.
 // AVX processes 4 float64 values per 256-bit register.
@@ -317,13 +321,72 @@ func cumulativeSum64(dst, a []float64) {
 
 func dotProductBatch64(results []float64, rows [][]float64, vec []float64) {
 	vecLen := len(vec)
-	for i, row := range rows {
+	if vecLen == 0 {
+		for i := range rows {
+			results[i] = 0
+		}
+		return
+	}
+	switch {
+	case cpu.X86.AVX512F && cpu.X86.AVX512VL && len(rows) >= 4 && vecLen >= minAVX512Elements:
+		dotProductBatchKernel(true, results, rows, vec, vecLen)
+	case cpu.X86.AVX && cpu.X86.FMA && len(rows) >= 4 && vecLen >= minAVXElements:
+		dotProductBatchKernel(false, results, rows, vec, vecLen)
+	default:
+		for i, row := range rows {
+			n := min(len(row), vecLen)
+			if n == 0 {
+				results[i] = 0
+				continue
+			}
+			results[i] = dotProduct(row[:n], vec[:n])
+		}
+	}
+}
+
+// dotProductBatchKernel scores rows against vec in groups of four, keeping the
+// query vector resident across each group via dotProduct4AVX/dotProduct4AVX512
+// instead of reloading it per row. Rows shorter than vecLen (and any tail past
+// the last full group of four) fall back to the per-row dotProduct, so results
+// stay anchored to the scalar contract regardless of row shape.
+func dotProductBatchKernel(useAVX512 bool, results []float64, rows [][]float64, vec []float64, vecLen int) {
+	i := 0
+	for i+3 < len(rows) {
+		row0, row1, row2, row3 := rows[i], rows[i+1], rows[i+2], rows[i+3]
+		if len(row0) >= vecLen && len(row1) >= vecLen && len(row2) >= vecLen && len(row3) >= vecLen {
+			res := (*float64)(unsafe.Pointer(&results[i]))
+			r0 := (*float64)(unsafe.Pointer(&row0[0]))
+			r1 := (*float64)(unsafe.Pointer(&row1[0]))
+			r2 := (*float64)(unsafe.Pointer(&row2[0]))
+			r3 := (*float64)(unsafe.Pointer(&row3[0]))
+			q := (*float64)(unsafe.Pointer(&vec[0]))
+			if useAVX512 {
+				dotProduct4AVX512(res, r0, r1, r2, r3, q, vecLen)
+			} else {
+				dotProduct4AVX(res, r0, r1, r2, r3, q, vecLen)
+			}
+			i += 4
+			continue
+		}
+		for j := range 4 {
+			row := rows[i+j]
+			n := min(len(row), vecLen)
+			if n == 0 {
+				results[i+j] = 0
+			} else {
+				results[i+j] = dotProduct(row[:n], vec[:n])
+			}
+		}
+		i += 4
+	}
+	for ; i < len(rows); i++ {
+		row := rows[i]
 		n := min(len(row), vecLen)
 		if n == 0 {
 			results[i] = 0
-			continue
+		} else {
+			results[i] = dotProduct(row[:n], vec[:n])
 		}
-		results[i] = dotProduct(row[:n], vec[:n])
 	}
 }
 
@@ -532,6 +595,9 @@ func sigmoidAVX(dst, src []float64)
 func dotProductAVX(a, b []float64) float64
 
 //go:noescape
+func dotProduct4AVX(results, row0, row1, row2, row3, vec *float64, n int)
+
+//go:noescape
 func convolveDecimateAVX(dst, signal, kernel []float64, factor, phase int)
 
 //go:noescape
@@ -604,6 +670,9 @@ func addScaledAVX(dst []float64, alpha float64, s []float64)
 //
 //go:noescape
 func dotProductAVX512(a, b []float64) float64
+
+//go:noescape
+func dotProduct4AVX512(results, row0, row1, row2, row3, vec *float64, n int)
 
 //go:noescape
 func addAVX512(dst, a, b []float64)

--- a/f64/f64_amd64.s
+++ b/f64/f64_amd64.s
@@ -1176,6 +1176,324 @@ dot_512_done:
     VZEROUPPER
     RET
 
+// func dotProduct4AVX(results, row0, row1, row2, row3, vec *float64, n int)
+// Computes four dot products against the same vec, reusing each vec load.
+// Two accumulator banks per row (a/b) hide FMA latency; 16 doubles per row per
+// main iteration (4 chunks of 4 lanes). Tail reuses dotProductAVX's reduction.
+TEXT ·dotProduct4AVX(SB), NOSPLIT, $0-56
+    MOVQ results+0(FP), DX
+    MOVQ row0+8(FP), SI
+    MOVQ row1+16(FP), R8
+    MOVQ row2+24(FP), R9
+    MOVQ row3+32(FP), R10
+    MOVQ vec+40(FP), DI
+    MOVQ n+48(FP), CX
+
+    VXORPD Y0, Y0, Y0          // acc0a
+    VXORPD Y3, Y3, Y3          // acc1a
+    VXORPD Y4, Y4, Y4          // acc2a
+    VXORPD Y5, Y5, Y5          // acc3a
+    VXORPD Y6, Y6, Y6          // acc0b
+    VXORPD Y7, Y7, Y7          // acc1b
+    VXORPD Y8, Y8, Y8          // acc2b
+    VXORPD Y9, Y9, Y9          // acc3b
+
+    MOVQ CX, AX
+    SHRQ $4, AX                // n / 16
+    JZ   dot4_avx_loop4_check
+
+dot4_avx_loop16:
+    VMOVUPD (DI), Y1
+    VMOVUPD (SI), Y2
+    VFMADD231PD Y1, Y2, Y0
+    VMOVUPD (R8), Y2
+    VFMADD231PD Y1, Y2, Y3
+    VMOVUPD (R9), Y2
+    VFMADD231PD Y1, Y2, Y4
+    VMOVUPD (R10), Y2
+    VFMADD231PD Y1, Y2, Y5
+
+    VMOVUPD 32(DI), Y1
+    VMOVUPD 32(SI), Y2
+    VFMADD231PD Y1, Y2, Y6
+    VMOVUPD 32(R8), Y2
+    VFMADD231PD Y1, Y2, Y7
+    VMOVUPD 32(R9), Y2
+    VFMADD231PD Y1, Y2, Y8
+    VMOVUPD 32(R10), Y2
+    VFMADD231PD Y1, Y2, Y9
+
+    VMOVUPD 64(DI), Y1
+    VMOVUPD 64(SI), Y2
+    VFMADD231PD Y1, Y2, Y0
+    VMOVUPD 64(R8), Y2
+    VFMADD231PD Y1, Y2, Y3
+    VMOVUPD 64(R9), Y2
+    VFMADD231PD Y1, Y2, Y4
+    VMOVUPD 64(R10), Y2
+    VFMADD231PD Y1, Y2, Y5
+
+    VMOVUPD 96(DI), Y1
+    VMOVUPD 96(SI), Y2
+    VFMADD231PD Y1, Y2, Y6
+    VMOVUPD 96(R8), Y2
+    VFMADD231PD Y1, Y2, Y7
+    VMOVUPD 96(R9), Y2
+    VFMADD231PD Y1, Y2, Y8
+    VMOVUPD 96(R10), Y2
+    VFMADD231PD Y1, Y2, Y9
+
+    ADDQ $128, DI
+    ADDQ $128, SI
+    ADDQ $128, R8
+    ADDQ $128, R9
+    ADDQ $128, R10
+    DECQ AX
+    JNZ  dot4_avx_loop16
+
+dot4_avx_loop4_check:
+    ANDQ $15, CX
+    MOVQ CX, AX
+    SHRQ $2, AX
+    JZ   dot4_avx_reduce
+
+dot4_avx_loop4:
+    VMOVUPD (DI), Y1
+    VMOVUPD (SI), Y2
+    VFMADD231PD Y1, Y2, Y0
+    VMOVUPD (R8), Y2
+    VFMADD231PD Y1, Y2, Y3
+    VMOVUPD (R9), Y2
+    VFMADD231PD Y1, Y2, Y4
+    VMOVUPD (R10), Y2
+    VFMADD231PD Y1, Y2, Y5
+    ADDQ $32, DI
+    ADDQ $32, SI
+    ADDQ $32, R8
+    ADDQ $32, R9
+    ADDQ $32, R10
+    DECQ AX
+    JNZ  dot4_avx_loop4
+
+dot4_avx_reduce:
+    VADDPD Y6, Y0, Y0
+    VADDPD Y7, Y3, Y3
+    VADDPD Y8, Y4, Y4
+    VADDPD Y9, Y5, Y5
+
+    // Reduce acc0 into X0.
+    VEXTRACTF128 $1, Y0, X1
+    VADDPD X1, X0, X0
+    VHADDPD X0, X0, X0
+
+    // Reduce acc1 into X3.
+    VEXTRACTF128 $1, Y3, X1
+    VADDPD X1, X3, X3
+    VHADDPD X3, X3, X3
+
+    // Reduce acc2 into X4.
+    VEXTRACTF128 $1, Y4, X1
+    VADDPD X1, X4, X4
+    VHADDPD X4, X4, X4
+
+    // Reduce acc3 into X5.
+    VEXTRACTF128 $1, Y5, X1
+    VADDPD X1, X5, X5
+    VHADDPD X5, X5, X5
+
+    ANDQ $3, CX
+    JZ   dot4_avx_done
+
+dot4_avx_scalar:
+    VMOVSD (DI), X1
+    VMOVSD (SI), X2
+    VFMADD231SD X1, X2, X0
+    VMOVSD (R8), X2
+    VFMADD231SD X1, X2, X3
+    VMOVSD (R9), X2
+    VFMADD231SD X1, X2, X4
+    VMOVSD (R10), X2
+    VFMADD231SD X1, X2, X5
+    ADDQ $8, DI
+    ADDQ $8, SI
+    ADDQ $8, R8
+    ADDQ $8, R9
+    ADDQ $8, R10
+    DECQ CX
+    JNZ  dot4_avx_scalar
+
+dot4_avx_done:
+    VMOVSD X0, (DX)
+    VMOVSD X3, 8(DX)
+    VMOVSD X4, 16(DX)
+    VMOVSD X5, 24(DX)
+    VZEROUPPER
+    RET
+
+// func dotProduct4AVX512(results, row0, row1, row2, row3, vec *float64, n int)
+// Computes four dot products against the same vec, reusing each vec load.
+// Two accumulator banks per row (a/b); 32 doubles per row per main iteration
+// (4 chunks of 8 lanes). Reduction stays on AVX512F (VEXTRACTF64X4, no DQ),
+// matching the AVX512F+VL dispatch gate.
+TEXT ·dotProduct4AVX512(SB), NOSPLIT, $0-56
+    MOVQ results+0(FP), DX
+    MOVQ row0+8(FP), SI
+    MOVQ row1+16(FP), R8
+    MOVQ row2+24(FP), R9
+    MOVQ row3+32(FP), R10
+    MOVQ vec+40(FP), DI
+    MOVQ n+48(FP), CX
+
+    VPXORQ Z0, Z0, Z0          // acc0a
+    VPXORQ Z3, Z3, Z3          // acc1a
+    VPXORQ Z4, Z4, Z4          // acc2a
+    VPXORQ Z5, Z5, Z5          // acc3a
+    VPXORQ Z6, Z6, Z6          // acc0b
+    VPXORQ Z7, Z7, Z7          // acc1b
+    VPXORQ Z8, Z8, Z8          // acc2b
+    VPXORQ Z9, Z9, Z9          // acc3b
+
+    MOVQ CX, AX
+    SHRQ $5, AX                // n / 32
+    JZ   dot4_512_loop8_check
+
+dot4_512_loop32:
+    VMOVUPD (DI), Z1
+    VMOVUPD (SI), Z2
+    VFMADD231PD Z1, Z2, Z0
+    VMOVUPD (R8), Z2
+    VFMADD231PD Z1, Z2, Z3
+    VMOVUPD (R9), Z2
+    VFMADD231PD Z1, Z2, Z4
+    VMOVUPD (R10), Z2
+    VFMADD231PD Z1, Z2, Z5
+
+    VMOVUPD 64(DI), Z1
+    VMOVUPD 64(SI), Z2
+    VFMADD231PD Z1, Z2, Z6
+    VMOVUPD 64(R8), Z2
+    VFMADD231PD Z1, Z2, Z7
+    VMOVUPD 64(R9), Z2
+    VFMADD231PD Z1, Z2, Z8
+    VMOVUPD 64(R10), Z2
+    VFMADD231PD Z1, Z2, Z9
+
+    VMOVUPD 128(DI), Z1
+    VMOVUPD 128(SI), Z2
+    VFMADD231PD Z1, Z2, Z0
+    VMOVUPD 128(R8), Z2
+    VFMADD231PD Z1, Z2, Z3
+    VMOVUPD 128(R9), Z2
+    VFMADD231PD Z1, Z2, Z4
+    VMOVUPD 128(R10), Z2
+    VFMADD231PD Z1, Z2, Z5
+
+    VMOVUPD 192(DI), Z1
+    VMOVUPD 192(SI), Z2
+    VFMADD231PD Z1, Z2, Z6
+    VMOVUPD 192(R8), Z2
+    VFMADD231PD Z1, Z2, Z7
+    VMOVUPD 192(R9), Z2
+    VFMADD231PD Z1, Z2, Z8
+    VMOVUPD 192(R10), Z2
+    VFMADD231PD Z1, Z2, Z9
+
+    ADDQ $256, DI
+    ADDQ $256, SI
+    ADDQ $256, R8
+    ADDQ $256, R9
+    ADDQ $256, R10
+    DECQ AX
+    JNZ  dot4_512_loop32
+
+dot4_512_loop8_check:
+    ANDQ $31, CX
+    MOVQ CX, AX
+    SHRQ $3, AX
+    JZ   dot4_512_reduce
+
+dot4_512_loop8:
+    VMOVUPD (DI), Z1
+    VMOVUPD (SI), Z2
+    VFMADD231PD Z1, Z2, Z0
+    VMOVUPD (R8), Z2
+    VFMADD231PD Z1, Z2, Z3
+    VMOVUPD (R9), Z2
+    VFMADD231PD Z1, Z2, Z4
+    VMOVUPD (R10), Z2
+    VFMADD231PD Z1, Z2, Z5
+    ADDQ $64, DI
+    ADDQ $64, SI
+    ADDQ $64, R8
+    ADDQ $64, R9
+    ADDQ $64, R10
+    DECQ AX
+    JNZ  dot4_512_loop8
+
+dot4_512_reduce:
+    VADDPD Z6, Z0, Z0
+    VADDPD Z7, Z3, Z3
+    VADDPD Z8, Z4, Z4
+    VADDPD Z9, Z5, Z5
+
+    // Reduce acc0 into X0. VEXTRACTF64X4 (AVX512F) keeps the upper-256 extract
+    // off the AVX512DQ path, matching the AVX512F+VL dispatch gate.
+    VEXTRACTF64X4 $1, Z0, Y1
+    VADDPD Y1, Y0, Y0
+    VEXTRACTF128 $1, Y0, X1
+    VADDPD X1, X0, X0
+    VHADDPD X0, X0, X0
+
+    // Reduce acc1 into X3.
+    VEXTRACTF64X4 $1, Z3, Y1
+    VADDPD Y1, Y3, Y3
+    VEXTRACTF128 $1, Y3, X1
+    VADDPD X1, X3, X3
+    VHADDPD X3, X3, X3
+
+    // Reduce acc2 into X4.
+    VEXTRACTF64X4 $1, Z4, Y1
+    VADDPD Y1, Y4, Y4
+    VEXTRACTF128 $1, Y4, X1
+    VADDPD X1, X4, X4
+    VHADDPD X4, X4, X4
+
+    // Reduce acc3 into X5.
+    VEXTRACTF64X4 $1, Z5, Y1
+    VADDPD Y1, Y5, Y5
+    VEXTRACTF128 $1, Y5, X1
+    VADDPD X1, X5, X5
+    VHADDPD X5, X5, X5
+
+    ANDQ $7, CX
+    JZ   dot4_512_done
+
+dot4_512_scalar:
+    VMOVSD (DI), X1
+    VMOVSD (SI), X2
+    VFMADD231SD X1, X2, X0
+    VMOVSD (R8), X2
+    VFMADD231SD X1, X2, X3
+    VMOVSD (R9), X2
+    VFMADD231SD X1, X2, X4
+    VMOVSD (R10), X2
+    VFMADD231SD X1, X2, X5
+    ADDQ $8, DI
+    ADDQ $8, SI
+    ADDQ $8, R8
+    ADDQ $8, R9
+    ADDQ $8, R10
+    DECQ CX
+    JNZ  dot4_512_scalar
+
+dot4_512_done:
+    VMOVSD X0, (DX)
+    VMOVSD X3, 8(DX)
+    VMOVSD X4, 16(DX)
+    VMOVSD X5, 24(DX)
+    VZEROUPPER
+    RET
+
 // func addAVX512(dst, a, b []float64)
 TEXT ·addAVX512(SB), NOSPLIT, $0-72
     MOVQ dst_base+0(FP), DX


### PR DESCRIPTION
## Summary

Completes the batch-of-4 query-load-reuse rollout for the dot-product batch APIs: four rows are scored against one query vector that stays resident in registers across the group, instead of reloading the query per row. Extends the pattern from f32 AMD64 (already merged) to f64 AMD64 and f32 ARM64 NEON.

### f64 `DotProductBatch` batch-of-4 (AMD64) - Fixes #70
- New `dotProduct4AVX` / `dotProduct4AVX512` f64 kernels (4 lanes per AVX vector, 8 per AVX-512), two accumulator banks per row to hide FMA latency.
- `dotProductBatch64` refactored into a `dotProductBatchKernel(useAVX512, ...)` helper gated on `AVX && FMA` and `AVX512F && AVX512VL`, with the per-row fallback for short rows and the sub-group tail.
- The AVX-512 reduce uses `VEXTRACTF64X4` to stay off the AVX512DQ path, matching the dispatch gate (consistent with #67/#73).

### f32 NEON 4-row kernel + Indexed/Strided wiring (ARM64) - Fixes #65
- Hand-encoded `dotProduct4NEON`: 8-element main loop with two accumulator banks (V0-V3, V4-V7), 4-element remainder, scalar tail. Every `WORD` is cross-checked against `arm64asm` by `TestArm64WordEncodings`.
- Extracted the portable row-major scaffolding (eligibility gate, full-row range math, ragged-safe fallback/tail helpers) out of `f32_amd64.go` into a shared `dot_product_rowmajor.go`.
- `DotProductIndexed` / `DotProductStrided` on ARM64 now run through the NEON kernel behind the same eligibility gate and per-row fallback the AMD64 path uses (they previously ran pure scalar Go).

### f32 NEON `DotProductBatch` (ARM64) - Fixes #71
- Routes `dotProductBatch32` through the same NEON kernel in groups of four; short rows and the trailing tail keep the per-row fallback.

## Profiling (both gates were profile-justified before committing the asm)

- f64 AMD64 (AVX path): batch-of-4 beats the per-row loop at every shape, ~2.1x at small dims (dispatch-overhead bound) down to ~1.3x at dim=768 (bandwidth bound).
- f32 ARM64 (Raspberry Pi 5): `DotProductIndexed` reaches ~47 GB/s vs ~24 GB/s for a per-row NEON loop and ~20 GB/s scalar (~2x from query-load reuse); `DotProductBatch` is ~1.4-1.6x over the per-row NEON loop at dim=768 across 4..128 rows.

## Reviewer note

The f64 `dotProduct4AVX512` kernel is assembler-validated and built, but not runtime-executed in CI (standard runners lack AVX-512), the same status as the existing f32 AVX-512 kernels. It mirrors f64's verified `dotProductAVX512` reduction. It will exercise on any AVX-512 host.

## Test Plan
- [x] `go test ./...` on amd64 (parity vs scalar oracle, varied row lengths, zero-allocation, asmcheck)
- [x] Full `f32` suite on arm64 (Raspberry Pi 5): NEON kernel parity, rowmajor parity, batch parity, ragged/tails, optimized-status flag, zero-allocation
- [x] `golangci-lint` clean on both amd64 and arm64 build views; gofmt clean
- [ ] f64 AVX-512 path runtime-verified on an AVX-512 host (not available locally/CI)