### PR TITLE
i16: new package with Interleave2/Deinterleave2 SIMD kernels (#79)

### DIFF
--- a/i16/benchmark_test.go
+++ b/i16/benchmark_test.go
@@ -3,8 +3,10 @@ package i16
 import "testing"
 
 // Benchmarks pair the dispatched (SIMD) path with the pure-Go baseline so the
-// speedup is visible directly. SetBytes counts the three buffers touched
-// (a + b read, dst written), 2 bytes per int16.
+// speedup is visible directly. SetBytes counts every byte moved: a and b (benchN
+// int16 each) plus the double-width interleaved buffer (dst for interleave, src
+// for deinterleave, 2*benchN int16), so 4*benchN int16 = 8*benchN bytes at 2
+// bytes per int16.
 
 const benchN = 1000
 
@@ -16,7 +18,7 @@ func BenchmarkInterleave2_1000(b *testing.B) {
 		a[i] = int16(i)
 		c[i] = int16(i + benchN)
 	}
-	b.SetBytes(benchN * 2 * 3)
+	b.SetBytes(benchN * 2 * 4)
 	for b.Loop() {
 		Interleave2(dst, a, c)
 	}
@@ -30,7 +32,7 @@ func BenchmarkInterleave2Go_1000(b *testing.B) {
 		a[i] = int16(i)
 		c[i] = int16(i + benchN)
 	}
-	b.SetBytes(benchN * 2 * 3)
+	b.SetBytes(benchN * 2 * 4)
 	for b.Loop() {
 		interleave2Go(dst, a, c)
 	}
@@ -43,7 +45,7 @@ func BenchmarkDeinterleave2_1000(b *testing.B) {
 	for i := range src {
 		src[i] = int16(i)
 	}
-	b.SetBytes(benchN * 2 * 3)
+	b.SetBytes(benchN * 2 * 4)
 	for b.Loop() {
 		Deinterleave2(a, c, src)
 	}
@@ -56,7 +58,7 @@ func BenchmarkDeinterleave2Go_1000(b *testing.B) {
 	for i := range src {
 		src[i] = int16(i)
 	}
-	b.SetBytes(benchN * 2 * 3)
+	b.SetBytes(benchN * 2 * 4)
 	for b.Loop() {
 		deinterleave2Go(a, c, src)
 	}

--- a/i16/benchmark_test.go
+++ b/i16/benchmark_test.go
@@ -1,0 +1,63 @@
+package i16
+
+import "testing"
+
+// Benchmarks pair the dispatched (SIMD) path with the pure-Go baseline so the
+// speedup is visible directly. SetBytes counts the three buffers touched
+// (a + b read, dst written), 2 bytes per int16.
+
+const benchN = 1000
+
+func BenchmarkInterleave2_1000(b *testing.B) {
+	a := make([]int16, benchN)
+	c := make([]int16, benchN)
+	dst := make([]int16, benchN*2)
+	for i := range a {
+		a[i] = int16(i)
+		c[i] = int16(i + benchN)
+	}
+	b.SetBytes(benchN * 2 * 3)
+	for b.Loop() {
+		Interleave2(dst, a, c)
+	}
+}
+
+func BenchmarkInterleave2Go_1000(b *testing.B) {
+	a := make([]int16, benchN)
+	c := make([]int16, benchN)
+	dst := make([]int16, benchN*2)
+	for i := range a {
+		a[i] = int16(i)
+		c[i] = int16(i + benchN)
+	}
+	b.SetBytes(benchN * 2 * 3)
+	for b.Loop() {
+		interleave2Go(dst, a, c)
+	}
+}
+
+func BenchmarkDeinterleave2_1000(b *testing.B) {
+	src := make([]int16, benchN*2)
+	a := make([]int16, benchN)
+	c := make([]int16, benchN)
+	for i := range src {
+		src[i] = int16(i)
+	}
+	b.SetBytes(benchN * 2 * 3)
+	for b.Loop() {
+		Deinterleave2(a, c, src)
+	}
+}
+
+func BenchmarkDeinterleave2Go_1000(b *testing.B) {
+	src := make([]int16, benchN*2)
+	a := make([]int16, benchN)
+	c := make([]int16, benchN)
+	for i := range src {
+		src[i] = int16(i)
+	}
+	b.SetBytes(benchN * 2 * 3)
+	for b.Loop() {
+		deinterleave2Go(a, c, src)
+	}
+}

--- a/i16/example_test.go
+++ b/i16/example_test.go
@@ -1,0 +1,27 @@
+package i16_test
+
+import (
+	"fmt"
+
+	"github.com/tphakala/simd/i16"
+)
+
+func ExampleInterleave2() {
+	left := []int16{1, 2, 3}
+	right := []int16{-1, -2, -3}
+	stereo := make([]int16, len(left)*2)
+
+	i16.Interleave2(stereo, left, right)
+	fmt.Println(stereo)
+	// Output: [1 -1 2 -2 3 -3]
+}
+
+func ExampleDeinterleave2() {
+	stereo := []int16{1, -1, 2, -2, 3, -3}
+	left := make([]int16, len(stereo)/2)
+	right := make([]int16, len(stereo)/2)
+
+	i16.Deinterleave2(left, right, stereo)
+	fmt.Println(left, right)
+	// Output: [1 2 3] [-1 -2 -3]
+}

--- a/i16/i16.go
+++ b/i16/i16.go
@@ -1,0 +1,50 @@
+// Package i16 provides SIMD-accelerated operations on int16 slices.
+//
+// It is the 16-bit integer counterpart to the i32 package and exists to serve
+// raw-PCM hot loops (for example a pure-Go FLAC codec) where the source samples
+// are 16-bit and the cheapest place to vectorize is the channel
+// (de)interleaving that happens before samples are widened to int32.
+//
+// Scope note: FLAC decorrelation widens samples (the side and mid channels can
+// exceed the source bit depth by one bit), so the arithmetic primitives live in
+// the i32 package. This package only carries the operations that provably help
+// at 16-bit width, namely splitting and packing raw 16-bit interleaved PCM.
+//
+// All functions automatically select the optimal implementation based on
+// runtime CPU feature detection and fall back to a pure-Go implementation on
+// unsupported architectures.
+//
+// Thread Safety: All functions are safe for concurrent use.
+// Memory: All functions are zero-allocation (no heap allocations).
+package i16
+
+// interleave2Channels is the number of channels handled by Interleave2 and
+// Deinterleave2 (stereo).
+const interleave2Channels = 2
+
+// Interleave2 interleaves two slices: dst[0]=a[0], dst[1]=b[0], dst[2]=a[1], dst[3]=b[1], ...
+// Processes min(len(a), len(b), len(dst)/2) pairs; any trailing capacity in dst
+// and ragged tails of a or b are left untouched.
+//
+// This is useful for packing separate channels into interleaved stereo PCM.
+func Interleave2(dst, a, b []int16) {
+	n := min(len(dst)/interleave2Channels, min(len(a), len(b)))
+	if n == 0 {
+		return
+	}
+	interleave2I16(dst[:n*interleave2Channels], a[:n], b[:n])
+}
+
+// Deinterleave2 deinterleaves a slice: a[0]=src[0], b[0]=src[1], a[1]=src[2], b[1]=src[3], ...
+// Processes min(len(a), len(b), len(src)/2) pairs; any trailing capacity in a or
+// b and a ragged tail of src are left untouched.
+//
+// This is the inverse of Interleave2, useful for splitting interleaved stereo
+// PCM into separate channels before widening to int32.
+func Deinterleave2(a, b, src []int16) {
+	n := min(len(src)/interleave2Channels, min(len(a), len(b)))
+	if n == 0 {
+		return
+	}
+	deinterleave2I16(a[:n], b[:n], src[:n*interleave2Channels])
+}

--- a/i16/i16_amd64.go
+++ b/i16/i16_amd64.go
@@ -1,0 +1,57 @@
+//go:build amd64
+
+package i16
+
+import "github.com/tphakala/simd/cpu"
+
+// Block sizes: the AVX2 kernels process 16 int16 pairs (one 256-bit register)
+// per iteration, the SSE2 kernels 8 (one 128-bit register). Below the chosen
+// block size each kernel falls through to a scalar tail, so these constants are
+// just the dispatch thresholds, not a correctness requirement of the kernels.
+const (
+	minAVX2Elements = 16
+	minSSE2Elements = 8
+)
+
+// Dispatch priority mirrors f32/f64: AVX2 > SSE2 > Go. The kernels gate on the
+// CPU feature explicitly (rather than relying on length alone) so the package is
+// correct on every amd64 baseline. SSE2 is part of the amd64 baseline, so the
+// pure-Go fallback below is effectively a non-amd64 safety net here.
+var (
+	hasAVX2 = cpu.X86.AVX2
+	hasSSE2 = cpu.X86.SSE2
+)
+
+func interleave2I16(dst, a, b []int16) {
+	switch {
+	case hasAVX2 && len(a) >= minAVX2Elements:
+		interleave2AVX2(dst, a, b)
+	case hasSSE2 && len(a) >= minSSE2Elements:
+		interleave2SSE2(dst, a, b)
+	default:
+		interleave2Go(dst, a, b)
+	}
+}
+
+func deinterleave2I16(a, b, src []int16) {
+	switch {
+	case hasAVX2 && len(a) >= minAVX2Elements:
+		deinterleave2AVX2(a, b, src)
+	case hasSSE2 && len(a) >= minSSE2Elements:
+		deinterleave2SSE2(a, b, src)
+	default:
+		deinterleave2Go(a, b, src)
+	}
+}
+
+//go:noescape
+func interleave2AVX2(dst, a, b []int16)
+
+//go:noescape
+func deinterleave2AVX2(a, b, src []int16)
+
+//go:noescape
+func interleave2SSE2(dst, a, b []int16)
+
+//go:noescape
+func deinterleave2SSE2(a, b, src []int16)

--- a/i16/i16_amd64.s
+++ b/i16/i16_amd64.s
@@ -1,0 +1,247 @@
+//go:build amd64
+
+#include "textflag.h"
+
+// int16 (de)interleave on AMD64.
+//
+// Interleaving is pure 16-bit-lane data movement: no arithmetic happens, so the
+// bit pattern of each lane is irrelevant. Unlike the 32-bit lane case there is
+// no float shuffle that moves 16-bit lanes, so these kernels use the integer
+// word shuffles directly: PUNPCKLWD/PUNPCKHWD pack the lanes (SSE2 and the AVX2
+// VEX form), the AVX2 deinterleave gathers even/odd words with a VPSHUFB byte
+// mask, and lane-crossing fixups use VPERM2I128/VPERMQ (AVX2) or
+// PUNPCKLQDQ/PUNPCKHQDQ (SSE2). The chain is load -> shuffle -> store with no
+// integer ALU op in between. The scalar tails use the 16-bit MOVW.
+//
+// Two ISA tiers are provided; i16_amd64.go dispatches AVX2 > SSE2 > Go.
+
+// deinterleave2Mask is the per-128-bit-lane VPSHUFB control that gathers the
+// even words (channel a) into the low 8 bytes and the odd words (channel b)
+// into the high 8 bytes of each lane. Each mask entry is a *source* byte offset
+// within the lane; read in output order (output byte i takes source byte
+// mask[i]):
+//   a (even words 0,2,4,6): source bytes 0,1, 4,5, 8,9, 12,13
+//   b (odd words 1,3,5,7):  source bytes 2,3, 6,7, 10,11, 14,15
+// The same 16 bytes are repeated for the upper lane (VPSHUFB is lane-local).
+DATA deinterleave2Mask<>+0(SB)/8, $0x0d0c090805040100
+DATA deinterleave2Mask<>+8(SB)/8, $0x0f0e0b0a07060302
+DATA deinterleave2Mask<>+16(SB)/8, $0x0d0c090805040100
+DATA deinterleave2Mask<>+24(SB)/8, $0x0f0e0b0a07060302
+GLOBL deinterleave2Mask<>(SB), RODATA|NOPTR, $32
+
+// func interleave2AVX2(dst, a, b []int16)
+// Interleaves two slices: dst[0]=a[0], dst[1]=b[0], dst[2]=a[1], dst[3]=b[1], ...
+TEXT ·interleave2AVX2(SB), NOSPLIT, $0-72
+    MOVQ dst_base+0(FP), DX    // dst pointer
+    MOVQ a_base+24(FP), SI     // a pointer
+    MOVQ a_len+32(FP), CX      // n = len(a)
+    MOVQ b_base+48(FP), DI     // b pointer
+
+    // Process 16 pairs at a time (32 output elements)
+    MOVQ CX, AX
+    SHRQ $4, AX                // AX = n / 16
+    JZ   interleave2_avx2_remainder
+
+interleave2_avx2_loop16:
+    VMOVDQU (SI), Y0           // Y0 = [a0..a15]
+    VMOVDQU (DI), Y1           // Y1 = [b0..b15]
+
+    // Interleave words within each 128-bit lane
+    VPUNPCKLWD Y1, Y0, Y2      // [a0,b0,a1,b1,a2,b2,a3,b3 | a8,b8,a9,b9,a10,b10,a11,b11]
+    VPUNPCKHWD Y1, Y0, Y3      // [a4,b4,a5,b5,a6,b6,a7,b7 | a12,b12,a13,b13,a14,b14,a15,b15]
+
+    // Reorder the 128-bit lanes into the final stereo stream
+    VPERM2I128 $0x20, Y3, Y2, Y4  // first 16 interleaved [a0,b0..a7,b7]
+    VPERM2I128 $0x31, Y3, Y2, Y5  // next 16 interleaved  [a8,b8..a15,b15]
+
+    VMOVDQU Y4, (DX)
+    VMOVDQU Y5, 32(DX)
+
+    ADDQ $32, SI               // a += 16 * 2
+    ADDQ $32, DI               // b += 16 * 2
+    ADDQ $64, DX               // dst += 32 * 2
+    DECQ AX
+    JNZ  interleave2_avx2_loop16
+
+interleave2_avx2_remainder:
+    ANDQ $15, CX
+    JZ   interleave2_avx2_done
+
+interleave2_avx2_scalar:
+    MOVW (SI), AX
+    MOVW (DI), BX
+    MOVW AX, (DX)
+    MOVW BX, 2(DX)
+    ADDQ $2, SI
+    ADDQ $2, DI
+    ADDQ $4, DX
+    DECQ CX
+    JNZ  interleave2_avx2_scalar
+
+interleave2_avx2_done:
+    VZEROUPPER
+    RET
+
+// func deinterleave2AVX2(a, b, src []int16)
+// Deinterleaves: a[0]=src[0], b[0]=src[1], a[1]=src[2], b[1]=src[3], ...
+// 1. VPSHUFB gathers evens (a's) to the low 8 bytes, odds (b's) to the high 8
+//    bytes of each 128-bit lane.
+// 2. VPUNPCKLQDQ/VPUNPCKHQDQ split the lanes into a-only and b-only registers.
+// 3. VPERMQ fixes the lane interleave the two 128-bit halves introduced.
+TEXT ·deinterleave2AVX2(SB), NOSPLIT, $0-72
+    MOVQ a_base+0(FP), DX      // a pointer
+    MOVQ a_len+8(FP), CX       // n = len(a)
+    MOVQ b_base+24(FP), R8     // b pointer
+    MOVQ src_base+48(FP), SI   // src pointer
+
+    VMOVDQU deinterleave2Mask<>(SB), Y7  // even/odd word gather mask
+
+    // Process 16 pairs at a time
+    MOVQ CX, AX
+    SHRQ $4, AX
+    JZ   deinterleave2_avx2_remainder
+
+deinterleave2_avx2_loop16:
+    VMOVDQU (SI), Y0           // [a0,b0..a7,b7]
+    VMOVDQU 32(SI), Y1         // [a8,b8..a15,b15]
+
+    VPSHUFB Y7, Y0, Y0         // [a0,a1,a2,a3,b0,b1,b2,b3 | a4,a5,a6,a7,b4,b5,b6,b7]
+    VPSHUFB Y7, Y1, Y1         // [a8..a11,b8..b11 | a12..a15,b12..b15]
+
+    VPUNPCKLQDQ Y1, Y0, Y2     // a's, lane-interleaved: [a0..a3,a8..a11 | a4..a7,a12..a15]
+    VPUNPCKHQDQ Y1, Y0, Y3     // b's, lane-interleaved: [b0..b3,b8..b11 | b4..b7,b12..b15]
+
+    VPERMQ $0xD8, Y2, Y2       // a in order [a0..a15]
+    VPERMQ $0xD8, Y3, Y3       // b in order [b0..b15]
+
+    VMOVDQU Y2, (DX)           // store a
+    VMOVDQU Y3, (R8)           // store b
+
+    ADDQ $64, SI               // src += 32 * 2
+    ADDQ $32, DX               // a += 16 * 2
+    ADDQ $32, R8               // b += 16 * 2
+    DECQ AX
+    JNZ  deinterleave2_avx2_loop16
+
+deinterleave2_avx2_remainder:
+    ANDQ $15, CX
+    JZ   deinterleave2_avx2_done
+
+deinterleave2_avx2_scalar:
+    MOVW (SI), AX
+    MOVW 2(SI), BX
+    MOVW AX, (DX)
+    MOVW BX, (R8)
+    ADDQ $4, SI
+    ADDQ $2, DX
+    ADDQ $2, R8
+    DECQ CX
+    JNZ  deinterleave2_avx2_scalar
+
+deinterleave2_avx2_done:
+    VZEROUPPER
+    RET
+
+// func interleave2SSE2(dst, a, b []int16)
+// 128-bit fallback: 8 pairs per iteration using PUNPCKLWD/PUNPCKHWD.
+TEXT ·interleave2SSE2(SB), NOSPLIT, $0-72
+    MOVQ dst_base+0(FP), DX    // dst pointer
+    MOVQ a_base+24(FP), SI     // a pointer
+    MOVQ a_len+32(FP), CX      // n = len(a)
+    MOVQ b_base+48(FP), DI     // b pointer
+
+    MOVQ CX, AX
+    SHRQ $3, AX                // AX = n / 8
+    JZ   interleave2_sse2_remainder
+
+interleave2_sse2_loop8:
+    MOVOU (SI), X0             // [a0..a7]
+    MOVOU (DI), X1             // [b0..b7]
+    MOVOU X0, X2               // copy a (PUNPCK overwrites its destination)
+    PUNPCKLWL X1, X0           // [a0,b0,a1,b1,a2,b2,a3,b3] (Intel PUNPCKLWD)
+    PUNPCKHWL X1, X2           // [a4,b4,a5,b5,a6,b6,a7,b7] (Intel PUNPCKHWD)
+    MOVOU X0, (DX)
+    MOVOU X2, 16(DX)
+
+    ADDQ $16, SI               // a += 8 * 2
+    ADDQ $16, DI               // b += 8 * 2
+    ADDQ $32, DX               // dst += 16 * 2
+    DECQ AX
+    JNZ  interleave2_sse2_loop8
+
+interleave2_sse2_remainder:
+    ANDQ $7, CX
+    JZ   interleave2_sse2_done
+
+interleave2_sse2_scalar:
+    MOVW (SI), AX
+    MOVW (DI), BX
+    MOVW AX, (DX)
+    MOVW BX, 2(DX)
+    ADDQ $2, SI
+    ADDQ $2, DI
+    ADDQ $4, DX
+    DECQ CX
+    JNZ  interleave2_sse2_scalar
+
+interleave2_sse2_done:
+    RET
+
+// func deinterleave2SSE2(a, b, src []int16)
+// 128-bit fallback: 8 pairs per iteration. PSHUFLW/PSHUFHW/PSHUFD move each
+// lane's evens to its low 64 bits and odds to its high 64 bits without a memory
+// mask; PUNPCKLQDQ/PUNPCKHQDQ then merge the two source halves into a and b.
+TEXT ·deinterleave2SSE2(SB), NOSPLIT, $0-72
+    MOVQ a_base+0(FP), DX      // a pointer
+    MOVQ a_len+8(FP), CX       // n = len(a)
+    MOVQ b_base+24(FP), R8     // b pointer
+    MOVQ src_base+48(FP), SI   // src pointer
+
+    MOVQ CX, AX
+    SHRQ $3, AX
+    JZ   deinterleave2_sse2_remainder
+
+deinterleave2_sse2_loop8:
+    MOVOU (SI), X0             // [a0,b0,a1,b1,a2,b2,a3,b3]
+    MOVOU 16(SI), X1           // [a4,b4,a5,b5,a6,b6,a7,b7]
+
+    // X0 -> [a0,a1,a2,a3 | b0,b1,b2,b3]
+    PSHUFLW $0xD8, X0, X0      // low words  -> [a0,a1,b0,b1]
+    PSHUFHW $0xD8, X0, X0      // high words -> [a2,a3,b2,b3]
+    PSHUFD  $0xD8, X0, X0      // dwords     -> [a0,a1,a2,a3,b0,b1,b2,b3]
+
+    // X1 -> [a4,a5,a6,a7 | b4,b5,b6,b7]
+    PSHUFLW $0xD8, X1, X1
+    PSHUFHW $0xD8, X1, X1
+    PSHUFD  $0xD8, X1, X1
+
+    MOVOU X0, X2
+    PUNPCKLQDQ X1, X2          // a = [a0..a3,a4..a7]
+    PUNPCKHQDQ X1, X0          // b = [b0..b3,b4..b7]
+
+    MOVOU X2, (DX)             // store a
+    MOVOU X0, (R8)             // store b
+
+    ADDQ $32, SI               // src += 16 * 2
+    ADDQ $16, DX               // a += 8 * 2
+    ADDQ $16, R8               // b += 8 * 2
+    DECQ AX
+    JNZ  deinterleave2_sse2_loop8
+
+deinterleave2_sse2_remainder:
+    ANDQ $7, CX
+    JZ   deinterleave2_sse2_done
+
+deinterleave2_sse2_scalar:
+    MOVW (SI), AX
+    MOVW 2(SI), BX
+    MOVW AX, (DX)
+    MOVW BX, (R8)
+    ADDQ $4, SI
+    ADDQ $2, DX
+    ADDQ $2, R8
+    DECQ CX
+    JNZ  deinterleave2_sse2_scalar
+
+deinterleave2_sse2_done:
+    RET

--- a/i16/i16_amd64_test.go
+++ b/i16/i16_amd64_test.go
@@ -1,0 +1,153 @@
+//go:build amd64
+
+package i16
+
+import (
+	"math"
+	"testing"
+
+	"github.com/tphakala/simd/cpu"
+)
+
+// interleaveKernel/deinterleaveKernel describe one SIMD tier so the parity and
+// no-overwrite checks run identically against AVX2 and SSE2.
+type interleaveKernel struct {
+	name      string
+	available bool
+	fn        func(dst, a, b []int16)
+}
+
+type deinterleaveKernel struct {
+	name      string
+	available bool
+	fn        func(a, b, src []int16)
+}
+
+func interleaveKernels() []interleaveKernel {
+	return []interleaveKernel{
+		{"AVX2", cpu.X86.AVX2, interleave2AVX2},
+		{"SSE2", cpu.X86.SSE2, interleave2SSE2},
+	}
+}
+
+func deinterleaveKernels() []deinterleaveKernel {
+	return []deinterleaveKernel{
+		{"AVX2", cpu.X86.AVX2, deinterleave2AVX2},
+		{"SSE2", cpu.X86.SSE2, deinterleave2SSE2},
+	}
+}
+
+func TestInterleave2_ParityWithGo(t *testing.T) {
+	for _, k := range interleaveKernels() {
+		t.Run(k.name, func(t *testing.T) {
+			if !k.available {
+				t.Skipf("%s not available", k.name)
+			}
+			for _, n := range paritySizes {
+				a := make([]int16, n)
+				b := make([]int16, n)
+				fillPattern(a, b)
+
+				gotSIMD := make([]int16, n*2)
+				gotGo := make([]int16, n*2)
+				k.fn(gotSIMD, a, b)
+				interleave2Go(gotGo, a, b)
+
+				for i := range gotGo {
+					if gotSIMD[i] != gotGo[i] {
+						t.Fatalf("n=%d: interleave2%s[%d] = %d, want %d (Go)", n, k.name, i, gotSIMD[i], gotGo[i])
+					}
+				}
+			}
+		})
+	}
+}
+
+func TestDeinterleave2_ParityWithGo(t *testing.T) {
+	for _, k := range deinterleaveKernels() {
+		t.Run(k.name, func(t *testing.T) {
+			if !k.available {
+				t.Skipf("%s not available", k.name)
+			}
+			for _, n := range paritySizes {
+				src := make([]int16, n*2)
+				for i := range src {
+					src[i] = int16(i) ^ math.MinInt16
+				}
+
+				aSIMD := make([]int16, n)
+				bSIMD := make([]int16, n)
+				aGo := make([]int16, n)
+				bGo := make([]int16, n)
+				k.fn(aSIMD, bSIMD, src)
+				deinterleave2Go(aGo, bGo, src)
+
+				for i := range aGo {
+					if aSIMD[i] != aGo[i] {
+						t.Fatalf("n=%d: deinterleave2%s a[%d] = %d, want %d (Go)", n, k.name, i, aSIMD[i], aGo[i])
+					}
+					if bSIMD[i] != bGo[i] {
+						t.Fatalf("n=%d: deinterleave2%s b[%d] = %d, want %d (Go)", n, k.name, i, bSIMD[i], bGo[i])
+					}
+				}
+			}
+		})
+	}
+}
+
+// TestInterleave2_NoOverwrite guards the scalar tail: the kernel must not write
+// past n*2 output elements even when n is not a multiple of the block.
+func TestInterleave2_NoOverwrite(t *testing.T) {
+	const n = 23 // one AVX2 block (16) + 7 tail; one SSE2 block (8) leaves a 7 tail too
+	for _, k := range interleaveKernels() {
+		t.Run(k.name, func(t *testing.T) {
+			if !k.available {
+				t.Skipf("%s not available", k.name)
+			}
+			a := make([]int16, n)
+			b := make([]int16, n)
+			fillPattern(a, b)
+			dst := make([]int16, n*2+8)
+			for i := range dst {
+				dst[i] = math.MaxInt16 // sentinel
+			}
+			k.fn(dst[:n*2], a, b)
+			for i := n * 2; i < len(dst); i++ {
+				if dst[i] != math.MaxInt16 {
+					t.Errorf("interleave2%s wrote past end at dst[%d] = %d", k.name, i, dst[i])
+				}
+			}
+		})
+	}
+}
+
+// TestDeinterleave2_NoOverwrite guards both output buffers' scalar tails.
+func TestDeinterleave2_NoOverwrite(t *testing.T) {
+	const n = 23
+	for _, k := range deinterleaveKernels() {
+		t.Run(k.name, func(t *testing.T) {
+			if !k.available {
+				t.Skipf("%s not available", k.name)
+			}
+			src := make([]int16, n*2)
+			for i := range src {
+				src[i] = int16(i) ^ math.MinInt16
+			}
+			a := make([]int16, n+8)
+			b := make([]int16, n+8)
+			for i := range a {
+				a[i] = math.MaxInt16
+				b[i] = math.MaxInt16
+			}
+			k.fn(a[:n], b[:n], src)
+			for i := n; i < len(a); i++ {
+				if a[i] != math.MaxInt16 {
+					t.Errorf("deinterleave2%s wrote past end of a at [%d] = %d", k.name, i, a[i])
+				}
+				if b[i] != math.MaxInt16 {
+					t.Errorf("deinterleave2%s wrote past end of b at [%d] = %d", k.name, i, b[i])
+				}
+			}
+		})
+	}
+}

--- a/i16/i16_arm64.go
+++ b/i16/i16_arm64.go
@@ -1,0 +1,32 @@
+//go:build arm64
+
+package i16
+
+import "github.com/tphakala/simd/cpu"
+
+// NEON processes 8 int16 pairs (one .8H register) per iteration.
+const minNEONElements = 8
+
+var hasNEON = cpu.ARM64.NEON
+
+func interleave2I16(dst, a, b []int16) {
+	if hasNEON && len(a) >= minNEONElements {
+		interleave2NEON(dst, a, b)
+		return
+	}
+	interleave2Go(dst, a, b)
+}
+
+func deinterleave2I16(a, b, src []int16) {
+	if hasNEON && len(a) >= minNEONElements {
+		deinterleave2NEON(a, b, src)
+		return
+	}
+	deinterleave2Go(a, b, src)
+}
+
+//go:noescape
+func interleave2NEON(dst, a, b []int16)
+
+//go:noescape
+func deinterleave2NEON(a, b, src []int16)

--- a/i16/i16_arm64.s
+++ b/i16/i16_arm64.s
@@ -7,7 +7,7 @@
 // ZIP1/ZIP2/UZP1/UZP2 on .8H operands and the VLD1/VST1 .H8 loads/stores all
 // move 16-bit lanes by bit pattern, so these kernels mirror the int32 .4S
 // kernels in ../i32/i32_arm64.s with the lane width halved (8 lanes per 128-bit
-// register instead of 4); only the scalar tails differ (16-bit MOVW). The
+// register instead of 4); only the scalar tails differ (16-bit MOVH). The
 // ZIP/UZP instructions are hand-encoded as WORD because the Go assembler lacks
 // mnemonics for them; the trailing comment is the decoded form and is
 // cross-checked by asmcheck_test.go.

--- a/i16/i16_arm64.s
+++ b/i16/i16_arm64.s
@@ -1,0 +1,93 @@
+//go:build arm64
+
+#include "textflag.h"
+
+// int16 (de)interleave on ARM64 (NEON / ASIMD).
+//
+// ZIP1/ZIP2/UZP1/UZP2 on .8H operands and the VLD1/VST1 .H8 loads/stores all
+// move 16-bit lanes by bit pattern, so these kernels mirror the int32 .4S
+// kernels in ../i32/i32_arm64.s with the lane width halved (8 lanes per 128-bit
+// register instead of 4); only the scalar tails differ (16-bit MOVW). The
+// ZIP/UZP instructions are hand-encoded as WORD because the Go assembler lacks
+// mnemonics for them; the trailing comment is the decoded form and is
+// cross-checked by asmcheck_test.go.
+
+// func interleave2NEON(dst, a, b []int16)
+// Interleaves: dst[0]=a[0], dst[1]=b[0], dst[2]=a[1], dst[3]=b[1], ...
+TEXT ·interleave2NEON(SB), NOSPLIT, $0-72
+    MOVD dst_base+0(FP), R0    // dst pointer
+    MOVD a_base+24(FP), R1     // a pointer
+    MOVD a_len+32(FP), R3      // n = len(a)
+    MOVD b_base+48(FP), R2     // b pointer
+
+    // Process 8 pairs at a time
+    LSR $3, R3, R4             // R4 = n / 8
+    CBZ R4, interleave2_neon_remainder
+
+interleave2_neon_loop8:
+    VLD1.P 16(R1), [V0.H8]     // V0 = [a0, a1, a2, a3, a4, a5, a6, a7]
+    VLD1.P 16(R2), [V1.H8]     // V1 = [b0, b1, b2, b3, b4, b5, b6, b7]
+    WORD $0x4E413802           // ZIP1 V2.8H, V0.8H, V1.8H -> [a0,b0,a1,b1,a2,b2,a3,b3]
+    WORD $0x4E417803           // ZIP2 V3.8H, V0.8H, V1.8H -> [a4,b4,a5,b5,a6,b6,a7,b7]
+    VST1.P [V2.H8], 16(R0)     // Store [a0,b0,a1,b1,a2,b2,a3,b3]
+    VST1.P [V3.H8], 16(R0)     // Store [a4,b4,a5,b5,a6,b6,a7,b7]
+    SUB $1, R4
+    CBNZ R4, interleave2_neon_loop8
+
+interleave2_neon_remainder:
+    AND $7, R3
+    CBZ R3, interleave2_neon_done
+
+interleave2_neon_loop1:
+    MOVH (R1), R5
+    MOVH (R2), R6
+    MOVH R5, (R0)
+    MOVH R6, 2(R0)
+    ADD $2, R1
+    ADD $2, R2
+    ADD $4, R0
+    SUB $1, R3
+    CBNZ R3, interleave2_neon_loop1
+
+interleave2_neon_done:
+    RET
+
+// func deinterleave2NEON(a, b, src []int16)
+// Deinterleaves: a[0]=src[0], b[0]=src[1], a[1]=src[2], b[1]=src[3], ...
+TEXT ·deinterleave2NEON(SB), NOSPLIT, $0-72
+    MOVD a_base+0(FP), R0      // a pointer
+    MOVD a_len+8(FP), R3       // n = len(a)
+    MOVD b_base+24(FP), R1     // b pointer
+    MOVD src_base+48(FP), R2   // src pointer
+
+    // Process 8 pairs at a time
+    LSR $3, R3, R4             // R4 = n / 8
+    CBZ R4, deinterleave2_neon_remainder
+
+deinterleave2_neon_loop8:
+    VLD1.P 16(R2), [V0.H8]     // V0 = [a0,b0,a1,b1,a2,b2,a3,b3]
+    VLD1.P 16(R2), [V1.H8]     // V1 = [a4,b4,a5,b5,a6,b6,a7,b7]
+    WORD $0x4E411802           // UZP1 V2.8H, V0.8H, V1.8H -> [a0,a1,a2,a3,a4,a5,a6,a7]
+    WORD $0x4E415803           // UZP2 V3.8H, V0.8H, V1.8H -> [b0,b1,b2,b3,b4,b5,b6,b7]
+    VST1.P [V2.H8], 16(R0)     // Store a
+    VST1.P [V3.H8], 16(R1)     // Store b
+    SUB $1, R4
+    CBNZ R4, deinterleave2_neon_loop8
+
+deinterleave2_neon_remainder:
+    AND $7, R3
+    CBZ R3, deinterleave2_neon_done
+
+deinterleave2_neon_loop1:
+    MOVH (R2), R5
+    MOVH 2(R2), R6
+    MOVH R5, (R0)
+    MOVH R6, (R1)
+    ADD $4, R2
+    ADD $2, R0
+    ADD $2, R1
+    SUB $1, R3
+    CBNZ R3, deinterleave2_neon_loop1
+
+deinterleave2_neon_done:
+    RET

--- a/i16/i16_arm64_test.go
+++ b/i16/i16_arm64_test.go
@@ -1,0 +1,109 @@
+//go:build arm64
+
+package i16
+
+import (
+	"math"
+	"testing"
+
+	"github.com/tphakala/simd/cpu"
+)
+
+func TestInterleave2NEON_ParityWithGo(t *testing.T) {
+	if !cpu.ARM64.NEON {
+		t.Skip("NEON not available")
+	}
+	for _, n := range paritySizes {
+		a := make([]int16, n)
+		b := make([]int16, n)
+		fillPattern(a, b)
+
+		gotNEON := make([]int16, n*2)
+		gotGo := make([]int16, n*2)
+		interleave2NEON(gotNEON, a, b)
+		interleave2Go(gotGo, a, b)
+
+		for i := range gotGo {
+			if gotNEON[i] != gotGo[i] {
+				t.Fatalf("n=%d: interleave2NEON[%d] = %d, want %d (Go)", n, i, gotNEON[i], gotGo[i])
+			}
+		}
+	}
+}
+
+func TestDeinterleave2NEON_ParityWithGo(t *testing.T) {
+	if !cpu.ARM64.NEON {
+		t.Skip("NEON not available")
+	}
+	for _, n := range paritySizes {
+		src := make([]int16, n*2)
+		for i := range src {
+			src[i] = int16(i) ^ math.MinInt16
+		}
+
+		aNEON := make([]int16, n)
+		bNEON := make([]int16, n)
+		aGo := make([]int16, n)
+		bGo := make([]int16, n)
+		deinterleave2NEON(aNEON, bNEON, src)
+		deinterleave2Go(aGo, bGo, src)
+
+		for i := range aGo {
+			if aNEON[i] != aGo[i] {
+				t.Fatalf("n=%d: deinterleave2NEON a[%d] = %d, want %d (Go)", n, i, aNEON[i], aGo[i])
+			}
+			if bNEON[i] != bGo[i] {
+				t.Fatalf("n=%d: deinterleave2NEON b[%d] = %d, want %d (Go)", n, i, bNEON[i], bGo[i])
+			}
+		}
+	}
+}
+
+// TestInterleave2NEON_NoOverwrite guards the scalar tail: the kernel must not
+// write past n*2 output elements when n is not a multiple of the 8-lane block.
+func TestInterleave2NEON_NoOverwrite(t *testing.T) {
+	if !cpu.ARM64.NEON {
+		t.Skip("NEON not available")
+	}
+	const n = 13
+	a := make([]int16, n)
+	b := make([]int16, n)
+	fillPattern(a, b)
+	dst := make([]int16, n*2+8)
+	for i := range dst {
+		dst[i] = math.MaxInt16 // sentinel
+	}
+	interleave2NEON(dst[:n*2], a, b)
+	for i := n * 2; i < len(dst); i++ {
+		if dst[i] != math.MaxInt16 {
+			t.Errorf("interleave2NEON wrote past end at dst[%d] = %d", i, dst[i])
+		}
+	}
+}
+
+// TestDeinterleave2NEON_NoOverwrite guards both output buffers' scalar tails.
+func TestDeinterleave2NEON_NoOverwrite(t *testing.T) {
+	if !cpu.ARM64.NEON {
+		t.Skip("NEON not available")
+	}
+	const n = 13
+	src := make([]int16, n*2)
+	for i := range src {
+		src[i] = int16(i) ^ math.MinInt16
+	}
+	a := make([]int16, n+8)
+	b := make([]int16, n+8)
+	for i := range a {
+		a[i] = math.MaxInt16
+		b[i] = math.MaxInt16
+	}
+	deinterleave2NEON(a[:n], b[:n], src)
+	for i := n; i < len(a); i++ {
+		if a[i] != math.MaxInt16 {
+			t.Errorf("deinterleave2NEON wrote past end of a at [%d] = %d", i, a[i])
+		}
+		if b[i] != math.MaxInt16 {
+			t.Errorf("deinterleave2NEON wrote past end of b at [%d] = %d", i, b[i])
+		}
+	}
+}

--- a/i16/i16_go.go
+++ b/i16/i16_go.go
@@ -1,0 +1,21 @@
+package i16
+
+// Pure-Go reference implementations.
+//
+// These are the source of truth for behavior: every SIMD kernel is validated
+// for bit-exact parity against the functions here. They are compiled on every
+// architecture and used directly as the fallback when no SIMD path applies.
+
+func interleave2Go(dst, a, b []int16) {
+	for i := range a {
+		dst[i*2] = a[i]
+		dst[i*2+1] = b[i]
+	}
+}
+
+func deinterleave2Go(a, b, src []int16) {
+	for i := range a {
+		a[i] = src[i*2]
+		b[i] = src[i*2+1]
+	}
+}

--- a/i16/i16_other.go
+++ b/i16/i16_other.go
@@ -1,0 +1,6 @@
+//go:build !amd64 && !arm64
+
+package i16
+
+func interleave2I16(dst, a, b []int16)   { interleave2Go(dst, a, b) }
+func deinterleave2I16(a, b, src []int16) { deinterleave2Go(a, b, src) }

--- a/i16/i16_simd_test.go
+++ b/i16/i16_simd_test.go
@@ -1,0 +1,25 @@
+//go:build amd64 || arm64
+
+package i16
+
+import "math"
+
+// Shared helpers for the architecture-specific SIMD parity tests
+// (i16_amd64_test.go, i16_arm64_test.go).
+
+// fillPattern fills a/b with values that exercise sign and high bits so a
+// lane-corrupting kernel cannot hide behind small positive integers.
+func fillPattern(a, b []int16) {
+	for i := range a {
+		a[i] = int16(i*2) ^ math.MinInt16
+		b[i] = int16(-(i*2 + 1))
+	}
+	if len(a) > 0 {
+		a[0] = math.MinInt16
+		b[0] = math.MaxInt16
+	}
+}
+
+// paritySizes straddle every SIMD block size in this package (8 lanes on NEON
+// and SSE2, 16 on AVX2) so each vector body and its scalar tail are covered.
+var paritySizes = []int{0, 1, 2, 3, 7, 8, 9, 15, 16, 17, 23, 31, 32, 33, 100, 1000, 1023, 1024, 1025}

--- a/i16/i16_test.go
+++ b/i16/i16_test.go
@@ -1,0 +1,304 @@
+package i16
+
+import (
+	"math"
+	"testing"
+)
+
+// Tests for Interleave2 and Deinterleave2.
+//
+// As with i32, the interesting cases for int16 are negative values and the
+// extremes of the type, because the SIMD kernels move 16-bit lanes by bit
+// pattern. If a kernel ever corrupted the sign or high bits those values would
+// expose it.
+
+func TestInterleave2(t *testing.T) {
+	tests := []struct {
+		name string
+		a    []int16
+		b    []int16
+		want []int16
+	}{
+		{"single", []int16{1}, []int16{2}, []int16{1, 2}},
+		{"two", []int16{1, 3}, []int16{2, 4}, []int16{1, 2, 3, 4}},
+		{"four", []int16{1, 3, 5, 7}, []int16{2, 4, 6, 8}, []int16{1, 2, 3, 4, 5, 6, 7, 8}},
+		{"eight", []int16{1, 3, 5, 7, 9, 11, 13, 15}, []int16{2, 4, 6, 8, 10, 12, 14, 16},
+			[]int16{1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16}},
+		{"negatives_and_extremes",
+			[]int16{math.MinInt16, -1, 0, math.MaxInt16},
+			[]int16{math.MaxInt16, 1, -2, math.MinInt16},
+			[]int16{math.MinInt16, math.MaxInt16, -1, 1, 0, -2, math.MaxInt16, math.MinInt16}},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			dst := make([]int16, len(tt.a)*2)
+			Interleave2(dst, tt.a, tt.b)
+			for i, want := range tt.want {
+				if dst[i] != want {
+					t.Errorf("Interleave2()[%d] = %d, want %d", i, dst[i], want)
+				}
+			}
+		})
+	}
+}
+
+func TestInterleave2_Large(t *testing.T) {
+	// Sizes chosen to straddle the SIMD block sizes: exact multiples plus
+	// off-by-one tails on the 8-lane (NEON/SSE2) and 16-lane (AVX2) widths, with
+	// 8..15 routing through SSE2 on an AVX2 host.
+	sizes := []int{8, 12, 15, 16, 17, 100, 1024, 1025}
+	for _, n := range sizes {
+		a := make([]int16, n)
+		b := make([]int16, n)
+		for i := range a {
+			a[i] = int16(i*2) ^ math.MinInt16 // flip the sign bit to exercise high bits
+			b[i] = int16(i*2 + 1)
+		}
+
+		dst := make([]int16, n*2)
+		Interleave2(dst, a, b)
+
+		for i := range n {
+			if dst[i*2] != a[i] {
+				t.Errorf("size=%d: Interleave2()[%d] = %d, want %d", n, i*2, dst[i*2], a[i])
+			}
+			if dst[i*2+1] != b[i] {
+				t.Errorf("size=%d: Interleave2()[%d] = %d, want %d", n, i*2+1, dst[i*2+1], b[i])
+			}
+		}
+	}
+}
+
+func TestDeinterleave2(t *testing.T) {
+	tests := []struct {
+		name  string
+		src   []int16
+		wantA []int16
+		wantB []int16
+	}{
+		{"single", []int16{1, 2}, []int16{1}, []int16{2}},
+		{"two", []int16{1, 2, 3, 4}, []int16{1, 3}, []int16{2, 4}},
+		{"four", []int16{1, 2, 3, 4, 5, 6, 7, 8}, []int16{1, 3, 5, 7}, []int16{2, 4, 6, 8}},
+		{"extremes",
+			[]int16{math.MinInt16, math.MaxInt16, -1, 1, 0, -2, 42, -42},
+			[]int16{math.MinInt16, -1, 0, 42},
+			[]int16{math.MaxInt16, 1, -2, -42}},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			n := len(tt.src) / 2
+			a := make([]int16, n)
+			b := make([]int16, n)
+			Deinterleave2(a, b, tt.src)
+			for i, want := range tt.wantA {
+				if a[i] != want {
+					t.Errorf("Deinterleave2() a[%d] = %d, want %d", i, a[i], want)
+				}
+			}
+			for i, want := range tt.wantB {
+				if b[i] != want {
+					t.Errorf("Deinterleave2() b[%d] = %d, want %d", i, b[i], want)
+				}
+			}
+		})
+	}
+}
+
+func TestDeinterleave2_Large(t *testing.T) {
+	sizes := []int{8, 12, 15, 16, 17, 100, 1024, 1025}
+	for _, n := range sizes {
+		src := make([]int16, n*2)
+		for i := range src {
+			src[i] = int16(i) ^ math.MinInt16
+		}
+
+		a := make([]int16, n)
+		b := make([]int16, n)
+		Deinterleave2(a, b, src)
+
+		for i := range n {
+			wantA := int16(i*2) ^ math.MinInt16
+			wantB := int16(i*2+1) ^ math.MinInt16
+			if a[i] != wantA {
+				t.Errorf("size=%d: Deinterleave2() a[%d] = %d, want %d", n, i, a[i], wantA)
+			}
+			if b[i] != wantB {
+				t.Errorf("size=%d: Deinterleave2() b[%d] = %d, want %d", n, i, b[i], wantB)
+			}
+		}
+	}
+}
+
+func TestInterleaveDeinterleaveRoundTrip(t *testing.T) {
+	sizes := []int{1, 2, 3, 4, 5, 7, 8, 9, 15, 16, 17, 100}
+	for _, n := range sizes {
+		a := make([]int16, n)
+		b := make([]int16, n)
+		for i := range a {
+			a[i] = int16(i) ^ math.MinInt16
+			b[i] = int16(-i - 1)
+		}
+
+		dst := make([]int16, n*2)
+		Interleave2(dst, a, b)
+
+		gotA := make([]int16, n)
+		gotB := make([]int16, n)
+		Deinterleave2(gotA, gotB, dst)
+
+		for i := range n {
+			if gotA[i] != a[i] {
+				t.Errorf("size=%d: round-trip a[%d] = %d, want %d", n, i, gotA[i], a[i])
+			}
+			if gotB[i] != b[i] {
+				t.Errorf("size=%d: round-trip b[%d] = %d, want %d", n, i, gotB[i], b[i])
+			}
+		}
+	}
+}
+
+// TestInterleave2_Clamp verifies the pair count is clamped to the shortest of
+// dst/2, a and b, leaving the rest of every buffer untouched.
+func TestInterleave2_Clamp(t *testing.T) {
+	a := []int16{1, 2, 3, 4}
+	b := []int16{10, 20}      // shorter than a
+	dst := make([]int16, 100) // longer than needed
+
+	Interleave2(dst, a, b)
+
+	want := []int16{1, 10, 2, 20}
+	for i, w := range want {
+		if dst[i] != w {
+			t.Errorf("dst[%d] = %d, want %d", i, dst[i], w)
+		}
+	}
+	for i := len(want); i < len(dst); i++ {
+		if dst[i] != 0 {
+			t.Errorf("dst[%d] = %d, want untouched 0", i, dst[i])
+		}
+	}
+}
+
+func TestDeinterleave2_Clamp(t *testing.T) {
+	src := []int16{1, 2, 3, 4, 5, 6}
+	a := make([]int16, 2) // only room for 2 pairs
+	b := make([]int16, 10)
+
+	Deinterleave2(a, b, src)
+
+	wantA := []int16{1, 3}
+	wantB := []int16{2, 4}
+	for i, w := range wantA {
+		if a[i] != w {
+			t.Errorf("a[%d] = %d, want %d", i, a[i], w)
+		}
+	}
+	for i, w := range wantB {
+		if b[i] != w {
+			t.Errorf("b[%d] = %d, want %d", i, b[i], w)
+		}
+	}
+	for i := len(wantB); i < len(b); i++ {
+		if b[i] != 0 {
+			t.Errorf("b[%d] = %d, want untouched 0", i, b[i])
+		}
+	}
+}
+
+// TestInterleave2_OddDstTail verifies that when dst is the limiting factor and
+// has an odd length, the pair count rounds down and the trailing element is
+// left untouched (the "ragged tail of dst" guarantee).
+func TestInterleave2_OddDstTail(t *testing.T) {
+	a := []int16{1, 2, 3, 4, 5}
+	b := []int16{10, 20, 30, 40, 50}
+	dst := []int16{0, 0, 0, 0, 99} // odd length: only 2 pairs fit, dst[4] is the tail
+
+	Interleave2(dst, a, b)
+
+	want := []int16{1, 10, 2, 20}
+	for i, w := range want {
+		if dst[i] != w {
+			t.Errorf("dst[%d] = %d, want %d", i, dst[i], w)
+		}
+	}
+	if dst[4] != 99 {
+		t.Errorf("odd dst tail dst[4] = %d, want untouched 99", dst[4])
+	}
+}
+
+// TestDeinterleave2_OddSrcTail verifies that an odd-length src does not panic
+// and leaves its trailing element unread (the "ragged tail of src" guarantee).
+func TestDeinterleave2_OddSrcTail(t *testing.T) {
+	src := []int16{1, 2, 3, 4, 5} // odd length: 2 full pairs, src[4] is the tail
+	a := make([]int16, 5)
+	b := make([]int16, 5)
+	for i := range a {
+		a[i] = 99
+		b[i] = 99
+	}
+
+	Deinterleave2(a, b, src)
+
+	wantA := []int16{1, 3}
+	wantB := []int16{2, 4}
+	for i, w := range wantA {
+		if a[i] != w {
+			t.Errorf("a[%d] = %d, want %d", i, a[i], w)
+		}
+	}
+	for i, w := range wantB {
+		if b[i] != w {
+			t.Errorf("b[%d] = %d, want %d", i, b[i], w)
+		}
+	}
+	// Only 2 pairs were processed; the rest of a and b stay untouched.
+	for i := len(wantA); i < len(a); i++ {
+		if a[i] != 99 {
+			t.Errorf("a[%d] = %d, want untouched 99", i, a[i])
+		}
+		if b[i] != 99 {
+			t.Errorf("b[%d] = %d, want untouched 99", i, b[i])
+		}
+	}
+}
+
+func TestInterleave2_Empty(t *testing.T) {
+	// No panics and no writes on empty/zero-length inputs.
+	Interleave2(nil, nil, nil)
+	Interleave2([]int16{}, []int16{}, []int16{})
+	dst := []int16{99, 99}
+	Interleave2(dst, nil, []int16{1})
+	if dst[0] != 99 || dst[1] != 99 {
+		t.Errorf("empty a wrote into dst: %v", dst)
+	}
+}
+
+func TestDeinterleave2_Empty(t *testing.T) {
+	Deinterleave2(nil, nil, nil)
+	Deinterleave2([]int16{}, []int16{}, []int16{})
+	a := []int16{99}
+	Deinterleave2(a, []int16{1}, nil)
+	if a[0] != 99 {
+		t.Errorf("empty src wrote into a: %v", a)
+	}
+}
+
+func TestInterleave2_AllocFree(t *testing.T) {
+	a := make([]int16, 1024)
+	b := make([]int16, 1024)
+	dst := make([]int16, 2048)
+	if got := testing.AllocsPerRun(100, func() { Interleave2(dst, a, b) }); got != 0 {
+		t.Errorf("Interleave2 allocated %v times per run, want 0", got)
+	}
+}
+
+func TestDeinterleave2_AllocFree(t *testing.T) {
+	src := make([]int16, 2048)
+	a := make([]int16, 1024)
+	b := make([]int16, 1024)
+	if got := testing.AllocsPerRun(100, func() { Deinterleave2(a, b, src) }); got != 0 {
+		t.Errorf("Deinterleave2 allocated %v times per run, want 0", got)
+	}
+}


