### PR TITLE
f32: AMD64 AVX2 gather/blend kernels for InterleaveN/DeinterleaveN N=3

### DIFF
--- a/README.md
+++ b/README.md
@@ -127,8 +127,8 @@ fmt.Println(cpu.HasFP16())     // true/false (ARM64 half-precision SIMD)
 |                 | `AccumulateAdd(dst, src, off)`      | Overlap-add: dst[off:] += src | 8x / 4x / 2x                        |
 | **Audio**       | `Interleave2(dst, a, b)`            | Pack stereo: [L,R,L,R,...]    | 4x / 2x                             |
 |                 | `Deinterleave2(a, b, src)`          | Unpack stereo to channels     | 4x / 2x                             |
-|                 | `InterleaveN(dst, srcs)`            | Pack N planar streams (any N; N-stream Interleave2) | N=2,3,4,8 AVX / N=2,3,4 NEON; else Go |
-|                 | `DeinterleaveN(dsts, src)`          | Unpack N interleaved streams (any N) | N=2,3,4,8 AVX / N=2,3,4 NEON; else Go |
+|                 | `InterleaveN(dst, srcs)`            | Pack N planar streams (any N; N-stream Interleave2) | N=2,4,8 AVX, N=3 AVX2 / N=2,3,4 NEON; else Go |
+|                 | `DeinterleaveN(dsts, src)`          | Unpack N interleaved streams (any N) | N=2,4,8 AVX, N=3 AVX2 / N=2,3,4 NEON; else Go |
 |                 | `CubicInterpDot(hist,a,b,c,d,x)`    | Fused cubic interp dot product| 4x / 2x                             |
 |                 | `Int32ToFloat32Scale(dst,src,s)`    | PCM int32 to normalized float | 8x / 4x                             |
 |                 | `Int16ToFloat32Scale(dst,src,s)`    | PCM int16 to normalized float | 8x (AVX2) / 4x (NEON)               |

--- a/README.md
+++ b/README.md
@@ -127,8 +127,8 @@ fmt.Println(cpu.HasFP16())     // true/false (ARM64 half-precision SIMD)
 |                 | `AccumulateAdd(dst, src, off)`      | Overlap-add: dst[off:] += src | 8x / 4x / 2x                        |
 | **Audio**       | `Interleave2(dst, a, b)`            | Pack stereo: [L,R,L,R,...]    | 4x / 2x                             |
 |                 | `Deinterleave2(a, b, src)`          | Unpack stereo to channels     | 4x / 2x                             |
-|                 | `InterleaveN(dst, srcs)`            | Pack N planar streams (any N; N-stream Interleave2) | N=2,4 AVX / N=2,3,4 NEON; else Go |
-|                 | `DeinterleaveN(dsts, src)`          | Unpack N interleaved streams (any N) | N=2,4 AVX / N=2,3,4 NEON; else Go |
+|                 | `InterleaveN(dst, srcs)`            | Pack N planar streams (any N; N-stream Interleave2) | N=2,3,4,8 AVX / N=2,3,4 NEON; else Go |
+|                 | `DeinterleaveN(dsts, src)`          | Unpack N interleaved streams (any N) | N=2,3,4,8 AVX / N=2,3,4 NEON; else Go |
 |                 | `CubicInterpDot(hist,a,b,c,d,x)`    | Fused cubic interp dot product| 4x / 2x                             |
 |                 | `Int32ToFloat32Scale(dst,src,s)`    | PCM int32 to normalized float | 8x / 4x                             |
 |                 | `Int16ToFloat32Scale(dst,src,s)`    | PCM int16 to normalized float | 8x (AVX2) / 4x (NEON)               |
@@ -150,9 +150,12 @@ Same API as `f64` but for `float32` with wider SIMD:
 | AMD64 (SSE2)    | 4x float32  |
 | ARM64 (NEON)    | 4x float32  |
 
