### PR TITLE
i32: AVX2/NEON decorrelation and fixed-predictor encode kernels (#79)

### DIFF
--- a/i32/benchmark_test.go
+++ b/i32/benchmark_test.go
@@ -61,3 +61,147 @@ func BenchmarkDeinterleave2Go_1000(b *testing.B) {
 		deinterleave2Go(a, c, src)
 	}
 }
+
+func benchAB() (a, b, dst []int32) {
+	a = make([]int32, benchN)
+	b = make([]int32, benchN)
+	dst = make([]int32, benchN)
+	for i := range a {
+		a[i] = int32(i)
+		b[i] = int32(i - benchN/2)
+	}
+	return a, b, dst
+}
+
+func BenchmarkAdd_1000(b *testing.B) {
+	x, y, dst := benchAB()
+	b.SetBytes(benchN * 4 * 3)
+	for b.Loop() {
+		Add(dst, x, y)
+	}
+}
+
+func BenchmarkAddGo_1000(b *testing.B) {
+	x, y, dst := benchAB()
+	b.SetBytes(benchN * 4 * 3)
+	for b.Loop() {
+		addGo(dst, x, y)
+	}
+}
+
+func BenchmarkSub_1000(b *testing.B) {
+	x, y, dst := benchAB()
+	b.SetBytes(benchN * 4 * 3)
+	for b.Loop() {
+		Sub(dst, x, y)
+	}
+}
+
+func BenchmarkSubGo_1000(b *testing.B) {
+	x, y, dst := benchAB()
+	b.SetBytes(benchN * 4 * 3)
+	for b.Loop() {
+		subGo(dst, x, y)
+	}
+}
+
+func benchStereo() (left, right, p, q []int32) {
+	left = make([]int32, benchN)
+	right = make([]int32, benchN)
+	p = make([]int32, benchN)
+	q = make([]int32, benchN)
+	for i := range left {
+		left[i] = int32(i*3 - benchN)
+		right[i] = int32(benchN - i)
+	}
+	return left, right, p, q
+}
+
+func BenchmarkMidSideEncode_1000(b *testing.B) {
+	left, right, mid, side := benchStereo()
+	b.SetBytes(benchN * 4 * 4)
+	for b.Loop() {
+		MidSideEncode(mid, side, left, right)
+	}
+}
+
+func BenchmarkMidSideEncodeGo_1000(b *testing.B) {
+	left, right, mid, side := benchStereo()
+	b.SetBytes(benchN * 4 * 4)
+	for b.Loop() {
+		midSideEncodeGo(mid, side, left, right)
+	}
+}
+
+func BenchmarkMidSideDecode_1000(b *testing.B) {
+	mid, side, left, right := benchStereo()
+	b.SetBytes(benchN * 4 * 4)
+	for b.Loop() {
+		MidSideDecode(left, right, mid, side)
+	}
+}
+
+func BenchmarkMidSideDecodeGo_1000(b *testing.B) {
+	mid, side, left, right := benchStereo()
+	b.SetBytes(benchN * 4 * 4)
+	for b.Loop() {
+		midSideDecodeGo(left, right, mid, side)
+	}
+}
+
+func benchSrcDst() (src, dst []int32) {
+	src = make([]int32, benchN)
+	dst = make([]int32, benchN)
+	for i := range src {
+		src[i] = int32(i * i)
+	}
+	return src, dst
+}
+
+func BenchmarkDiff1_1000(b *testing.B) {
+	src, dst := benchSrcDst()
+	b.SetBytes(benchN * 4 * 2)
+	for b.Loop() {
+		Diff1(dst, src)
+	}
+}
+
+func BenchmarkDiff1Go_1000(b *testing.B) {
+	src, dst := benchSrcDst()
+	b.SetBytes(benchN * 4 * 2)
+	for b.Loop() {
+		diff1Go(dst, src)
+	}
+}
+
+func BenchmarkDiff2_1000(b *testing.B) {
+	src, dst := benchSrcDst()
+	b.SetBytes(benchN * 4 * 2)
+	for b.Loop() {
+		Diff2(dst, src)
+	}
+}
+
+func BenchmarkDiff2Go_1000(b *testing.B) {
+	src, dst := benchSrcDst()
+	b.SetBytes(benchN * 4 * 2)
+	for b.Loop() {
+		diff2Go(dst, src)
+	}
+}
+
+func BenchmarkDiff4_1000(b *testing.B) {
+	src, dst := benchSrcDst()
+	b.SetBytes(benchN * 4 * 2)
+	for b.Loop() {
+		Diff4(dst, src)
+	}
+}
+
+func BenchmarkDiff4Go_1000(b *testing.B) {
+	src, dst := benchSrcDst()
+	b.SetBytes(benchN * 4 * 2)
+	for b.Loop() {
+		diff4Go(dst, src)
+	}
+}

--- a/i32/benchmark_test.go
+++ b/i32/benchmark_test.go
@@ -190,6 +190,22 @@ func BenchmarkDiff2Go_1000(b *testing.B) {
 	}
 }
 