### PR DESCRIPTION
## Summary

Adds a new `i16` package providing `Interleave2`/`Deinterleave2` on `[]int16`, for splitting and packing raw 16-bit interleaved stereo PCM before widening to int32. This is PR2 of the integer-SIMD roadmap in #79 and mirrors the `i32` package (PR1, #81).

Interleaving is pure 16-bit-lane data movement (no arithmetic), so every kernel preserves the exact bit pattern of each lane, including sign and high bits.

**AMD64: tiered dispatch AVX2 (16 int16/iter) > SSE2 (8/iter) > pure Go.**
- Interleave: `VPUNPCKLWD`/`VPUNPCKHWD` + `VPERM2I128` (AVX2), `PUNPCKLWL`/`PUNPCKHWL` (SSE2).
- Deinterleave: `VPSHUFB` even/odd gather mask + `VPUNPCKLQDQ`/`VPUNPCKHQDQ` + `VPERMQ` (AVX2), `PSHUFLW`/`PSHUFHW`/`PSHUFD` + `PUNPCKLQDQ`/`PUNPCKHQDQ` (SSE2, no data mask).

**ARM64: NEON** `ZIP1`/`ZIP2` and `UZP1`/`UZP2` on `.8H`, hand-encoded as `WORD` with decoded comments that asmcheck cross-checks against `arm64asm`.

