### PR TITLE
test: vector-path SIMD-vs-Go parity for f32/f64/c64/c128 (#45)

### DIFF
--- a/c128/vector_path_test.go
+++ b/c128/vector_path_test.go
@@ -1,0 +1,139 @@
+package c128
+
+import (
+	"math"
+	"testing"
+)
+
+// These tests exercise the SIMD-dispatched paths (NEON on arm64; AVX-512/AVX/SSE2
+// on amd64) at and beyond the vector width, including non-multiples of the width
+// so both the main assembly loop and the scalar remainder run. Every result is
+// cross-checked against the pure-Go fallback, which is the trusted reference.
+//
+// Before this file the only SIMD-vs-Go cross-check in the package was
+// TestAbsSqKernels, which is amd64-only and calls the kernels directly, so the
+// NEON path and the seven other public operations had no parity test at len >=
+// the vector width. That is the gap described in issue #45: a looping-body or
+// encoding bug stays invisible when the inputs are shorter than the SIMD width
+// because only the Go fallback runs.
+//
+// complex128 is laid out as interleaved [re, im] float64 pairs. The widest kernel
+// stride is 4 elements (AVX-512); the length set covers one, two and several
+// blocks plus odd remainders.
+
+// vpLens are lengths at or beyond every SIMD stride (NEON/AVX = 2, AVX-512 = 4),
+// with non-multiples so the remainder path is always taken too.
+var vpLens = []int{4, 5, 6, 7, 8, 9, 11, 16, 17, 23, 32, 33}
+
+// vpClose64 is a relative+absolute tolerance comparison. The SIMD kernels reduce
+// in a different order than the scalar Go reference (and Abs uses sqrt versus the
+// fallback's math.Hypot), so the tolerance is set tighter than any block-boundary
+// or encoding bug but loose enough for benign float64 reassociation.
+func vpClose64(got, want float64) bool {
+	d := math.Abs(got - want)
+	return d <= 1e-12*math.Abs(want)+1e-12
+}
+
+func vpCClose(got, want complex128) bool {
+	return vpClose64(real(got), real(want)) && vpClose64(imag(got), imag(want))
+}
+
+// vpMakeC128 builds a deterministic, non-trivial complex128 slice; values vary
+// per index and per seed so a kernel that shuffles or drops a lane cannot match.
+func vpMakeC128(n, seed int) []complex128 {
+	s := make([]complex128, n)
+	for i := range s {
+		re := float64((i*7+seed)%23) - 11
+		im := float64((i*5+seed*3)%17) - 8
+		s[i] = complex(re, im)
+	}
+	return s
+}
+
+func TestVectorPathBinaryC128(t *testing.T) {
+	ops := []struct {
+		name string
+		simd func(dst, a, b []complex128)
+		gold func(dst, a, b []complex128)
+	}{
+		{"Mul", Mul, mulGo},
+		{"MulConj", MulConj, mulConjGo},
+		{"Add", Add, addGo},
+		{"Sub", Sub, subGo},
+	}
+	for _, op := range ops {
+		for _, n := range vpLens {
+			a := vpMakeC128(n, 1)
+			b := vpMakeC128(n, 2)
+			got := make([]complex128, n)
+			want := make([]complex128, n)
+			op.simd(got, a, b)
+			op.gold(want, a, b)
+			for i := range got {
+				if !vpCClose(got[i], want[i]) {
+					t.Errorf("%s n=%d [%d] = %v, want %v (Go fallback)", op.name, n, i, got[i], want[i])
+				}
+			}
+		}
+	}
+}
+
+func TestVectorPathScaleC128(t *testing.T) {
+	s := complex(1.5, -0.5)
+	for _, n := range vpLens {
+		a := vpMakeC128(n, 3)
+		got := make([]complex128, n)
+		want := make([]complex128, n)
+		Scale(got, a, s)
+		scaleGo(want, a, s)
+		for i := range got {
+			if !vpCClose(got[i], want[i]) {
+				t.Errorf("Scale n=%d [%d] = %v, want %v (Go fallback)", n, i, got[i], want[i])
+			}
+		}
+	}
+}
+
+func TestVectorPathConjC128(t *testing.T) {
+	for _, n := range vpLens {
+		a := vpMakeC128(n, 4)
+		got := make([]complex128, n)
+		want := make([]complex128, n)
+		Conj(got, a)
+		conjGo(want, a)
+		for i := range got {
+			if !vpCClose(got[i], want[i]) {
+				t.Errorf("Conj n=%d [%d] = %v, want %v (Go fallback)", n, i, got[i], want[i])
+			}
+		}
+	}
+}
+
+// TestVectorPathToRealC128 covers the complex -> real reductions, whose output is
+// a float64 slice. AbsSq is exact arithmetic; Abs involves a square root, so both
+// go through the same relative-tolerance check.
+func TestVectorPathToRealC128(t *testing.T) {
+	ops := []struct {
+		name string
+		simd func(dst []float64, a []complex128)
+		gold func(dst []float64, a []complex128)
+	}{
+		{"Abs", Abs, absGo},
+		{"AbsSq", AbsSq, absSqGo},
+	}
+	for _, op := range ops {
+		for _, n := range vpLens {
+			a := vpMakeC128(n, 5)
+			got := make([]float64, n)
+			want := make([]float64, n)
+			op.simd(got, a)
+			op.gold(want, a)
+			for i := range got {
+				if !vpClose64(got[i], want[i]) {
+					t.Errorf("%s n=%d [%d] = %v, want %v (Go fallback, input %v)",
+						op.name, n, i, got[i], want[i], a[i])
+				}
+			}
+		}
+	}
+}

--- a/c64/vector_path_test.go
+++ b/c64/vector_path_test.go
@@ -1,0 +1,163 @@
+package c64
+
+import (
+	"math"
+	"testing"
+)
+
+// These tests exercise the SIMD-dispatched paths (NEON on arm64; AVX/AVX-512/SSE2
+// on amd64) at and beyond the vector width, including non-multiples of the width
+// so both the main assembly loop and the scalar remainder run. Every result is
+// cross-checked against the pure-Go fallback, which is the trusted reference.
+//
+// The c64 package previously had no test that compared a SIMD-dispatched public
+// function against its *Go fallback at len >= the vector width: the *Go tests
+// exercise only the fallback, and the size-sweep tests do not cross-check. That
+// is exactly the gap that let three broken NEON encodings ship in f16 (see issue
+// #45): a kernel bug in the looping body stays invisible when the inputs are
+// shorter than the SIMD width because only the Go path runs.
+//
+// complex64 is laid out as interleaved [re, im] float32 pairs. The widest kernel
+// stride here is 8 elements (AVX-512), so the length set covers one, two and
+// several blocks plus odd remainders.
+
+// vpLens are lengths at or beyond every SIMD stride (NEON/AVX = 4, AVX-512 = 8),
+// with non-multiples so the remainder path is always taken too.
+var vpLens = []int{4, 5, 6, 7, 8, 9, 11, 16, 17, 23, 32, 33}
+
+// vpClose32 is a relative+absolute tolerance comparison. The SIMD kernels reduce
+// in a different order than the scalar Go reference (and Abs uses a float32 sqrt
+// versus the fallback's float64 math.Hypot), so an exact match is not expected;
+// the tolerance is still far tighter than any block-boundary or encoding bug.
+func vpClose32(got, want float32) bool {
+	d := math.Abs(float64(got - want))
+	return d <= 1e-4*math.Abs(float64(want))+1e-5
+}
+
+func vpCClose(got, want complex64) bool {
+	return vpClose32(real(got), real(want)) && vpClose32(imag(got), imag(want))
+}
+
+// vpMakeC64 builds a deterministic, non-trivial complex64 slice. Values vary per
+// index and per seed so neighbouring lanes differ (a kernel that shuffles or
+// drops a lane cannot accidentally match).
+func vpMakeC64(n, seed int) []complex64 {
+	s := make([]complex64, n)
+	for i := range s {
+		re := float32((i*7+seed)%23) - 11
+		im := float32((i*5+seed*3)%17) - 8
+		s[i] = complex(re, im)
+	}
+	return s
+}
+
+func vpMakeF32(n, seed int) []float32 {
+	s := make([]float32, n)
+	for i := range s {
+		s[i] = float32((i*3+seed)%19) - 9
+	}
+	return s
+}
+
+func TestVectorPathBinaryC64(t *testing.T) {
+	ops := []struct {
+		name string
+		simd func(dst, a, b []complex64)
+		gold func(dst, a, b []complex64)
+	}{
+		{"Mul", Mul, mulGo},
+		{"MulConj", MulConj, mulConjGo},
+		{"Add", Add, addGo},
+		{"Sub", Sub, subGo},
+	}
+	for _, op := range ops {
+		for _, n := range vpLens {
+			a := vpMakeC64(n, 1)
+			b := vpMakeC64(n, 2)
+			got := make([]complex64, n)
+			want := make([]complex64, n)
+			op.simd(got, a, b)
+			op.gold(want, a, b)
+			for i := range got {
+				if !vpCClose(got[i], want[i]) {
+					t.Errorf("%s n=%d [%d] = %v, want %v (Go fallback)", op.name, n, i, got[i], want[i])
+				}
+			}
+		}
+	}
+}
+
+func TestVectorPathScaleC64(t *testing.T) {
+	s := complex64(complex(1.5, -0.5))
+	for _, n := range vpLens {
+		a := vpMakeC64(n, 3)
+		got := make([]complex64, n)
+		want := make([]complex64, n)
+		Scale(got, a, s)
+		scaleGo(want, a, s)
+		for i := range got {
+			if !vpCClose(got[i], want[i]) {
+				t.Errorf("Scale n=%d [%d] = %v, want %v (Go fallback)", n, i, got[i], want[i])
+			}
+		}
+	}
+}
+
+func TestVectorPathConjC64(t *testing.T) {
+	for _, n := range vpLens {
+		a := vpMakeC64(n, 4)
+		got := make([]complex64, n)
+		want := make([]complex64, n)
+		Conj(got, a)
+		conjGo(want, a)
+		for i := range got {
+			if !vpCClose(got[i], want[i]) {
+				t.Errorf("Conj n=%d [%d] = %v, want %v (Go fallback)", n, i, got[i], want[i])
+			}
+		}
+	}
+}
+
+// TestVectorPathToRealC64 covers the complex -> real reductions, whose output is
+// a float32 slice. AbsSq is exact arithmetic; Abs involves a square root, so both
+// go through the same relative-tolerance check.
+func TestVectorPathToRealC64(t *testing.T) {
+	ops := []struct {
+		name string
+		simd func(dst []float32, a []complex64)
+		gold func(dst []float32, a []complex64)
+	}{
+		{"Abs", Abs, absGo},
+		{"AbsSq", AbsSq, absSqGo},
+	}
+	for _, op := range ops {
+		for _, n := range vpLens {
+			a := vpMakeC64(n, 5)
+			got := make([]float32, n)
+			want := make([]float32, n)
+			op.simd(got, a)
+			op.gold(want, a)
+			for i := range got {
+				if !vpClose32(got[i], want[i]) {
+					t.Errorf("%s n=%d [%d] = %v, want %v (Go fallback, input %v)",
+						op.name, n, i, got[i], want[i], a[i])
+				}
+			}
+		}
+	}
+}
+
+func TestVectorPathFromRealC64(t *testing.T) {
+	for _, n := range vpLens {
+		src := vpMakeF32(n, 6)
+		got := make([]complex64, n)
+		want := make([]complex64, n)
+		FromReal(got, src)
+		fromRealGo(want, src)
+		for i := range got {
+			if got[i] != want[i] {
+				t.Errorf("FromReal n=%d [%d] = %v, want %v (Go fallback)", n, i, got[i], want[i])
+			}
+		}
+	}
+}

--- a/f32/vector_path_test.go
+++ b/f32/vector_path_test.go
@@ -307,7 +307,7 @@ func TestVectorPathInterleave2_32(t *testing.T) {
 		want := make([]float32, 2*n)
 		Interleave2(got, a, b)
 		interleave2Go(want, a, b)
-		vpCheck32(t, "Interleave2", n, got, want, vpClose32)
+		vpCheck32(t, "Interleave2", 2*n, got, want, vpClose32)
 
 		src := vpSeq32(2*n, 22)
 		gotA := make([]float32, n)

--- a/f32/vector_path_test.go
+++ b/f32/vector_path_test.go
@@ -1,0 +1,421 @@
+package f32
+
+import (
+	"math"
+	"testing"
+)
+
+// These tests exercise the SIMD-dispatched paths (NEON on arm64; SSE/AVX/AVX-512
+// on amd64) at and beyond the vector width, including non-multiples of the width
+// so both the main assembly loop and the scalar remainder run. Every result is
+// cross-checked against the pure-Go fallback, which is the trusted reference and
+// the code that actually runs on architectures without SIMD.
+//
+// This guards the gap described in issue #45: a kernel bug in the looping body
+// stays invisible when a test uses fewer elements than the SIMD width, because
+// the dispatch falls through to the Go fallback and silently produces the right
+// answer (that is how three broken f16 NEON encodings shipped). On amd64 several
+// elementwise ops only take the AVX path at len >= 8, so a single len-6 or len-7
+// fixture never executes the vectorized code at all.
+//
+// Ops that already have dedicated SIMD-vs-Go parity sweeps are not duplicated
+// here: the split-format complex ops (TestMulComplex_SIMDvsGo and friends),
+// Reverse (TestReverse_GoVsSIMD) and AddSub (TestAddSub_GoVsSIMD). The core
+// arithmetic and reductions are additionally pinned by the C-reference tests
+// (f32_cref_test.go / reference_test.go); this file adds the missing direct
+// Go-fallback parity for them and for the activation, scale, clamp, conversion,
+// interleave and resampling kernels.
+
+// vpLens spans every SIMD stride: NEON (4), AVX (8) and AVX-512 (16), with
+// non-multiples so the remainder path is always taken too. Lengths below an
+// architecture's threshold simply compare the Go path against itself, which is
+// harmless; the larger lengths are what exercise the assembly.
+var vpLens = []int{4, 5, 7, 8, 9, 15, 16, 17, 31, 32, 33}
+
+func vpClose32(got, want float32) bool {
+	d := math.Abs(float64(got - want))
+	return d <= 1e-4*math.Abs(float64(want))+1e-5
+}
+
+// vpCloseActiv32 is the looser tolerance used for the activation kernels, whose
+// SIMD paths are polynomial approximations while the Go fallback calls the
+// accurate math.Exp/math.Tanh. It is still far tighter than any block-boundary
+// or encoding bug (those leave whole lanes at zero or garbage).
+func vpCloseActiv32(got, want float32) bool {
+	d := math.Abs(float64(got - want))
+	return d <= 1e-3*math.Abs(float64(want))+1e-4
+}
+
+func vpSeq32(n, seed int) []float32 {
+	s := make([]float32, n)
+	for i := range s {
+		s[i] = float32((i*7+seed)%23) - 11
+	}
+	return s
+}
+
+// vpPos32 returns strictly positive values, for divisors and for Sqrt/Reciprocal.
+func vpPos32(n, seed int) []float32 {
+	s := make([]float32, n)
+	for i := range s {
+		s[i] = float32((i*5+seed)%13) + 0.5
+	}
+	return s
+}
+
+// vpActiv32 returns moderate values in roughly [-4, 4] for the activation kernels.
+func vpActiv32(n, seed int) []float32 {
+	s := make([]float32, n)
+	for i := range s {
+		s[i] = float32(-4.0 + 0.37*float64((i*3+seed)%23))
+	}
+	return s
+}
+
+func vpCheck32(t *testing.T, name string, n int, got, want []float32, cmp func(a, b float32) bool) {
+	t.Helper()
+	for i := range got {
+		if !cmp(got[i], want[i]) {
+			t.Errorf("%s n=%d [%d] = %v, want %v (Go fallback)", name, n, i, got[i], want[i])
+		}
+	}
+}
+
+func TestVectorPathBinary32(t *testing.T) {
+	ops := []struct {
+		name string
+		simd func(dst, a, b []float32)
+		gold func(dst, a, b []float32)
+		posB bool // divisor must be non-zero
+	}{
+		{"Add", Add, addGo, false},
+		{"Sub", Sub, subGo, false},
+		{"Mul", Mul, mulGo, false},
+		{"Div", Div, divGo, true},
+	}
+	for _, op := range ops {
+		for _, n := range vpLens {
+			a := vpSeq32(n, 1)
+			var b []float32
+			if op.posB {
+				b = vpPos32(n, 2)
+			} else {
+				b = vpSeq32(n, 2)
+			}
+			got := make([]float32, n)
+			want := make([]float32, n)
+			op.simd(got, a, b)
+			op.gold(want, a, b)
+			vpCheck32(t, op.name, n, got, want, vpClose32)
+		}
+	}
+}
+
+func TestVectorPathUnary32(t *testing.T) {
+	ops := []struct {
+		name string
+		simd func(dst, a []float32)
+		gold func(dst, a []float32)
+		pos  bool
+	}{
+		{"Abs", Abs, absGo, false},
+		{"Neg", Neg, negGo, false},
+		{"Sqrt", Sqrt, sqrt32Go, true},
+		{"Reciprocal", Reciprocal, reciprocal32Go, true},
+	}
+	for _, op := range ops {
+		for _, n := range vpLens {
+			var a []float32
+			if op.pos {
+				a = vpPos32(n, 3)
+			} else {
+				a = vpSeq32(n, 3)
+			}
+			got := make([]float32, n)
+			want := make([]float32, n)
+			op.simd(got, a)
+			op.gold(want, a)
+			vpCheck32(t, op.name, n, got, want, vpClose32)
+		}
+	}
+}
+
+// TestVectorPathActivations32 covers the (dst, src) activation kernels. ReLU is
+// exact; Sigmoid/Tanh/Exp use the looser approximation tolerance.
+func TestVectorPathActivations32(t *testing.T) {
+	ops := []struct {
+		name string
+		simd func(dst, src []float32)
+		gold func(dst, src []float32)
+		cmp  func(a, b float32) bool
+	}{
+		{"ReLU", ReLU, relu32Go, vpClose32},
+		{"Sigmoid", Sigmoid, sigmoid32Go, vpCloseActiv32},
+		{"Tanh", Tanh, tanh32Go, vpCloseActiv32},
+		{"Exp", Exp, exp32Go, vpCloseActiv32},
+	}
+	for _, op := range ops {
+		for _, n := range vpLens {
+			src := vpActiv32(n, 4)
+			got := make([]float32, n)
+			want := make([]float32, n)
+			op.simd(got, src)
+			op.gold(want, src)
+			vpCheck32(t, op.name, n, got, want, op.cmp)
+		}
+	}
+}
+
+func TestVectorPathScalar32(t *testing.T) {
+	const s = float32(1.75)
+	ops := []struct {
+		name string
+		simd func(dst, a []float32)
+		gold func(dst, a []float32)
+	}{
+		{"Scale", func(dst, a []float32) { Scale(dst, a, s) }, func(dst, a []float32) { scaleGo(dst, a, s) }},
+		{"AddScalar", func(dst, a []float32) { AddScalar(dst, a, s) }, func(dst, a []float32) { addScalarGo(dst, a, s) }},
+	}
+	for _, op := range ops {
+		for _, n := range vpLens {
+			a := vpSeq32(n, 5)
+			got := make([]float32, n)
+			want := make([]float32, n)
+			op.simd(got, a)
+			op.gold(want, a)
+			vpCheck32(t, op.name, n, got, want, vpClose32)
+		}
+	}
+}
+
+func TestVectorPathClamp32(t *testing.T) {
+	const lo, hi = float32(-3), float32(4)
+	for _, n := range vpLens {
+		a := vpSeq32(n, 6)
+		got := make([]float32, n)
+		want := make([]float32, n)
+		Clamp(got, a, lo, hi)
+		clampGo(want, a, lo, hi)
+		vpCheck32(t, "Clamp", n, got, want, vpClose32)
+	}
+}
+
+func TestVectorPathClampScale32(t *testing.T) {
+	const lo, hi, sc = float32(-3), float32(4), float32(0.25)
+	for _, n := range vpLens {
+		src := vpSeq32(n, 7)
+		got := make([]float32, n)
+		want := make([]float32, n)
+		ClampScale(got, src, lo, hi, sc)
+		clampScale32Go(want, src, lo, hi, sc)
+		vpCheck32(t, "ClampScale", n, got, want, vpClose32)
+	}
+}
+
+func TestVectorPathAddScaled32(t *testing.T) {
+	const alpha = float32(0.6)
+	for _, n := range vpLens {
+		s := vpSeq32(n, 8)
+		got := vpSeq32(n, 9)
+		want := append([]float32(nil), got...)
+		AddScaled(got, alpha, s)
+		addScaledGo(want, alpha, s)
+		vpCheck32(t, "AddScaled", n, got, want, vpClose32)
+	}
+}
+
+func TestVectorPathAccumulateAdd32(t *testing.T) {
+	for _, n := range vpLens {
+		src := vpSeq32(n, 10)
+		got := vpSeq32(n, 11)
+		want := append([]float32(nil), got...)
+		AccumulateAdd(got, src, 0)
+		accumulateAdd32Go(want, src)
+		vpCheck32(t, "AccumulateAdd", n, got, want, vpClose32)
+	}
+}
+
+func TestVectorPathFMA32(t *testing.T) {
+	for _, n := range vpLens {
+		a := vpSeq32(n, 12)
+		b := vpSeq32(n, 13)
+		c := vpSeq32(n, 14)
+		got := make([]float32, n)
+		want := make([]float32, n)
+		FMA(got, a, b, c)
+		fmaGo(want, a, b, c)
+		vpCheck32(t, "FMA", n, got, want, vpClose32)
+	}
+}
+
+// TestVectorPathReductions32 covers scalar-returning reductions. For Min/Max the
+// true extremum is planted in the final block so a kernel that fails to fold its
+// later lanes into the accumulator cannot find it.
+func TestVectorPathReductions32(t *testing.T) {
+	for _, n := range vpLens {
+		a := vpSeq32(n, 15)
+		if got, want := Sum(a), sumGo(a); !vpClose32(got, want) {
+			t.Errorf("Sum n=%d = %v, want %v (Go fallback)", n, got, want)
+		}
+
+		ext := vpSeq32(n, 16)
+		ext[n-2] = -123.5 // global min, last block
+		ext[n-1] = 234.5  // global max, last block
+		if got, want := Min(ext), minGo(ext); got != want {
+			t.Errorf("Min n=%d = %v, want %v (Go fallback)", n, got, want)
+		}
+		if got, want := Max(ext), maxGo(ext); got != want {
+			t.Errorf("Max n=%d = %v, want %v (Go fallback)", n, got, want)
+		}
+	}
+}
+
+func TestVectorPathDot32(t *testing.T) {
+	for _, n := range vpLens {
+		a := vpSeq32(n, 17)
+		b := vpSeq32(n, 18)
+		if got, want := DotProduct(a, b), dotProductGo(a, b); !vpClose32(got, want) {
+			t.Errorf("DotProduct n=%d = %v, want %v (Go fallback)", n, got, want)
+		}
+		if got, want := EuclideanDistance(a, b), euclideanDistance32Go(a, b); !vpClose32(got, want) {
+			t.Errorf("EuclideanDistance n=%d = %v, want %v (Go fallback)", n, got, want)
+		}
+	}
+}
+
+func TestVectorPathVariance32(t *testing.T) {
+	for _, n := range vpLens {
+		a := vpSeq32(n, 19)
+		// Use one shared mean (computed in float64 for accuracy) so the SIMD and
+		// Go variance kernels are compared on identical inputs.
+		var sum float64
+		for _, v := range a {
+			sum += float64(v)
+		}
+		mean := float32(sum / float64(n))
+		if got, want := variance32(a, mean), variance32Go(a, mean); !vpClose32(got, want) {
+			t.Errorf("variance32 n=%d = %v, want %v (Go fallback)", n, got, want)
+		}
+	}
+}
+
+func TestVectorPathInterleave2_32(t *testing.T) {
+	for _, n := range vpLens {
+		a := vpSeq32(n, 20)
+		b := vpSeq32(n, 21)
+		got := make([]float32, 2*n)
+		want := make([]float32, 2*n)
+		Interleave2(got, a, b)
+		interleave2Go(want, a, b)
+		vpCheck32(t, "Interleave2", n, got, want, vpClose32)
+
+		src := vpSeq32(2*n, 22)
+		gotA := make([]float32, n)
+		gotB := make([]float32, n)
+		wantA := make([]float32, n)
+		wantB := make([]float32, n)
+		Deinterleave2(gotA, gotB, src)
+		deinterleave2Go(wantA, wantB, src)
+		vpCheck32(t, "Deinterleave2.a", n, gotA, wantA, vpClose32)
+		vpCheck32(t, "Deinterleave2.b", n, gotB, wantB, vpClose32)
+	}
+}
+
+// TestVectorPathInterleaveN_32 covers the N=3 (ST3/LD3) and N=4 (ST4/LD4) NEON
+// structured-store kernels and the amd64 N=4 transpose against the generic Go path.
+func TestVectorPathInterleaveN_32(t *testing.T) {
+	for _, nc := range []int{3, 4} {
+		for _, n := range vpLens {
+			srcs := make([][]float32, nc)
+			for c := range srcs {
+				srcs[c] = vpSeq32(n, 30+c)
+			}
+			got := make([]float32, n*nc)
+			want := make([]float32, n*nc)
+			InterleaveN(got, srcs)
+			interleaveNGo(want, srcs, n)
+			vpCheck32(t, "InterleaveN", n*nc, got, want, vpClose32)
+
+			src := vpSeq32(n*nc, 40)
+			gotD := make([][]float32, nc)
+			wantD := make([][]float32, nc)
+			for c := range gotD {
+				gotD[c] = make([]float32, n)
+				wantD[c] = make([]float32, n)
+			}
+			DeinterleaveN(gotD, src)
+			deinterleaveNGo(wantD, src, n)
+			for c := range gotD {
+				vpCheck32(t, "DeinterleaveN", n, gotD[c], wantD[c], vpClose32)
+			}
+		}
+	}
+}
+
+func TestVectorPathCubicInterpDot32(t *testing.T) {
+	const x = float32(0.375)
+	for _, n := range vpLens {
+		hist := vpSeq32(n, 50)
+		a := vpSeq32(n, 51)
+		b := vpSeq32(n, 52)
+		c := vpSeq32(n, 53)
+		d := vpSeq32(n, 54)
+		got := CubicInterpDot(hist, a, b, c, d, x)
+		want := cubicInterpDotGo(hist, a, b, c, d, x)
+		if !vpClose32(got, want) {
+			t.Errorf("CubicInterpDot n=%d = %v, want %v (Go fallback)", n, got, want)
+		}
+	}
+}
+
+// TestVectorPathConvert32 covers the int<->float conversion kernels. Their Go
+// fallbacks are documented to be bit-identical to the SIMD paths, so an exact
+// match is required.
+func TestVectorPathConvert32(t *testing.T) {
+	for _, n := range vpLens {
+		// int32 -> float32
+		s32 := make([]int32, n)
+		for i := range s32 {
+			s32[i] = int32((i*131+7)%2000 - 1000)
+		}
+		g32 := make([]float32, n)
+		w32 := make([]float32, n)
+		Int32ToFloat32Scale(g32, s32, 0.5)
+		int32ToFloat32ScaleGo(w32, s32, 0.5)
+		for i := range g32 {
+			if g32[i] != w32[i] {
+				t.Errorf("Int32ToFloat32Scale n=%d [%d] = %v, want %v", n, i, g32[i], w32[i])
+			}
+		}
+
+		// int16 -> float32
+		s16 := make([]int16, n)
+		for i := range s16 {
+			s16[i] = int16((i*97+3)%2000 - 1000)
+		}
+		gi := make([]float32, n)
+		wi := make([]float32, n)
+		Int16ToFloat32Scale(gi, s16, 0.25)
+		int16ToFloat32ScaleGo(wi, s16, 0.25)
+		for i := range gi {
+			if gi[i] != wi[i] {
+				t.Errorf("Int16ToFloat32Scale n=%d [%d] = %v, want %v", n, i, gi[i], wi[i])
+			}
+		}
+
+		// float32 -> int16 (includes saturation at both ends)
+		sf := make([]float32, n)
+		for i := range sf {
+			sf[i] = float32((i*1103+17)%80000-40000) + 0.3
+		}
+		go16 := make([]int16, n)
+		wo16 := make([]int16, n)
+		Float32ToInt16Scale(go16, sf, 1.0)
+		float32ToInt16ScaleGo(wo16, sf, 1.0)
+		for i := range go16 {
+			if go16[i] != wo16[i] {
+				t.Errorf("Float32ToInt16Scale n=%d [%d] = %v, want %v (in %v)", n, i, go16[i], wo16[i], sf[i])
+			}
+		}
+	}
+}

--- a/f64/vector_path_test.go
+++ b/f64/vector_path_test.go
@@ -316,7 +316,7 @@ func TestVectorPathInterleave2_64(t *testing.T) {
 		want := make([]float64, 2*n)
 		Interleave2(got, a, b)
 		interleave2Go(want, a, b)
-		vpCheck64(t, "Interleave2", n, got, want, vpClose64)
+		vpCheck64(t, "Interleave2", 2*n, got, want, vpClose64)
 
 		src := vpSeq64(2*n, 22)
 		gotA := make([]float64, n)

--- a/f64/vector_path_test.go
+++ b/f64/vector_path_test.go
@@ -1,0 +1,378 @@
+package f64
+
+import (
+	"math"
+	"testing"
+)
+
+// These tests exercise the SIMD-dispatched paths (NEON on arm64; SSE2/AVX/AVX-512
+// on amd64) at and beyond the vector width, including non-multiples of the width
+// so both the main assembly loop and the scalar remainder run. Every result is
+// cross-checked against the pure-Go fallback, which is the trusted reference and
+// the code that actually runs on architectures without SIMD.
+//
+// This guards the gap described in issue #45: a kernel bug in the looping body
+// stays invisible when a test uses fewer elements than the SIMD width, because
+// the dispatch falls through to the Go fallback and silently produces the right
+// answer. The core arithmetic and reductions are also pinned by the C-reference
+// tests (f64_cref_test.go / reference_test.go); this file adds the missing direct
+// Go-fallback parity for them and for the activation, scale, clamp, interleave and
+// resampling kernels.
+
+// vpLens spans every f64 SIMD stride: NEON (2), AVX (4) and AVX-512 (8), with
+// non-multiples so the remainder path is always taken too.
+var vpLens = []int{2, 3, 4, 5, 7, 8, 9, 15, 16, 17, 31, 33}
+
+func vpClose64(got, want float64) bool {
+	d := math.Abs(got - want)
+	return d <= 1e-9*math.Abs(want)+1e-12
+}
+
+// vpCloseActiv64 is the looser tolerance for the activation kernels, whose SIMD
+// paths are polynomial approximations while the Go fallback calls the accurate
+// math.Exp/math.Tanh. It is still far tighter than any block-boundary bug.
+func vpCloseActiv64(got, want float64) bool {
+	d := math.Abs(got - want)
+	return d <= 1e-3*math.Abs(want)+1e-4
+}
+
+func vpSeq64(n, seed int) []float64 {
+	s := make([]float64, n)
+	for i := range s {
+		s[i] = float64((i*7+seed)%23) - 11
+	}
+	return s
+}
+
+func vpPos64(n, seed int) []float64 {
+	s := make([]float64, n)
+	for i := range s {
+		s[i] = float64((i*5+seed)%13) + 0.5
+	}
+	return s
+}
+
+func vpActiv64(n, seed int) []float64 {
+	s := make([]float64, n)
+	for i := range s {
+		s[i] = -4.0 + 0.37*float64((i*3+seed)%23)
+	}
+	return s
+}
+
+func vpCheck64(t *testing.T, name string, n int, got, want []float64, cmp func(a, b float64) bool) {
+	t.Helper()
+	for i := range got {
+		if !cmp(got[i], want[i]) {
+			t.Errorf("%s n=%d [%d] = %v, want %v (Go fallback)", name, n, i, got[i], want[i])
+		}
+	}
+}
+
+func TestVectorPathBinary64(t *testing.T) {
+	ops := []struct {
+		name string
+		simd func(dst, a, b []float64)
+		gold func(dst, a, b []float64)
+		posB bool
+	}{
+		{"Add", Add, addGo, false},
+		{"Sub", Sub, subGo, false},
+		{"Mul", Mul, mulGo, false},
+		{"Div", Div, divGo, true},
+	}
+	for _, op := range ops {
+		for _, n := range vpLens {
+			a := vpSeq64(n, 1)
+			var b []float64
+			if op.posB {
+				b = vpPos64(n, 2)
+			} else {
+				b = vpSeq64(n, 2)
+			}
+			got := make([]float64, n)
+			want := make([]float64, n)
+			op.simd(got, a, b)
+			op.gold(want, a, b)
+			vpCheck64(t, op.name, n, got, want, vpClose64)
+		}
+	}
+}
+
+func TestVectorPathUnary64(t *testing.T) {
+	ops := []struct {
+		name string
+		simd func(dst, a []float64)
+		gold func(dst, a []float64)
+		pos  bool
+	}{
+		{"Abs", Abs, absGo, false},
+		{"Neg", Neg, negGo, false},
+		{"Sqrt", Sqrt, sqrt64Go, true},
+		{"Reciprocal", Reciprocal, reciprocal64Go, true},
+	}
+	for _, op := range ops {
+		for _, n := range vpLens {
+			var a []float64
+			if op.pos {
+				a = vpPos64(n, 3)
+			} else {
+				a = vpSeq64(n, 3)
+			}
+			got := make([]float64, n)
+			want := make([]float64, n)
+			op.simd(got, a)
+			op.gold(want, a)
+			vpCheck64(t, op.name, n, got, want, vpClose64)
+		}
+	}
+}
+
+// TestVectorPathRound64 uses non-tie fractional inputs so the result is identical
+// regardless of the half-way rounding rule, and an exact match is required.
+func TestVectorPathRound64(t *testing.T) {
+	for _, n := range vpLens {
+		src := make([]float64, n)
+		for i := range src {
+			frac := 0.3
+			if i%2 == 1 {
+				frac = 0.7
+			}
+			src[i] = float64((i*3+1)%17-8) + frac
+		}
+		got := make([]float64, n)
+		want := make([]float64, n)
+		Round(got, src)
+		round64Go(want, src)
+		for i := range got {
+			if got[i] != want[i] {
+				t.Errorf("Round n=%d [%d] = %v, want %v (in %v)", n, i, got[i], want[i], src[i])
+			}
+		}
+	}
+}
+
+func TestVectorPathActivations64(t *testing.T) {
+	ops := []struct {
+		name string
+		simd func(dst, src []float64)
+		gold func(dst, src []float64)
+		cmp  func(a, b float64) bool
+	}{
+		{"ReLU", ReLU, relu64Go, vpClose64},
+		{"Sigmoid", Sigmoid, sigmoid64Go, vpCloseActiv64},
+		{"Tanh", Tanh, tanh64Go, vpCloseActiv64},
+		{"Exp", Exp, exp64Go, vpCloseActiv64},
+	}
+	for _, op := range ops {
+		for _, n := range vpLens {
+			src := vpActiv64(n, 4)
+			got := make([]float64, n)
+			want := make([]float64, n)
+			op.simd(got, src)
+			op.gold(want, src)
+			vpCheck64(t, op.name, n, got, want, op.cmp)
+		}
+	}
+}
+
+func TestVectorPathScalar64(t *testing.T) {
+	const s = 1.75
+	ops := []struct {
+		name string
+		simd func(dst, a []float64)
+		gold func(dst, a []float64)
+	}{
+		{"Scale", func(dst, a []float64) { Scale(dst, a, s) }, func(dst, a []float64) { scaleGo(dst, a, s) }},
+		{"AddScalar", func(dst, a []float64) { AddScalar(dst, a, s) }, func(dst, a []float64) { addScalarGo(dst, a, s) }},
+		{"SubFromScalar", func(dst, a []float64) { SubFromScalar(dst, a, s) }, func(dst, a []float64) { subFromScalarGo(dst, a, s) }},
+	}
+	for _, op := range ops {
+		for _, n := range vpLens {
+			a := vpSeq64(n, 5)
+			got := make([]float64, n)
+			want := make([]float64, n)
+			op.simd(got, a)
+			op.gold(want, a)
+			vpCheck64(t, op.name, n, got, want, vpClose64)
+		}
+	}
+}
+
+func TestVectorPathClamp64(t *testing.T) {
+	const lo, hi = -3.0, 4.0
+	for _, n := range vpLens {
+		a := vpSeq64(n, 6)
+		got := make([]float64, n)
+		want := make([]float64, n)
+		Clamp(got, a, lo, hi)
+		clampGo(want, a, lo, hi)
+		vpCheck64(t, "Clamp", n, got, want, vpClose64)
+	}
+}
+
+func TestVectorPathClampScale64(t *testing.T) {
+	const lo, hi, sc = -3.0, 4.0, 0.25
+	for _, n := range vpLens {
+		src := vpSeq64(n, 7)
+		got := make([]float64, n)
+		want := make([]float64, n)
+		ClampScale(got, src, lo, hi, sc)
+		clampScale64Go(want, src, lo, hi, sc)
+		vpCheck64(t, "ClampScale", n, got, want, vpClose64)
+	}
+}
+
+func TestVectorPathAddScaled64(t *testing.T) {
+	const alpha = 0.6
+	for _, n := range vpLens {
+		s := vpSeq64(n, 8)
+		got := vpSeq64(n, 9)
+		want := append([]float64(nil), got...)
+		AddScaled(got, alpha, s)
+		addScaledGo64(want, alpha, s)
+		vpCheck64(t, "AddScaled", n, got, want, vpClose64)
+	}
+}
+
+func TestVectorPathAccumulateAdd64(t *testing.T) {
+	for _, n := range vpLens {
+		src := vpSeq64(n, 10)
+		got := vpSeq64(n, 11)
+		want := append([]float64(nil), got...)
+		AccumulateAdd(got, src, 0)
+		accumulateAdd64Go(want, src)
+		vpCheck64(t, "AccumulateAdd", n, got, want, vpClose64)
+	}
+}
+
+func TestVectorPathFMA64(t *testing.T) {
+	for _, n := range vpLens {
+		a := vpSeq64(n, 12)
+		b := vpSeq64(n, 13)
+		c := vpSeq64(n, 14)
+		got := make([]float64, n)
+		want := make([]float64, n)
+		FMA(got, a, b, c)
+		fmaGo(want, a, b, c)
+		vpCheck64(t, "FMA", n, got, want, vpClose64)
+	}
+}
+
+// TestVectorPathReductions64 covers scalar-returning reductions. For Min/Max the
+// true extremum is planted in the final block so a kernel that fails to fold its
+// later lanes into the accumulator cannot find it.
+func TestVectorPathReductions64(t *testing.T) {
+	for _, n := range vpLens {
+		a := vpSeq64(n, 15)
+		if got, want := Sum(a), sumGo(a); !vpClose64(got, want) {
+			t.Errorf("Sum n=%d = %v, want %v (Go fallback)", n, got, want)
+		}
+
+		ext := vpSeq64(n, 16)
+		ext[n-2] = -123.5 // global min, last block
+		ext[n-1] = 234.5  // global max, last block
+		if got, want := Min(ext), minGo(ext); got != want {
+			t.Errorf("Min n=%d = %v, want %v (Go fallback)", n, got, want)
+		}
+		if got, want := Max(ext), maxGo(ext); got != want {
+			t.Errorf("Max n=%d = %v, want %v (Go fallback)", n, got, want)
+		}
+	}
+}
+
+func TestVectorPathDot64(t *testing.T) {
+	for _, n := range vpLens {
+		a := vpSeq64(n, 17)
+		b := vpSeq64(n, 18)
+		if got, want := DotProduct(a, b), dotProductGo(a, b); !vpClose64(got, want) {
+			t.Errorf("DotProduct n=%d = %v, want %v (Go fallback)", n, got, want)
+		}
+		if got, want := EuclideanDistance(a, b), euclideanDistance64Go(a, b); !vpClose64(got, want) {
+			t.Errorf("EuclideanDistance n=%d = %v, want %v (Go fallback)", n, got, want)
+		}
+	}
+}
+
+func TestVectorPathVariance64(t *testing.T) {
+	for _, n := range vpLens {
+		a := vpSeq64(n, 19)
+		var sum float64
+		for _, v := range a {
+			sum += v
+		}
+		mean := sum / float64(n)
+		if got, want := variance64(a, mean), variance64Go(a, mean); !vpClose64(got, want) {
+			t.Errorf("variance64 n=%d = %v, want %v (Go fallback)", n, got, want)
+		}
+	}
+}
+
+func TestVectorPathInterleave2_64(t *testing.T) {
+	for _, n := range vpLens {
+		a := vpSeq64(n, 20)
+		b := vpSeq64(n, 21)
+		got := make([]float64, 2*n)
+		want := make([]float64, 2*n)
+		Interleave2(got, a, b)
+		interleave2Go(want, a, b)
+		vpCheck64(t, "Interleave2", n, got, want, vpClose64)
+
+		src := vpSeq64(2*n, 22)
+		gotA := make([]float64, n)
+		gotB := make([]float64, n)
+		wantA := make([]float64, n)
+		wantB := make([]float64, n)
+		Deinterleave2(gotA, gotB, src)
+		deinterleave2Go(wantA, wantB, src)
+		vpCheck64(t, "Deinterleave2.a", n, gotA, wantA, vpClose64)
+		vpCheck64(t, "Deinterleave2.b", n, gotB, wantB, vpClose64)
+	}
+}
+
+// TestVectorPathInterleaveN_64 covers the N=3 (ST3/LD3) and N=4 (ST4/LD4) NEON
+// structured-store kernels and the amd64 N=4 transpose against the generic Go path.
+func TestVectorPathInterleaveN_64(t *testing.T) {
+	for _, nc := range []int{3, 4} {
+		for _, n := range vpLens {
+			srcs := make([][]float64, nc)
+			for c := range srcs {
+				srcs[c] = vpSeq64(n, 30+c)
+			}
+			got := make([]float64, n*nc)
+			want := make([]float64, n*nc)
+			InterleaveN(got, srcs)
+			interleaveNGo(want, srcs, n)
+			vpCheck64(t, "InterleaveN", n*nc, got, want, vpClose64)
+
+			src := vpSeq64(n*nc, 40)
+			gotD := make([][]float64, nc)
+			wantD := make([][]float64, nc)
+			for c := range gotD {
+				gotD[c] = make([]float64, n)
+				wantD[c] = make([]float64, n)
+			}
+			DeinterleaveN(gotD, src)
+			deinterleaveNGo(wantD, src, n)
+			for c := range gotD {
+				vpCheck64(t, "DeinterleaveN", n, gotD[c], wantD[c], vpClose64)
+			}
+		}
+	}
+}
+
+func TestVectorPathCubicInterpDot64(t *testing.T) {
+	const x = 0.375
+	for _, n := range vpLens {
+		hist := vpSeq64(n, 50)
+		a := vpSeq64(n, 51)
+		b := vpSeq64(n, 52)
+		c := vpSeq64(n, 53)
+		d := vpSeq64(n, 54)
+		got := CubicInterpDot(hist, a, b, c, d, x)
+		want := cubicInterpDotGo(hist, a, b, c, d, x)
+		if !vpClose64(got, want) {
+			t.Errorf("CubicInterpDot n=%d = %v, want %v (Go fallback)", n, got, want)
+		}
+	}
+}


### PR DESCRIPTION
## What

Adds `vector_path_test.go` to `f32`, `f64`, `c64` and `c128`. Each cross-checks every SIMD-dispatched public function against its pure-Go fallback over a length matrix that includes non-multiples of the vector width, so both the assembly main loop and the scalar remainder execute on every architecture the test runs on (NEON on arm64, SSE/AVX/AVX-512 on amd64).

## Why

This is the audit requested in #45. The gap: when a test feeds fewer elements than the SIMD width, dispatch falls through to the Go fallback and a kernel bug in the looping body stays invisible. That is exactly how three broken f16 NEON encodings shipped (reciprocal returning 0, min/max ignoring elements past the first block).

Findings from the audit across the four packages:

- **c64 / c128**: had no SIMD-vs-Go parity check at vector widths at all. The `*Go` tests exercise only the fallback, no C reference exists for complex types, and the only place a SIMD op met its Go fallback was a benchmark. Their NEON paths were entirely unverified against the oracle. Now every op (Mul, MulConj, Add, Sub, Scale, Conj, Abs, AbsSq, and FromReal for c64) is checked at lengths 4..33.
- **f32 / f64**: core arithmetic and reductions are already pinned by the C-reference tests (which do run on arm64), so those were not the gap. The genuinely under-covered ops were the activations (Sigmoid/Tanh had only fixed-length fixtures), ReLU/ClampScale (fixed len < 8, so the amd64 AVX path never ran), Variance/AccumulateAdd, plus the scale/clamp/conversion/interleave/cubic kernels. This adds direct Go-fallback parity for all of them.

Ops that already have dedicated SIMD-vs-Go sweeps (the split-format complex ops, `Reverse`, `AddSub`) are not duplicated.

Reductions plant the extremum in the final block so a kernel that drops its later lanes is caught.

## Testing

- `go test ./...` passes on amd64 (AVX/AVX2 here).
- All four suites pass on arm64 NEON (Raspberry Pi 5): new vector-path tests and the full existing suites.
- `golangci-lint run ./...` reports 0 issues.

No SIMD bugs surfaced; the existing kernels are correct for the audited ops. The value is the regression guard going forward.

Closes #45.