### PR TITLE
i32: new package with Interleave2/Deinterleave2 SIMD kernels

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 [![Go Report Card](https://goreportcard.com/badge/github.com/tphakala/simd)](https://goreportcard.com/report/github.com/tphakala/simd)
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
 
-A high-performance SIMD (Single Instruction, Multiple Data) library for Go providing vectorized operations on float64, float32, float16, complex128, and complex64 slices.
+A high-performance SIMD (Single Instruction, Multiple Data) library for Go providing vectorized operations on float64, float32, float16, int32, complex128, and complex64 slices.
 
 ## Features
 
@@ -368,6 +368,28 @@ c64.Mul(result, signalFFT, kernelFFT)     // Complex multiply
 c64.Abs(magnitude, signalFFT)              // Extract magnitude
 ```
 
+### `i32` - int32 Operations
+
+SIMD-accelerated integer-domain operations for codec and integer-DSP hot loops (for example a pure-Go FLAC encoder/decoder), where the per-sample work is integer arithmetic and channel (de)interleaving rather than floating-point math:
+
+| Category        | Function                  | Description                                  | SIMD Width                          |
+| --------------- | ------------------------- | -------------------------------------------- | ----------------------------------- |
+| **Interleave**  | `Interleave2(dst, a, b)`  | Pack two channels into interleaved stereo    | 8x (AVX) / 4x (NEON)                |
+|                 | `Deinterleave2(a, b, src)`| Split interleaved stereo into two channels   | 8x (AVX) / 4x (NEON)                |
+
+```go
+import "github.com/tphakala/simd/i32"
+
+left := make([]int32, n)
+right := make([]int32, n)
+stereo := make([]int32, n*2)
+
+i32.Interleave2(stereo, left, right)   // [l0, r0, l1, r1, ...]
+i32.Deinterleave2(left, right, stereo) // inverse: split back to channels
+```
+
+Interleaving is pure 32-bit-lane movement, so the kernels reuse the proven `f32` shuffle/permute encodings (AVX `VUNPCKLPS`/`VPERM2F128`, NEON `ZIP`/`UZP` on `.4S`); the bit pattern of each lane is irrelevant, so negative values and the type extremes round-trip exactly. This is the first slice of a broader integer surface (decorrelation, fixed-predictor differences, LPC FIR) tracked in the project issues.
+
 ## Performance
 
 ### AMD64 (Intel Core i7-1260P, AVX+FMA)
@@ -531,6 +553,15 @@ a Raspberry Pi 5):
 | DotProduct (f64) | 1000 | 513 ns | 1353 ns | **2.6x** |
 | Add (f32)        | 1000 | 389 ns | 2015 ns | **5.2x** |
 | Sum (f32)        | 1000 | 343 ns | 1327 ns | **3.9x** |
+
+### int32 (i32) - SIMD vs Pure Go (1000 elements)
+
+| Operation     | AMD64 (AVX)                  | ARM64 (NEON, Pi 5)            |
+| ------------- | ---------------------------- | ----------------------------- |
+| Interleave2   | 121 ns vs 487 ns (**4.0x**)  | 322 ns vs 1679 ns (**5.2x**)  |
+| Deinterleave2 | 228 ns vs 482 ns (**2.1x**)  | 322 ns vs 1682 ns (**5.2x**)  |
+
+All int32 kernels are zero-allocation and bit-exact against the pure-Go reference (verified across the sign and high bits with negative values and the type extremes).
 
 ### Performance Notes
 

--- a/doc.go
+++ b/doc.go
@@ -6,6 +6,7 @@
 //   - [github.com/tphakala/simd/cpu] - CPU feature detection
 //   - [github.com/tphakala/simd/f64] - float64 SIMD operations
 //   - [github.com/tphakala/simd/f32] - float32 SIMD operations
+//   - [github.com/tphakala/simd/i32] - int32 SIMD operations (integer DSP)
 //   - [github.com/tphakala/simd/c128] - complex128 SIMD operations
 //
 // # Architecture Support
@@ -51,6 +52,8 @@
 // Activation functions: Sigmoid, ReLU, Tanh, Exp, ClampScale
 //
 // Audio DSP: Interleave2, Deinterleave2, ConvolveValid, ConvolveValidMulti, ConvolveDecimate, AccumulateAdd, CumulativeSum, CubicInterpDot, Int32ToFloat32Scale, Int16ToFloat32Scale, Float32ToInt16Scale
+//
+// Integer DSP (i32): Interleave2, Deinterleave2
 //
 // Complex (c128): Add, Sub, Mul, MulConj, Conj, Abs, AbsSq, Scale
 //

--- a/i32/benchmark_test.go
+++ b/i32/benchmark_test.go
@@ -1,0 +1,63 @@
+package i32
+
+import "testing"
+
+// Benchmarks pair the dispatched (SIMD) path with the pure-Go baseline so the
+// speedup is visible directly. SetBytes counts the three buffers touched
+// (a + b read, dst written), 4 bytes per int32.
+
+const benchN = 1000
+
+func BenchmarkInterleave2_1000(b *testing.B) {
+	a := make([]int32, benchN)
+	c := make([]int32, benchN)
+	dst := make([]int32, benchN*2)
+	for i := range a {
+		a[i] = int32(i)
+		c[i] = int32(i + benchN)
+	}
+	b.SetBytes(benchN * 4 * 3)
+	for b.Loop() {
+		Interleave2(dst, a, c)
+	}
+}
+
+func BenchmarkInterleave2Go_1000(b *testing.B) {
+	a := make([]int32, benchN)
+	c := make([]int32, benchN)
+	dst := make([]int32, benchN*2)
+	for i := range a {
+		a[i] = int32(i)
+		c[i] = int32(i + benchN)
+	}
+	b.SetBytes(benchN * 4 * 3)
+	for b.Loop() {
+		interleave2Go(dst, a, c)
+	}
+}
+
+func BenchmarkDeinterleave2_1000(b *testing.B) {
+	src := make([]int32, benchN*2)
+	a := make([]int32, benchN)
+	c := make([]int32, benchN)
+	for i := range src {
+		src[i] = int32(i)
+	}
+	b.SetBytes(benchN * 4 * 3)
+	for b.Loop() {
+		Deinterleave2(a, c, src)
+	}
+}
+
+func BenchmarkDeinterleave2Go_1000(b *testing.B) {
+	src := make([]int32, benchN*2)
+	a := make([]int32, benchN)
+	c := make([]int32, benchN)
+	for i := range src {
+		src[i] = int32(i)
+	}
+	b.SetBytes(benchN * 4 * 3)
+	for b.Loop() {
+		deinterleave2Go(a, c, src)
+	}
+}

--- a/i32/example_test.go
+++ b/i32/example_test.go
@@ -1,0 +1,27 @@
+package i32_test
+
+import (
+	"fmt"
+
+	"github.com/tphakala/simd/i32"
+)
+
+func ExampleInterleave2() {
+	left := []int32{1, 2, 3}
+	right := []int32{-1, -2, -3}
+	stereo := make([]int32, len(left)*2)
+
+	i32.Interleave2(stereo, left, right)
+	fmt.Println(stereo)
+	// Output: [1 -1 2 -2 3 -3]
+}
+
+func ExampleDeinterleave2() {
+	stereo := []int32{1, -1, 2, -2, 3, -3}
+	left := make([]int32, len(stereo)/2)
+	right := make([]int32, len(stereo)/2)
+
+	i32.Deinterleave2(left, right, stereo)
+	fmt.Println(left, right)
+	// Output: [1 2 3] [-1 -2 -3]
+}

--- a/i32/i32.go
+++ b/i32/i32.go
@@ -1,0 +1,45 @@
+// Package i32 provides SIMD-accelerated operations on int32 slices.
+//
+// It is the integer counterpart to the f32/f64 packages and exists to serve
+// integer-domain DSP hot loops (for example a pure-Go FLAC codec) where the
+// per-sample work is integer arithmetic and channel (de)interleaving rather
+// than floating-point math.
+//
+// All functions automatically select the optimal implementation based on
+// runtime CPU feature detection and fall back to a pure-Go implementation on
+// unsupported architectures.
+//
+// Thread Safety: All functions are safe for concurrent use.
+// Memory: All functions are zero-allocation (no heap allocations).
+package i32
+
+// interleave2Channels is the number of channels handled by Interleave2 and
+// Deinterleave2 (stereo).
+const interleave2Channels = 2
+
+// Interleave2 interleaves two slices: dst[0]=a[0], dst[1]=b[0], dst[2]=a[1], dst[3]=b[1], ...
+// Processes min(len(a), len(b), len(dst)/2) pairs; any trailing capacity in dst
+// and ragged tails of a or b are left untouched.
+//
+// This is useful for packing separate channels into interleaved stereo PCM.
+func Interleave2(dst, a, b []int32) {
+	n := min(len(dst)/interleave2Channels, min(len(a), len(b)))
+	if n == 0 {
+		return
+	}
+	interleave2I32(dst[:n*interleave2Channels], a[:n], b[:n])
+}
+
+// Deinterleave2 deinterleaves a slice: a[0]=src[0], b[0]=src[1], a[1]=src[2], b[1]=src[3], ...
+// Processes min(len(a), len(b), len(src)/2) pairs; any trailing capacity in a or
+// b and a ragged tail of src are left untouched.
+//
+// This is the inverse of Interleave2, useful for splitting interleaved stereo
+// PCM into separate channels (for example raw 16-bit input widened to int32).
+func Deinterleave2(a, b, src []int32) {
+	n := min(len(src)/interleave2Channels, min(len(a), len(b)))
+	if n == 0 {
+		return
+	}
+	deinterleave2I32(a[:n], b[:n], src[:n*interleave2Channels])
+}

--- a/i32/i32_amd64.go
+++ b/i32/i32_amd64.go
@@ -1,0 +1,38 @@
+//go:build amd64
+
+package i32
+
+import "github.com/tphakala/simd/cpu"
+
+// Minimum number of int32 pairs before the AVX kernel beats the scalar loop.
+// AVX processes 8 pairs (8 int32 per 256-bit register) per iteration.
+const minAVXElements = 8
+
+// hasAVX gates the SIMD kernels. The interleave kernels use only AVX1
+// instructions (VUNPCKLPS / VPERM2F128 / VSHUFPS), so AVX without AVX2 is
+// sufficient. Unlike f32's interleave path this checks the CPU feature
+// explicitly rather than relying on length alone, so the package is safe on the
+// (now rare) AVX-less amd64 baseline.
+var hasAVX = cpu.X86.AVX
+
+func interleave2I32(dst, a, b []int32) {
+	if hasAVX && len(a) >= minAVXElements {
+		interleave2AVX(dst, a, b)
+		return
+	}
+	interleave2Go(dst, a, b)
+}
+
+func deinterleave2I32(a, b, src []int32) {
+	if hasAVX && len(a) >= minAVXElements {
+		deinterleave2AVX(a, b, src)
+		return
+	}
+	deinterleave2Go(a, b, src)
+}
+
+//go:noescape
+func interleave2AVX(dst, a, b []int32)
+
+//go:noescape
+func deinterleave2AVX(a, b, src []int32)

--- a/i32/i32_amd64.s
+++ b/i32/i32_amd64.s
@@ -1,0 +1,130 @@
+//go:build amd64
+
+#include "textflag.h"
+
+// int32 (de)interleave on AMD64.
+//
+// Interleaving is pure 32-bit-lane data movement: no arithmetic happens, so the
+// bit pattern of each lane is irrelevant and the AVX1 floating-point shuffles
+// (VUNPCKLPS / VUNPCKHPS / VPERM2F128 / VSHUFPS / VUNPCKLPD / VUNPCKHPD) move
+// int32 lanes exactly as they move float32 lanes. The chain is load -> shuffle
+// -> store with no integer ALU op in between, so there is no FP/integer
+// domain-crossing penalty. The scalar tails use the integer MOVL instead of the
+// f32 VMOVSS. These kernels are the int32 counterparts of interleave2AVX /
+// deinterleave2AVX in ../f32/f32_amd64.s and require only AVX (not AVX2).
+
+// func interleave2AVX(dst, a, b []int32)
+// Interleaves two slices: dst[0]=a[0], dst[1]=b[0], dst[2]=a[1], dst[3]=b[1], ...
+TEXT ·interleave2AVX(SB), NOSPLIT, $0-72
+    MOVQ dst_base+0(FP), DX    // dst pointer
+    MOVQ a_base+24(FP), SI     // a pointer
+    MOVQ a_len+32(FP), CX      // n = len(a)
+    MOVQ b_base+48(FP), DI     // b pointer
+
+    // Process 8 pairs at a time (16 output elements)
+    MOVQ CX, AX
+    SHRQ $3, AX                // AX = n / 8
+    JZ   interleave2_avx_remainder
+
+interleave2_avx_loop8:
+    VMOVUPS (SI), Y0           // Y0 = [a0..a7]
+    VMOVUPS (DI), Y1           // Y1 = [b0..b7]
+
+    // Unpack within 128-bit lanes
+    VUNPCKLPS Y1, Y0, Y2       // [a0,b0,a1,b1 | a4,b4,a5,b5]
+    VUNPCKHPS Y1, Y0, Y3       // [a2,b2,a3,b3 | a6,b6,a7,b7]
+
+    // Permute to get final order
+    VPERM2F128 $0x20, Y3, Y2, Y4  // [a0,b0,a1,b1,a2,b2,a3,b3]
+    VPERM2F128 $0x31, Y3, Y2, Y5  // [a4,b4,a5,b5,a6,b6,a7,b7]
+
+    VMOVUPS Y4, (DX)
+    VMOVUPS Y5, 32(DX)
+
+    ADDQ $32, SI               // a += 8 * 4
+    ADDQ $32, DI               // b += 8 * 4
+    ADDQ $64, DX               // dst += 16 * 4
+    DECQ AX
+    JNZ  interleave2_avx_loop8
+
+interleave2_avx_remainder:
+    ANDQ $7, CX
+    JZ   interleave2_avx_done
+
+interleave2_avx_scalar:
+    MOVL (SI), AX
+    MOVL (DI), BX
+    MOVL AX, (DX)
+    MOVL BX, 4(DX)
+    ADDQ $4, SI
+    ADDQ $4, DI
+    ADDQ $8, DX
+    DECQ CX
+    JNZ  interleave2_avx_scalar
+
+interleave2_avx_done:
+    VZEROUPPER
+    RET
+
+// func deinterleave2AVX(a, b, src []int32)
+// Deinterleaves: a[0]=src[0], b[0]=src[1], a[1]=src[2], b[1]=src[3], ...
+// 1. VSHUFPS $0x88 gathers the evens (a's), $0xDD gathers the odds (b's)
+// 2. VPERM2F128 + VUNPCKLPD/VUNPCKHPD reorder the 64-bit chunks across lanes
+TEXT ·deinterleave2AVX(SB), NOSPLIT, $0-72
+    MOVQ a_base+0(FP), DX      // a pointer
+    MOVQ a_len+8(FP), CX       // n = len(a)
+    MOVQ b_base+24(FP), R8     // b pointer
+    MOVQ src_base+48(FP), SI   // src pointer
+
+    // Process 8 pairs at a time
+    MOVQ CX, AX
+    SHRQ $3, AX
+    JZ   deinterleave2_avx_remainder
+
+deinterleave2_avx_loop8:
+    VMOVUPS (SI), Y0           // [a0,b0,a1,b1 | a2,b2,a3,b3]
+    VMOVUPS 32(SI), Y1         // [a4,b4,a5,b5 | a6,b6,a7,b7]
+
+    // Gather evens / odds within each 128-bit lane
+    VSHUFPS $0x88, Y1, Y0, Y2  // [a0,a1,a4,a5 | a2,a3,a6,a7]
+    VSHUFPS $0xDD, Y1, Y0, Y3  // [b0,b1,b4,b5 | b2,b3,b6,b7]
+
+    // Reorder Y2 -> [a0,a1,a2,a3 | a4,a5,a6,a7]
+    VPERM2F128 $0x01, Y2, Y2, Y4  // [a2,a3,a6,a7 | a0,a1,a4,a5]
+    VUNPCKLPD Y4, Y2, Y5
+    VUNPCKHPD Y4, Y2, Y6
+    VPERM2F128 $0x20, Y6, Y5, Y7  // a's in order
+
+    // Reorder Y3 -> [b0,b1,b2,b3 | b4,b5,b6,b7]
+    VPERM2F128 $0x01, Y3, Y3, Y4
+    VUNPCKLPD Y4, Y3, Y5
+    VUNPCKHPD Y4, Y3, Y6
+    VPERM2F128 $0x20, Y6, Y5, Y4  // b's in order
+
+    VMOVUPS Y7, (DX)           // store a
+    VMOVUPS Y4, (R8)           // store b
+
+    ADDQ $64, SI               // src += 16 * 4
+    ADDQ $32, DX               // a += 8 * 4
+    ADDQ $32, R8               // b += 8 * 4
+    DECQ AX
+    JNZ  deinterleave2_avx_loop8
+
+deinterleave2_avx_remainder:
+    ANDQ $7, CX
+    JZ   deinterleave2_avx_done
+
+deinterleave2_avx_scalar:
+    MOVL (SI), AX
+    MOVL 4(SI), BX
+    MOVL AX, (DX)
+    MOVL BX, (R8)
+    ADDQ $8, SI
+    ADDQ $4, DX
+    ADDQ $4, R8
+    DECQ CX
+    JNZ  deinterleave2_avx_scalar
+
+deinterleave2_avx_done:
+    VZEROUPPER
+    RET

--- a/i32/i32_amd64_test.go
+++ b/i32/i32_amd64_test.go
@@ -1,0 +1,82 @@
+//go:build amd64
+
+package i32
+
+import (
+	"math"
+	"testing"
+
+	"github.com/tphakala/simd/cpu"
+)
+
+func TestInterleave2AVX_ParityWithGo(t *testing.T) {
+	if !cpu.X86.AVX {
+		t.Skip("AVX not available")
+	}
+	for _, n := range paritySizes {
+		a := make([]int32, n)
+		b := make([]int32, n)
+		fillPattern(a, b)
+
+		gotAVX := make([]int32, n*2)
+		gotGo := make([]int32, n*2)
+		interleave2AVX(gotAVX, a, b)
+		interleave2Go(gotGo, a, b)
+
+		for i := range gotGo {
+			if gotAVX[i] != gotGo[i] {
+				t.Fatalf("n=%d: interleave2AVX[%d] = %d, want %d (Go)", n, i, gotAVX[i], gotGo[i])
+			}
+		}
+	}
+}
+
+func TestDeinterleave2AVX_ParityWithGo(t *testing.T) {
+	if !cpu.X86.AVX {
+		t.Skip("AVX not available")
+	}
+	for _, n := range paritySizes {
+		src := make([]int32, n*2)
+		for i := range src {
+			src[i] = int32(i) ^ math.MinInt32
+		}
+
+		aAVX := make([]int32, n)
+		bAVX := make([]int32, n)
+		aGo := make([]int32, n)
+		bGo := make([]int32, n)
+		deinterleave2AVX(aAVX, bAVX, src)
+		deinterleave2Go(aGo, bGo, src)
+
+		for i := range aGo {
+			if aAVX[i] != aGo[i] {
+				t.Fatalf("n=%d: deinterleave2AVX a[%d] = %d, want %d (Go)", n, i, aAVX[i], aGo[i])
+			}
+			if bAVX[i] != bGo[i] {
+				t.Fatalf("n=%d: deinterleave2AVX b[%d] = %d, want %d (Go)", n, i, bAVX[i], bGo[i])
+			}
+		}
+	}
+}
+
+// TestInterleave2AVX_NoOverwrite guards the scalar tail: the kernel must not
+// write past n*2 output elements even when n is not a multiple of the block.
+func TestInterleave2AVX_NoOverwrite(t *testing.T) {
+	if !cpu.X86.AVX {
+		t.Skip("AVX not available")
+	}
+	const n = 17
+	a := make([]int32, n)
+	b := make([]int32, n)
+	fillPattern(a, b)
+	dst := make([]int32, n*2+4)
+	for i := range dst {
+		dst[i] = math.MaxInt32 // sentinel
+	}
+	interleave2AVX(dst[:n*2], a, b)
+	for i := n * 2; i < len(dst); i++ {
+		if dst[i] != math.MaxInt32 {
+			t.Errorf("interleave2AVX wrote past end at dst[%d] = %d", i, dst[i])
+		}
+	}
+}

--- a/i32/i32_arm64.go
+++ b/i32/i32_arm64.go
@@ -1,0 +1,32 @@
+//go:build arm64
+
+package i32
+
+import "github.com/tphakala/simd/cpu"
+
+// NEON processes 4 int32 pairs (one .4S register) per iteration.
+const minNEONElements = 4
+
+var hasNEON = cpu.ARM64.NEON
+
+func interleave2I32(dst, a, b []int32) {
+	if hasNEON && len(a) >= minNEONElements {
+		interleave2NEON(dst, a, b)
+		return
+	}
+	interleave2Go(dst, a, b)
+}
+
+func deinterleave2I32(a, b, src []int32) {
+	if hasNEON && len(a) >= minNEONElements {
+		deinterleave2NEON(a, b, src)
+		return
+	}
+	deinterleave2Go(a, b, src)
+}
+
+//go:noescape
+func interleave2NEON(dst, a, b []int32)
+
+//go:noescape
+func deinterleave2NEON(a, b, src []int32)

--- a/i32/i32_arm64.s
+++ b/i32/i32_arm64.s
@@ -1,0 +1,93 @@
+//go:build arm64
+
+#include "textflag.h"
+
+// int32 (de)interleave on ARM64 (NEON / ASIMD).
+//
+// ZIP1/ZIP2/UZP1/UZP2 on .4S operands and the VLD1/VST1 .S4 loads/stores all
+// move 32-bit lanes by bit pattern, so these kernels are the int32 counterparts
+// of interleave2NEON / deinterleave2NEON in ../f32/f32_arm64.s with identical
+// vector bodies; only the scalar tails differ (integer MOVW instead of FMOVS).
+// The ZIP/UZP instructions are hand-encoded as WORD because the Go assembler
+// lacks mnemonics for them; the trailing comment is the decoded form and is
+// cross-checked by asmcheck_test.go.
+
+// func interleave2NEON(dst, a, b []int32)
+// Interleaves: dst[0]=a[0], dst[1]=b[0], dst[2]=a[1], dst[3]=b[1], ...
+TEXT ·interleave2NEON(SB), NOSPLIT, $0-72
+    MOVD dst_base+0(FP), R0    // dst pointer
+    MOVD a_base+24(FP), R1     // a pointer
+    MOVD a_len+32(FP), R3      // n = len(a)
+    MOVD b_base+48(FP), R2     // b pointer
+
+    // Process 4 pairs at a time
+    LSR $2, R3, R4             // R4 = n / 4
+    CBZ R4, interleave2_neon_remainder
+
+interleave2_neon_loop4:
+    VLD1.P 16(R1), [V0.S4]     // V0 = [a0, a1, a2, a3]
+    VLD1.P 16(R2), [V1.S4]     // V1 = [b0, b1, b2, b3]
+    WORD $0x4E813802           // ZIP1 V2.4S, V0.4S, V1.4S -> [a0, b0, a1, b1]
+    WORD $0x4E817803           // ZIP2 V3.4S, V0.4S, V1.4S -> [a2, b2, a3, b3]
+    VST1.P [V2.S4], 16(R0)     // Store [a0, b0, a1, b1]
+    VST1.P [V3.S4], 16(R0)     // Store [a2, b2, a3, b3]
+    SUB $1, R4
+    CBNZ R4, interleave2_neon_loop4
+
+interleave2_neon_remainder:
+    AND $3, R3
+    CBZ R3, interleave2_neon_done
+
+interleave2_neon_loop1:
+    MOVW (R1), R5
+    MOVW (R2), R6
+    MOVW R5, (R0)
+    MOVW R6, 4(R0)
+    ADD $4, R1
+    ADD $4, R2
+    ADD $8, R0
+    SUB $1, R3
+    CBNZ R3, interleave2_neon_loop1
+
+interleave2_neon_done:
+    RET
+
+// func deinterleave2NEON(a, b, src []int32)
+// Deinterleaves: a[0]=src[0], b[0]=src[1], a[1]=src[2], b[1]=src[3], ...
+TEXT ·deinterleave2NEON(SB), NOSPLIT, $0-72
+    MOVD a_base+0(FP), R0      // a pointer
+    MOVD a_len+8(FP), R3       // n = len(a)
+    MOVD b_base+24(FP), R1     // b pointer
+    MOVD src_base+48(FP), R2   // src pointer
+
+    // Process 4 pairs at a time
+    LSR $2, R3, R4             // R4 = n / 4
+    CBZ R4, deinterleave2_neon_remainder
+
+deinterleave2_neon_loop4:
+    VLD1.P 16(R2), [V0.S4]     // V0 = [a0, b0, a1, b1]
+    VLD1.P 16(R2), [V1.S4]     // V1 = [a2, b2, a3, b3]
+    WORD $0x4E811802           // UZP1 V2.4S, V0.4S, V1.4S -> [a0, a1, a2, a3]
+    WORD $0x4E815803           // UZP2 V3.4S, V0.4S, V1.4S -> [b0, b1, b2, b3]
+    VST1.P [V2.S4], 16(R0)     // Store a
+    VST1.P [V3.S4], 16(R1)     // Store b
+    SUB $1, R4
+    CBNZ R4, deinterleave2_neon_loop4
+
+deinterleave2_neon_remainder:
+    AND $3, R3
+    CBZ R3, deinterleave2_neon_done
+
+deinterleave2_neon_loop1:
+    MOVW (R2), R5
+    MOVW 4(R2), R6
+    MOVW R5, (R0)
+    MOVW R6, (R1)
+    ADD $8, R2
+    ADD $4, R0
+    ADD $4, R1
+    SUB $1, R3
+    CBNZ R3, deinterleave2_neon_loop1
+
+deinterleave2_neon_done:
+    RET

--- a/i32/i32_arm64_test.go
+++ b/i32/i32_arm64_test.go
@@ -1,0 +1,82 @@
+//go:build arm64
+
+package i32
+
+import (
+	"math"
+	"testing"
+
+	"github.com/tphakala/simd/cpu"
+)
+
+func TestInterleave2NEON_ParityWithGo(t *testing.T) {
+	if !cpu.ARM64.NEON {
+		t.Skip("NEON not available")
+	}
+	for _, n := range paritySizes {
+		a := make([]int32, n)
+		b := make([]int32, n)
+		fillPattern(a, b)
+
+		gotNEON := make([]int32, n*2)
+		gotGo := make([]int32, n*2)
+		interleave2NEON(gotNEON, a, b)
+		interleave2Go(gotGo, a, b)
+
+		for i := range gotGo {
+			if gotNEON[i] != gotGo[i] {
+				t.Fatalf("n=%d: interleave2NEON[%d] = %d, want %d (Go)", n, i, gotNEON[i], gotGo[i])
+			}
+		}
+	}
+}
+
+func TestDeinterleave2NEON_ParityWithGo(t *testing.T) {
+	if !cpu.ARM64.NEON {
+		t.Skip("NEON not available")
+	}
+	for _, n := range paritySizes {
+		src := make([]int32, n*2)
+		for i := range src {
+			src[i] = int32(i) ^ math.MinInt32
+		}
+
+		aNEON := make([]int32, n)
+		bNEON := make([]int32, n)
+		aGo := make([]int32, n)
+		bGo := make([]int32, n)
+		deinterleave2NEON(aNEON, bNEON, src)
+		deinterleave2Go(aGo, bGo, src)
+
+		for i := range aGo {
+			if aNEON[i] != aGo[i] {
+				t.Fatalf("n=%d: deinterleave2NEON a[%d] = %d, want %d (Go)", n, i, aNEON[i], aGo[i])
+			}
+			if bNEON[i] != bGo[i] {
+				t.Fatalf("n=%d: deinterleave2NEON b[%d] = %d, want %d (Go)", n, i, bNEON[i], bGo[i])
+			}
+		}
+	}
+}
+
+// TestInterleave2NEON_NoOverwrite guards the scalar tail: the kernel must not
+// write past n*2 output elements when n is not a multiple of the 4-lane block.
+func TestInterleave2NEON_NoOverwrite(t *testing.T) {
+	if !cpu.ARM64.NEON {
+		t.Skip("NEON not available")
+	}
+	const n = 17
+	a := make([]int32, n)
+	b := make([]int32, n)
+	fillPattern(a, b)
+	dst := make([]int32, n*2+4)
+	for i := range dst {
+		dst[i] = math.MaxInt32 // sentinel
+	}
+	interleave2NEON(dst[:n*2], a, b)
+	for i := n * 2; i < len(dst); i++ {
+		if dst[i] != math.MaxInt32 {
+			t.Errorf("interleave2NEON wrote past end at dst[%d] = %d", i, dst[i])
+		}
+	}
+}

--- a/i32/i32_go.go
+++ b/i32/i32_go.go
@@ -1,0 +1,21 @@
+package i32
+
+// Pure-Go reference implementations.
+//
+// These are the source of truth for behavior: every SIMD kernel is validated
+// for bit-exact parity against the functions here. They are compiled on every
+// architecture and used directly as the fallback when no SIMD path applies.
+
+func interleave2Go(dst, a, b []int32) {
+	for i := range a {
+		dst[i*2] = a[i]
+		dst[i*2+1] = b[i]
+	}
+}
+
+func deinterleave2Go(a, b, src []int32) {
+	for i := range a {
+		a[i] = src[i*2]
+		b[i] = src[i*2+1]
+	}
+}

--- a/i32/i32_other.go
+++ b/i32/i32_other.go
@@ -1,0 +1,6 @@
+//go:build !amd64 && !arm64
+
+package i32
+
+func interleave2I32(dst, a, b []int32)   { interleave2Go(dst, a, b) }
+func deinterleave2I32(a, b, src []int32) { deinterleave2Go(a, b, src) }

--- a/i32/i32_simd_test.go
+++ b/i32/i32_simd_test.go
@@ -1,0 +1,25 @@
+//go:build amd64 || arm64
+
+package i32
+
+import "math"
+
+// Shared helpers for the architecture-specific SIMD parity tests
+// (i32_amd64_test.go, i32_arm64_test.go).
+
+// fillPattern fills a/b with values that exercise sign and high bits so a
+// lane-corrupting kernel cannot hide behind small positive integers.
+func fillPattern(a, b []int32) {
+	for i := range a {
+		a[i] = int32(i*2) ^ math.MinInt32
+		b[i] = int32(-(i*2 + 1))
+	}
+	if len(a) > 0 {
+		a[0] = math.MinInt32
+		b[0] = math.MaxInt32
+	}
+}
+
+// paritySizes straddle both SIMD block sizes (4 lanes on NEON, 8 on AVX) so the
+// vector body and the scalar tail are both covered on either architecture.
+var paritySizes = []int{0, 1, 2, 3, 7, 8, 9, 15, 16, 17, 31, 32, 33, 100, 1000, 1023, 1024, 1025}

--- a/i32/i32_test.go
+++ b/i32/i32_test.go
@@ -1,0 +1,246 @@
+package i32
+
+import (
+	"math"
+	"testing"
+)
+
+// Tests for Interleave2 and Deinterleave2.
+//
+// Unlike the float packages, the interesting cases for int32 are negative
+// values and the extremes of the type, because the SIMD kernels move 32-bit
+// lanes by bit pattern. If a kernel ever corrupted the sign or high bits those
+// values would expose it.
+
+func TestInterleave2(t *testing.T) {
+	tests := []struct {
+		name string
+		a    []int32
+		b    []int32
+		want []int32
+	}{
+		{"single", []int32{1}, []int32{2}, []int32{1, 2}},
+		{"two", []int32{1, 3}, []int32{2, 4}, []int32{1, 2, 3, 4}},
+		{"four", []int32{1, 3, 5, 7}, []int32{2, 4, 6, 8}, []int32{1, 2, 3, 4, 5, 6, 7, 8}},
+		{"eight", []int32{1, 3, 5, 7, 9, 11, 13, 15}, []int32{2, 4, 6, 8, 10, 12, 14, 16},
+			[]int32{1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16}},
+		{"negatives_and_extremes",
+			[]int32{math.MinInt32, -1, 0, math.MaxInt32},
+			[]int32{math.MaxInt32, 1, -2, math.MinInt32},
+			[]int32{math.MinInt32, math.MaxInt32, -1, 1, 0, -2, math.MaxInt32, math.MinInt32}},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			dst := make([]int32, len(tt.a)*2)
+			Interleave2(dst, tt.a, tt.b)
+			for i, want := range tt.want {
+				if dst[i] != want {
+					t.Errorf("Interleave2()[%d] = %d, want %d", i, dst[i], want)
+				}
+			}
+		})
+	}
+}
+
+func TestInterleave2_Large(t *testing.T) {
+	// Sizes chosen to straddle the SIMD block size: exact multiples plus
+	// off-by-one tails on both the 4-lane (NEON) and 8-lane (AVX) widths.
+	sizes := []int{8, 16, 17, 100, 1024, 1025}
+	for _, n := range sizes {
+		a := make([]int32, n)
+		b := make([]int32, n)
+		for i := range a {
+			a[i] = int32(i*2) ^ math.MinInt32 // flip the sign bit to exercise high bits
+			b[i] = int32(i*2 + 1)
+		}
+
+		dst := make([]int32, n*2)
+		Interleave2(dst, a, b)
+
+		for i := range n {
+			if dst[i*2] != a[i] {
+				t.Errorf("size=%d: Interleave2()[%d] = %d, want %d", n, i*2, dst[i*2], a[i])
+			}
+			if dst[i*2+1] != b[i] {
+				t.Errorf("size=%d: Interleave2()[%d] = %d, want %d", n, i*2+1, dst[i*2+1], b[i])
+			}
+		}
+	}
+}
+
+func TestDeinterleave2(t *testing.T) {
+	tests := []struct {
+		name  string
+		src   []int32
+		wantA []int32
+		wantB []int32
+	}{
+		{"single", []int32{1, 2}, []int32{1}, []int32{2}},
+		{"two", []int32{1, 2, 3, 4}, []int32{1, 3}, []int32{2, 4}},
+		{"four", []int32{1, 2, 3, 4, 5, 6, 7, 8}, []int32{1, 3, 5, 7}, []int32{2, 4, 6, 8}},
+		{"extremes",
+			[]int32{math.MinInt32, math.MaxInt32, -1, 1, 0, -2, 42, -42},
+			[]int32{math.MinInt32, -1, 0, 42},
+			[]int32{math.MaxInt32, 1, -2, -42}},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			n := len(tt.src) / 2
+			a := make([]int32, n)
+			b := make([]int32, n)
+			Deinterleave2(a, b, tt.src)
+			for i, want := range tt.wantA {
+				if a[i] != want {
+					t.Errorf("Deinterleave2() a[%d] = %d, want %d", i, a[i], want)
+				}
+			}
+			for i, want := range tt.wantB {
+				if b[i] != want {
+					t.Errorf("Deinterleave2() b[%d] = %d, want %d", i, b[i], want)
+				}
+			}
+		})
+	}
+}
+
+func TestDeinterleave2_Large(t *testing.T) {
+	sizes := []int{8, 16, 17, 100, 1024, 1025}
+	for _, n := range sizes {
+		src := make([]int32, n*2)
+		for i := range src {
+			src[i] = int32(i) ^ math.MinInt32
+		}
+
+		a := make([]int32, n)
+		b := make([]int32, n)
+		Deinterleave2(a, b, src)
+
+		for i := range n {
+			wantA := int32(i*2) ^ math.MinInt32
+			wantB := int32(i*2+1) ^ math.MinInt32
+			if a[i] != wantA {
+				t.Errorf("size=%d: Deinterleave2() a[%d] = %d, want %d", n, i, a[i], wantA)
+			}
+			if b[i] != wantB {
+				t.Errorf("size=%d: Deinterleave2() b[%d] = %d, want %d", n, i, b[i], wantB)
+			}
+		}
+	}
+}
+
+func TestInterleaveDeinterleaveRoundTrip(t *testing.T) {
+	sizes := []int{1, 2, 3, 4, 5, 7, 8, 15, 16, 17, 100}
+	for _, n := range sizes {
+		a := make([]int32, n)
+		b := make([]int32, n)
+		for i := range a {
+			a[i] = int32(i) ^ math.MinInt32
+			b[i] = int32(-i - 1)
+		}
+
+		dst := make([]int32, n*2)
+		Interleave2(dst, a, b)
+
+		gotA := make([]int32, n)
+		gotB := make([]int32, n)
+		Deinterleave2(gotA, gotB, dst)
+
+		for i := range n {
+			if gotA[i] != a[i] {
+				t.Errorf("size=%d: round-trip a[%d] = %d, want %d", n, i, gotA[i], a[i])
+			}
+			if gotB[i] != b[i] {
+				t.Errorf("size=%d: round-trip b[%d] = %d, want %d", n, i, gotB[i], b[i])
+			}
+		}
+	}
+}
+
+// TestInterleave2_Clamp verifies the pair count is clamped to the shortest of
+// dst/2, a and b, leaving the rest of every buffer untouched.
+func TestInterleave2_Clamp(t *testing.T) {
+	a := []int32{1, 2, 3, 4}
+	b := []int32{10, 20}      // shorter than a
+	dst := make([]int32, 100) // longer than needed
+
+	Interleave2(dst, a, b)
+
+	want := []int32{1, 10, 2, 20}
+	for i, w := range want {
+		if dst[i] != w {
+			t.Errorf("dst[%d] = %d, want %d", i, dst[i], w)
+		}
+	}
+	for i := len(want); i < len(dst); i++ {
+		if dst[i] != 0 {
+			t.Errorf("dst[%d] = %d, want untouched 0", i, dst[i])
+		}
+	}
+}
+
+func TestDeinterleave2_Clamp(t *testing.T) {
+	src := []int32{1, 2, 3, 4, 5, 6}
+	a := make([]int32, 2) // only room for 2 pairs
+	b := make([]int32, 10)
+
+	Deinterleave2(a, b, src)
+
+	wantA := []int32{1, 3}
+	wantB := []int32{2, 4}
+	for i, w := range wantA {
+		if a[i] != w {
+			t.Errorf("a[%d] = %d, want %d", i, a[i], w)
+		}
+	}
+	for i, w := range wantB {
+		if b[i] != w {
+			t.Errorf("b[%d] = %d, want %d", i, b[i], w)
+		}
+	}
+	for i := len(wantB); i < len(b); i++ {
+		if b[i] != 0 {
+			t.Errorf("b[%d] = %d, want untouched 0", i, b[i])
+		}
+	}
+}
+
+func TestInterleave2_Empty(t *testing.T) {
+	// No panics and no writes on empty/zero-length inputs.
+	Interleave2(nil, nil, nil)
+	Interleave2([]int32{}, []int32{}, []int32{})
+	dst := []int32{99, 99}
+	Interleave2(dst, nil, []int32{1})
+	if dst[0] != 99 || dst[1] != 99 {
+		t.Errorf("empty a wrote into dst: %v", dst)
+	}
+}
+
+func TestDeinterleave2_Empty(t *testing.T) {
+	Deinterleave2(nil, nil, nil)
+	Deinterleave2([]int32{}, []int32{}, []int32{})
+	a := []int32{99}
+	Deinterleave2(a, []int32{1}, nil)
+	if a[0] != 99 {
+		t.Errorf("empty src wrote into a: %v", a)
+	}
+}
+
+func TestInterleave2_AllocFree(t *testing.T) {
+	a := make([]int32, 1024)
+	b := make([]int32, 1024)
+	dst := make([]int32, 2048)
+	if got := testing.AllocsPerRun(100, func() { Interleave2(dst, a, b) }); got != 0 {
+		t.Errorf("Interleave2 allocated %v times per run, want 0", got)
+	}
+}
+
+func TestDeinterleave2_AllocFree(t *testing.T) {
+	src := make([]int32, 2048)
+	a := make([]int32, 1024)
+	b := make([]int32, 1024)
+	if got := testing.AllocsPerRun(100, func() { Deinterleave2(a, b, src) }); got != 0 {
+		t.Errorf("Deinterleave2 allocated %v times per run, want 0", got)
+	}
+}


### PR DESCRIPTION
## Summary

Adds the `i32` package, the integer counterpart to `f32`/`f64`, to serve integer-domain DSP hot loops (for example a pure-Go FLAC codec) where the per-sample work is integer arithmetic and channel (de)interleaving rather than floating-point math. This is the first of a sequence of manageable PRs that build out the integer SIMD surface described in #79.

Surface added:

- `Interleave2(dst, a, b []int32)` - pack two channels into interleaved stereo
- `Deinterleave2(a, b, src []int32)` - split interleaved stereo back into two channels

Interleaving is pure 32-bit-lane data movement (no arithmetic), so the kernels reuse the proven `f32` shuffle/permute encodings:

- **AMD64 (AVX):** `VUNPCKLPS`/`VUNPCKHPS`/`VPERM2F128` for interleave, plus `VSHUFPS`/`VUNPCKLPD`/`VUNPCKHPD` for deinterleave. Dispatch gates on the AVX CPU feature (the kernels need only AVX1) with a pure-Go fallback, rather than relying on input length alone as the `f32` interleave path does, so the package is safe on the AVX-less amd64 baseline.
- **ARM64 (NEON):** `ZIP1`/`ZIP2`/`UZP1`/`UZP2` on `.4S`, gated on NEON.
- **Other:** pure-Go reference.

The bit pattern of each lane is irrelevant since no arithmetic happens, so negative values and the int32 extremes round-trip exactly. The scalar tails use integer `MOVL`/`MOVW` instead of the `f32` FP moves.

## Benchmarks (1000 elements, vs pure Go, zero-alloc)

| Op | amd64 AVX | arm64 NEON (Pi 5) |
|----|-----------|-------------------|
| Interleave2 | 121 ns, 4.0x | 322 ns, 5.2x |
| Deinterleave2 | 228 ns, 2.1x | 322 ns, 5.2x |

## Related Issues

Relates to #79 (PR1 of the integer SIMD roadmap).

## Test Plan

- [x] SIMD-vs-Go bit-exact parity across sizes straddling both block widths (4-lane NEON, 8-lane AVX)
- [x] Sign/high-bit and int32-extreme coverage (MinInt32/MaxInt32, negatives)
- [x] Interleave/Deinterleave round-trip, length clamping, empty-input no-op, scalar-tail no-overwrite guard
- [x] `testing.AllocsPerRun == 0` for both functions
- [x] asmcheck (WORD-encoding cross-check + reserved-register guard) picks up the new `.s` files automatically
- [x] Verified on amd64 (AVX) natively and arm64 (NEON) on a Raspberry Pi 5
- [x] `gofmt`, `go vet`, `golangci-lint` clean; full repo `go test ./...` green
