### PR TITLE
f64: AMD64 AVX interleave/deinterleave kernels for N=3 and N=8

### DIFF
--- a/README.md
+++ b/README.md
@@ -156,6 +156,10 @@ streams do not map onto a clean register transpose) on top of the shared N=2/4 (
 and N=2/3/4 (NEON) kernels; all other stream counts use the allocation-free generic
 path. The N=3 case is the 16k -> 48k upsample hot path: the AVX2 gather/blend kernel
 runs roughly 2.8x (interleave) and 3.2x (deinterleave) over the generic loop on AVX2.
+`f64` mirrors the same N=3 and N=8 AVX coverage, processing 4 frames per block (a YMM
+holds 4 doubles): N=3 uses immediate `VPERMPD` gathers merged with `VBLENDPD`, and N=8
+runs two stacked 4x4 transposes (streams 0-3 fill each frame's low YMM, streams 4-7 the
+high YMM).
 
 **Row-major batch dot products** (for flat vector stores):
 

--- a/f64/f64_amd64.go
+++ b/f64/f64_amd64.go
@@ -428,21 +428,43 @@ func deinterleave2_64(a, b, src []float64) {
 // reuses the existing Interleave2 SIMD; other small N use shuffle-based
 // transposes (added incrementally); the rest fall back to the generic Go path.
 // Stream counts with dedicated AMD64 SIMD interleave/deinterleave kernels (the
-// 2-stream path reuses interleave2Channels). interleave4BlockMask aligns a
-// frame count down to a whole 4-frame SIMD block; the caller handles the tail.
+// 2-stream path reuses interleave2Channels). Every f64 YMM kernel (N=3, N=4,
+// N=8) processes interleaveBlockFrames frames per block because a YMM holds 4
+// float64; interleaveBlockMask aligns a frame count down to a whole block and
+// the caller handles the tail.
 const (
-	interleave4Streams   = 4
-	interleave4BlockMask = interleave4Streams - 1
+	interleave3Streams = 3
+	interleave4Streams = 4
+	interleave8Streams = 8
+
+	interleaveBlockFrames = 4
+	interleaveBlockMask   = interleaveBlockFrames - 1
 )
 
 func interleaveN64(dst []float64, srcs [][]float64, n int) {
 	switch len(srcs) {
 	case interleave2Channels:
 		interleave2_64(dst[:n*interleave2Channels], srcs[0][:n], srcs[1][:n])
+	case interleave3Streams:
+		if cpu.X86.AVX2 && n >= interleaveBlockFrames {
+			blk := n &^ interleaveBlockMask
+			interleave3AVX(dst, srcs[0], srcs[1], srcs[2], blk)
+			interleaveNTailGo(dst, srcs, blk, n)
+			return
+		}
+		interleaveNGo(dst, srcs, n)
 	case interleave4Streams:
-		if cpu.X86.AVX && n >= interleave4Streams {
-			blk := n &^ interleave4BlockMask
+		if cpu.X86.AVX && n >= interleaveBlockFrames {
+			blk := n &^ interleaveBlockMask
 			interleave4AVX(dst, srcs[0], srcs[1], srcs[2], srcs[3], blk)
+			interleaveNTailGo(dst, srcs, blk, n)
+			return
+		}
+		interleaveNGo(dst, srcs, n)
+	case interleave8Streams:
+		if cpu.X86.AVX && n >= interleaveBlockFrames {
+			blk := n &^ interleaveBlockMask
+			interleave8AVX(dst, srcs, blk)
 			interleaveNTailGo(dst, srcs, blk, n)
 			return
 		}
@@ -483,10 +505,26 @@ func deinterleaveN64(dsts [][]float64, src []float64, n int) {
 	switch len(dsts) {
 	case interleave2Channels:
 		deinterleave2_64(dsts[0][:n], dsts[1][:n], src[:n*interleave2Channels])
+	case interleave3Streams:
+		if cpu.X86.AVX2 && n >= interleaveBlockFrames {
+			blk := n &^ interleaveBlockMask
+			deinterleave3AVX(dsts[0], dsts[1], dsts[2], src, blk)
+			deinterleaveNTailGo(dsts, src, blk, n)
+			return
+		}
+		deinterleaveNGo(dsts, src, n)
 	case interleave4Streams:
-		if cpu.X86.AVX && n >= interleave4Streams {
-			blk := n &^ interleave4BlockMask
+		if cpu.X86.AVX && n >= interleaveBlockFrames {
+			blk := n &^ interleaveBlockMask
 			deinterleave4AVX(dsts[0], dsts[1], dsts[2], dsts[3], src, blk)
+			deinterleaveNTailGo(dsts, src, blk, n)
+			return
+		}
+		deinterleaveNGo(dsts, src, n)
+	case interleave8Streams:
+		if cpu.X86.AVX && n >= interleaveBlockFrames {
+			blk := n &^ interleaveBlockMask
+			deinterleave8AVX(dsts, src, blk)
 			deinterleaveNTailGo(dsts, src, blk, n)
 			return
 		}
@@ -796,10 +834,22 @@ func interleave2AVX(dst, a, b []float64)
 func deinterleave2AVX(a, b, src []float64)
 
 //go:noescape
+func interleave3AVX(dst, s0, s1, s2 []float64, n int)
+
+//go:noescape
+func deinterleave3AVX(d0, d1, d2, src []float64, n int)
+
+//go:noescape
 func interleave4AVX(dst, s0, s1, s2, s3 []float64, n int)
 
 //go:noescape
 func deinterleave4AVX(d0, d1, d2, d3, src []float64, n int)
+
+//go:noescape
+func interleave8AVX(dst []float64, srcs [][]float64, n int)
+
+//go:noescape
+func deinterleave8AVX(dsts [][]float64, src []float64, n int)
 
 //go:noescape
 func interleave2SSE2(dst, a, b []float64)

--- a/f64/f64_amd64.s
+++ b/f64/f64_amd64.s
@@ -3384,6 +3384,255 @@ deinterleave4_avx_done:
     VZEROUPPER
     RET
 
+// func interleave3AVX(dst, s0, s1, s2 []float64, n int)
+// Interleaves 3 planar streams (dst[i*3+c] = s_c[i]) into 12 contiguous doubles
+// per 4 frames via per-stream VPERMPD gathers + VBLENDPD merges (3 streams do
+// not map onto a clean register transpose like N=4 does). n is a multiple of 4
+// (the caller handles the tail). Requires AVX2.
+//
+// Per 4-frame block, with a=s0/b=s1/c=s2, the 3 output rows (4 doubles each) are
+//   O0 = [a0,b0,c0,a1]  O1 = [b1,c1,a2,b2]  O2 = [c2,a3,b3,c3].
+// VPERMPD imm bits [2k+1:2k] pick output lane k's source lane; VBLENDPD imm
+// bit k selects the first source operand for lane k (the gathered value).
+TEXT ·interleave3AVX(SB), NOSPLIT, $0-104
+    MOVQ dst_base+0(FP), DI
+    MOVQ s0_base+24(FP), AX
+    MOVQ s1_base+48(FP), BX
+    MOVQ s2_base+72(FP), CX
+    MOVQ n+96(FP), SI
+    SHRQ $2, SI                // SI = n/4 blocks
+    TESTQ SI, SI
+    JZ interleave3_avx_done
+
+interleave3_avx_loop:
+    VMOVUPD (AX), Y0           // A = s0[i:i+4]
+    VMOVUPD (BX), Y1           // B = s1[i:i+4]
+    VMOVUPD (CX), Y2           // C = s2[i:i+4]
+    VPERMPD $0x40, Y0, Y3      // O0 base: [a0,a0,a0,a1]
+    VPERMPD $0x00, Y1, Y4      // [b0,b0,b0,b0]
+    VPERMPD $0x00, Y2, Y5      // [c0,c0,c0,c0]
+    VBLENDPD $0x2, Y4, Y3, Y3  // lane1 <- b0
+    VBLENDPD $0x4, Y5, Y3, Y3  // lane2 <- c0
+    VMOVUPD Y3, (DI)           // O0 = [a0,b0,c0,a1]
+    VPERMPD $0x81, Y1, Y4      // O1 base: [b1,b0,b0,b2]
+    VPERMPD $0x04, Y2, Y5      // [c0,c1,c0,c0]
+    VPERMPD $0x20, Y0, Y3      // [a0,a0,a2,a0]
+    VBLENDPD $0x2, Y5, Y4, Y4  // lane1 <- c1
+    VBLENDPD $0x4, Y3, Y4, Y4  // lane2 <- a2
+    VMOVUPD Y4, 32(DI)         // O1 = [b1,c1,a2,b2]
+    VPERMPD $0xC2, Y2, Y5      // O2 base: [c2,c0,c0,c3]
+    VPERMPD $0x0C, Y0, Y3      // [a0,a3,a0,a0]
+    VPERMPD $0x30, Y1, Y4      // [b0,b0,b3,b0]
+    VBLENDPD $0x2, Y3, Y5, Y5  // lane1 <- a3
+    VBLENDPD $0x4, Y4, Y5, Y5  // lane2 <- b3
+    VMOVUPD Y5, 64(DI)         // O2 = [c2,a3,b3,c3]
+    ADDQ $32, AX
+    ADDQ $32, BX
+    ADDQ $32, CX
+    ADDQ $96, DI
+    DECQ SI
+    JNZ interleave3_avx_loop
+
+interleave3_avx_done:
+    VZEROUPPER
+    RET
+
+// func deinterleave3AVX(d0, d1, d2, src []float64, n int)
+// Splits a 3-stream interleaved buffer (d_c[i] = src[i*3+c]) into planar streams,
+// 4 frames per iteration, via per-stream VPERMPD gathers + VBLENDPD merges. n is
+// a multiple of 4 (the caller handles the tail). Requires AVX2.
+//
+// Per block the 3 input rows are S0=[a0,b0,c0,a1] S1=[b1,c1,a2,b2] S2=[c2,a3,b3,c3]
+// and the planar outputs are A=[a0,a1,a2,a3] B=[b0,b1,b2,b3] C=[c0,c1,c2,c3].
+TEXT ·deinterleave3AVX(SB), NOSPLIT, $0-104
+    MOVQ d0_base+0(FP), AX
+    MOVQ d1_base+24(FP), BX
+    MOVQ d2_base+48(FP), CX
+    MOVQ src_base+72(FP), SI
+    MOVQ n+96(FP), DI
+    SHRQ $2, DI                // DI = n/4 blocks
+    TESTQ DI, DI
+    JZ deinterleave3_avx_done
+
+deinterleave3_avx_loop:
+    VMOVUPD (SI), Y0           // S0 = src[0:4]
+    VMOVUPD 32(SI), Y1         // S1 = src[4:8]
+    VMOVUPD 64(SI), Y2         // S2 = src[8:12]
+    VPERMPD $0x0C, Y0, Y3      // A base: [a0,a1,a0,a0]
+    VPERMPD $0x20, Y1, Y4      // [.,.,a2,.]
+    VPERMPD $0x40, Y2, Y5      // [.,.,.,a3]
+    VBLENDPD $0x4, Y4, Y3, Y3  // lane2 <- a2
+    VBLENDPD $0x8, Y5, Y3, Y3  // lane3 <- a3
+    VMOVUPD Y3, (AX)           // A = [a0,a1,a2,a3]
+    VPERMPD $0x01, Y0, Y3      // B base: [b0,a0,a0,a0]
+    VPERMPD $0x30, Y1, Y4      // [b1,b1,b2,.]
+    VPERMPD $0x80, Y2, Y5      // [.,.,.,b3]
+    VBLENDPD $0x6, Y4, Y3, Y3  // lanes1,2 <- b1,b2
+    VBLENDPD $0x8, Y5, Y3, Y3  // lane3 <- b3
+    VMOVUPD Y3, (BX)           // B = [b0,b1,b2,b3]
+    VPERMPD $0x02, Y0, Y3      // C base: [c0,.,.,.]
+    VPERMPD $0x04, Y1, Y4      // [.,c1,.,.]
+    VPERMPD $0xC0, Y2, Y5      // [c2,.,c2,c3]
+    VBLENDPD $0x2, Y4, Y3, Y3  // lane1 <- c1
+    VBLENDPD $0xC, Y5, Y3, Y3  // lanes2,3 <- c2,c3
+    VMOVUPD Y3, (CX)           // C = [c0,c1,c2,c3]
+    ADDQ $96, SI
+    ADDQ $32, AX
+    ADDQ $32, BX
+    ADDQ $32, CX
+    DECQ DI
+    JNZ deinterleave3_avx_loop
+
+deinterleave3_avx_done:
+    VZEROUPPER
+    RET
+
+// func interleave8AVX(dst []float64, srcs [][]float64, n int)
+// Interleaves 8 planar streams (dst[i*8+c] = srcs[c][i]) into 32 doubles per 4
+// frames. A YMM holds 4 doubles, so each output frame spans two YMM rows; the
+// kernel runs two independent 4x4 transposes (interleave4AVX's algorithm):
+// streams 0-3 produce each frame's low YMM, streams 4-7 the high YMM. n is a
+// multiple of 4 (the caller handles the tail). srcs must have exactly 8 elements.
+TEXT ·interleave8AVX(SB), NOSPLIT, $0-56
+    MOVQ srcs_base+24(FP), R12   // R12 = &srcs[0] (array of slice headers)
+    MOVQ 0(R12), AX              // srcs[0].ptr
+    MOVQ 24(R12), BX             // srcs[1].ptr
+    MOVQ 48(R12), CX             // srcs[2].ptr
+    MOVQ 72(R12), DX             // srcs[3].ptr
+    MOVQ 96(R12), R8             // srcs[4].ptr
+    MOVQ 120(R12), R9            // srcs[5].ptr
+    MOVQ 144(R12), R10           // srcs[6].ptr
+    MOVQ 168(R12), R11           // srcs[7].ptr
+    MOVQ dst_base+0(FP), DI
+    MOVQ n+48(FP), SI
+    SHRQ $2, SI                  // SI = n/4 blocks
+    TESTQ SI, SI
+    JZ interleave8_avx_done
+
+interleave8_avx_loop:
+    // streams 0-3 -> low YMM of frames 0..3
+    VMOVUPD (AX), Y0             // s0[i:i+4]
+    VMOVUPD (BX), Y1             // s1
+    VMOVUPD (CX), Y2             // s2
+    VMOVUPD (DX), Y3             // s3
+    VUNPCKLPD Y1, Y0, Y4         // [s0.0,s1.0,s0.2,s1.2]
+    VUNPCKHPD Y1, Y0, Y5         // [s0.1,s1.1,s0.3,s1.3]
+    VUNPCKLPD Y3, Y2, Y6         // [s2.0,s3.0,s2.2,s3.2]
+    VUNPCKHPD Y3, Y2, Y7         // [s2.1,s3.1,s2.3,s3.3]
+    VPERM2F128 $0x20, Y6, Y4, Y8    // f0 lo = [s0.0,s1.0,s2.0,s3.0]
+    VPERM2F128 $0x20, Y7, Y5, Y9    // f1 lo
+    VPERM2F128 $0x31, Y6, Y4, Y10   // f2 lo
+    VPERM2F128 $0x31, Y7, Y5, Y11   // f3 lo
+    VMOVUPD Y8, (DI)             // dst[0:4]
+    VMOVUPD Y9, 64(DI)           // dst[8:12]
+    VMOVUPD Y10, 128(DI)         // dst[16:20]
+    VMOVUPD Y11, 192(DI)         // dst[24:28]
+    // streams 4-7 -> high YMM of frames 0..3
+    VMOVUPD (R8), Y0             // s4
+    VMOVUPD (R9), Y1             // s5
+    VMOVUPD (R10), Y2            // s6
+    VMOVUPD (R11), Y3            // s7
+    VUNPCKLPD Y1, Y0, Y4
+    VUNPCKHPD Y1, Y0, Y5
+    VUNPCKLPD Y3, Y2, Y6
+    VUNPCKHPD Y3, Y2, Y7
+    VPERM2F128 $0x20, Y6, Y4, Y8    // f0 hi = [s4.0,s5.0,s6.0,s7.0]
+    VPERM2F128 $0x20, Y7, Y5, Y9    // f1 hi
+    VPERM2F128 $0x31, Y6, Y4, Y10   // f2 hi
+    VPERM2F128 $0x31, Y7, Y5, Y11   // f3 hi
+    VMOVUPD Y8, 32(DI)           // dst[4:8]
+    VMOVUPD Y9, 96(DI)           // dst[12:16]
+    VMOVUPD Y10, 160(DI)         // dst[20:24]
+    VMOVUPD Y11, 224(DI)         // dst[28:32]
+    ADDQ $32, AX
+    ADDQ $32, BX
+    ADDQ $32, CX
+    ADDQ $32, DX
+    ADDQ $32, R8
+    ADDQ $32, R9
+    ADDQ $32, R10
+    ADDQ $32, R11
+    ADDQ $256, DI
+    DECQ SI
+    JNZ interleave8_avx_loop
+
+interleave8_avx_done:
+    VZEROUPPER
+    RET
+
+// func deinterleave8AVX(dsts [][]float64, src []float64, n int)
+// Splits an interleaved 8-stream buffer (dsts[c][i] = src[i*8+c]) into planar
+// streams, 4 frames per iteration. Each frame spans two YMM rows; the low rows
+// (src[f*8:f*8+4]) transpose into streams 0-3 and the high rows
+// (src[f*8+4:f*8+8]) into streams 4-7. n is a multiple of 4 (the caller handles
+// the tail). dsts must have exactly 8 elements.
+TEXT ·deinterleave8AVX(SB), NOSPLIT, $0-56
+    MOVQ dsts_base+0(FP), R12    // R12 = &dsts[0] (array of slice headers)
+    MOVQ 0(R12), AX              // dsts[0].ptr
+    MOVQ 24(R12), BX             // dsts[1].ptr
+    MOVQ 48(R12), CX             // dsts[2].ptr
+    MOVQ 72(R12), DX             // dsts[3].ptr
+    MOVQ 96(R12), R8             // dsts[4].ptr
+    MOVQ 120(R12), R9            // dsts[5].ptr
+    MOVQ 144(R12), R10           // dsts[6].ptr
+    MOVQ 168(R12), R11           // dsts[7].ptr
+    MOVQ src_base+24(FP), SI
+    MOVQ n+48(FP), DI
+    SHRQ $2, DI                  // DI = n/4 blocks
+    TESTQ DI, DI
+    JZ deinterleave8_avx_done
+
+deinterleave8_avx_loop:
+    // low rows of frames 0..3 -> streams 0-3
+    VMOVUPD (SI), Y0             // f0 lo = [s0.0,s1.0,s2.0,s3.0]
+    VMOVUPD 64(SI), Y1           // f1 lo
+    VMOVUPD 128(SI), Y2          // f2 lo
+    VMOVUPD 192(SI), Y3          // f3 lo
+    VUNPCKLPD Y1, Y0, Y4
+    VUNPCKHPD Y1, Y0, Y5
+    VUNPCKLPD Y3, Y2, Y6
+    VUNPCKHPD Y3, Y2, Y7
+    VPERM2F128 $0x20, Y6, Y4, Y8    // s0 = [s0.0,s0.1,s0.2,s0.3]
+    VPERM2F128 $0x20, Y7, Y5, Y9    // s1
+    VPERM2F128 $0x31, Y6, Y4, Y10   // s2
+    VPERM2F128 $0x31, Y7, Y5, Y11   // s3
+    VMOVUPD Y8, (AX)
+    VMOVUPD Y9, (BX)
+    VMOVUPD Y10, (CX)
+    VMOVUPD Y11, (DX)
+    // high rows of frames 0..3 -> streams 4-7
+    VMOVUPD 32(SI), Y0           // f0 hi = [s4.0,s5.0,s6.0,s7.0]
+    VMOVUPD 96(SI), Y1           // f1 hi
+    VMOVUPD 160(SI), Y2          // f2 hi
+    VMOVUPD 224(SI), Y3          // f3 hi
+    VUNPCKLPD Y1, Y0, Y4
+    VUNPCKHPD Y1, Y0, Y5
+    VUNPCKLPD Y3, Y2, Y6
+    VUNPCKHPD Y3, Y2, Y7
+    VPERM2F128 $0x20, Y6, Y4, Y8    // s4
+    VPERM2F128 $0x20, Y7, Y5, Y9    // s5
+    VPERM2F128 $0x31, Y6, Y4, Y10   // s6
+    VPERM2F128 $0x31, Y7, Y5, Y11   // s7
+    VMOVUPD Y8, (R8)
+    VMOVUPD Y9, (R9)
+    VMOVUPD Y10, (R10)
+    VMOVUPD Y11, (R11)
+    ADDQ $32, AX
+    ADDQ $32, BX
+    ADDQ $32, CX
+    ADDQ $32, DX
+    ADDQ $32, R8
+    ADDQ $32, R9
+    ADDQ $32, R10
+    ADDQ $32, R11
+    ADDQ $256, SI
+    DECQ DI
+    JNZ deinterleave8_avx_loop
+
+deinterleave8_avx_done:
+    VZEROUPPER
+    RET
+
 // ============================================================================
 // ADDSCALED - dst[i] += alpha * s[i] (AXPY operation)
 // ============================================================================

--- a/f64/interleave3_amd64_test.go
+++ b/f64/interleave3_amd64_test.go
@@ -1,0 +1,78 @@
+//go:build amd64
+
+package f64
+
+import (
+	"testing"
+
+	"github.com/tphakala/simd/cpu"
+)
+
+// The N=3 AMD64 gather/blend kernels process whole 4-frame blocks (4 f64 frames
+// = 3 YMM rows of 4 doubles); the dispatch reslices the tail to Go. These tests
+// drive the kernels directly with block-aligned frame counts so a misplaced
+// lane (wrong VPERMPD control or VBLENDPD mask) is caught against the literal
+// scalar oracle. chanVal makes every (channel, frame) value unique, so no
+// transpose bug can alias.
+
+// kernelFrameCounts returns block-aligned frame counts (multiples of 4, the
+// f64 YMM block) used to drive the N=3 and N=8 kernels directly.
+func kernelFrameCounts() []int { return []int{4, 8, 12, 64, 256, 1024} }
+
+func TestInterleave3AVX_MatchesOracle(t *testing.T) {
+	if !cpu.X86.AVX2 {
+		t.Skip("AVX2 not available on this CPU")
+	}
+	const nc = 3
+	for _, n := range kernelFrameCounts() {
+		srcs := make([][]float64, nc)
+		for c := range srcs {
+			srcs[c] = make([]float64, n)
+			for i := range srcs[c] {
+				srcs[c][i] = chanVal(c, i)
+			}
+		}
+		got := make([]float64, n*nc)
+		interleave3AVX(got, srcs[0], srcs[1], srcs[2], n)
+
+		want := make([]float64, n*nc)
+		interleaveNRef(want, srcs, n)
+		for i := range want {
+			if got[i] != want[i] {
+				t.Fatalf("n=%d: interleave3AVX[%d] = %v, want %v", n, i, got[i], want[i])
+			}
+		}
+	}
+}
+
+func TestDeinterleave3AVX_MatchesOracle(t *testing.T) {
+	if !cpu.X86.AVX2 {
+		t.Skip("AVX2 not available on this CPU")
+	}
+	const nc = 3
+	for _, n := range kernelFrameCounts() {
+		src := make([]float64, n*nc)
+		for i := range src {
+			src[i] = float64(i + 1)
+		}
+		dsts := make([][]float64, nc)
+		for c := range dsts {
+			dsts[c] = make([]float64, n)
+		}
+		deinterleave3AVX(dsts[0], dsts[1], dsts[2], src, n)
+
+		want := make([][]float64, nc)
+		for c := range want {
+			want[c] = make([]float64, n)
+		}
+		deinterleaveNRef(want, src, n)
+		for c := range dsts {
+			for i := range dsts[c] {
+				if dsts[c][i] != want[c][i] {
+					t.Fatalf("n=%d: deinterleave3AVX dst[%d][%d] = %v, want %v",
+						n, c, i, dsts[c][i], want[c][i])
+				}
+			}
+		}
+	}
+}

--- a/f64/interleave8_amd64_test.go
+++ b/f64/interleave8_amd64_test.go
@@ -1,0 +1,74 @@
+//go:build amd64
+
+package f64
+
+import (
+	"testing"
+
+	"github.com/tphakala/simd/cpu"
+)
+
+// The N=8 AMD64 kernels transpose 4 f64 frames per block as two stacked 4x4
+// transposes (streams 0-3 fill each output frame's low YMM, streams 4-7 the
+// high YMM). These tests drive the kernels directly with block-aligned frame
+// counts so a misplaced lane (wrong VUNPCKxPD or VPERM2F128 selector, or a
+// swapped store offset) is caught against the literal scalar oracle. chanVal
+// makes every (channel, frame) value unique, so no transpose bug can alias.
+
+func TestInterleave8AVX_MatchesOracle(t *testing.T) {
+	if !cpu.X86.AVX {
+		t.Skip("AVX not available on this CPU")
+	}
+	const nc = 8
+	for _, n := range kernelFrameCounts() {
+		srcs := make([][]float64, nc)
+		for c := range srcs {
+			srcs[c] = make([]float64, n)
+			for i := range srcs[c] {
+				srcs[c][i] = chanVal(c, i)
+			}
+		}
+		got := make([]float64, n*nc)
+		interleave8AVX(got, srcs, n)
+
+		want := make([]float64, n*nc)
+		interleaveNRef(want, srcs, n)
+		for i := range want {
+			if got[i] != want[i] {
+				t.Fatalf("n=%d: interleave8AVX[%d] = %v, want %v", n, i, got[i], want[i])
+			}
+		}
+	}
+}
+
+func TestDeinterleave8AVX_MatchesOracle(t *testing.T) {
+	if !cpu.X86.AVX {
+		t.Skip("AVX not available on this CPU")
+	}
+	const nc = 8
+	for _, n := range kernelFrameCounts() {
+		src := make([]float64, n*nc)
+		for i := range src {
+			src[i] = float64(i + 1)
+		}
+		dsts := make([][]float64, nc)
+		for c := range dsts {
+			dsts[c] = make([]float64, n)
+		}
+		deinterleave8AVX(dsts, src, n)
+
+		want := make([][]float64, nc)
+		for c := range want {
+			want[c] = make([]float64, n)
+		}
+		deinterleaveNRef(want, src, n)
+		for c := range dsts {
+			for i := range dsts[c] {
+				if dsts[c][i] != want[c][i] {
+					t.Fatalf("n=%d: deinterleave8AVX dst[%d][%d] = %v, want %v",
+						n, c, i, dsts[c][i], want[c][i])
+				}
+			}
+		}
+	}
+}


### PR DESCRIPTION
## What

Adds AMD64 AVX `InterleaveN`/`DeinterleaveN` kernels for the `f64` stream counts that still fell back to the generic Go path: **N=3** and **N=8**. This brings `f64` up to the N=3/N=8 coverage `f32` already has (added in #77 / earlier) and that the README coverage table already advertised for `f64`.

Before this, `f64` only had dedicated AVX paths for N=2 and N=4; N=3/N=6/N=8 all used the scalar Go loop.

## How

- **N=3 (AVX2):** 3 streams do not map onto a clean register transpose, so each 4-frame block (3 YMM output rows of 4 doubles) is assembled from per-stream immediate `VPERMPD` gathers merged with `VBLENDPD`. This is the f64 analogue of the f32 `VPERMPS`/`VPBLENDD` N=3 kernel.
- **N=8 (AVX):** each output frame spans two YMM rows (a YMM holds 4 doubles), so the kernel runs two stacked 4x4 transposes per 4-frame block (streams 0-3 fill each frame's low YMM, streams 4-7 the high YMM), reusing the proven `interleave4AVX` `VUNPCKxPD`/`VPERM2F128` algorithm. Uses `R12` as the slice-header base like the f32 N=8 kernel; `R14`/`R15` untouched.

## Tests

- New direct-kernel oracle tests (`interleave3_amd64_test.go`, `interleave8_amd64_test.go`) drive the kernels at block-aligned sizes with unique per-(channel, frame) values so any misplaced lane fails.
- Existing `InterleaveN`/`DeinterleaveN` parity, round-trip, and alloc-free tests already exercise N=3/N=8 at ragged sizes (n = 0..1000) through the dispatch + Go tail.
- `go vet ./...` (asmdecl) clean, `golangci-lint run ./...` clean.
- Cross-compiled and ran the full `f64` suite on arm64 (Raspberry Pi 5); passes. These cells keep the unchanged Go fallback on arm64, so behavior there is unaffected.

## Benchmarks (i7-1260P, n=1024 frames, all zero-alloc)

| op | before (Go) | after | speedup |
|----|------------:|------:|--------:|
| InterleaveN N=3 | 720 ns | 522 ns | 1.4x |
| DeinterleaveN N=3 | 883 ns | 512 ns | 1.7x |
| InterleaveN N=8 | 7540 ns | 1580 ns | 4.7x |
| DeinterleaveN N=8 | 3148 ns | 1830 ns | 1.7x |

## Scope / remaining work

The N=6 cells (f32 and f64) intentionally stay on the generic Go path. They need gather/blend with no clean register transpose (dozens of permute/blend ops and index vectors per output), serve no documented hot path, and are weak on the profiling-gate from the issue. Left as a profiling-justified follow-up.

Advances #60.