+func BenchmarkDiff3_1000(b *testing.B) {
+	src, dst := benchSrcDst()
+	b.SetBytes(benchN * 4 * 2)
+	for b.Loop() {
+		Diff3(dst, src)
+	}
+}
+
+func BenchmarkDiff3Go_1000(b *testing.B) {
+	src, dst := benchSrcDst()
+	b.SetBytes(benchN * 4 * 2)
+	for b.Loop() {
+		diff3Go(dst, src)
+	}
+}
+
 func BenchmarkDiff4_1000(b *testing.B) {
 	src, dst := benchSrcDst()
 	b.SetBytes(benchN * 4 * 2)

--- a/i32/decorrelate.go
+++ b/i32/decorrelate.go
@@ -1,0 +1,72 @@
+package i32
+
+// Element-wise integer arithmetic and FLAC stereo decorrelation.
+//
+// These primitives cover all three of FLAC's inter-channel decorrelation modes
+// in both directions. Add and Sub are the building blocks; MidSideEncode and
+// MidSideDecode handle the mid/side mode, which needs the parity trick and so is
+// not expressible as a single Add/Sub:
+//
+//	mode        encode (from left,right)     decode (to left,right)
+//	---------   --------------------------   --------------------------
+//	LEFT_SIDE   Sub(side, left, right)       Sub(right, left, side)
+//	RIGHT_SIDE  Sub(side, left, right)       Add(left, right, side)
+//	MID_SIDE    MidSideEncode(...)           MidSideDecode(...)
+//
+// All operations clamp to the shortest operand, write into caller-provided
+// slices, and use int32 wraparound (two's complement) so the SIMD and pure-Go
+// paths are bit-identical across the full int32 range.
+
+// Add writes dst[i] = a[i] + b[i] for i in [0, n), n = min(len(dst), len(a),
+// len(b)). It reconstructs the left channel in FLAC RIGHT_SIDE decode:
+// Add(left, right, side).
+func Add(dst, a, b []int32) {
+	n := min(len(dst), min(len(a), len(b)))
+	if n == 0 {
+		return
+	}
+	addI32(dst[:n], a[:n], b[:n])
+}
+
+// Sub writes dst[i] = a[i] - b[i] for i in [0, n), n = min(len(dst), len(a),
+// len(b)). It computes the FLAC side channel (Sub(side, left, right)) and
+// reconstructs the right channel in LEFT_SIDE decode (Sub(right, left, side)).
+func Sub(dst, a, b []int32) {
+	n := min(len(dst), min(len(a), len(b)))
+	if n == 0 {
+		return
+	}
+	subI32(dst[:n], a[:n], b[:n])
+}
+
+// MidSideEncode computes FLAC mid/side decorrelation, forward direction:
+//
+//	mid[i]  = (left[i] + right[i]) >> 1   (arithmetic shift; the low bit is dropped)
+//	side[i] = left[i] - right[i]
+//
+// It processes n = min over all four slices and leaves any trailing capacity
+// untouched. MidSideDecode is the exact inverse for inputs within the codec's
+// effective bit depth.
+func MidSideEncode(mid, side, left, right []int32) {
+	n := min(min(len(mid), len(side)), min(len(left), len(right)))
+	if n == 0 {
+		return
+	}
+	midSideEncodeI32(mid[:n], side[:n], left[:n], right[:n])
+}
+
+// MidSideDecode inverts MidSideEncode, reconstructing the original channels:
+//
+//	sum      = (mid[i] << 1) | (side[i] & 1)
+//	left[i]  = (sum + side[i]) >> 1
+//	right[i] = (sum - side[i]) >> 1
+//
+// The parity bit (side[i] & 1) restores the low bit of left+right that the
+// encoder's >>1 discarded; left+right and left-right always share parity.
+func MidSideDecode(left, right, mid, side []int32) {
+	n := min(min(len(left), len(right)), min(len(mid), len(side)))
+	if n == 0 {
+		return
+	}
+	midSideDecodeI32(left[:n], right[:n], mid[:n], side[:n])
+}

--- a/i32/decorrelate.go
+++ b/i32/decorrelate.go
@@ -21,7 +21,7 @@ package i32
 // len(b)). It reconstructs the left channel in FLAC RIGHT_SIDE decode:
 // Add(left, right, side).
 func Add(dst, a, b []int32) {
-	n := min(len(dst), min(len(a), len(b)))
+	n := min(len(dst), len(a), len(b))
 	if n == 0 {
 		return
 	}
@@ -32,7 +32,7 @@ func Add(dst, a, b []int32) {
 // len(b)). It computes the FLAC side channel (Sub(side, left, right)) and
 // reconstructs the right channel in LEFT_SIDE decode (Sub(right, left, side)).
 func Sub(dst, a, b []int32) {
-	n := min(len(dst), min(len(a), len(b)))
+	n := min(len(dst), len(a), len(b))
 	if n == 0 {
 		return
 	}
@@ -48,7 +48,7 @@ func Sub(dst, a, b []int32) {
 // untouched. MidSideDecode is the exact inverse for inputs within the codec's
 // effective bit depth.
 func MidSideEncode(mid, side, left, right []int32) {
-	n := min(min(len(mid), len(side)), min(len(left), len(right)))
+	n := min(len(mid), len(side), len(left), len(right))
 	if n == 0 {
 		return
 	}
@@ -64,7 +64,7 @@ func MidSideEncode(mid, side, left, right []int32) {
 // The parity bit (side[i] & 1) restores the low bit of left+right that the
 // encoder's >>1 discarded; left+right and left-right always share parity.
 func MidSideDecode(left, right, mid, side []int32) {
-	n := min(min(len(left), len(right)), min(len(mid), len(side)))
+	n := min(len(left), len(right), len(mid), len(side))
 	if n == 0 {
 		return
 	}

--- a/i32/decorrelate_test.go
+++ b/i32/decorrelate_test.go
@@ -1,0 +1,231 @@
+package i32
+
+import (
+	"math"
+	"testing"
+)
+
+// Tests for the element-wise integer primitives (Add, Sub) and the FLAC
+// mid/side stereo decorrelation (MidSideEncode, MidSideDecode).
+//
+// As with interleave, the interesting int32 cases are negatives and the type
+// extremes: the SIMD kernels operate on 32-bit lanes, so a kernel that
+// mishandled the sign bit or wrapped differently than Go would be exposed by
+// MinInt32/MaxInt32 inputs.
+
+func TestAdd(t *testing.T) {
+	tests := []struct {
+		name string
+		a    []int32
+		b    []int32
+		want []int32
+	}{
+		{"basic", []int32{1, 2, 3}, []int32{10, 20, 30}, []int32{11, 22, 33}},
+		{"negatives", []int32{-5, 7, -1}, []int32{5, -7, 1}, []int32{0, 0, 0}},
+		{"wraps", []int32{math.MaxInt32, math.MinInt32}, []int32{1, -1},
+			[]int32{math.MinInt32, math.MaxInt32}},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			dst := make([]int32, len(tt.a))
+			Add(dst, tt.a, tt.b)
+			for i, want := range tt.want {
+				if dst[i] != want {
+					t.Errorf("Add()[%d] = %d, want %d", i, dst[i], want)
+				}
+			}
+		})
+	}
+}
+
+func TestSub(t *testing.T) {
+	tests := []struct {
+		name string
+		a    []int32
+		b    []int32
+		want []int32
+	}{
+		{"basic", []int32{11, 22, 33}, []int32{10, 20, 30}, []int32{1, 2, 3}},
+		{"negatives", []int32{0, 0}, []int32{5, -7}, []int32{-5, 7}},
+		{"wraps", []int32{math.MinInt32, math.MaxInt32}, []int32{1, -1},
+			[]int32{math.MaxInt32, math.MinInt32}},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			dst := make([]int32, len(tt.a))
+			Sub(dst, tt.a, tt.b)
+			for i, want := range tt.want {
+				if dst[i] != want {
+					t.Errorf("Sub()[%d] = %d, want %d", i, dst[i], want)
+				}
+			}
+		})
+	}
+}
+
+// midSideEncodeScalar / midSideDecodeScalar are the by-the-spec definitions used
+// to pin MidSideEncode/MidSideDecode independently of the package's own Go
+// reference, so a mistake duplicated into the reference cannot hide.
+func midSideEncodeScalar(l, r int32) (mid, side int32) {
+	return (l + r) >> 1, l - r
+}
+
+func midSideDecodeScalar(mid, side int32) (l, r int32) {
+	sum := (mid << 1) | (side & 1)
+	return (sum + side) >> 1, (sum - side) >> 1
+}
+
+func TestMidSideEncode(t *testing.T) {
+	left := []int32{5, 2, -3, 5, math.MaxInt32, math.MinInt32}
+	right := []int32{5, -3, 2, 4, 1, -1}
+	mid := make([]int32, len(left))
+	side := make([]int32, len(left))
+
+	MidSideEncode(mid, side, left, right)
+
+	for i := range left {
+		wantMid, wantSide := midSideEncodeScalar(left[i], right[i])
+		if mid[i] != wantMid {
+			t.Errorf("MidSideEncode mid[%d] = %d, want %d", i, mid[i], wantMid)
+		}
+		if side[i] != wantSide {
+			t.Errorf("MidSideEncode side[%d] = %d, want %d", i, side[i], wantSide)
+		}
+	}
+}
+
+func TestMidSideDecode(t *testing.T) {
+	mid := []int32{5, -1, -1, 4, 0}
+	side := []int32{0, -5, 5, 1, 7}
+	left := make([]int32, len(mid))
+	right := make([]int32, len(mid))
+
+	MidSideDecode(left, right, mid, side)
+
+	for i := range mid {
+		wantL, wantR := midSideDecodeScalar(mid[i], side[i])
+		if left[i] != wantL {
+			t.Errorf("MidSideDecode left[%d] = %d, want %d", i, left[i], wantL)
+		}
+		if right[i] != wantR {
+			t.Errorf("MidSideDecode right[%d] = %d, want %d", i, right[i], wantR)
+		}
+	}
+}
+
+// TestMidSideRoundTrip is the property that matters to a FLAC codec: for inputs
+// within the codec's effective bit depth (no l+r overflow), decode(encode(l,r))
+// reconstructs the original samples exactly, including odd parity.
+func TestMidSideRoundTrip(t *testing.T) {
+	sizes := []int{1, 2, 3, 7, 8, 9, 16, 17, 100, 1000}
+	for _, n := range sizes {
+		left := make([]int32, n)
+		right := make([]int32, n)
+		for i := range left {
+			// 24-bit-ranged values with mixed parity and sign so the parity
+			// reconstruction is exercised; small enough that l+r cannot overflow.
+			left[i] = int32((i*37+11)%(1<<23)) - (1 << 22)
+			right[i] = int32((i*53+7)%(1<<23)) - (1 << 22)
+		}
+
+		mid := make([]int32, n)
+		side := make([]int32, n)
+		MidSideEncode(mid, side, left, right)
+
+		gotL := make([]int32, n)
+		gotR := make([]int32, n)
+		MidSideDecode(gotL, gotR, mid, side)
+
+		for i := range left {
+			if gotL[i] != left[i] || gotR[i] != right[i] {
+				t.Fatalf("n=%d round-trip[%d] = (%d,%d), want (%d,%d)",
+					n, i, gotL[i], gotR[i], left[i], right[i])
+			}
+		}
+	}
+}
+
+func TestAddSub_Clamp(t *testing.T) {
+	a := []int32{1, 2, 3, 4}
+	b := []int32{10, 20}        // shorter than a
+	dst := make([]int32, 100)   // longer than needed
+	Add(dst, a, b)
+	want := []int32{11, 22}
+	for i, w := range want {
+		if dst[i] != w {
+			t.Errorf("Add clamp dst[%d] = %d, want %d", i, dst[i], w)
+		}
+	}
+	for i := len(want); i < len(dst); i++ {
+		if dst[i] != 0 {
+			t.Errorf("Add wrote past clamp at dst[%d] = %d, want untouched 0", i, dst[i])
+		}
+	}
+}
+
+func TestMidSide_Clamp(t *testing.T) {
+	left := []int32{8, 12, 4}
+	right := []int32{2, 4, 2}
+	mid := make([]int32, 2)  // only room for 2
+	side := make([]int32, 10)
+	MidSideEncode(mid, side, left, right)
+	if mid[0] != 5 || mid[1] != 8 {
+		t.Errorf("MidSideEncode clamp mid = %v, want [5 8 ...]", mid[:2])
+	}
+	for i := 2; i < len(side); i++ {
+		if side[i] != 0 {
+			t.Errorf("MidSideEncode wrote past clamp at side[%d] = %d", i, side[i])
+		}
+	}
+}
+
+func TestDecorrelate_Empty(t *testing.T) {
+	// No panics and no writes on empty/nil inputs.
+	Add(nil, nil, nil)
+	Sub([]int32{}, []int32{}, []int32{})
+	MidSideEncode(nil, nil, nil, nil)
+	MidSideDecode(nil, nil, nil, nil)
+	dst := []int32{99}
+	Add(dst, nil, []int32{1})
+	if dst[0] != 99 {
+		t.Errorf("Add wrote on empty input: %v", dst)
+	}
+}
+
+func TestAdd_AllocFree(t *testing.T) {
+	a := make([]int32, 1024)
+	b := make([]int32, 1024)
+	dst := make([]int32, 1024)
+	if got := testing.AllocsPerRun(100, func() { Add(dst, a, b) }); got != 0 {
+		t.Errorf("Add allocated %v times per run, want 0", got)
+	}
+}
+
+func TestSub_AllocFree(t *testing.T) {
+	a := make([]int32, 1024)
+	b := make([]int32, 1024)
+	dst := make([]int32, 1024)
+	if got := testing.AllocsPerRun(100, func() { Sub(dst, a, b) }); got != 0 {
+		t.Errorf("Sub allocated %v times per run, want 0", got)
+	}
+}
+
+func TestMidSideEncode_AllocFree(t *testing.T) {
+	left := make([]int32, 1024)
+	right := make([]int32, 1024)
+	mid := make([]int32, 1024)
+	side := make([]int32, 1024)
+	if got := testing.AllocsPerRun(100, func() { MidSideEncode(mid, side, left, right) }); got != 0 {
+		t.Errorf("MidSideEncode allocated %v times per run, want 0", got)
+	}
+}
+
+func TestMidSideDecode_AllocFree(t *testing.T) {
+	mid := make([]int32, 1024)
+	side := make([]int32, 1024)
+	left := make([]int32, 1024)
+	right := make([]int32, 1024)
+	if got := testing.AllocsPerRun(100, func() { MidSideDecode(left, right, mid, side) }); got != 0 {
+		t.Errorf("MidSideDecode allocated %v times per run, want 0", got)
+	}
+}

--- a/i32/example_test.go
+++ b/i32/example_test.go
@@ -25,3 +25,47 @@ func ExampleDeinterleave2() {
 	fmt.Println(left, right)
 	// Output: [1 2 3] [-1 -2 -3]
 }
+
+func ExampleMidSideEncode() {
+	left := []int32{5, 2, -3}
+	right := []int32{5, 4, 1}
+	mid := make([]int32, len(left))
+	side := make([]int32, len(left))
+
+	i32.MidSideEncode(mid, side, left, right)
+	fmt.Println(mid, side)
+	// Output: [5 3 -1] [0 -2 -4]
+}
+
+func ExampleMidSideDecode() {
+	mid := []int32{5, 3, -1}
+	side := []int32{0, -2, -4}
+	left := make([]int32, len(mid))
+	right := make([]int32, len(mid))
+
+	i32.MidSideDecode(left, right, mid, side)
+	fmt.Println(left, right)
+	// Output: [5 2 -3] [5 4 1]
+}
+
+// ExampleSub shows the FLAC left/side encode: the side channel is left - right.
+func ExampleSub() {
+	left := []int32{10, 20, 30}
+	right := []int32{1, 2, 3}
+	side := make([]int32, len(left))
+
+	i32.Sub(side, left, right)
+	fmt.Println(side)
+	// Output: [9 18 27]
+}
+
+// ExampleDiff1 shows the order-1 fixed-predictor residual. dst[0] is the
+// verbatim warm-up sample; the rest are src[n]-src[n-1].
+func ExampleDiff1() {
+	samples := []int32{10, 13, 13, 8, 20}
+	res := make([]int32, len(samples))
+
+	i32.Diff1(res, samples)
+	fmt.Println(res)
+	// Output: [10 3 0 -5 12]
+}

--- a/i32/fixed.go
+++ b/i32/fixed.go
@@ -1,0 +1,53 @@
+package i32
+
+// Fixed-predictor encode differences for the FLAC codec.
+//
+// FLAC's fixed predictors of order 1..4 predict each sample from the previous
+// ones with fixed integer coefficients; the residual the encoder Rice-codes is
+// the order-K forward finite difference of the samples. DiffK writes that
+// residual into dst:
+//
+//	dst[i] = src[i]                            for i < K  (verbatim warm-up)
+//	dst[n] = sum_j (-1)^j * C(K,j) * src[n-j]  for n >= K (the residual)
+//
+// so dst is laid out as [K warm-up samples | residuals], exactly the order a
+// FLAC subframe stores. Each function clamps to n = min(len(dst), len(src)),
+// uses int32 wraparound (the residual can exceed the source range), and writes
+// only into the caller's dst. Inputs shorter than K hold warm-up only.
+
+// Diff1 writes the order-1 residual: dst[0]=src[0], dst[n]=src[n]-src[n-1].
+func Diff1(dst, src []int32) {
+	n := min(len(dst), len(src))
+	if n == 0 {
+		return
+	}
+	diff1I32(dst[:n], src[:n])
+}
+
+// Diff2 writes the order-2 residual: dst[n]=src[n]-2src[n-1]+src[n-2].
+func Diff2(dst, src []int32) {
+	n := min(len(dst), len(src))
+	if n == 0 {
+		return
+	}
+	diff2I32(dst[:n], src[:n])
+}
+
+// Diff3 writes the order-3 residual: dst[n]=src[n]-3src[n-1]+3src[n-2]-src[n-3].
+func Diff3(dst, src []int32) {
+	n := min(len(dst), len(src))
+	if n == 0 {
+		return
+	}
+	diff3I32(dst[:n], src[:n])
+}
+
+// Diff4 writes the order-4 residual:
+// dst[n]=src[n]-4src[n-1]+6src[n-2]-4src[n-3]+src[n-4].
+func Diff4(dst, src []int32) {
+	n := min(len(dst), len(src))
+	if n == 0 {
+		return
+	}
+	diff4I32(dst[:n], src[:n])
+}

--- a/i32/fixed_test.go
+++ b/i32/fixed_test.go
@@ -34,23 +34,27 @@ func diffResidualRepeated(src []int32, order int) []int32 {
 
 func TestDiffOrders(t *testing.T) {
 	diffs := []func(dst, src []int32){Diff1, Diff2, Diff3, Diff4}
-	src := []int32{3, 1, 4, 1, 5, 9, 2, 6, 5, 3, 5, 8, 9, 7, 9, 3, 2, 3, 8, 4}
-	for order := 1; order <= 4; order++ {
-		t.Run([]string{"", "Diff1", "Diff2", "Diff3", "Diff4"}[order], func(t *testing.T) {
-			dst := make([]int32, len(src))
-			diffs[order-1](dst, src)
-			want := diffResidualRepeated(src, order)
-			for i := 0; i < order; i++ {
-				if dst[i] != src[i] {
-					t.Errorf("order %d warm-up dst[%d] = %d, want src %d", order, i, dst[i], src[i])
+	full := []int32{3, 1, 4, 1, 5, 9, 2, 6, 5, 3, 5, 8, 9, 7, 9, 3, 2, 3, 8, 4}
+	// Two lengths so both the dispatched SIMD path (len >= block threshold) and
+	// the pure-Go fallback (len < threshold) are exercised through the public API.
+	for _, src := range [][]int32{full, full[:6]} {
+		for order := 1; order <= 4; order++ {
+			t.Run([]string{"", "Diff1", "Diff2", "Diff3", "Diff4"}[order], func(t *testing.T) {
+				dst := make([]int32, len(src))
+				diffs[order-1](dst, src)
+				want := diffResidualRepeated(src, order)
+				for i := 0; i < order; i++ {
+					if dst[i] != src[i] {
+						t.Errorf("len %d order %d warm-up dst[%d] = %d, want src %d", len(src), order, i, dst[i], src[i])
+					}
 				}
-			}
-			for n := order; n < len(src); n++ {
-				if dst[n] != want[n] {
-					t.Errorf("order %d residual dst[%d] = %d, want %d", order, n, dst[n], want[n])
+				for n := order; n < len(src); n++ {
+					if dst[n] != want[n] {
+						t.Errorf("len %d order %d residual dst[%d] = %d, want %d", len(src), order, n, dst[n], want[n])
+					}
 				}
-			}
-		})
+			})
+		}
 	}
 }
 

--- a/i32/fixed_test.go
+++ b/i32/fixed_test.go
@@ -1,0 +1,131 @@
+package i32
+
+import (
+	"math"
+	"testing"
+)
+
+// Tests for the fixed-predictor encode differences Diff1..Diff4.
+//
+// DiffK(dst, src) writes the order-K forward finite difference: the first K
+// entries are the verbatim warm-up (dst[i]=src[i] for i<K) and dst[n] for n>=K
+// is the residual the FLAC fixed predictor of order K produces. The residual
+// coefficients are the signed binomials (-1)^j * C(K,j).
+
+// diffResidualRepeated computes the order-K residual by applying the first
+// difference K times (holding index 0 at the boundary). This is an algorithm
+// independent of the binomial-coefficient form the package uses, so the two
+// agreeing at n>=K is a meaningful cross-check rather than a restatement.
+func diffResidualRepeated(src []int32, order int) []int32 {
+	cur := append([]int32(nil), src...)
+	for range order {
+		next := make([]int32, len(cur))
+		for i := range cur {
+			if i == 0 {
+				next[i] = cur[i]
+				continue
+			}
+			next[i] = cur[i] - cur[i-1]
+		}
+		cur = next
+	}
+	return cur
+}
+
+func TestDiffOrders(t *testing.T) {
+	diffs := []func(dst, src []int32){Diff1, Diff2, Diff3, Diff4}
+	src := []int32{3, 1, 4, 1, 5, 9, 2, 6, 5, 3, 5, 8, 9, 7, 9, 3, 2, 3, 8, 4}
+	for order := 1; order <= 4; order++ {
+		t.Run([]string{"", "Diff1", "Diff2", "Diff3", "Diff4"}[order], func(t *testing.T) {
+			dst := make([]int32, len(src))
+			diffs[order-1](dst, src)
+			want := diffResidualRepeated(src, order)
+			for i := 0; i < order; i++ {
+				if dst[i] != src[i] {
+					t.Errorf("order %d warm-up dst[%d] = %d, want src %d", order, i, dst[i], src[i])
+				}
+			}
+			for n := order; n < len(src); n++ {
+				if dst[n] != want[n] {
+					t.Errorf("order %d residual dst[%d] = %d, want %d", order, n, dst[n], want[n])
+				}
+			}
+		})
+	}
+}
+
+// TestDiff1Simple checks the order-1 difference against a hand-computed result.
+func TestDiff1Simple(t *testing.T) {
+	src := []int32{10, 13, 13, 8, 20}
+	dst := make([]int32, len(src))
+	Diff1(dst, src)
+	want := []int32{10, 3, 0, -5, 12} // dst[0]=src[0] warm-up, then s[n]-s[n-1]
+	for i, w := range want {
+		if dst[i] != w {
+			t.Errorf("Diff1[%d] = %d, want %d", i, dst[i], w)
+		}
+	}
+}
+
+// TestDiffWraps verifies int32 wraparound matches the SIMD kernels at the type
+// extremes (the residual can exceed the source range).
+func TestDiffWraps(t *testing.T) {
+	src := []int32{math.MinInt32, math.MaxInt32, math.MinInt32, math.MaxInt32, math.MinInt32, 0}
+	dst := make([]int32, len(src))
+	Diff1(dst, src)
+	// dst[1] = MaxInt32 - MinInt32 = -1 (wraps)
+	if dst[1] != -1 {
+		t.Errorf("Diff1 wrap dst[1] = %d, want -1", dst[1])
+	}
+}
+
+func TestDiff_Clamp(t *testing.T) {
+	src := []int32{1, 2, 4, 7, 11}
+	dst := make([]int32, 100)
+	Diff1(dst, src)
+	want := []int32{1, 1, 2, 3, 4}
+	for i, w := range want {
+		if dst[i] != w {
+			t.Errorf("Diff1 clamp dst[%d] = %d, want %d", i, dst[i], w)
+		}
+	}
+	for i := len(want); i < len(dst); i++ {
+		if dst[i] != 0 {
+			t.Errorf("Diff1 wrote past clamp at dst[%d] = %d, want untouched 0", i, dst[i])
+		}
+	}
+}
+
+// TestDiff_ShortInput checks inputs shorter than the order: with fewer than K
+// samples there is no residual, only warm-up, and nothing should panic.
+func TestDiff_ShortInput(t *testing.T) {
+	src := []int32{42, 7}
+	dst := make([]int32, len(src))
+	Diff4(dst, src) // order 4 but only 2 samples
+	if dst[0] != 42 || dst[1] != 7 {
+		t.Errorf("Diff4 short input = %v, want [42 7] warm-up", dst)
+	}
+}
+
+func TestDiff_Empty(t *testing.T) {
+	Diff1(nil, nil)
+	Diff2([]int32{}, []int32{})
+	Diff3(nil, nil)
+	Diff4(nil, nil)
+	dst := []int32{99}
+	Diff1(dst, nil)
+	if dst[0] != 99 {
+		t.Errorf("Diff1 wrote on empty input: %v", dst)
+	}
+}
+
+func TestDiff_AllocFree(t *testing.T) {
+	src := make([]int32, 1024)
+	dst := make([]int32, 1024)
+	diffs := map[string]func(dst, src []int32){"Diff1": Diff1, "Diff2": Diff2, "Diff3": Diff3, "Diff4": Diff4}
+	for name, fn := range diffs {
+		if got := testing.AllocsPerRun(100, func() { fn(dst, src) }); got != 0 {
+			t.Errorf("%s allocated %v times per run, want 0", name, got)
+		}
+	}
+}

--- a/i32/i32_amd64.go
+++ b/i32/i32_amd64.go
@@ -36,3 +36,97 @@ func interleave2AVX(dst, a, b []int32)
 
 //go:noescape
 func deinterleave2AVX(a, b, src []int32)
+
+// The arithmetic / decorrelation / fixed-predictor kernels operate on 256-bit
+// integer lanes (VPADDD/VPSUBD/VPSRAD/...), which require AVX2 rather than the
+// AVX1 that suffices for the float-shuffle interleave kernels above. They gate
+// on AVX2 explicitly and fall back to the pure-Go reference otherwise.
+var hasAVX2 = cpu.X86.AVX2
+
+func addI32(dst, a, b []int32) {
+	if hasAVX2 && len(dst) >= minAVXElements {
+		addAVX2(dst, a, b)
+		return
+	}
+	addGo(dst, a, b)
+}
+
+func subI32(dst, a, b []int32) {
+	if hasAVX2 && len(dst) >= minAVXElements {
+		subAVX2(dst, a, b)
+		return
+	}
+	subGo(dst, a, b)
+}
+
+func midSideEncodeI32(mid, side, left, right []int32) {
+	if hasAVX2 && len(mid) >= minAVXElements {
+		midSideEncodeAVX2(mid, side, left, right)
+		return
+	}
+	midSideEncodeGo(mid, side, left, right)
+}
+
+func midSideDecodeI32(left, right, mid, side []int32) {
+	if hasAVX2 && len(left) >= minAVXElements {
+		midSideDecodeAVX2(left, right, mid, side)
+		return
+	}
+	midSideDecodeGo(left, right, mid, side)
+}
+
+func diff1I32(dst, src []int32) {
+	if hasAVX2 && len(dst) >= minAVXElements {
+		diff1AVX2(dst, src)
+		return
+	}
+	diff1Go(dst, src)
+}
+
+func diff2I32(dst, src []int32) {
+	if hasAVX2 && len(dst) >= minAVXElements {
+		diff2AVX2(dst, src)
+		return
+	}
+	diff2Go(dst, src)
+}
+
+func diff3I32(dst, src []int32) {
+	if hasAVX2 && len(dst) >= minAVXElements {
+		diff3AVX2(dst, src)
+		return
+	}
+	diff3Go(dst, src)
+}
+
+func diff4I32(dst, src []int32) {
+	if hasAVX2 && len(dst) >= minAVXElements {
+		diff4AVX2(dst, src)
+		return
+	}
+	diff4Go(dst, src)
+}
+
+//go:noescape
+func addAVX2(dst, a, b []int32)
+
+//go:noescape
+func subAVX2(dst, a, b []int32)
+
+//go:noescape
+func midSideEncodeAVX2(mid, side, left, right []int32)
+
+//go:noescape
+func midSideDecodeAVX2(left, right, mid, side []int32)
+
+//go:noescape
+func diff1AVX2(dst, src []int32)
+
+//go:noescape
+func diff2AVX2(dst, src []int32)
+
+//go:noescape
+func diff3AVX2(dst, src []int32)
+
+//go:noescape
+func diff4AVX2(dst, src []int32)

--- a/i32/i32_amd64.s
+++ b/i32/i32_amd64.s
@@ -128,3 +128,435 @@ deinterleave2_avx_scalar:
 deinterleave2_avx_done:
     VZEROUPPER
     RET
+
+// Arithmetic, decorrelation and fixed-predictor kernels.
+//
+// Unlike the (de)interleave kernels above (pure 32-bit-lane data movement on
+// AVX1 float shuffles), these do integer ALU work on 256-bit lanes, which
+// requires AVX2 (VPADDD/VPSUBD/VPSRAD/VPSLLD/VPAND/VPOR). They are dispatched
+// from i32_amd64.go gated on the AVX2 CPU feature, with the pure-Go reference as
+// the fallback. Each processes 8 int32 (one YMM) per iteration with a scalar
+// tail. The Go assembler's 3-operand order is dst-last: VPSUBD a, b, c is
+// c = b - a.
+
+// func addAVX2(dst, a, b []int32)
+TEXT ·addAVX2(SB), NOSPLIT, $0-72
+    MOVQ dst_base+0(FP), DX
+    MOVQ dst_len+8(FP), CX
+    MOVQ a_base+24(FP), SI
+    MOVQ b_base+48(FP), DI
+
+    MOVQ CX, AX
+    SHRQ $3, AX
+    JZ   add_remainder
+
+add_loop8:
+    VMOVDQU (SI), Y0
+    VMOVDQU (DI), Y1
+    VPADDD  Y1, Y0, Y2         // Y2 = a + b
+    VMOVDQU Y2, (DX)
+    ADDQ $32, SI
+    ADDQ $32, DI
+    ADDQ $32, DX
+    DECQ AX
+    JNZ  add_loop8
+
+add_remainder:
+    ANDQ $7, CX
+    JZ   add_done
+
+add_scalar:
+    MOVL (SI), AX
+    ADDL (DI), AX
+    MOVL AX, (DX)
+    ADDQ $4, SI
+    ADDQ $4, DI
+    ADDQ $4, DX
+    DECQ CX
+    JNZ  add_scalar
+
+add_done:
+    VZEROUPPER
+    RET
+
+// func subAVX2(dst, a, b []int32)
+TEXT ·subAVX2(SB), NOSPLIT, $0-72
+    MOVQ dst_base+0(FP), DX
+    MOVQ dst_len+8(FP), CX
+    MOVQ a_base+24(FP), SI
+    MOVQ b_base+48(FP), DI
+
+    MOVQ CX, AX
+    SHRQ $3, AX
+    JZ   sub_remainder
+
+sub_loop8:
+    VMOVDQU (SI), Y0
+    VMOVDQU (DI), Y1
+    VPSUBD  Y1, Y0, Y2         // Y2 = a - b
+    VMOVDQU Y2, (DX)
+    ADDQ $32, SI
+    ADDQ $32, DI
+    ADDQ $32, DX
+    DECQ AX
+    JNZ  sub_loop8
+
+sub_remainder:
+    ANDQ $7, CX
+    JZ   sub_done
+
+sub_scalar:
+    MOVL (SI), AX
+    SUBL (DI), AX
+    MOVL AX, (DX)
+    ADDQ $4, SI
+    ADDQ $4, DI
+    ADDQ $4, DX
+    DECQ CX
+    JNZ  sub_scalar
+
+sub_done:
+    VZEROUPPER
+    RET
+
+// func midSideEncodeAVX2(mid, side, left, right []int32)
+// mid = (left + right) >> 1 (arithmetic), side = left - right
+TEXT ·midSideEncodeAVX2(SB), NOSPLIT, $0-96
+    MOVQ mid_base+0(FP), DX
+    MOVQ mid_len+8(FP), CX
+    MOVQ side_base+24(FP), R8
+    MOVQ left_base+48(FP), SI
+    MOVQ right_base+72(FP), DI
+
+    MOVQ CX, AX
+    SHRQ $3, AX
+    JZ   mse_remainder
+
+mse_loop8:
+    VMOVDQU (SI), Y0           // left
+    VMOVDQU (DI), Y1           // right
+    VPADDD  Y1, Y0, Y2         // left + right
+    VPSRAD  $1, Y2, Y2         // (left + right) >> 1
+    VMOVDQU Y2, (DX)           // mid
+    VPSUBD  Y1, Y0, Y3         // left - right
+    VMOVDQU Y3, (R8)           // side
+    ADDQ $32, SI
+    ADDQ $32, DI
+    ADDQ $32, DX
+    ADDQ $32, R8
+    DECQ AX
+    JNZ  mse_loop8
+
+mse_remainder:
+    ANDQ $7, CX
+    JZ   mse_done
+
+mse_scalar:
+    MOVL (SI), AX              // left
+    MOVL (DI), BX              // right
+    MOVL AX, R9
+    ADDL BX, R9                // left + right
+    SARL $1, R9                // >> 1 arithmetic
+    MOVL R9, (DX)              // mid
+    SUBL BX, AX                // left - right
+    MOVL AX, (R8)              // side
+    ADDQ $4, SI
+    ADDQ $4, DI
+    ADDQ $4, DX
+    ADDQ $4, R8
+    DECQ CX
+    JNZ  mse_scalar
+
+mse_done:
+    VZEROUPPER
+    RET
+
+// func midSideDecodeAVX2(left, right, mid, side []int32)
+// sum = (mid<<1)|(side&1); left = (sum+side)>>1; right = (sum-side)>>1
+TEXT ·midSideDecodeAVX2(SB), NOSPLIT, $0-96
+    MOVQ left_base+0(FP), DX
+    MOVQ left_len+8(FP), CX
+    MOVQ right_base+24(FP), R8
+    MOVQ mid_base+48(FP), SI
+    MOVQ side_base+72(FP), DI
+
+    MOVQ CX, AX
+    SHRQ $3, AX
+    JZ   msd_remainder
+
+    VPCMPEQD Y4, Y4, Y4        // all ones
+    VPSRLD   $31, Y4, Y4       // each lane = 1 (the parity mask)
+
+msd_loop8:
+    VMOVDQU (SI), Y0           // mid
+    VMOVDQU (DI), Y1           // side
+    VPSLLD  $1, Y0, Y2         // mid << 1
+    VPAND   Y4, Y1, Y3         // side & 1
+    VPOR    Y3, Y2, Y2         // sum = (mid<<1)|(side&1)
+    VPADDD  Y1, Y2, Y5         // sum + side
+    VPSRAD  $1, Y5, Y5         // left
+    VMOVDQU Y5, (DX)
+    VPSUBD  Y1, Y2, Y6         // sum - side
+    VPSRAD  $1, Y6, Y6         // right
+    VMOVDQU Y6, (R8)
+    ADDQ $32, SI
+    ADDQ $32, DI
+    ADDQ $32, DX
+    ADDQ $32, R8
+    DECQ AX
+    JNZ  msd_loop8
+
+msd_remainder:
+    ANDQ $7, CX
+    JZ   msd_done
+
+msd_scalar:
+    MOVL (SI), AX              // mid
+    MOVL (DI), BX              // side
+    MOVL AX, R9
+    SHLL $1, R9                // mid << 1
+    MOVL BX, R10
+    ANDL $1, R10               // side & 1
+    ORL  R10, R9               // sum
+    MOVL R9, AX
+    ADDL BX, AX
+    SARL $1, AX                // (sum+side)>>1
+    MOVL AX, (DX)              // left
+    MOVL R9, AX
+    SUBL BX, AX
+    SARL $1, AX                // (sum-side)>>1
+    MOVL AX, (R8)              // right
+    ADDQ $4, SI
+    ADDQ $4, DI
+    ADDQ $4, DX
+    ADDQ $4, R8
+    DECQ CX
+    JNZ  msd_scalar
+
+msd_done:
+    VZEROUPPER
+    RET
+
+// func diff1AVX2(dst, src []int32)
+// dst[0]=src[0]; dst[n]=src[n]-src[n-1]
+TEXT ·diff1AVX2(SB), NOSPLIT, $0-48
+    MOVQ dst_base+0(FP), DX
+    MOVQ src_base+24(FP), SI
+    MOVQ src_len+32(FP), CX
+
+    MOVL (SI), AX
+    MOVL AX, (DX)              // warm-up dst[0]=src[0]
+    DECQ CX                    // residual count = len-1
+    JZ   diff1_done
+    ADDQ $4, DX                // &dst[1]
+
+    MOVQ CX, AX
+    SHRQ $3, AX
+    JZ   diff1_remainder
+
+diff1_loop8:
+    VMOVDQU 4(SI), Y0          // src[n]
+    VMOVDQU (SI), Y1           // src[n-1]
+    VPSUBD  Y1, Y0, Y2         // src[n] - src[n-1]
+    VMOVDQU Y2, (DX)
+    ADDQ $32, SI
+    ADDQ $32, DX
+    DECQ AX
+    JNZ  diff1_loop8
+
+diff1_remainder:
+    ANDQ $7, CX
+    JZ   diff1_done
+
+diff1_scalar:
+    MOVL 4(SI), AX
+    SUBL (SI), AX
+    MOVL AX, (DX)
+    ADDQ $4, SI
+    ADDQ $4, DX
+    DECQ CX
+    JNZ  diff1_scalar
+
+diff1_done:
+    VZEROUPPER
+    RET
+
+// func diff2AVX2(dst, src []int32)
+// dst[0:2]=src[0:2]; dst[n]=src[n]-2*src[n-1]+src[n-2] = (v0+v2)-2*v1
+TEXT ·diff2AVX2(SB), NOSPLIT, $0-48
+    MOVQ dst_base+0(FP), DX
+    MOVQ src_base+24(FP), SI
+    MOVQ src_len+32(FP), CX
+
+    MOVL (SI), AX
+    MOVL AX, (DX)
+    MOVL 4(SI), AX
+    MOVL AX, 4(DX)             // warm-up dst[0:2]=src[0:2]
+    SUBQ $2, CX                // residual count = len-2
+    ADDQ $8, DX                // &dst[2]
+
+    MOVQ CX, AX
+    SHRQ $3, AX
+    JZ   diff2_remainder
+
+diff2_loop8:
+    VMOVDQU 8(SI), Y0          // v0 = src[n]
+    VMOVDQU (SI), Y2           // v2 = src[n-2]
+    VPADDD  Y2, Y0, Y0         // v0 + v2
+    VMOVDQU 4(SI), Y1          // v1 = src[n-1]
+    VPSLLD  $1, Y1, Y1         // 2*v1
+    VPSUBD  Y1, Y0, Y0         // (v0+v2) - 2*v1
+    VMOVDQU Y0, (DX)
+    ADDQ $32, SI
+    ADDQ $32, DX
+    DECQ AX
+    JNZ  diff2_loop8
+
+diff2_remainder:
+    ANDQ $7, CX
+    JZ   diff2_done
+
+diff2_scalar:
+    MOVL 8(SI), AX             // v0
+    MOVL 4(SI), BX             // v1
+    SHLL $1, BX                // 2*v1
+    SUBL BX, AX                // v0 - 2*v1
+    ADDL (SI), AX              // + v2
+    MOVL AX, (DX)
+    ADDQ $4, SI
+    ADDQ $4, DX
+    DECQ CX
+    JNZ  diff2_scalar
+
+diff2_done:
+    VZEROUPPER
+    RET
+
+// func diff3AVX2(dst, src []int32)
+// dst[0:3]=src[0:3]; dst[n]=src[n]-3src[n-1]+3src[n-2]-src[n-3] = (v0-v3)-3*(v1-v2)
+TEXT ·diff3AVX2(SB), NOSPLIT, $0-48
+    MOVQ dst_base+0(FP), DX
+    MOVQ src_base+24(FP), SI
+    MOVQ src_len+32(FP), CX
+
+    MOVL (SI), AX
+    MOVL AX, (DX)
+    MOVL 4(SI), AX
+    MOVL AX, 4(DX)
+    MOVL 8(SI), AX
+    MOVL AX, 8(DX)             // warm-up dst[0:3]=src[0:3]
+    SUBQ $3, CX                // residual count = len-3
+    ADDQ $12, DX               // &dst[3]
+
+    MOVQ CX, AX
+    SHRQ $3, AX
+    JZ   diff3_remainder
+
+diff3_loop8:
+    VMOVDQU 12(SI), Y0         // v0 = src[n]
+    VMOVDQU (SI), Y3           // v3 = src[n-3]
+    VPSUBD  Y3, Y0, Y0         // a = v0 - v3
+    VMOVDQU 8(SI), Y1          // v1 = src[n-1]
+    VMOVDQU 4(SI), Y2          // v2 = src[n-2]
+    VPSUBD  Y2, Y1, Y1         // b = v1 - v2
+    VPSLLD  $1, Y1, Y4         // 2*b
+    VPADDD  Y1, Y4, Y4         // 3*b
+    VPSUBD  Y4, Y0, Y0         // a - 3*b
+    VMOVDQU Y0, (DX)
+    ADDQ $32, SI
+    ADDQ $32, DX
+    DECQ AX
+    JNZ  diff3_loop8
+
+diff3_remainder:
+    ANDQ $7, CX
+    JZ   diff3_done
+
+diff3_scalar:
+    MOVL 12(SI), AX            // v0
+    SUBL (SI), AX              // v0 - v3
+    MOVL 8(SI), BX             // v1
+    SUBL 4(SI), BX             // b = v1 - v2
+    MOVL BX, R9
+    SHLL $1, R9                // 2*b
+    ADDL R9, BX                // 3*b
+    SUBL BX, AX                // (v0-v3) - 3*b
+    MOVL AX, (DX)
+    ADDQ $4, SI
+    ADDQ $4, DX
+    DECQ CX
+    JNZ  diff3_scalar
+
+diff3_done:
+    VZEROUPPER
+    RET
+
+// func diff4AVX2(dst, src []int32)
+// dst[0:4]=src[0:4]; dst[n]=src[n]-4src[n-1]+6src[n-2]-4src[n-3]+src[n-4]
+//                          = (v0+v4) - 4*(v1+v3) + 6*v2
+TEXT ·diff4AVX2(SB), NOSPLIT, $0-48
+    MOVQ dst_base+0(FP), DX
+    MOVQ src_base+24(FP), SI
+    MOVQ src_len+32(FP), CX
+
+    MOVL (SI), AX
+    MOVL AX, (DX)
+    MOVL 4(SI), AX
+    MOVL AX, 4(DX)
+    MOVL 8(SI), AX
+    MOVL AX, 8(DX)
+    MOVL 12(SI), AX
+    MOVL AX, 12(DX)            // warm-up dst[0:4]=src[0:4]
+    SUBQ $4, CX                // residual count = len-4
+    ADDQ $16, DX               // &dst[4]
+
+    MOVQ CX, AX
+    SHRQ $3, AX
+    JZ   diff4_remainder
+
+diff4_loop8:
+    VMOVDQU 16(SI), Y0         // v0 = src[n]
+    VMOVDQU (SI), Y1           // v4 = src[n-4]
+    VPADDD  Y1, Y0, Y0         // s04 = v0 + v4
+    VMOVDQU 12(SI), Y1         // v1 = src[n-1]
+    VMOVDQU 4(SI), Y2          // v3 = src[n-3]
+    VPADDD  Y2, Y1, Y1         // s13 = v1 + v3
+    VPSLLD  $2, Y1, Y1         // 4*s13
+    VPSUBD  Y1, Y0, Y0         // s04 - 4*s13
+    VMOVDQU 8(SI), Y2          // v2 = src[n-2]
+    VPSLLD  $2, Y2, Y3         // 4*v2
+    VPSLLD  $1, Y2, Y2         // 2*v2
+    VPADDD  Y2, Y3, Y3         // 6*v2
+    VPADDD  Y3, Y0, Y0         // + 6*v2
+    VMOVDQU Y0, (DX)
+    ADDQ $32, SI
+    ADDQ $32, DX
+    DECQ AX
+    JNZ  diff4_loop8
+
+diff4_remainder:
+    ANDQ $7, CX
+    JZ   diff4_done
+
+diff4_scalar:
+    MOVL 16(SI), AX            // v0
+    ADDL (SI), AX              // v0 + v4
+    MOVL 12(SI), BX            // v1
+    ADDL 4(SI), BX             // v1 + v3
+    SHLL $2, BX                // 4*(v1+v3)
+    SUBL BX, AX                // s04 - 4*s13
+    MOVL 8(SI), BX             // v2
+    MOVL BX, R9
+    SHLL $2, R9                // 4*v2
+    SHLL $1, BX                // 2*v2
+    ADDL R9, BX                // 6*v2
+    ADDL BX, AX                // + 6*v2
+    MOVL AX, (DX)
+    ADDQ $4, SI
+    ADDQ $4, DX
+    DECQ CX
+    JNZ  diff4_scalar
+
+diff4_done:
+    VZEROUPPER
+    RET

--- a/i32/i32_amd64_test.go
+++ b/i32/i32_amd64_test.go
@@ -215,6 +215,38 @@ func TestDiff1AVX2_NoOverwrite(t *testing.T) {
 	}
 }
 
+// TestAVX2Kernels_AllocFree asserts each AVX2 kernel runs allocation-free, the
+// repo's zero-allocation contract enforced directly at the kernel boundary
+// (the public-API alloc tests cover the dispatch, these cover the kernels).
+func TestAVX2Kernels_AllocFree(t *testing.T) {
+	if !cpu.X86.AVX2 {
+		t.Skip("AVX2 not available")
+	}
+	const n = 1024
+	a := make([]int32, n)
+	b := make([]int32, n)
+	dst := make([]int32, n)
+	dst2 := make([]int32, n)
+	checks := []struct {
+		name string
+		fn   func()
+	}{
+		{"addAVX2", func() { addAVX2(dst, a, b) }},
+		{"subAVX2", func() { subAVX2(dst, a, b) }},
+		{"midSideEncodeAVX2", func() { midSideEncodeAVX2(dst, dst2, a, b) }},
+		{"midSideDecodeAVX2", func() { midSideDecodeAVX2(dst, dst2, a, b) }},
+		{"diff1AVX2", func() { diff1AVX2(dst, a) }},
+		{"diff2AVX2", func() { diff2AVX2(dst, a) }},
+		{"diff3AVX2", func() { diff3AVX2(dst, a) }},
+		{"diff4AVX2", func() { diff4AVX2(dst, a) }},
+	}
+	for _, c := range checks {
+		if got := testing.AllocsPerRun(100, c.fn); got != 0 {
+			t.Errorf("%s allocated %v times per run, want 0", c.name, got)
+		}
+	}
+}
+
 // TestMidSideEncodeAVX2_NoOverwrite guards both output tails.
 func TestMidSideEncodeAVX2_NoOverwrite(t *testing.T) {
 	if !cpu.X86.AVX2 {

--- a/i32/i32_amd64_test.go
+++ b/i32/i32_amd64_test.go
@@ -80,3 +80,163 @@ func TestInterleave2AVX_NoOverwrite(t *testing.T) {
 		}
 	}
 }
+
+// fillDiffSrc fills src with values that exercise the sign bit and force the
+// residual to wrap int32 at the extremes, so a kernel that handled overflow
+// differently than Go would be caught.
+func fillDiffSrc(src []int32) {
+	for i := range src {
+		src[i] = int32(i*7-3) ^ math.MinInt32
+	}
+	if len(src) > 1 {
+		src[0] = math.MaxInt32
+		src[1] = math.MinInt32
+	}
+}
+
+func TestAddSubAVX2_ParityWithGo(t *testing.T) {
+	if !cpu.X86.AVX2 {
+		t.Skip("AVX2 not available")
+	}
+	for _, n := range paritySizes {
+		a := make([]int32, n)
+		b := make([]int32, n)
+		fillPattern(a, b)
+		for _, tc := range []struct {
+			name   string
+			simd   func(dst, a, b []int32)
+			ref    func(dst, a, b []int32)
+		}{
+			{"add", addAVX2, addGo},
+			{"sub", subAVX2, subGo},
+		} {
+			gotAVX := make([]int32, n)
+			gotGo := make([]int32, n)
+			tc.simd(gotAVX, a, b)
+			tc.ref(gotGo, a, b)
+			for i := range gotGo {
+				if gotAVX[i] != gotGo[i] {
+					t.Fatalf("n=%d: %sAVX2[%d] = %d, want %d (Go)", n, tc.name, i, gotAVX[i], gotGo[i])
+				}
+			}
+		}
+	}
+}
+
+func TestMidSideAVX2_ParityWithGo(t *testing.T) {
+	if !cpu.X86.AVX2 {
+		t.Skip("AVX2 not available")
+	}
+	for _, n := range paritySizes {
+		left := make([]int32, n)
+		right := make([]int32, n)
+		fillPattern(left, right)
+
+		midAVX := make([]int32, n)
+		sideAVX := make([]int32, n)
+		midGo := make([]int32, n)
+		sideGo := make([]int32, n)
+		midSideEncodeAVX2(midAVX, sideAVX, left, right)
+		midSideEncodeGo(midGo, sideGo, left, right)
+		for i := range midGo {
+			if midAVX[i] != midGo[i] || sideAVX[i] != sideGo[i] {
+				t.Fatalf("n=%d: midSideEncodeAVX2[%d] = (%d,%d), want (%d,%d)", n, i, midAVX[i], sideAVX[i], midGo[i], sideGo[i])
+			}
+		}
+
+		lAVX := make([]int32, n)
+		rAVX := make([]int32, n)
+		lGo := make([]int32, n)
+		rGo := make([]int32, n)
+		midSideDecodeAVX2(lAVX, rAVX, midAVX, sideAVX)
+		midSideDecodeGo(lGo, rGo, midGo, sideGo)
+		for i := range lGo {
+			if lAVX[i] != lGo[i] || rAVX[i] != rGo[i] {
+				t.Fatalf("n=%d: midSideDecodeAVX2[%d] = (%d,%d), want (%d,%d)", n, i, lAVX[i], rAVX[i], lGo[i], rGo[i])
+			}
+		}
+	}
+}
+
+func TestDiffAVX2_ParityWithGo(t *testing.T) {
+	if !cpu.X86.AVX2 {
+		t.Skip("AVX2 not available")
+	}
+	kernels := []struct {
+		name string
+		simd func(dst, src []int32)
+		ref  func(dst, src []int32)
+	}{
+		{"diff1", diff1AVX2, diff1Go},
+		{"diff2", diff2AVX2, diff2Go},
+		{"diff3", diff3AVX2, diff3Go},
+		{"diff4", diff4AVX2, diff4Go},
+	}
+	for _, n := range paritySizes {
+		if n < minAVXElements {
+			continue // the kernel's warm-up reads assume len >= order; the
+			// dispatch only calls it for len >= minAVXElements, routing
+			// shorter inputs (and len < order) to the Go path.
+		}
+		src := make([]int32, n)
+		fillDiffSrc(src)
+		for _, k := range kernels {
+			gotAVX := make([]int32, n)
+			gotGo := make([]int32, n)
+			k.simd(gotAVX, src)
+			k.ref(gotGo, src)
+			for i := range gotGo {
+				if gotAVX[i] != gotGo[i] {
+					t.Fatalf("n=%d: %sAVX2[%d] = %d, want %d (Go)", n, k.name, i, gotAVX[i], gotGo[i])
+				}
+			}
+		}
+	}
+}
+
+// TestDiff1AVX2_NoOverwrite guards the scalar tail: the kernel must write exactly
+// n elements and not run past the end when n is not a multiple of the block.
+func TestDiff1AVX2_NoOverwrite(t *testing.T) {
+	if !cpu.X86.AVX2 {
+		t.Skip("AVX2 not available")
+	}
+	const n = 17
+	src := make([]int32, n)
+	fillDiffSrc(src)
+	dst := make([]int32, n+4)
+	for i := range dst {
+		dst[i] = math.MaxInt32 // sentinel
+	}
+	diff1AVX2(dst[:n], src)
+	for i := n; i < len(dst); i++ {
+		if dst[i] != math.MaxInt32 {
+			t.Errorf("diff1AVX2 wrote past end at dst[%d] = %d", i, dst[i])
+		}
+	}
+}
+
+// TestMidSideEncodeAVX2_NoOverwrite guards both output tails.
+func TestMidSideEncodeAVX2_NoOverwrite(t *testing.T) {
+	if !cpu.X86.AVX2 {
+		t.Skip("AVX2 not available")
+	}
+	const n = 17
+	left := make([]int32, n)
+	right := make([]int32, n)
+	fillPattern(left, right)
+	mid := make([]int32, n+4)
+	side := make([]int32, n+4)
+	for i := range mid {
+		mid[i] = math.MaxInt32
+		side[i] = math.MaxInt32
+	}
+	midSideEncodeAVX2(mid[:n], side[:n], left, right)
+	for i := n; i < len(mid); i++ {
+		if mid[i] != math.MaxInt32 {
+			t.Errorf("midSideEncodeAVX2 wrote past mid end at [%d] = %d", i, mid[i])
+		}
+		if side[i] != math.MaxInt32 {
+			t.Errorf("midSideEncodeAVX2 wrote past side end at [%d] = %d", i, side[i])
+		}
+	}
+}

--- a/i32/i32_arm64.go
+++ b/i32/i32_arm64.go
@@ -30,3 +30,91 @@ func interleave2NEON(dst, a, b []int32)
 
 //go:noescape
 func deinterleave2NEON(a, b, src []int32)
+
+func addI32(dst, a, b []int32) {
+	if hasNEON && len(dst) >= minNEONElements {
+		addNEON(dst, a, b)
+		return
+	}
+	addGo(dst, a, b)
+}
+
+func subI32(dst, a, b []int32) {
+	if hasNEON && len(dst) >= minNEONElements {
+		subNEON(dst, a, b)
+		return
+	}
+	subGo(dst, a, b)
+}
+
+func midSideEncodeI32(mid, side, left, right []int32) {
+	if hasNEON && len(mid) >= minNEONElements {
+		midSideEncodeNEON(mid, side, left, right)
+		return
+	}
+	midSideEncodeGo(mid, side, left, right)
+}
+
+func midSideDecodeI32(left, right, mid, side []int32) {
+	if hasNEON && len(left) >= minNEONElements {
+		midSideDecodeNEON(left, right, mid, side)
+		return
+	}
+	midSideDecodeGo(left, right, mid, side)
+}
+
+func diff1I32(dst, src []int32) {
+	if hasNEON && len(dst) >= minNEONElements {
+		diff1NEON(dst, src)
+		return
+	}
+	diff1Go(dst, src)
+}
+
+func diff2I32(dst, src []int32) {
+	if hasNEON && len(dst) >= minNEONElements {
+		diff2NEON(dst, src)
+		return
+	}
+	diff2Go(dst, src)
+}
+
+func diff3I32(dst, src []int32) {
+	if hasNEON && len(dst) >= minNEONElements {
+		diff3NEON(dst, src)
+		return
+	}
+	diff3Go(dst, src)
+}
+
+func diff4I32(dst, src []int32) {
+	if hasNEON && len(dst) >= minNEONElements {
+		diff4NEON(dst, src)
+		return
+	}
+	diff4Go(dst, src)
+}
+
+//go:noescape
+func addNEON(dst, a, b []int32)
+
+//go:noescape
+func subNEON(dst, a, b []int32)
+
+//go:noescape
+func midSideEncodeNEON(mid, side, left, right []int32)
+
+//go:noescape
+func midSideDecodeNEON(left, right, mid, side []int32)
+
+//go:noescape
+func diff1NEON(dst, src []int32)
+
+//go:noescape
+func diff2NEON(dst, src []int32)
+
+//go:noescape
+func diff3NEON(dst, src []int32)
+
+//go:noescape
+func diff4NEON(dst, src []int32)

--- a/i32/i32_arm64.s
+++ b/i32/i32_arm64.s
@@ -91,3 +91,416 @@ deinterleave2_neon_loop1:
 
 deinterleave2_neon_done:
     RET
+
+// Arithmetic, decorrelation and fixed-predictor kernels (NEON / ASIMD).
+//
+// These do integer ALU work on .4S vectors (4 int32/iter): ADD/SUB/SSHR/SHL and
+// the AND/ORR/MOVI used for the mid/side parity bit. The Go assembler has no
+// mnemonics for these vector ops, so they are hand-encoded as WORD with the
+// decoded GNU form in the trailing comment (cross-checked by asmcheck_test.go).
+// Each vector lane is 32 bits, so the SIMD path wraps exactly like the int32 Go
+// reference; the scalar tails use the W-register (32-bit) ALU forms (ADDW/SUBW/
+// ASRW/...) so they wrap identically. Dispatched from i32_arm64.go gated on the
+// NEON CPU feature, with the pure-Go reference as the fallback.
+
+// func addNEON(dst, a, b []int32)
+TEXT ·addNEON(SB), NOSPLIT, $0-72
+    MOVD dst_base+0(FP), R0
+    MOVD dst_len+8(FP), R3
+    MOVD a_base+24(FP), R1
+    MOVD b_base+48(FP), R2
+
+    LSR $2, R3, R4
+    CBZ R4, add_neon_remainder
+
+add_neon_loop4:
+    VLD1.P 16(R1), [V0.S4]
+    VLD1.P 16(R2), [V1.S4]
+    WORD $0x4EA18402           // ADD V2.4S, V0.4S, V1.4S
+    VST1.P [V2.S4], 16(R0)
+    SUB $1, R4
+    CBNZ R4, add_neon_loop4
+
+add_neon_remainder:
+    AND $3, R3
+    CBZ R3, add_neon_done
+
+add_neon_loop1:
+    MOVW (R1), R5
+    MOVW (R2), R6
+    ADDW R6, R5, R5
+    MOVW R5, (R0)
+    ADD $4, R1
+    ADD $4, R2
+    ADD $4, R0
+    SUB $1, R3
+    CBNZ R3, add_neon_loop1
+
+add_neon_done:
+    RET
+
+// func subNEON(dst, a, b []int32)
+TEXT ·subNEON(SB), NOSPLIT, $0-72
+    MOVD dst_base+0(FP), R0
+    MOVD dst_len+8(FP), R3
+    MOVD a_base+24(FP), R1
+    MOVD b_base+48(FP), R2
+
+    LSR $2, R3, R4
+    CBZ R4, sub_neon_remainder
+
+sub_neon_loop4:
+    VLD1.P 16(R1), [V0.S4]
+    VLD1.P 16(R2), [V1.S4]
+    WORD $0x6EA18402           // SUB V2.4S, V0.4S, V1.4S
+    VST1.P [V2.S4], 16(R0)
+    SUB $1, R4
+    CBNZ R4, sub_neon_loop4
+
+sub_neon_remainder:
+    AND $3, R3
+    CBZ R3, sub_neon_done
+
+sub_neon_loop1:
+    MOVW (R1), R5
+    MOVW (R2), R6
+    SUBW R6, R5, R5
+    MOVW R5, (R0)
+    ADD $4, R1
+    ADD $4, R2
+    ADD $4, R0
+    SUB $1, R3
+    CBNZ R3, sub_neon_loop1
+
+sub_neon_done:
+    RET
+
+// func midSideEncodeNEON(mid, side, left, right []int32)
+// mid = (left + right) >> 1 (arithmetic), side = left - right
+TEXT ·midSideEncodeNEON(SB), NOSPLIT, $0-96
+    MOVD mid_base+0(FP), R0
+    MOVD mid_len+8(FP), R3
+    MOVD side_base+24(FP), R1
+    MOVD left_base+48(FP), R2
+    MOVD right_base+72(FP), R5
+
+    LSR $2, R3, R4
+    CBZ R4, mse_neon_remainder
+
+mse_neon_loop4:
+    VLD1.P 16(R2), [V0.S4]     // left
+    VLD1.P 16(R5), [V1.S4]     // right
+    WORD $0x4EA18402           // ADD V2.4S, V0.4S, V1.4S   (left + right)
+    WORD $0x4F3F0442           // SSHR V2.4S, V2.4S, #1      ((left+right)>>1)
+    VST1.P [V2.S4], 16(R0)     // mid
+    WORD $0x6EA18403           // SUB V3.4S, V0.4S, V1.4S    (left - right)
+    VST1.P [V3.S4], 16(R1)     // side
+    SUB $1, R4
+    CBNZ R4, mse_neon_loop4
+
+mse_neon_remainder:
+    AND $3, R3
+    CBZ R3, mse_neon_done
+
+mse_neon_loop1:
+    MOVW (R2), R6              // left
+    MOVW (R5), R7             // right
+    ADDW R7, R6, R8           // left + right
+    ASRW $1, R8, R8           // >> 1 arithmetic
+    MOVW R8, (R0)             // mid
+    SUBW R7, R6, R9           // left - right
+    MOVW R9, (R1)             // side
+    ADD $4, R2
+    ADD $4, R5
+    ADD $4, R0
+    ADD $4, R1
+    SUB $1, R3
+    CBNZ R3, mse_neon_loop1
+
+mse_neon_done:
+    RET
+
+// func midSideDecodeNEON(left, right, mid, side []int32)
+// sum = (mid<<1)|(side&1); left = (sum+side)>>1; right = (sum-side)>>1
+TEXT ·midSideDecodeNEON(SB), NOSPLIT, $0-96
+    MOVD left_base+0(FP), R0
+    MOVD left_len+8(FP), R3
+    MOVD right_base+24(FP), R1
+    MOVD mid_base+48(FP), R2
+    MOVD side_base+72(FP), R5
+
+    LSR $2, R3, R4
+    CBZ R4, msd_neon_remainder
+    WORD $0x4F000424           // MOVI V4.4S, #0x1   (per-lane parity mask)
+
+msd_neon_loop4:
+    VLD1.P 16(R2), [V0.S4]     // mid
+    VLD1.P 16(R5), [V1.S4]     // side
+    WORD $0x4F215402           // SHL V2.4S, V0.4S, #1        (mid << 1)
+    WORD $0x4E241C23           // AND V3.16B, V1.16B, V4.16B  (side & 1)
+    WORD $0x4EA31C42           // ORR V2.16B, V2.16B, V3.16B  (sum)
+    WORD $0x4EA18445           // ADD V5.4S, V2.4S, V1.4S     (sum + side)
+    WORD $0x4F3F04A5           // SSHR V5.4S, V5.4S, #1       (left)
+    VST1.P [V5.S4], 16(R0)
+    WORD $0x6EA18446           // SUB V6.4S, V2.4S, V1.4S     (sum - side)
+    WORD $0x4F3F04C6           // SSHR V6.4S, V6.4S, #1       (right)
+    VST1.P [V6.S4], 16(R1)
+    SUB $1, R4
+    CBNZ R4, msd_neon_loop4
+
+msd_neon_remainder:
+    AND $3, R3
+    CBZ R3, msd_neon_done
+
+msd_neon_loop1:
+    MOVW (R2), R6              // mid
+    MOVW (R5), R7             // side
+    LSLW $1, R6, R8           // mid << 1
+    ANDW $1, R7, R9           // side & 1
+    ORRW R9, R8, R8           // sum
+    ADDW R7, R8, R10
+    ASRW $1, R10, R10         // (sum+side)>>1
+    MOVW R10, (R0)            // left
+    SUBW R7, R8, R11
+    ASRW $1, R11, R11         // (sum-side)>>1
+    MOVW R11, (R1)            // right
+    ADD $4, R2
+    ADD $4, R5
+    ADD $4, R0
+    ADD $4, R1
+    SUB $1, R3
+    CBNZ R3, msd_neon_loop1
+
+msd_neon_done:
+    RET
+
+// func diff1NEON(dst, src []int32)
+// dst[0]=src[0]; dst[n]=src[n]-src[n-1]
+TEXT ·diff1NEON(SB), NOSPLIT, $0-48
+    MOVD dst_base+0(FP), R0
+    MOVD src_base+24(FP), R1
+    MOVD src_len+32(FP), R3
+
+    MOVW (R1), R5
+    MOVW R5, (R0)              // warm-up dst[0]=src[0]
+    SUB $1, R3, R3             // residual count = len-1
+    CBZ R3, diff1_neon_done
+    ADD $4, R0                 // &dst[1]
+    ADD $4, R1, R6             // R6 = &src[1] (src[n]); R1 = &src[0] (src[n-1])
+
+    LSR $2, R3, R4
+    CBZ R4, diff1_neon_remainder
+
+diff1_neon_loop4:
+    VLD1.P 16(R6), [V0.S4]     // src[n]
+    VLD1.P 16(R1), [V1.S4]     // src[n-1]
+    WORD $0x6EA18402           // SUB V2.4S, V0.4S, V1.4S
+    VST1.P [V2.S4], 16(R0)
+    SUB $1, R4
+    CBNZ R4, diff1_neon_loop4
+
+diff1_neon_remainder:
+    AND $3, R3
+    CBZ R3, diff1_neon_done
+
+diff1_neon_loop1:
+    MOVW (R6), R5
+    MOVW (R1), R7
+    SUBW R7, R5, R5
+    MOVW R5, (R0)
+    ADD $4, R6
+    ADD $4, R1
+    ADD $4, R0
+    SUB $1, R3
+    CBNZ R3, diff1_neon_loop1
+
+diff1_neon_done:
+    RET
+
+// func diff2NEON(dst, src []int32)
+// dst[0:2]=src[0:2]; dst[n]=(v0+v2)-2*v1 where v0=src[n],v1=src[n-1],v2=src[n-2]
+TEXT ·diff2NEON(SB), NOSPLIT, $0-48
+    MOVD dst_base+0(FP), R0
+    MOVD src_base+24(FP), R1
+    MOVD src_len+32(FP), R3
+
+    MOVW (R1), R5
+    MOVW R5, (R0)
+    MOVW 4(R1), R5
+    MOVW R5, 4(R0)             // warm-up dst[0:2]=src[0:2]
+    SUB $2, R3, R3             // residual count = len-2
+    ADD $8, R0                 // &dst[2]
+    ADD $8, R1, R5             // pv0 = &src[2]
+    ADD $4, R1, R6             // pv1 = &src[1]; R1 = pv2 = &src[0]
+
+    LSR $2, R3, R4
+    CBZ R4, diff2_neon_remainder
+
+diff2_neon_loop4:
+    VLD1.P 16(R5), [V0.S4]     // v0
+    VLD1.P 16(R1), [V2.S4]     // v2
+    WORD $0x4EA28403           // ADD V3.4S, V0.4S, V2.4S   (v0 + v2)
+    VLD1.P 16(R6), [V1.S4]     // v1
+    WORD $0x4F215424           // SHL V4.4S, V1.4S, #1      (2*v1)
+    WORD $0x6EA48463           // SUB V3.4S, V3.4S, V4.4S   ((v0+v2) - 2*v1)
+    VST1.P [V3.S4], 16(R0)
+    SUB $1, R4
+    CBNZ R4, diff2_neon_loop4
+
+diff2_neon_remainder:
+    AND $3, R3
+    CBZ R3, diff2_neon_done
+
+diff2_neon_loop1:
+    MOVW (R5), R7              // v0
+    MOVW (R6), R8             // v1
+    LSLW $1, R8, R8           // 2*v1
+    SUBW R8, R7, R7           // v0 - 2*v1
+    MOVW (R1), R9             // v2
+    ADDW R9, R7, R7           // + v2
+    MOVW R7, (R0)
+    ADD $4, R5
+    ADD $4, R6
+    ADD $4, R1
+    ADD $4, R0
+    SUB $1, R3
+    CBNZ R3, diff2_neon_loop1
+
+diff2_neon_done:
+    RET
+
+// func diff3NEON(dst, src []int32)
+// dst[0:3]=src[0:3]; dst[n]=(v0-v3)-3*(v1-v2)
+TEXT ·diff3NEON(SB), NOSPLIT, $0-48
+    MOVD dst_base+0(FP), R0
+    MOVD src_base+24(FP), R1
+    MOVD src_len+32(FP), R3
+
+    MOVW (R1), R5
+    MOVW R5, (R0)
+    MOVW 4(R1), R5
+    MOVW R5, 4(R0)
+    MOVW 8(R1), R5
+    MOVW R5, 8(R0)             // warm-up dst[0:3]=src[0:3]
+    SUB $3, R3, R3             // residual count = len-3
+    ADD $12, R0                // &dst[3]
+    ADD $12, R1, R5            // pv0 = &src[3]
+    ADD $8, R1, R6             // pv1 = &src[2]
+    ADD $4, R1, R7             // pv2 = &src[1]; R1 = pv3 = &src[0]
+
+    LSR $2, R3, R4
+    CBZ R4, diff3_neon_remainder
+
+diff3_neon_loop4:
+    VLD1.P 16(R5), [V0.S4]     // v0
+    VLD1.P 16(R1), [V3.S4]     // v3
+    WORD $0x6EA38400           // SUB V0.4S, V0.4S, V3.4S   (a = v0 - v3)
+    VLD1.P 16(R6), [V1.S4]     // v1
+    VLD1.P 16(R7), [V2.S4]     // v2
+    WORD $0x6EA28421           // SUB V1.4S, V1.4S, V2.4S   (b = v1 - v2)
+    WORD $0x4F215424           // SHL V4.4S, V1.4S, #1      (2*b)
+    WORD $0x4EA18484           // ADD V4.4S, V4.4S, V1.4S   (3*b)
+    WORD $0x6EA48400           // SUB V0.4S, V0.4S, V4.4S   (a - 3*b)
+    VST1.P [V0.S4], 16(R0)
+    SUB $1, R4
+    CBNZ R4, diff3_neon_loop4
+
+diff3_neon_remainder:
+    AND $3, R3
+    CBZ R3, diff3_neon_done
+
+diff3_neon_loop1:
+    MOVW (R5), R8             // v0
+    MOVW (R1), R9             // v3
+    SUBW R9, R8, R8           // v0 - v3
+    MOVW (R6), R9             // v1
+    MOVW (R7), R10            // v2
+    SUBW R10, R9, R9          // b = v1 - v2
+    LSLW $1, R9, R11
+    ADDW R9, R11, R11         // 3*b
+    SUBW R11, R8, R8          // (v0-v3) - 3*b
+    MOVW R8, (R0)
+    ADD $4, R5
+    ADD $4, R6
+    ADD $4, R7
+    ADD $4, R1
+    ADD $4, R0
+    SUB $1, R3
+    CBNZ R3, diff3_neon_loop1
+
+diff3_neon_done:
+    RET
+
+// func diff4NEON(dst, src []int32)
+// dst[0:4]=src[0:4]; dst[n]=(v0+v4)-4*(v1+v3)+6*v2
+TEXT ·diff4NEON(SB), NOSPLIT, $0-48
+    MOVD dst_base+0(FP), R0
+    MOVD src_base+24(FP), R1
+    MOVD src_len+32(FP), R3
+
+    MOVW (R1), R5
+    MOVW R5, (R0)
+    MOVW 4(R1), R5
+    MOVW R5, 4(R0)
+    MOVW 8(R1), R5
+    MOVW R5, 8(R0)
+    MOVW 12(R1), R5
+    MOVW R5, 12(R0)            // warm-up dst[0:4]=src[0:4]
+    SUB $4, R3, R3             // residual count = len-4
+    ADD $16, R0                // &dst[4]
+    ADD $16, R1, R5            // pv0 = &src[4]
+    ADD $12, R1, R6            // pv1 = &src[3]
+    ADD $8, R1, R7             // pv2 = &src[2]
+    ADD $4, R1, R8             // pv3 = &src[1]; R1 = pv4 = &src[0]
+
+    LSR $2, R3, R4
+    CBZ R4, diff4_neon_remainder
+
+diff4_neon_loop4:
+    VLD1.P 16(R5), [V0.S4]     // v0
+    VLD1.P 16(R1), [V4.S4]     // v4
+    WORD $0x4EA48400           // ADD V0.4S, V0.4S, V4.4S   (s04 = v0 + v4)
+    VLD1.P 16(R6), [V1.S4]     // v1
+    VLD1.P 16(R8), [V3.S4]     // v3
+    WORD $0x4EA38421           // ADD V1.4S, V1.4S, V3.4S   (s13 = v1 + v3)
+    WORD $0x4F225421           // SHL V1.4S, V1.4S, #2      (4*s13)
+    WORD $0x6EA18400           // SUB V0.4S, V0.4S, V1.4S   (s04 - 4*s13)
+    VLD1.P 16(R7), [V2.S4]     // v2
+    WORD $0x4F225445           // SHL V5.4S, V2.4S, #2      (4*v2)
+    WORD $0x4F215446           // SHL V6.4S, V2.4S, #1      (2*v2)
+    WORD $0x4EA684A5           // ADD V5.4S, V5.4S, V6.4S   (6*v2)
+    WORD $0x4EA58400           // ADD V0.4S, V0.4S, V5.4S   (+ 6*v2)
+    VST1.P [V0.S4], 16(R0)
+    SUB $1, R4
+    CBNZ R4, diff4_neon_loop4
+
+diff4_neon_remainder:
+    AND $3, R3
+    CBZ R3, diff4_neon_done
+
+diff4_neon_loop1:
+    MOVW (R5), R9             // v0
+    MOVW (R1), R10            // v4
+    ADDW R10, R9, R9          // s04
+    MOVW (R6), R10            // v1
+    MOVW (R8), R11            // v3
+    ADDW R11, R10, R10        // s13
+    LSLW $2, R10, R10         // 4*s13
+    SUBW R10, R9, R9          // s04 - 4*s13
+    MOVW (R7), R10            // v2
+    LSLW $2, R10, R11         // 4*v2
+    LSLW $1, R10, R10         // 2*v2
+    ADDW R10, R11, R11        // 6*v2
+    ADDW R11, R9, R9          // + 6*v2
+    MOVW R9, (R0)
+    ADD $4, R5
+    ADD $4, R6
+    ADD $4, R7
+    ADD $4, R8
+    ADD $4, R1
+    ADD $4, R0
+    SUB $1, R3
+    CBNZ R3, diff4_neon_loop1
+
+diff4_neon_done:
+    RET

--- a/i32/i32_arm64_test.go
+++ b/i32/i32_arm64_test.go
@@ -193,6 +193,38 @@ func TestDiffNEON_ParityWithGo(t *testing.T) {
 	}
 }
 
+// TestNEONKernels_AllocFree asserts each NEON kernel runs allocation-free, the
+// repo's zero-allocation contract enforced directly at the kernel boundary
+// (the public-API alloc tests cover the dispatch, these cover the kernels).
+func TestNEONKernels_AllocFree(t *testing.T) {
+	if !cpu.ARM64.NEON {
+		t.Skip("NEON not available")
+	}
+	const n = 1024
+	a := make([]int32, n)
+	b := make([]int32, n)
+	dst := make([]int32, n)
+	dst2 := make([]int32, n)
+	checks := []struct {
+		name string
+		fn   func()
+	}{
+		{"addNEON", func() { addNEON(dst, a, b) }},
+		{"subNEON", func() { subNEON(dst, a, b) }},
+		{"midSideEncodeNEON", func() { midSideEncodeNEON(dst, dst2, a, b) }},
+		{"midSideDecodeNEON", func() { midSideDecodeNEON(dst, dst2, a, b) }},
+		{"diff1NEON", func() { diff1NEON(dst, a) }},
+		{"diff2NEON", func() { diff2NEON(dst, a) }},
+		{"diff3NEON", func() { diff3NEON(dst, a) }},
+		{"diff4NEON", func() { diff4NEON(dst, a) }},
+	}
+	for _, c := range checks {
+		if got := testing.AllocsPerRun(100, c.fn); got != 0 {
+			t.Errorf("%s allocated %v times per run, want 0", c.name, got)
+		}
+	}
+}
+
 // TestDiff1NEON_NoOverwrite guards the scalar tail.
 func TestDiff1NEON_NoOverwrite(t *testing.T) {
 	if !cpu.ARM64.NEON {

--- a/i32/i32_arm64_test.go
+++ b/i32/i32_arm64_test.go
@@ -80,3 +80,135 @@ func TestInterleave2NEON_NoOverwrite(t *testing.T) {
 		}
 	}
 }
+
+// fillDiffSrc fills src with values that exercise the sign bit and force the
+// residual to wrap int32 at the extremes.
+func fillDiffSrc(src []int32) {
+	for i := range src {
+		src[i] = int32(i*7-3) ^ math.MinInt32
+	}
+	if len(src) > 1 {
+		src[0] = math.MaxInt32
+		src[1] = math.MinInt32
+	}
+}
+
+func TestAddSubNEON_ParityWithGo(t *testing.T) {
+	if !cpu.ARM64.NEON {
+		t.Skip("NEON not available")
+	}
+	for _, n := range paritySizes {
+		a := make([]int32, n)
+		b := make([]int32, n)
+		fillPattern(a, b)
+		for _, tc := range []struct {
+			name string
+			simd func(dst, a, b []int32)
+			ref  func(dst, a, b []int32)
+		}{
+			{"add", addNEON, addGo},
+			{"sub", subNEON, subGo},
+		} {
+			gotNEON := make([]int32, n)
+			gotGo := make([]int32, n)
+			tc.simd(gotNEON, a, b)
+			tc.ref(gotGo, a, b)
+			for i := range gotGo {
+				if gotNEON[i] != gotGo[i] {
+					t.Fatalf("n=%d: %sNEON[%d] = %d, want %d (Go)", n, tc.name, i, gotNEON[i], gotGo[i])
+				}
+			}
+		}
+	}
+}
+
+func TestMidSideNEON_ParityWithGo(t *testing.T) {
+	if !cpu.ARM64.NEON {
+		t.Skip("NEON not available")
+	}
+	for _, n := range paritySizes {
+		left := make([]int32, n)
+		right := make([]int32, n)
+		fillPattern(left, right)
+
+		midNEON := make([]int32, n)
+		sideNEON := make([]int32, n)
+		midGo := make([]int32, n)
+		sideGo := make([]int32, n)
+		midSideEncodeNEON(midNEON, sideNEON, left, right)
+		midSideEncodeGo(midGo, sideGo, left, right)
+		for i := range midGo {
+			if midNEON[i] != midGo[i] || sideNEON[i] != sideGo[i] {
+				t.Fatalf("n=%d: midSideEncodeNEON[%d] = (%d,%d), want (%d,%d)", n, i, midNEON[i], sideNEON[i], midGo[i], sideGo[i])
+			}
+		}
+
+		lNEON := make([]int32, n)
+		rNEON := make([]int32, n)
+		lGo := make([]int32, n)
+		rGo := make([]int32, n)
+		midSideDecodeNEON(lNEON, rNEON, midNEON, sideNEON)
+		midSideDecodeGo(lGo, rGo, midGo, sideGo)
+		for i := range lGo {
+			if lNEON[i] != lGo[i] || rNEON[i] != rGo[i] {
+				t.Fatalf("n=%d: midSideDecodeNEON[%d] = (%d,%d), want (%d,%d)", n, i, lNEON[i], rNEON[i], lGo[i], rGo[i])
+			}
+		}
+	}
+}
+
+func TestDiffNEON_ParityWithGo(t *testing.T) {
+	if !cpu.ARM64.NEON {
+		t.Skip("NEON not available")
+	}
+	kernels := []struct {
+		name string
+		simd func(dst, src []int32)
+		ref  func(dst, src []int32)
+	}{
+		{"diff1", diff1NEON, diff1Go},
+		{"diff2", diff2NEON, diff2Go},
+		{"diff3", diff3NEON, diff3Go},
+		{"diff4", diff4NEON, diff4Go},
+	}
+	for _, n := range paritySizes {
+		if n < minNEONElements {
+			continue // the kernel's warm-up reads assume len >= order; the
+			// dispatch only calls it for len >= minNEONElements, routing
+			// shorter inputs to the Go path.
+		}
+		src := make([]int32, n)
+		fillDiffSrc(src)
+		for _, k := range kernels {
+			gotNEON := make([]int32, n)
+			gotGo := make([]int32, n)
+			k.simd(gotNEON, src)
+			k.ref(gotGo, src)
+			for i := range gotGo {
+				if gotNEON[i] != gotGo[i] {
+					t.Fatalf("n=%d: %sNEON[%d] = %d, want %d (Go)", n, k.name, i, gotNEON[i], gotGo[i])
+				}
+			}
+		}
+	}
+}
+
+// TestDiff1NEON_NoOverwrite guards the scalar tail.
+func TestDiff1NEON_NoOverwrite(t *testing.T) {
+	if !cpu.ARM64.NEON {
+		t.Skip("NEON not available")
+	}
+	const n = 17
+	src := make([]int32, n)
+	fillDiffSrc(src)
+	dst := make([]int32, n+4)
+	for i := range dst {
+		dst[i] = math.MaxInt32
+	}
+	diff1NEON(dst[:n], src)
+	for i := n; i < len(dst); i++ {
+		if dst[i] != math.MaxInt32 {
+			t.Errorf("diff1NEON wrote past end at dst[%d] = %d", i, dst[i])
+		}
+	}
+}

--- a/i32/i32_go.go
+++ b/i32/i32_go.go
@@ -19,3 +19,65 @@ func deinterleave2Go(a, b, src []int32) {
 		b[i] = src[i*2+1]
 	}
 }
+
+
+func addGo(dst, a, b []int32) {
+	for i := range dst {
+		dst[i] = a[i] + b[i]
+	}
+}
+
+func subGo(dst, a, b []int32) {
+	for i := range dst {
+		dst[i] = a[i] - b[i]
+	}
+}
+
+func midSideEncodeGo(mid, side, left, right []int32) {
+	for i := range mid {
+		mid[i] = (left[i] + right[i]) >> 1
+		side[i] = left[i] - right[i]
+	}
+}
+
+func midSideDecodeGo(left, right, mid, side []int32) {
+	for i := range left {
+		// The encoder's mid = (l+r)>>1 dropped the low bit of l+r. Because l+r
+		// and l-r have the same parity, side&1 restores it.
+		sum := (mid[i] << 1) | (side[i] & 1)
+		left[i] = (sum + side[i]) >> 1
+		right[i] = (sum - side[i]) >> 1
+	}
+}
+
+// The order-K fixed-predictor residual coefficients: the signed binomials
+// (-1)^j * C(K,j) applied to src[n], src[n-1], ..., src[n-K]. The order is the
+// slice length minus one, so diffGo needs no separate order argument.
+var (
+	fixedCoeffs1 = []int32{1, -1}
+	fixedCoeffs2 = []int32{1, -2, 1}
+	fixedCoeffs3 = []int32{1, -3, 3, -1}
+	fixedCoeffs4 = []int32{1, -4, 6, -4, 1}
+)
+
+// diffGo writes the fixed-predictor residual for coefficients c into dst: the
+// first order=len(c)-1 entries are the verbatim warm-up (dst[i]=src[i]) and
+// dst[n] for n>=order is the binomial combination. int32 arithmetic wraps,
+// matching the SIMD kernels.
+func diffGo(dst, src, c []int32) {
+	order := len(c) - 1
+	w := min(order, len(src))
+	copy(dst[:w], src[:w])
+	for n := order; n < len(src); n++ {
+		var acc int32
+		for j, cj := range c {
+			acc += cj * src[n-j]
+		}
+		dst[n] = acc
+	}
+}
+
+func diff1Go(dst, src []int32) { diffGo(dst, src, fixedCoeffs1) }
+func diff2Go(dst, src []int32) { diffGo(dst, src, fixedCoeffs2) }
+func diff3Go(dst, src []int32) { diffGo(dst, src, fixedCoeffs3) }
+func diff4Go(dst, src []int32) { diffGo(dst, src, fixedCoeffs4) }

--- a/i32/i32_other.go
+++ b/i32/i32_other.go
@@ -4,3 +4,14 @@ package i32
 
 func interleave2I32(dst, a, b []int32)   { interleave2Go(dst, a, b) }
 func deinterleave2I32(a, b, src []int32) { deinterleave2Go(a, b, src) }
+
+func addI32(dst, a, b []int32) { addGo(dst, a, b) }
+func subI32(dst, a, b []int32) { subGo(dst, a, b) }
+
+func midSideEncodeI32(mid, side, left, right []int32) { midSideEncodeGo(mid, side, left, right) }
+func midSideDecodeI32(left, right, mid, side []int32) { midSideDecodeGo(left, right, mid, side) }
+
+func diff1I32(dst, src []int32) { diff1Go(dst, src) }
+func diff2I32(dst, src []int32) { diff2Go(dst, src) }
+func diff3I32(dst, src []int32) { diff3Go(dst, src) }
+func diff4I32(dst, src []int32) { diff4Go(dst, src) }


### PR DESCRIPTION
## i32: decorrelation + fixed-predictor encode kernels (PR3 + PR4)

Implements the next two roadmap items from #79 for the native-Go FLAC codec, batched into one PR because both are element-wise integer kernels that share the same new integer-ALU assembly scaffolding (VPADDD/VPSUBD/VPSRAD on AMD64, hand-encoded ADD/SUB/SSHR on NEON). The recurrence kernels (PR5 `Restore`, PR7 `LPCRestore`) stay separate since they are a different kernel shape.

### New API

Element-wise integer primitives and FLAC stereo decorrelation (`decorrelate.go`):

- `Add(dst, a, b)` / `Sub(dst, a, b)` - element-wise int32, wraparound.
- `MidSideEncode(mid, side, left, right)` - `mid=(l+r)>>1`, `side=l-r`.
- `MidSideDecode(left, right, mid, side)` - inverse, restoring the dropped LSB via the `side&1` parity bit.

Rather than ship near-identical named per-mode functions, the three FLAC stereo modes map onto these generic primitives (documented in the package and `Example`s), matching how `f32`/`f64` expose generic `Mul`/`DotProduct`:

| mode | encode | decode |
|------|--------|--------|
| LEFT_SIDE | `Sub(side, left, right)` | `Sub(right, left, side)` |
| RIGHT_SIDE | `Sub(side, left, right)` | `Add(left, right, side)` |
| MID_SIDE | `MidSideEncode(...)` | `MidSideDecode(...)` |

Fixed-predictor encode residuals (`fixed.go`):

- `Diff1..Diff4(dst, src)` - order-K forward finite difference (signed binomial coefficients); `dst[0:K]` is the verbatim warm-up, `dst[K:]` the residual, so `dst` is laid out as a FLAC subframe expects.

### Implementation

- AMD64 AVX2 kernels (8 int32/iter), gated on the AVX2 CPU feature (256-bit integer ops need AVX2, unlike the AVX1 float shuffles the interleave kernels reuse), with the pure-Go reference as fallback.
- ARM64 NEON kernels (4 int32/iter), hand-encoded `WORD` + decoded comment, cross-checked against `arm64asm` by the existing asmcheck harness.
- The pure-Go reference is the source of truth; the diff reference computes the binomial form while the test cross-checks with an independent repeated-differencing algorithm.
- Vector lanes are 32-bit so the SIMD path wraps exactly like the int32 reference; scalar tails use the W-register (32-bit) ALU forms so they wrap identically.

### Testing

Bit-exact SIMD-vs-Go parity across sizes straddling both block widths, with sign/high-bit and int32-extreme coverage; mid/side round-trip; length clamping; empty/short inputs; scalar-tail no-overwrite guards; zero-alloc assertions; benches; runnable examples; asmcheck for every new NEON encoding. Verified on amd64 (AVX2) natively and arm64 (NEON) on a Raspberry Pi 5. `golangci-lint run ./...` clean; `go vet` clean on both arches.

### Benchmarks (1000 elements, vs pure Go, zero-alloc)

| Op | amd64 AVX2 | arm64 NEON (Pi 5) |
|----|-----------|-------------------|
| Add | 77 ns, 4.6x | 243 ns, 5.2x |
| Sub | 74 ns, 4.9x | 243 ns, 5.2x |
| MidSideEncode | 116 ns, 5.3x | 353 ns, 5.9x |
| MidSideDecode | 135 ns, 5.5x | 618 ns, 3.4x |
| Diff1 | 72 ns, 15.8x | 244 ns, 18.8x |
| Diff2 | 115 ns, 13.6x | 347 ns, 15.6x |
| Diff4 | 188 ns, 12.2x | 624 ns, 11.3x |

Refs #79.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added int32 stereo audio decorrelation operations including Mid/Side encoding and decoding
  * Added fixed-predictor forward difference encoding functions

* **Performance**
  * Implemented SIMD-accelerated kernels for AVX2 (x86-64) and NEON (ARM64) architectures
  * Pure-Go reference implementations ensure broad platform compatibility

* **Tests**
  * Comprehensive benchmarking and unit test coverage for all new operations

<!-- end of auto-generated comment: release notes by coderabbit.ai -->