### PR TITLE
f32/f64: AMD64 AVX2 interleave/deinterleave kernels for N=6 (#60)

### DIFF
--- a/README.md
+++ b/README.md
@@ -159,11 +159,11 @@ runs roughly 2.8x (interleave) and 3.2x (deinterleave) over the generic loop on 
 The 6-stream AVX2 path (the 8k -> 48k upsample) zips stream pairs into three
 double-wide pair streams, then reuses the f64 N=3 interleave on those pairs, so it
 needs no index tables; it runs roughly 2x (interleave and deinterleave) on AVX2.
-`f64` mirrors the same N=3, N=6, and N=8 AVX coverage, processing 4 frames per block (a
-YMM holds 4 doubles): N=3 uses immediate `VPERMPD` gathers merged with `VBLENDPD`, N=6
-zips pairs at 128-bit-lane granularity with `VPERM2F128` (roughly 4x interleave, 1.5x
-deinterleave), and N=8 runs two stacked 4x4 transposes (streams 0-3 fill each frame's
-low YMM, streams 4-7 the high YMM).
+`f64` adds N=3 and N=6 (AVX2) plus N=8 (AVX), processing 4 frames per block (a YMM holds
+4 doubles): N=3 uses immediate `VPERMPD` gathers merged with `VBLENDPD`, N=6 zips pairs
+at 128-bit-lane granularity with `VPERM2F128` (roughly 4x interleave, 1.5x deinterleave),
+and N=8 runs two stacked 4x4 transposes (streams 0-3 fill each frame's low YMM, streams
+4-7 the high YMM).
 
 **Row-major batch dot products** (for flat vector stores):
 

--- a/README.md
+++ b/README.md
@@ -127,8 +127,8 @@ fmt.Println(cpu.HasFP16())     // true/false (ARM64 half-precision SIMD)
 |                 | `AccumulateAdd(dst, src, off)`      | Overlap-add: dst[off:] += src | 8x / 4x / 2x                        |
 | **Audio**       | `Interleave2(dst, a, b)`            | Pack stereo: [L,R,L,R,...]    | 4x / 2x                             |
 |                 | `Deinterleave2(a, b, src)`          | Unpack stereo to channels     | 4x / 2x                             |
-|                 | `InterleaveN(dst, srcs)`            | Pack N planar streams (any N; N-stream Interleave2) | N=2,4,8 AVX, N=3 AVX2 / N=2,3,4 NEON; else Go |
-|                 | `DeinterleaveN(dsts, src)`          | Unpack N interleaved streams (any N) | N=2,4,8 AVX, N=3 AVX2 / N=2,3,4 NEON; else Go |
+|                 | `InterleaveN(dst, srcs)`            | Pack N planar streams (any N; N-stream Interleave2) | N=2,4,8 AVX, N=3,6 AVX2 / N=2,3,4 NEON; else Go |
+|                 | `DeinterleaveN(dsts, src)`          | Unpack N interleaved streams (any N) | N=2,4,8 AVX, N=3,6 AVX2 / N=2,3,4 NEON; else Go |
 |                 | `CubicInterpDot(hist,a,b,c,d,x)`    | Fused cubic interp dot product| 4x / 2x                             |
 |                 | `Int32ToFloat32Scale(dst,src,s)`    | PCM int32 to normalized float | 8x / 4x                             |
 |                 | `Int16ToFloat32Scale(dst,src,s)`    | PCM int16 to normalized float | 8x (AVX2) / 4x (NEON)               |
@@ -156,10 +156,14 @@ streams do not map onto a clean register transpose) on top of the shared N=2/4 (
 and N=2/3/4 (NEON) kernels; all other stream counts use the allocation-free generic
 path. The N=3 case is the 16k -> 48k upsample hot path: the AVX2 gather/blend kernel
 runs roughly 2.8x (interleave) and 3.2x (deinterleave) over the generic loop on AVX2.
-`f64` mirrors the same N=3 and N=8 AVX coverage, processing 4 frames per block (a YMM
-holds 4 doubles): N=3 uses immediate `VPERMPD` gathers merged with `VBLENDPD`, and N=8
-runs two stacked 4x4 transposes (streams 0-3 fill each frame's low YMM, streams 4-7 the
-high YMM).
+The 6-stream AVX2 path (the 8k -> 48k upsample) zips stream pairs into three
+double-wide pair streams, then reuses the f64 N=3 interleave on those pairs, so it
+needs no index tables; it runs roughly 2x (interleave and deinterleave) on AVX2.
+`f64` mirrors the same N=3, N=6, and N=8 AVX coverage, processing 4 frames per block (a
+YMM holds 4 doubles): N=3 uses immediate `VPERMPD` gathers merged with `VBLENDPD`, N=6
+zips pairs at 128-bit-lane granularity with `VPERM2F128` (roughly 4x interleave, 1.5x
+deinterleave), and N=8 runs two stacked 4x4 transposes (streams 0-3 fill each frame's
+low YMM, streams 4-7 the high YMM).
 
 **Row-major batch dot products** (for flat vector stores):
 

--- a/f32/f32_amd64.go
+++ b/f32/f32_amd64.go
@@ -482,9 +482,11 @@ func deinterleave2_32(a, b, src []float32) {
 const (
 	interleave3Streams   = 3
 	interleave4Streams   = 4
+	interleave6Streams   = 6
 	interleave8Streams   = 8
 	interleave3BlockMask = interleave8Streams - 1 // N=3 gathers 8 frames per block
 	interleave4BlockMask = interleave4Streams - 1
+	interleave6BlockMask = interleave8Streams - 1 // N=6 zips pairs, 8 frames per block
 	interleave8BlockMask = interleave8Streams - 1
 )
 
@@ -504,6 +506,14 @@ func interleaveN32(dst []float32, srcs [][]float32, n int) {
 		if cpu.X86.AVX && n >= interleave4Streams {
 			blk := n &^ interleave4BlockMask
 			interleave4AVX(dst, srcs[0], srcs[1], srcs[2], srcs[3], blk)
+			interleaveNTailGo(dst, srcs, blk, n)
+			return
+		}
+		interleaveNGo(dst, srcs, n)
+	case interleave6Streams:
+		if cpu.X86.AVX2 && n >= interleave8Streams {
+			blk := n &^ interleave6BlockMask
+			interleave6AVX(dst, srcs[0], srcs[1], srcs[2], srcs[3], srcs[4], srcs[5], blk)
 			interleaveNTailGo(dst, srcs, blk, n)
 			return
 		}
@@ -564,6 +574,14 @@ func deinterleaveN32(dsts [][]float32, src []float32, n int) {
 		if cpu.X86.AVX && n >= interleave4Streams {
 			blk := n &^ interleave4BlockMask
 			deinterleave4AVX(dsts[0], dsts[1], dsts[2], dsts[3], src, blk)
+			deinterleaveNTailGo(dsts, src, blk, n)
+			return
+		}
+		deinterleaveNGo(dsts, src, n)
+	case interleave6Streams:
+		if cpu.X86.AVX2 && n >= interleave8Streams {
+			blk := n &^ interleave6BlockMask
+			deinterleave6AVX(dsts[0], dsts[1], dsts[2], dsts[3], dsts[4], dsts[5], src, blk)
 			deinterleaveNTailGo(dsts, src, blk, n)
 			return
 		}
@@ -784,6 +802,12 @@ func interleave4AVX(dst, s0, s1, s2, s3 []float32, n int)
 
 //go:noescape
 func deinterleave4AVX(d0, d1, d2, d3, src []float32, n int)
+
+//go:noescape
+func interleave6AVX(dst, s0, s1, s2, s3, s4, s5 []float32, n int)
+
+//go:noescape
+func deinterleave6AVX(d0, d1, d2, d3, d4, d5, src []float32, n int)
 
 //go:noescape
 func interleave8AVX(dst []float32, srcs [][]float32, n int)

--- a/f32/f32_amd64.s
+++ b/f32/f32_amd64.s
@@ -2658,6 +2658,194 @@ deinterleave8_avx_done:
     VZEROUPPER
     RET
 
+// func interleave6AVX(dst, s0, s1, s2, s3, s4, s5 []float32, n int)
+// Interleaves 6 planar streams (dst[i*6+c] = s_c[i]) into 48 contiguous floats
+// per 8 frames. N=6 has no clean register transpose, so the kernel zips each
+// stream pair (s0,s1)(s2,s3)(s4,s5) into a float64-pair stream via VUNPCKLPS/
+// VUNPCKHPS + VPERM2F128, then runs the f64 N=3 interleave (immediate VPERMPD/
+// VBLENDPD on those pairs) twice: once for frames 0-3, once for frames 4-7. n is
+// a multiple of 8 (the caller handles the tail). Requires AVX2.
+//
+// After the zip, PA=[a0,b0,a1,b1,...] holds pair k = (s0[k],s1[k]) as one f64
+// lane; PB/PC hold (s2,s3)/(s4,s5). Interleaving the three pair-streams with the
+// f64 N=3 rows O0=[A0,B0,C0,A1] O1=[B1,C1,A2,B2] O2=[C2,A3,B3,C3] lays the six
+// streams down frame-by-frame.
+TEXT ·interleave6AVX(SB), NOSPLIT, $0-176
+    MOVQ dst_base+0(FP), DI
+    MOVQ s0_base+24(FP), AX
+    MOVQ s1_base+48(FP), BX
+    MOVQ s2_base+72(FP), CX
+    MOVQ s3_base+96(FP), DX
+    MOVQ s4_base+120(FP), R8
+    MOVQ s5_base+144(FP), R9
+    MOVQ n+168(FP), SI
+    SHRQ $3, SI                  // SI = n/8 blocks
+    TESTQ SI, SI
+    JZ interleave6_avx_done
+
+interleave6_avx_loop:
+    VMOVUPS (AX), Y0             // s0[i:i+8]
+    VMOVUPS (BX), Y1             // s1
+    VMOVUPS (CX), Y2             // s2
+    VMOVUPS (DX), Y3             // s3
+    VMOVUPS (R8), Y4             // s4
+    VMOVUPS (R9), Y5             // s5
+    VUNPCKLPS Y1, Y0, Y6         // zip (s0,s1): [a0,b0,a1,b1|a4,b4,a5,b5]
+    VUNPCKHPS Y1, Y0, Y7         // [a2,b2,a3,b3|a6,b6,a7,b7]
+    VPERM2F128 $0x20, Y7, Y6, Y8 // PA_lo=[a0,b0,a1,b1,a2,b2,a3,b3]
+    VPERM2F128 $0x31, Y7, Y6, Y9 // PA_hi=[a4,b4,a5,b5,a6,b6,a7,b7]
+    VUNPCKLPS Y3, Y2, Y6         // zip (s2,s3)
+    VUNPCKHPS Y3, Y2, Y7
+    VPERM2F128 $0x20, Y7, Y6, Y10 // PB_lo
+    VPERM2F128 $0x31, Y7, Y6, Y11 // PB_hi
+    VUNPCKLPS Y5, Y4, Y6         // zip (s4,s5)
+    VUNPCKHPS Y5, Y4, Y7
+    VPERM2F128 $0x20, Y7, Y6, Y12 // PC_lo
+    VPERM2F128 $0x31, Y7, Y6, Y13 // PC_hi
+    // interleave3 of pairs (frames 0-3): a=PA_lo b=PB_lo c=PC_lo
+    VPERMPD $0x40, Y8, Y0        // [a0,a0,a0,a1]
+    VPERMPD $0x00, Y10, Y1       // [b0,b0,b0,b0]
+    VPERMPD $0x00, Y12, Y2       // [c0,c0,c0,c0]
+    VBLENDPD $0x2, Y1, Y0, Y0    // lane1 <- b0
+    VBLENDPD $0x4, Y2, Y0, Y0    // lane2 <- c0
+    VMOVUPD Y0, (DI)             // O0=[a0,b0,c0,a1]
+    VPERMPD $0x81, Y10, Y1       // [b1,b0,b0,b2]
+    VPERMPD $0x04, Y12, Y2       // [c0,c1,c0,c0]
+    VPERMPD $0x20, Y8, Y0        // [a0,a0,a2,a0]
+    VBLENDPD $0x2, Y2, Y1, Y1    // lane1 <- c1
+    VBLENDPD $0x4, Y0, Y1, Y1    // lane2 <- a2
+    VMOVUPD Y1, 32(DI)           // O1=[b1,c1,a2,b2]
+    VPERMPD $0xC2, Y12, Y2       // [c2,c0,c0,c3]
+    VPERMPD $0x0C, Y8, Y0        // [a0,a3,a0,a0]
+    VPERMPD $0x30, Y10, Y1       // [b0,b0,b3,b0]
+    VBLENDPD $0x2, Y0, Y2, Y2    // lane1 <- a3
+    VBLENDPD $0x4, Y1, Y2, Y2    // lane2 <- b3
+    VMOVUPD Y2, 64(DI)           // O2=[c2,a3,b3,c3]
+    // interleave3 of pairs (frames 4-7): a=PA_hi b=PB_hi c=PC_hi
+    VPERMPD $0x40, Y9, Y0
+    VPERMPD $0x00, Y11, Y1
+    VPERMPD $0x00, Y13, Y2
+    VBLENDPD $0x2, Y1, Y0, Y0
+    VBLENDPD $0x4, Y2, Y0, Y0
+    VMOVUPD Y0, 96(DI)
+    VPERMPD $0x81, Y11, Y1
+    VPERMPD $0x04, Y13, Y2
+    VPERMPD $0x20, Y9, Y0
+    VBLENDPD $0x2, Y2, Y1, Y1
+    VBLENDPD $0x4, Y0, Y1, Y1
+    VMOVUPD Y1, 128(DI)
+    VPERMPD $0xC2, Y13, Y2
+    VPERMPD $0x0C, Y9, Y0
+    VPERMPD $0x30, Y11, Y1
+    VBLENDPD $0x2, Y0, Y2, Y2
+    VBLENDPD $0x4, Y1, Y2, Y2
+    VMOVUPD Y2, 160(DI)
+    ADDQ $32, AX
+    ADDQ $32, BX
+    ADDQ $32, CX
+    ADDQ $32, DX
+    ADDQ $32, R8
+    ADDQ $32, R9
+    ADDQ $192, DI
+    DECQ SI
+    JNZ interleave6_avx_loop
+
+interleave6_avx_done:
+    VZEROUPPER
+    RET
+
+// func deinterleave6AVX(d0, d1, d2, d3, d4, d5, src []float32, n int)
+// Splits a 6-stream interleaved buffer (d_c[i] = src[i*6+c]) into planar streams,
+// 8 frames per iteration. The inverse of interleave6AVX: reinterpreting src as a
+// 3-stream interleaved float64-pair buffer, the f64 N=3 deinterleave recovers the
+// three pair-streams PA/PB/PC, then VSHUFPS/VPERMPD unzip each pair back into its
+// two float32 planar streams. n is a multiple of 8 (the caller handles the tail).
+// Requires AVX2.
+TEXT ·deinterleave6AVX(SB), NOSPLIT, $0-176
+    MOVQ d0_base+0(FP), AX
+    MOVQ d1_base+24(FP), BX
+    MOVQ d2_base+48(FP), CX
+    MOVQ d3_base+72(FP), DX
+    MOVQ d4_base+96(FP), R8
+    MOVQ d5_base+120(FP), R9
+    MOVQ src_base+144(FP), SI
+    MOVQ n+168(FP), DI
+    SHRQ $3, DI                  // DI = n/8 blocks
+    TESTQ DI, DI
+    JZ deinterleave6_avx_done
+
+deinterleave6_avx_loop:
+    VMOVUPD (SI), Y0             // S0=[A0,B0,C0,A1] (frames 0-3, pair-interleaved)
+    VMOVUPD 32(SI), Y1           // S1=[B1,C1,A2,B2]
+    VMOVUPD 64(SI), Y2           // S2=[C2,A3,B3,C3]
+    VMOVUPD 96(SI), Y3           // S3..S5 = frames 4-7
+    VMOVUPD 128(SI), Y4
+    VMOVUPD 160(SI), Y5
+    // f64 N=3 deinterleave (frames 0-3) -> PA_lo,PB_lo,PC_lo
+    VPERMPD $0x0C, Y0, Y8        // A base [a0,a1,a0,a0]
+    VPERMPD $0x20, Y1, Y6        // [.,.,a2,.]
+    VPERMPD $0x40, Y2, Y7        // [.,.,.,a3]
+    VBLENDPD $0x4, Y6, Y8, Y8    // lane2 <- a2
+    VBLENDPD $0x8, Y7, Y8, Y8    // lane3 <- a3; PA_lo=[a0,a1,a2,a3]
+    VPERMPD $0x01, Y0, Y10       // B base [b0,a0,a0,a0]
+    VPERMPD $0x30, Y1, Y6        // [b1,b1,b2,.]
+    VPERMPD $0x80, Y2, Y7        // [.,.,.,b3]
+    VBLENDPD $0x6, Y6, Y10, Y10  // lanes1,2 <- b1,b2
+    VBLENDPD $0x8, Y7, Y10, Y10  // lane3 <- b3; PB_lo=[b0,b1,b2,b3]
+    VPERMPD $0x02, Y0, Y12       // C base [c0,.,.,.]
+    VPERMPD $0x04, Y1, Y6        // [.,c1,.,.]
+    VPERMPD $0xC0, Y2, Y7        // [c2,.,c2,c3]
+    VBLENDPD $0x2, Y6, Y12, Y12  // lane1 <- c1
+    VBLENDPD $0xC, Y7, Y12, Y12  // lanes2,3 <- c2,c3; PC_lo=[c0,c1,c2,c3]
+    // f64 N=3 deinterleave (frames 4-7) -> PA_hi,PB_hi,PC_hi
+    VPERMPD $0x0C, Y3, Y9
+    VPERMPD $0x20, Y4, Y6
+    VPERMPD $0x40, Y5, Y7
+    VBLENDPD $0x4, Y6, Y9, Y9
+    VBLENDPD $0x8, Y7, Y9, Y9
+    VPERMPD $0x01, Y3, Y11
+    VPERMPD $0x30, Y4, Y6
+    VPERMPD $0x80, Y5, Y7
+    VBLENDPD $0x6, Y6, Y11, Y11
+    VBLENDPD $0x8, Y7, Y11, Y11
+    VPERMPD $0x02, Y3, Y13
+    VPERMPD $0x04, Y4, Y6
+    VPERMPD $0xC0, Y5, Y7
+    VBLENDPD $0x2, Y6, Y13, Y13
+    VBLENDPD $0xC, Y7, Y13, Y13
+    // unzip pair-streams back to planar float32 (a even lanes, b odd lanes)
+    VSHUFPS $0x88, Y9, Y8, Y0    // [a0,a1,a4,a5,a2,a3,a6,a7]
+    VSHUFPS $0xDD, Y9, Y8, Y1    // [b0,b1,b4,b5,b2,b3,b6,b7]
+    VPERMPD $0xD8, Y0, Y0        // s0=[a0..a7]
+    VPERMPD $0xD8, Y1, Y1        // s1=[b0..b7]
+    VMOVUPS Y0, (AX)
+    VMOVUPS Y1, (BX)
+    VSHUFPS $0x88, Y11, Y10, Y2
+    VSHUFPS $0xDD, Y11, Y10, Y6
+    VPERMPD $0xD8, Y2, Y2        // s2
+    VPERMPD $0xD8, Y6, Y6        // s3
+    VMOVUPS Y2, (CX)
+    VMOVUPS Y6, (DX)
+    VSHUFPS $0x88, Y13, Y12, Y3
+    VSHUFPS $0xDD, Y13, Y12, Y7
+    VPERMPD $0xD8, Y3, Y3        // s4
+    VPERMPD $0xD8, Y7, Y7        // s5
+    VMOVUPS Y3, (R8)
+    VMOVUPS Y7, (R9)
+    ADDQ $192, SI
+    ADDQ $32, AX
+    ADDQ $32, BX
+    ADDQ $32, CX
+    ADDQ $32, DX
+    ADDQ $32, R8
+    ADDQ $32, R9
+    DECQ DI
+    JNZ deinterleave6_avx_loop
+
+deinterleave6_avx_done:
+    VZEROUPPER
+    RET
+
 // ============================================================================
 // SQRT, RECIPROCAL, ADDSCALED IMPLEMENTATIONS
 // ============================================================================

--- a/f32/interleave6_amd64_test.go
+++ b/f32/interleave6_amd64_test.go
@@ -1,0 +1,75 @@
+//go:build amd64
+
+package f32
+
+import (
+	"testing"
+
+	"github.com/tphakala/simd/cpu"
+)
+
+// The N=6 AMD64 kernels process whole 8-frame blocks; the dispatch reslices the
+// tail to Go. These tests drive the kernels directly with block-aligned frame
+// counts so a misplaced lane (wrong zip, VPERMPD gather, or VBLENDPD mask) is
+// caught against the literal scalar oracle. chanVal makes every (channel, frame)
+// value unique, so no transpose bug can alias.
+
+func interleave6KernelFrameCounts() []int { return []int{8, 16, 24, 64, 256, 1024} }
+
+func TestInterleave6AVX_MatchesOracle(t *testing.T) {
+	if !cpu.X86.AVX2 {
+		t.Skip("AVX2 not available on this CPU")
+	}
+	const nc = 6
+	for _, n := range interleave6KernelFrameCounts() {
+		srcs := make([][]float32, nc)
+		for c := range srcs {
+			srcs[c] = make([]float32, n)
+			for i := range srcs[c] {
+				srcs[c][i] = chanVal(c, i)
+			}
+		}
+		got := make([]float32, n*nc)
+		interleave6AVX(got, srcs[0], srcs[1], srcs[2], srcs[3], srcs[4], srcs[5], n)
+
+		want := make([]float32, n*nc)
+		interleaveNRef(want, srcs, n)
+		for i := range want {
+			if got[i] != want[i] {
+				t.Fatalf("n=%d: interleave6AVX[%d] = %v, want %v", n, i, got[i], want[i])
+			}
+		}
+	}
+}
+
+func TestDeinterleave6AVX_MatchesOracle(t *testing.T) {
+	if !cpu.X86.AVX2 {
+		t.Skip("AVX2 not available on this CPU")
+	}
+	const nc = 6
+	for _, n := range interleave6KernelFrameCounts() {
+		src := make([]float32, n*nc)
+		for i := range src {
+			src[i] = float32(i + 1)
+		}
+		dsts := make([][]float32, nc)
+		for c := range dsts {
+			dsts[c] = make([]float32, n)
+		}
+		deinterleave6AVX(dsts[0], dsts[1], dsts[2], dsts[3], dsts[4], dsts[5], src, n)
+
+		want := make([][]float32, nc)
+		for c := range want {
+			want[c] = make([]float32, n)
+		}
+		deinterleaveNRef(want, src, n)
+		for c := range dsts {
+			for i := range dsts[c] {
+				if dsts[c][i] != want[c][i] {
+					t.Fatalf("n=%d: deinterleave6AVX dst[%d][%d] = %v, want %v",
+						n, c, i, dsts[c][i], want[c][i])
+				}
+			}
+		}
+	}
+}

--- a/f64/f64_amd64.go
+++ b/f64/f64_amd64.go
@@ -435,6 +435,7 @@ func deinterleave2_64(a, b, src []float64) {
 const (
 	interleave3Streams = 3
 	interleave4Streams = 4
+	interleave6Streams = 6
 	interleave8Streams = 8
 
 	interleaveBlockFrames = 4
@@ -457,6 +458,14 @@ func interleaveN64(dst []float64, srcs [][]float64, n int) {
 		if cpu.X86.AVX && n >= interleaveBlockFrames {
 			blk := n &^ interleaveBlockMask
 			interleave4AVX(dst, srcs[0], srcs[1], srcs[2], srcs[3], blk)
+			interleaveNTailGo(dst, srcs, blk, n)
+			return
+		}
+		interleaveNGo(dst, srcs, n)
+	case interleave6Streams:
+		if cpu.X86.AVX2 && n >= interleaveBlockFrames {
+			blk := n &^ interleaveBlockMask
+			interleave6AVX(dst, srcs[0], srcs[1], srcs[2], srcs[3], srcs[4], srcs[5], blk)
 			interleaveNTailGo(dst, srcs, blk, n)
 			return
 		}
@@ -517,6 +526,14 @@ func deinterleaveN64(dsts [][]float64, src []float64, n int) {
 		if cpu.X86.AVX && n >= interleaveBlockFrames {
 			blk := n &^ interleaveBlockMask
 			deinterleave4AVX(dsts[0], dsts[1], dsts[2], dsts[3], src, blk)
+			deinterleaveNTailGo(dsts, src, blk, n)
+			return
+		}
+		deinterleaveNGo(dsts, src, n)
+	case interleave6Streams:
+		if cpu.X86.AVX2 && n >= interleaveBlockFrames {
+			blk := n &^ interleaveBlockMask
+			deinterleave6AVX(dsts[0], dsts[1], dsts[2], dsts[3], dsts[4], dsts[5], src, blk)
 			deinterleaveNTailGo(dsts, src, blk, n)
 			return
 		}
@@ -844,6 +861,12 @@ func interleave4AVX(dst, s0, s1, s2, s3 []float64, n int)
 
 //go:noescape
 func deinterleave4AVX(d0, d1, d2, d3, src []float64, n int)
+
+//go:noescape
+func interleave6AVX(dst, s0, s1, s2, s3, s4, s5 []float64, n int)
+
+//go:noescape
+func deinterleave6AVX(d0, d1, d2, d3, d4, d5, src []float64, n int)
 
 //go:noescape
 func interleave8AVX(dst []float64, srcs [][]float64, n int)

--- a/f64/f64_amd64.s
+++ b/f64/f64_amd64.s
@@ -3633,6 +3633,141 @@ deinterleave8_avx_done:
     VZEROUPPER
     RET
 
+// func interleave6AVX(dst, s0, s1, s2, s3, s4, s5 []float64, n int)
+// Interleaves 6 planar streams (dst[i*6+c] = s_c[i]) into 24 contiguous doubles
+// per 4 frames. N=6 has no clean register transpose, so the kernel zips each
+// stream pair (s0,s1)(s2,s3)(s4,s5) into a 128-bit pair stream via VUNPCKLPD/
+// VUNPCKHPD + VPERM2F128, then interleaves the three pair-streams at 128-bit lane
+// granularity with VPERM2F128 (the f64 analogue of the f32 N=6 zip, working on
+// 2-double pairs instead of 2-float pairs). n is a multiple of 4 (the caller
+// handles the tail). Requires AVX2.
+//
+// PA pairs hold (s0[k],s1[k]); PB (s2,s3); PC (s4,s5). The 6 output rows of 2
+// pairs each, [A0,B0] [C0,A1] [B1,C1] [A2,B2] [C2,A3] [B3,C3], lay the six
+// streams down frame-by-frame.
+TEXT ·interleave6AVX(SB), NOSPLIT, $0-176
+    MOVQ dst_base+0(FP), DI
+    MOVQ s0_base+24(FP), AX
+    MOVQ s1_base+48(FP), BX
+    MOVQ s2_base+72(FP), CX
+    MOVQ s3_base+96(FP), DX
+    MOVQ s4_base+120(FP), R8
+    MOVQ s5_base+144(FP), R9
+    MOVQ n+168(FP), SI
+    SHRQ $2, SI                  // SI = n/4 blocks
+    TESTQ SI, SI
+    JZ interleave6_avx_done
+
+interleave6_avx_loop:
+    VMOVUPD (AX), Y0             // s0[i:i+4]
+    VMOVUPD (BX), Y1             // s1
+    VMOVUPD (CX), Y2             // s2
+    VMOVUPD (DX), Y3             // s3
+    VMOVUPD (R8), Y4             // s4
+    VMOVUPD (R9), Y5             // s5
+    VUNPCKLPD Y1, Y0, Y6         // zip (s0,s1): [a0,b0|a2,b2]
+    VUNPCKHPD Y1, Y0, Y7         // [a1,b1|a3,b3]
+    VPERM2F128 $0x20, Y7, Y6, Y8 // PA_lo=[a0,b0,a1,b1] pairs (frames 0,1)
+    VPERM2F128 $0x31, Y7, Y6, Y9 // PA_hi=[a2,b2,a3,b3] pairs (frames 2,3)
+    VUNPCKLPD Y3, Y2, Y6         // zip (s2,s3)
+    VUNPCKHPD Y3, Y2, Y7
+    VPERM2F128 $0x20, Y7, Y6, Y10 // PB_lo
+    VPERM2F128 $0x31, Y7, Y6, Y11 // PB_hi
+    VUNPCKLPD Y5, Y4, Y6         // zip (s4,s5)
+    VUNPCKHPD Y5, Y4, Y7
+    VPERM2F128 $0x20, Y7, Y6, Y12 // PC_lo
+    VPERM2F128 $0x31, Y7, Y6, Y13 // PC_hi
+    VPERM2F128 $0x20, Y10, Y8, Y0  // [A0,B0]
+    VPERM2F128 $0x30, Y8, Y12, Y1  // [C0,A1]
+    VPERM2F128 $0x31, Y12, Y10, Y2 // [B1,C1]
+    VPERM2F128 $0x20, Y11, Y9, Y3  // [A2,B2]
+    VPERM2F128 $0x30, Y9, Y13, Y4  // [C2,A3]
+    VPERM2F128 $0x31, Y13, Y11, Y5 // [B3,C3]
+    VMOVUPD Y0, (DI)
+    VMOVUPD Y1, 32(DI)
+    VMOVUPD Y2, 64(DI)
+    VMOVUPD Y3, 96(DI)
+    VMOVUPD Y4, 128(DI)
+    VMOVUPD Y5, 160(DI)
+    ADDQ $32, AX
+    ADDQ $32, BX
+    ADDQ $32, CX
+    ADDQ $32, DX
+    ADDQ $32, R8
+    ADDQ $32, R9
+    ADDQ $192, DI
+    DECQ SI
+    JNZ interleave6_avx_loop
+
+interleave6_avx_done:
+    VZEROUPPER
+    RET
+
+// func deinterleave6AVX(d0, d1, d2, d3, d4, d5, src []float64, n int)
+// Splits a 6-stream interleaved buffer (d_c[i] = src[i*6+c]) into planar streams,
+// 4 frames per iteration. The inverse of interleave6AVX: VPERM2F128 regroups the
+// six input rows into the three 128-bit pair-streams PA/PB/PC, then VUNPCKLPD/
+// VUNPCKHPD + VPERMPD unzip each pair back into its two float64 planar streams. n
+// is a multiple of 4 (the caller handles the tail). Requires AVX2.
+TEXT ·deinterleave6AVX(SB), NOSPLIT, $0-176
+    MOVQ d0_base+0(FP), AX
+    MOVQ d1_base+24(FP), BX
+    MOVQ d2_base+48(FP), CX
+    MOVQ d3_base+72(FP), DX
+    MOVQ d4_base+96(FP), R8
+    MOVQ d5_base+120(FP), R9
+    MOVQ src_base+144(FP), SI
+    MOVQ n+168(FP), DI
+    SHRQ $2, DI                  // DI = n/4 blocks
+    TESTQ DI, DI
+    JZ deinterleave6_avx_done
+
+deinterleave6_avx_loop:
+    VMOVUPD (SI), Y0             // [A0,B0]
+    VMOVUPD 32(SI), Y1           // [C0,A1]
+    VMOVUPD 64(SI), Y2           // [B1,C1]
+    VMOVUPD 96(SI), Y3           // [A2,B2]
+    VMOVUPD 128(SI), Y4          // [C2,A3]
+    VMOVUPD 160(SI), Y5          // [B3,C3]
+    VPERM2F128 $0x30, Y1, Y0, Y8  // PA_lo=[A0,A1]
+    VPERM2F128 $0x30, Y4, Y3, Y9  // PA_hi=[A2,A3]
+    VPERM2F128 $0x21, Y2, Y0, Y10 // PB_lo=[B0,B1]
+    VPERM2F128 $0x21, Y5, Y3, Y11 // PB_hi=[B2,B3]
+    VPERM2F128 $0x30, Y2, Y1, Y12 // PC_lo=[C0,C1]
+    VPERM2F128 $0x30, Y5, Y4, Y13 // PC_hi=[C2,C3]
+    // unzip pair-streams back to planar float64 (a even lanes, b odd lanes)
+    VUNPCKLPD Y9, Y8, Y6         // [a0,a2,a1,a3]
+    VPERMPD $0xD8, Y6, Y0        // s0=[a0,a1,a2,a3]
+    VUNPCKHPD Y9, Y8, Y7         // [b0,b2,b1,b3]
+    VPERMPD $0xD8, Y7, Y1        // s1=[b0,b1,b2,b3]
+    VMOVUPD Y0, (AX)
+    VMOVUPD Y1, (BX)
+    VUNPCKLPD Y11, Y10, Y6
+    VPERMPD $0xD8, Y6, Y2        // s2
+    VUNPCKHPD Y11, Y10, Y7
+    VPERMPD $0xD8, Y7, Y6        // s3
+    VMOVUPD Y2, (CX)
+    VMOVUPD Y6, (DX)
+    VUNPCKLPD Y13, Y12, Y6
+    VPERMPD $0xD8, Y6, Y3        // s4
+    VUNPCKHPD Y13, Y12, Y7
+    VPERMPD $0xD8, Y7, Y7        // s5
+    VMOVUPD Y3, (R8)
+    VMOVUPD Y7, (R9)
+    ADDQ $192, SI
+    ADDQ $32, AX
+    ADDQ $32, BX
+    ADDQ $32, CX
+    ADDQ $32, DX
+    ADDQ $32, R8
+    ADDQ $32, R9
+    DECQ DI
+    JNZ deinterleave6_avx_loop
+
+deinterleave6_avx_done:
+    VZEROUPPER
+    RET
+
 // ============================================================================
 // ADDSCALED - dst[i] += alpha * s[i] (AXPY operation)
 // ============================================================================

--- a/f64/interleave6_amd64_test.go
+++ b/f64/interleave6_amd64_test.go
@@ -1,0 +1,73 @@
+//go:build amd64
+
+package f64
+
+import (
+	"testing"
+
+	"github.com/tphakala/simd/cpu"
+)
+
+// The N=6 AMD64 kernels process whole 4-frame blocks; the dispatch reslices the
+// tail to Go. These tests drive the kernels directly with block-aligned frame
+// counts so a misplaced lane (wrong pair zip, VPERM2F128 lane select, or
+// VPERMPD/VBLENDPD gather) is caught against the literal scalar oracle. chanVal
+// makes every (channel, frame) value unique, so no transpose bug can alias.
+
+func TestInterleave6AVX_MatchesOracle(t *testing.T) {
+	if !cpu.X86.AVX2 {
+		t.Skip("AVX2 not available on this CPU")
+	}
+	const nc = 6
+	for _, n := range kernelFrameCounts() {
+		srcs := make([][]float64, nc)
+		for c := range srcs {
+			srcs[c] = make([]float64, n)
+			for i := range srcs[c] {
+				srcs[c][i] = chanVal(c, i)
+			}
+		}
+		got := make([]float64, n*nc)
+		interleave6AVX(got, srcs[0], srcs[1], srcs[2], srcs[3], srcs[4], srcs[5], n)
+
+		want := make([]float64, n*nc)
+		interleaveNRef(want, srcs, n)
+		for i := range want {
+			if got[i] != want[i] {
+				t.Fatalf("n=%d: interleave6AVX[%d] = %v, want %v", n, i, got[i], want[i])
+			}
+		}
+	}
+}
+
+func TestDeinterleave6AVX_MatchesOracle(t *testing.T) {
+	if !cpu.X86.AVX2 {
+		t.Skip("AVX2 not available on this CPU")
+	}
+	const nc = 6
+	for _, n := range kernelFrameCounts() {
+		src := make([]float64, n*nc)
+		for i := range src {
+			src[i] = float64(i + 1)
+		}
+		dsts := make([][]float64, nc)
+		for c := range dsts {
+			dsts[c] = make([]float64, n)
+		}
+		deinterleave6AVX(dsts[0], dsts[1], dsts[2], dsts[3], dsts[4], dsts[5], src, n)
+
+		want := make([][]float64, nc)
+		for c := range want {
+			want[c] = make([]float64, n)
+		}
+		deinterleaveNRef(want, src, n)
+		for c := range dsts {
+			for i := range dsts[c] {
+				if dsts[c][i] != want[c][i] {
+					t.Fatalf("n=%d: deinterleave6AVX dst[%d][%d] = %v, want %v",
+						n, c, i, dsts[c][i], want[c][i])
+				}
+			}
+		}
+	}
+}


### PR DESCRIPTION
Completes the last remaining cells of #60: the `InterleaveN`/`DeinterleaveN` **N=6** stream count, which fell back to the generic Go path on AMD64. With #77 (f32 N=3) and #78 (f64 N=3/N=8) already merged, this finishes the documented AMD64 stream-count matrix. N=6 is the 8k -> 48k upsample.

## Approach

Six streams have no clean register transpose, so rather than the N=3-style per-stream `VPERMPS` index tables (which would need ~18 tables per direction since every output YMM touches all six streams), the kernels **zip stream pairs** `(s0,s1)(s2,s3)(s4,s5)` into three double-wide pair streams, then reuse the proven f64 N=3 interleave on those pairs. This needs **no index tables**, only immediate `VPERMPD`/`VPERM2F128`/`VBLENDPD`.

- **f32** (8 frames/block): `VUNPCKLPS`/`VUNPCKHPS` + `VPERM2F128` zip, then the f64 N=3 immediate gather twice (frames 0-3, 4-7); deinterleave reverses with `VSHUFPS`/`VPERMPD` unzip.
- **f64** (4 frames/block): pairs are 128-bit, so both the zip and the three-way merge are pure `VPERM2F128` lane moves.

## Benchmarks (i7-1260P, AVX2, n=1024, zero-alloc)

| Path | before (Go) | after | speedup |
|------|------|------|---------|
| f32 InterleaveN N=6 | 1780 ns | 880 ns | ~2.0x |
| f32 DeinterleaveN N=6 | 1485 ns | 720 ns | ~2.05x |
| f64 InterleaveN N=6 | 4300 ns | 1065 ns | ~4.0x |
| f64 DeinterleaveN N=6 | 2020 ns | 1310 ns | ~1.55x |

## Validation

- Parity against the scalar oracle at block-aligned and ragged sizes (kernel-level tests + the existing N=6 public-API matrix).
- Allocation-free (`testing.AllocsPerRun == 0`).
- `go vet` (asmdecl) and `golangci-lint` clean; no goroutine-register clobber (no R14/R15).
- ARM64 keeps the Go fallback; cross-checked on a Raspberry Pi 5 (parity + zero-alloc hold, full f32/f64 suites pass).

Closes #60.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added AVX2 SIMD acceleration for 6-stream interleaving/deinterleaving operations on compatible processors.

* **Documentation**
  * Updated coverage tables to reflect expanded AVX2 support for 6-stream operations.

* **Tests**
  * Added comprehensive test suite validating new AVX2 implementations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->