Pure-Go reference is the source of truth and the fallback. All paths are zero-allocation, clamp inputs to the shortest buffer, and use 16-bit scalar tails (`MOVW` on amd64, `MOVH` on arm64).

## Related Issues

Relates to #79 (PR2 of the i32/i16 integer-SIMD roadmap).

## Benchmarks

1000 int16 elements, zero-alloc, vs the pure-Go baseline:

| Op | amd64 AVX2 | arm64 NEON (Pi 5) |
|----|-----------|-------------------|
| Interleave2 | 71.9 ns, 13.2x | 164.8 ns, 12.8x |
| Deinterleave2 | 58.2 ns, 11.2x | 165.1 ns, 12.8x |

## Test Plan

- [x] Bit-exact SIMD-vs-Go parity (AVX2, SSE2, NEON) with sign/high-bit and int16-extreme patterns across sizes straddling every block width.
- [x] Scalar-tail no-overwrite guards for both output buffers.
- [x] Round-trip, length clamping (including odd-length ragged tails), empty/nil input, zero-alloc assertions.
- [x] `go vet`, full module suite, `golangci-lint run ./i16/...` (0 issues) on amd64.
- [x] asmcheck WORD decode with `SIMD_REQUIRE_OBJDUMP=1`; no goroutine-register clobber.
- [x] Verified on amd64 (AVX2) natively and arm64 (NEON) on a Raspberry Pi 5.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## New Features
- Added stereo PCM audio processing package with `Interleave2` and `Deinterleave2` functions for `int16` samples
- Optimized implementations with hardware-accelerated paths and efficient fallbacks across x86-64 and ARM64 architectures
- Zero-allocation operations designed for high-performance audio stream processing

## Tests
- Comprehensive test suite including correctness checks, performance benchmarks, boundary condition validation, and round-trip verification

<!-- end of auto-generated comment: release notes by coderabbit.ai -->