-`InterleaveN`/`DeinterleaveN` add an 8-stream AVX path (8x8 register transpose) on
-top of the shared N=2/4 (AVX) and N=2/3/4 (NEON) kernels; all other stream counts
-use the allocation-free generic path.
+`InterleaveN`/`DeinterleaveN` add an 8-stream AVX path (8x8 register transpose) and
+a 3-stream AVX2 path (per-stream `VPERMPS` gathers merged with `VPBLENDD`, since 3
+streams do not map onto a clean register transpose) on top of the shared N=2/4 (AVX)
+and N=2/3/4 (NEON) kernels; all other stream counts use the allocation-free generic
+path. The N=3 case is the 16k -> 48k upsample hot path: the AVX2 gather/blend kernel
+runs roughly 2.8x (interleave) and 3.2x (deinterleave) over the generic loop on AVX2.
 
 **Row-major batch dot products** (for flat vector stores):
 

--- a/f32/f32_amd64.go
+++ b/f32/f32_amd64.go
@@ -480,8 +480,10 @@ func deinterleave2_32(a, b, src []float32) {
 // 2-stream path reuses interleave2Channels). interleave4BlockMask/8 align a
 // frame count down to a whole SIMD block; the caller handles the remainder.
 const (
+	interleave3Streams   = 3
 	interleave4Streams   = 4
 	interleave8Streams   = 8
+	interleave3BlockMask = interleave8Streams - 1 // N=3 gathers 8 frames per block
 	interleave4BlockMask = interleave4Streams - 1
 	interleave8BlockMask = interleave8Streams - 1
 )
@@ -490,6 +492,14 @@ func interleaveN32(dst []float32, srcs [][]float32, n int) {
 	switch len(srcs) {
 	case interleave2Channels:
 		interleave2_32(dst[:n*interleave2Channels], srcs[0][:n], srcs[1][:n])
+	case interleave3Streams:
+		if cpu.X86.AVX2 && n >= interleave8Streams {
+			blk := n &^ interleave3BlockMask
+			interleave3AVX(dst, srcs[0], srcs[1], srcs[2], blk)
+			interleaveNTailGo(dst, srcs, blk, n)
+			return
+		}
+		interleaveNGo(dst, srcs, n)
 	case interleave4Streams:
 		if cpu.X86.AVX && n >= interleave4Streams {
 			blk := n &^ interleave4BlockMask
@@ -542,6 +552,14 @@ func deinterleaveN32(dsts [][]float32, src []float32, n int) {
 	switch len(dsts) {
 	case interleave2Channels:
 		deinterleave2_32(dsts[0][:n], dsts[1][:n], src[:n*interleave2Channels])
+	case interleave3Streams:
+		if cpu.X86.AVX2 && n >= interleave8Streams {
+			blk := n &^ interleave3BlockMask
+			deinterleave3AVX(dsts[0], dsts[1], dsts[2], src, blk)
+			deinterleaveNTailGo(dsts, src, blk, n)
+			return
+		}
+		deinterleaveNGo(dsts, src, n)
 	case interleave4Streams:
 		if cpu.X86.AVX && n >= interleave4Streams {
 			blk := n &^ interleave4BlockMask
@@ -754,6 +772,12 @@ func interleave2AVX(dst, a, b []float32)
 
 //go:noescape
 func deinterleave2AVX(a, b, src []float32)
+
+//go:noescape
+func interleave3AVX(dst, s0, s1, s2 []float32, n int)
+
+//go:noescape
+func deinterleave3AVX(d0, d1, d2, src []float32, n int)
 
 //go:noescape
 func interleave4AVX(dst, s0, s1, s2, s3 []float32, n int)

--- a/f32/f32_amd64.s
+++ b/f32/f32_amd64.s
@@ -2123,6 +2123,300 @@ deinterleave2_avx32_done:
     VZEROUPPER
     RET
 
+// 3-stream interleave/deinterleave gather indices (AVX2 VPERMPS).
+//
+// N=3 does not map onto a clean register transpose the way N=4 (4x4) and N=8
+// (8x8) do, because 8 frames span 24 interleaved slots that straddle the
+// 128-bit lane boundaries. Instead each 256-bit output is assembled from three
+// VPERMPS gathers (one per source stream), merged with two VPBLENDD masks. The
+// index vectors are loop-invariant, so the kernels load all nine into YMM
+// registers once before the loop. "don't care" lanes are 0; the blend discards
+// them. See interleave3AVX / deinterleave3AVX below for the slot maps.
+
+// interleave: per 8 frames, dst = [a0 b0 c0 a1 b1 c1 ... a7 b7 c7].
+// O0 = dst[0:8]   A@{0,3,6} B@{1,4,7} C@{2,5}
+DATA il3idxA0<>+0(SB)/4, $0
+DATA il3idxA0<>+4(SB)/4, $0
+DATA il3idxA0<>+8(SB)/4, $0
+DATA il3idxA0<>+12(SB)/4, $1
+DATA il3idxA0<>+16(SB)/4, $0
+DATA il3idxA0<>+20(SB)/4, $0
+DATA il3idxA0<>+24(SB)/4, $2
+DATA il3idxA0<>+28(SB)/4, $0
+GLOBL il3idxA0<>(SB), RODATA|NOPTR, $32
+DATA il3idxB0<>+0(SB)/4, $0
+DATA il3idxB0<>+4(SB)/4, $0
+DATA il3idxB0<>+8(SB)/4, $0
+DATA il3idxB0<>+12(SB)/4, $0
+DATA il3idxB0<>+16(SB)/4, $1
+DATA il3idxB0<>+20(SB)/4, $0
+DATA il3idxB0<>+24(SB)/4, $0
+DATA il3idxB0<>+28(SB)/4, $2
+GLOBL il3idxB0<>(SB), RODATA|NOPTR, $32
+DATA il3idxC0<>+0(SB)/4, $0
+DATA il3idxC0<>+4(SB)/4, $0
+DATA il3idxC0<>+8(SB)/4, $0
+DATA il3idxC0<>+12(SB)/4, $0
+DATA il3idxC0<>+16(SB)/4, $0
+DATA il3idxC0<>+20(SB)/4, $1
+DATA il3idxC0<>+24(SB)/4, $0
+DATA il3idxC0<>+28(SB)/4, $0
+GLOBL il3idxC0<>(SB), RODATA|NOPTR, $32
+// O1 = dst[8:16]  C@{0,3,6} A@{1,4,7} B@{2,5}
+DATA il3idxA1<>+0(SB)/4, $0
+DATA il3idxA1<>+4(SB)/4, $3
+DATA il3idxA1<>+8(SB)/4, $0
+DATA il3idxA1<>+12(SB)/4, $0
+DATA il3idxA1<>+16(SB)/4, $4
+DATA il3idxA1<>+20(SB)/4, $0
+DATA il3idxA1<>+24(SB)/4, $0
+DATA il3idxA1<>+28(SB)/4, $5
+GLOBL il3idxA1<>(SB), RODATA|NOPTR, $32
+DATA il3idxB1<>+0(SB)/4, $0
+DATA il3idxB1<>+4(SB)/4, $0
+DATA il3idxB1<>+8(SB)/4, $3
+DATA il3idxB1<>+12(SB)/4, $0
+DATA il3idxB1<>+16(SB)/4, $0
+DATA il3idxB1<>+20(SB)/4, $4
+DATA il3idxB1<>+24(SB)/4, $0
+DATA il3idxB1<>+28(SB)/4, $0
+GLOBL il3idxB1<>(SB), RODATA|NOPTR, $32
+DATA il3idxC1<>+0(SB)/4, $2
+DATA il3idxC1<>+4(SB)/4, $0
+DATA il3idxC1<>+8(SB)/4, $0
+DATA il3idxC1<>+12(SB)/4, $3
+DATA il3idxC1<>+16(SB)/4, $0
+DATA il3idxC1<>+20(SB)/4, $0
+DATA il3idxC1<>+24(SB)/4, $4
+DATA il3idxC1<>+28(SB)/4, $0
+GLOBL il3idxC1<>(SB), RODATA|NOPTR, $32
+// O2 = dst[16:24] B@{0,3,6} C@{1,4,7} A@{2,5}
+DATA il3idxA2<>+0(SB)/4, $0
+DATA il3idxA2<>+4(SB)/4, $0
+DATA il3idxA2<>+8(SB)/4, $6
+DATA il3idxA2<>+12(SB)/4, $0
+DATA il3idxA2<>+16(SB)/4, $0
+DATA il3idxA2<>+20(SB)/4, $7
+DATA il3idxA2<>+24(SB)/4, $0
+DATA il3idxA2<>+28(SB)/4, $0
+GLOBL il3idxA2<>(SB), RODATA|NOPTR, $32
+DATA il3idxB2<>+0(SB)/4, $5
+DATA il3idxB2<>+4(SB)/4, $0
+DATA il3idxB2<>+8(SB)/4, $0
+DATA il3idxB2<>+12(SB)/4, $6
+DATA il3idxB2<>+16(SB)/4, $0
+DATA il3idxB2<>+20(SB)/4, $0
+DATA il3idxB2<>+24(SB)/4, $7
+DATA il3idxB2<>+28(SB)/4, $0
+GLOBL il3idxB2<>(SB), RODATA|NOPTR, $32
+DATA il3idxC2<>+0(SB)/4, $0
+DATA il3idxC2<>+4(SB)/4, $5
+DATA il3idxC2<>+8(SB)/4, $0
+DATA il3idxC2<>+12(SB)/4, $0
+DATA il3idxC2<>+16(SB)/4, $6
+DATA il3idxC2<>+20(SB)/4, $0
+DATA il3idxC2<>+24(SB)/4, $0
+DATA il3idxC2<>+28(SB)/4, $7
+GLOBL il3idxC2<>(SB), RODATA|NOPTR, $32
+
+// deinterleave: src = [a0 b0 c0 a1 ...]; S0=src[0:8] S1=src[8:16] S2=src[16:24].
+// A=d0[0:8]  A@out{0,1,2}<-S0{0,3,6}  {3,4,5}<-S1{1,4,7}  {6,7}<-S2{2,5}
+DATA dl3idxS0A<>+0(SB)/4, $0
+DATA dl3idxS0A<>+4(SB)/4, $3
+DATA dl3idxS0A<>+8(SB)/4, $6
+DATA dl3idxS0A<>+12(SB)/4, $0
+DATA dl3idxS0A<>+16(SB)/4, $0
+DATA dl3idxS0A<>+20(SB)/4, $0
+DATA dl3idxS0A<>+24(SB)/4, $0
+DATA dl3idxS0A<>+28(SB)/4, $0
+GLOBL dl3idxS0A<>(SB), RODATA|NOPTR, $32
+DATA dl3idxS1A<>+0(SB)/4, $0
+DATA dl3idxS1A<>+4(SB)/4, $0
+DATA dl3idxS1A<>+8(SB)/4, $0
+DATA dl3idxS1A<>+12(SB)/4, $1
+DATA dl3idxS1A<>+16(SB)/4, $4
+DATA dl3idxS1A<>+20(SB)/4, $7
+DATA dl3idxS1A<>+24(SB)/4, $0
+DATA dl3idxS1A<>+28(SB)/4, $0
+GLOBL dl3idxS1A<>(SB), RODATA|NOPTR, $32
+DATA dl3idxS2A<>+0(SB)/4, $0
+DATA dl3idxS2A<>+4(SB)/4, $0
+DATA dl3idxS2A<>+8(SB)/4, $0
+DATA dl3idxS2A<>+12(SB)/4, $0
+DATA dl3idxS2A<>+16(SB)/4, $0
+DATA dl3idxS2A<>+20(SB)/4, $0
+DATA dl3idxS2A<>+24(SB)/4, $2
+DATA dl3idxS2A<>+28(SB)/4, $5
+GLOBL dl3idxS2A<>(SB), RODATA|NOPTR, $32
+// B=d1  {0,1,2}<-S0{1,4,7}  {3,4}<-S1{2,5}  {5,6,7}<-S2{0,3,6}
+DATA dl3idxS0B<>+0(SB)/4, $1
+DATA dl3idxS0B<>+4(SB)/4, $4
+DATA dl3idxS0B<>+8(SB)/4, $7
+DATA dl3idxS0B<>+12(SB)/4, $0
+DATA dl3idxS0B<>+16(SB)/4, $0
+DATA dl3idxS0B<>+20(SB)/4, $0
+DATA dl3idxS0B<>+24(SB)/4, $0
+DATA dl3idxS0B<>+28(SB)/4, $0
+GLOBL dl3idxS0B<>(SB), RODATA|NOPTR, $32
+DATA dl3idxS1B<>+0(SB)/4, $0
+DATA dl3idxS1B<>+4(SB)/4, $0
+DATA dl3idxS1B<>+8(SB)/4, $0
+DATA dl3idxS1B<>+12(SB)/4, $2
+DATA dl3idxS1B<>+16(SB)/4, $5
+DATA dl3idxS1B<>+20(SB)/4, $0
+DATA dl3idxS1B<>+24(SB)/4, $0
+DATA dl3idxS1B<>+28(SB)/4, $0
+GLOBL dl3idxS1B<>(SB), RODATA|NOPTR, $32
+DATA dl3idxS2B<>+0(SB)/4, $0
+DATA dl3idxS2B<>+4(SB)/4, $0
+DATA dl3idxS2B<>+8(SB)/4, $0
+DATA dl3idxS2B<>+12(SB)/4, $0
+DATA dl3idxS2B<>+16(SB)/4, $0
+DATA dl3idxS2B<>+20(SB)/4, $0
+DATA dl3idxS2B<>+24(SB)/4, $3
+DATA dl3idxS2B<>+28(SB)/4, $6
+GLOBL dl3idxS2B<>(SB), RODATA|NOPTR, $32
+// C=d2  {0,1}<-S0{2,5}  {2,3,4}<-S1{0,3,6}  {5,6,7}<-S2{1,4,7}
+DATA dl3idxS0C<>+0(SB)/4, $2
+DATA dl3idxS0C<>+4(SB)/4, $5
+DATA dl3idxS0C<>+8(SB)/4, $0
+DATA dl3idxS0C<>+12(SB)/4, $0
+DATA dl3idxS0C<>+16(SB)/4, $0
+DATA dl3idxS0C<>+20(SB)/4, $0
+DATA dl3idxS0C<>+24(SB)/4, $0
+DATA dl3idxS0C<>+28(SB)/4, $0
+GLOBL dl3idxS0C<>(SB), RODATA|NOPTR, $32
+DATA dl3idxS1C<>+0(SB)/4, $0
+DATA dl3idxS1C<>+4(SB)/4, $0
+DATA dl3idxS1C<>+8(SB)/4, $0
+DATA dl3idxS1C<>+12(SB)/4, $3
+DATA dl3idxS1C<>+16(SB)/4, $6
+DATA dl3idxS1C<>+20(SB)/4, $0
+DATA dl3idxS1C<>+24(SB)/4, $0
+DATA dl3idxS1C<>+28(SB)/4, $0
+GLOBL dl3idxS1C<>(SB), RODATA|NOPTR, $32
+DATA dl3idxS2C<>+0(SB)/4, $0
+DATA dl3idxS2C<>+4(SB)/4, $0
+DATA dl3idxS2C<>+8(SB)/4, $0
+DATA dl3idxS2C<>+12(SB)/4, $0
+DATA dl3idxS2C<>+16(SB)/4, $0
+DATA dl3idxS2C<>+20(SB)/4, $1
+DATA dl3idxS2C<>+24(SB)/4, $4
+DATA dl3idxS2C<>+28(SB)/4, $7
+GLOBL dl3idxS2C<>(SB), RODATA|NOPTR, $32
+
+// func interleave3AVX(dst, s0, s1, s2 []float32, n int)
+// Interleaves 3 planar streams (dst[i*3+c] = s_c[i]) into 24 contiguous floats
+// per 8 frames via per-stream VPERMPS gathers + VPBLENDD merges. n is a
+// multiple of 8 (the caller handles the tail). Requires AVX2.
+TEXT ·interleave3AVX(SB), NOSPLIT, $0-104
+    MOVQ dst_base+0(FP), DI
+    MOVQ s0_base+24(FP), AX
+    MOVQ s1_base+48(FP), BX
+    MOVQ s2_base+72(FP), CX
+    MOVQ n+96(FP), SI
+    SHRQ $3, SI                // SI = n/8 blocks
+    TESTQ SI, SI
+    JZ interleave3_avx_done
+    VMOVUPS il3idxA0<>(SB), Y3
+    VMOVUPS il3idxB0<>(SB), Y4
+    VMOVUPS il3idxC0<>(SB), Y5
+    VMOVUPS il3idxA1<>(SB), Y6
+    VMOVUPS il3idxB1<>(SB), Y7
+    VMOVUPS il3idxC1<>(SB), Y8
+    VMOVUPS il3idxA2<>(SB), Y9
+    VMOVUPS il3idxB2<>(SB), Y10
+    VMOVUPS il3idxC2<>(SB), Y11
+
+interleave3_avx_loop:
+    VMOVUPS (AX), Y0           // A = s0[i:i+8]
+    VMOVUPS (BX), Y1           // B = s1[i:i+8]
+    VMOVUPS (CX), Y2           // C = s2[i:i+8]
+    VPERMPS Y0, Y3, Y12        // O0: gather A
+    VPERMPS Y1, Y4, Y15        // gather B
+    VPBLENDD $0x92, Y15, Y12, Y12
+    VPERMPS Y2, Y5, Y15        // gather C
+    VPBLENDD $0x24, Y15, Y12, Y12
+    VMOVUPS Y12, (DI)
+    VPERMPS Y0, Y6, Y12        // O1
+    VPERMPS Y1, Y7, Y15
+    VPBLENDD $0x24, Y15, Y12, Y12
+    VPERMPS Y2, Y8, Y15
+    VPBLENDD $0x49, Y15, Y12, Y12
+    VMOVUPS Y12, 32(DI)
+    VPERMPS Y0, Y9, Y12        // O2
+    VPERMPS Y1, Y10, Y15
+    VPBLENDD $0x49, Y15, Y12, Y12
+    VPERMPS Y2, Y11, Y15
+    VPBLENDD $0x92, Y15, Y12, Y12
+    VMOVUPS Y12, 64(DI)
+    ADDQ $32, AX
+    ADDQ $32, BX
+    ADDQ $32, CX
+    ADDQ $96, DI
+    DECQ SI
+    JNZ interleave3_avx_loop
+
+interleave3_avx_done:
+    VZEROUPPER
+    RET
+
+// func deinterleave3AVX(d0, d1, d2, src []float32, n int)
+// Splits a 3-stream interleaved buffer (d_c[i] = src[i*3+c]) into planar
+// streams, 8 frames per iteration, via per-stream VPERMPS gathers + VPBLENDD
+// merges. n is a multiple of 8 (the caller handles the tail). Requires AVX2.
+TEXT ·deinterleave3AVX(SB), NOSPLIT, $0-104
+    MOVQ d0_base+0(FP), AX
+    MOVQ d1_base+24(FP), BX
+    MOVQ d2_base+48(FP), CX
+    MOVQ src_base+72(FP), SI
+    MOVQ n+96(FP), DI
+    SHRQ $3, DI                // DI = n/8 blocks
+    TESTQ DI, DI
+    JZ deinterleave3_avx_done
+    VMOVUPS dl3idxS0A<>(SB), Y3
+    VMOVUPS dl3idxS1A<>(SB), Y4
+    VMOVUPS dl3idxS2A<>(SB), Y5
+    VMOVUPS dl3idxS0B<>(SB), Y6
+    VMOVUPS dl3idxS1B<>(SB), Y7
+    VMOVUPS dl3idxS2B<>(SB), Y8
+    VMOVUPS dl3idxS0C<>(SB), Y9
+    VMOVUPS dl3idxS1C<>(SB), Y10
+    VMOVUPS dl3idxS2C<>(SB), Y11
+
+deinterleave3_avx_loop:
+    VMOVUPS (SI), Y0           // S0 = src[0:8]
+    VMOVUPS 32(SI), Y1         // S1 = src[8:16]
+    VMOVUPS 64(SI), Y2         // S2 = src[16:24]
+    VPERMPS Y0, Y3, Y12        // d0 = A
+    VPERMPS Y1, Y4, Y15
+    VPBLENDD $0x38, Y15, Y12, Y12
+    VPERMPS Y2, Y5, Y15
+    VPBLENDD $0xC0, Y15, Y12, Y12
+    VMOVUPS Y12, (AX)
+    VPERMPS Y0, Y6, Y12        // d1 = B
+    VPERMPS Y1, Y7, Y15
+    VPBLENDD $0x18, Y15, Y12, Y12
+    VPERMPS Y2, Y8, Y15
+    VPBLENDD $0xE0, Y15, Y12, Y12
+    VMOVUPS Y12, (BX)
+    VPERMPS Y0, Y9, Y12        // d2 = C
+    VPERMPS Y1, Y10, Y15
+    VPBLENDD $0x1C, Y15, Y12, Y12
+    VPERMPS Y2, Y11, Y15
+    VPBLENDD $0xE0, Y15, Y12, Y12
+    VMOVUPS Y12, (CX)
+    ADDQ $32, AX
+    ADDQ $32, BX
+    ADDQ $32, CX
+    ADDQ $96, SI
+    DECQ DI
+    JNZ deinterleave3_avx_loop
+
+deinterleave3_avx_done:
+    VZEROUPPER
+    RET
+
 // func interleave4AVX(dst, s0, s1, s2, s3 []float32, n int)
 // Interleaves 4 planar streams (dst[i*4+c] = s_c[i]) via a 4x4 transpose of
 // XMM registers, 4 frames per iteration. n is a multiple of 4 (the caller

--- a/f32/interleave3_amd64_test.go
+++ b/f32/interleave3_amd64_test.go
@@ -1,0 +1,75 @@
+//go:build amd64
+
+package f32
+
+import (
+	"testing"
+
+	"github.com/tphakala/simd/cpu"
+)
+
+// The N=3 AMD64 gather/blend kernels process whole 8-frame blocks; the dispatch
+// reslices the tail to Go. These tests drive the kernels directly with
+// block-aligned frame counts so a misplaced lane (wrong VPERMPS index or
+// VPBLENDD mask) is caught against the literal scalar oracle. chanVal makes
+// every (channel, frame) value unique, so no transpose bug can alias.
+
+func interleave3KernelFrameCounts() []int { return []int{8, 16, 24, 64, 256, 1024} }
+
+func TestInterleave3AVX_MatchesOracle(t *testing.T) {
+	if !cpu.X86.AVX2 {
+		t.Skip("AVX2 not available on this CPU")
+	}
+	const nc = 3
+	for _, n := range interleave3KernelFrameCounts() {
+		srcs := make([][]float32, nc)
+		for c := range srcs {
+			srcs[c] = make([]float32, n)
+			for i := range srcs[c] {
+				srcs[c][i] = chanVal(c, i)
+			}
+		}
+		got := make([]float32, n*nc)
+		interleave3AVX(got, srcs[0], srcs[1], srcs[2], n)
+
+		want := make([]float32, n*nc)
+		interleaveNRef(want, srcs, n)
+		for i := range want {
+			if got[i] != want[i] {
+				t.Fatalf("n=%d: interleave3AVX[%d] = %v, want %v", n, i, got[i], want[i])
+			}
+		}
+	}
+}
+
+func TestDeinterleave3AVX_MatchesOracle(t *testing.T) {
+	if !cpu.X86.AVX2 {
+		t.Skip("AVX2 not available on this CPU")
+	}
+	const nc = 3
+	for _, n := range interleave3KernelFrameCounts() {
+		src := make([]float32, n*nc)
+		for i := range src {
+			src[i] = float32(i + 1)
+		}
+		dsts := make([][]float32, nc)
+		for c := range dsts {
+			dsts[c] = make([]float32, n)
+		}
+		deinterleave3AVX(dsts[0], dsts[1], dsts[2], src, n)
+
+		want := make([][]float32, nc)
+		for c := range want {
+			want[c] = make([]float32, n)
+		}
+		deinterleaveNRef(want, src, n)
+		for c := range dsts {
+			for i := range dsts[c] {
+				if dsts[c][i] != want[c][i] {
+					t.Fatalf("n=%d: deinterleave3AVX dst[%d][%d] = %v, want %v",
+						n, c, i, dsts[c][i], want[c][i])
+				}
+			}
+		}
+	}
+}


### PR DESCRIPTION
## What

Adds dedicated AMD64 SIMD for the `f32` 3-stream `InterleaveN`/`DeinterleaveN` cells, which were the only documented x86 hot path still falling back to the generic Go loop. Addresses the f32 N=3 portion of #60.

3 streams do not map onto a clean register transpose the way N=4 (4x4) and N=8 (8x8) do: 8 frames span 24 interleaved slots that straddle the 128-bit lane boundaries. `interleave3AVX` / `deinterleave3AVX` instead assemble each 256-bit result from three per-stream `VPERMPS` gathers merged with two `VPBLENDD` masks, 8 frames per iteration. The nine gather-index vectors are loop-invariant and loaded into YMM once before the loop.

The dispatch gates on AVX2 (`VPERMPS`/`VPBLENDD`) and `n >= 8`; the trailing frames reuse the existing Go tail helpers, so the path stays allocation-free.

## Profiling (acceptance gate)

Profile-justified first per the issue. i7-1260P, n=1024:

| op | generic Go (before) | AVX2 (after) | speedup |
|----|--------------------:|-------------:|--------:|
| `InterleaveN` N=3   | 745 ns (16.5 GB/s) | 268 ns (45 GB/s) | **2.8x** |
| `DeinterleaveN` N=3 | 868 ns (14 GB/s)   | 268 ns (46 GB/s) | **3.2x** |

Both remain zero-alloc.

## Tests

- New `f32/interleave3_amd64_test.go` drives the kernels directly against the scalar oracle (written test-first; watched it fail on a stub before implementing).
- Existing `TestInterleaveN_Parity` / `TestDeinterleaveN_Parity` cover the dispatch + Go tail across the full frame-count matrix (block boundaries, +/-1 tails, padding-untouched), plus round-trip and `AllocsPerRun == 0`.
- `go vet` (asmdecl) clean; `TestNoGoroutineRegisterClobber` (no R14) and `TestNoUncheckedAmd64Encodings` (no hand-encoded directives) pass.
- Verified on amd64 (i7-1260P) and on a native arm64 host (Raspberry Pi 5); the change is amd64-only, so arm64 is unaffected and its full f32 suite still passes.

## Out of scope (still tracked by #60)

N=6 and the f64 N=3/N=6/N=8 cells stay on the generic path. They are not documented hot paths, and #60 gates them on separate profiling.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added optimized 3-stream float32 interleaving/deinterleaving support for AMD64 processors with AVX2 capabilities, delivering enhanced performance for multi-channel audio operations.

* **Documentation**
  * Updated SIMD coverage documentation for float32 and float64 operations, detailing expanded AVX/AVX2 support and available optimization paths for different stream counts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->