### PR TITLE
i32: AVX2/NEON fixed-predictor decode Restore1..Restore4 via SIMD prefix sum

### DIFF
--- a/README.md
+++ b/README.md
@@ -372,10 +372,16 @@ c64.Abs(magnitude, signalFFT)              // Extract magnitude
 
 SIMD-accelerated integer-domain operations for codec and integer-DSP hot loops (for example a pure-Go FLAC encoder/decoder), where the per-sample work is integer arithmetic and channel (de)interleaving rather than floating-point math:
 
-| Category        | Function                  | Description                                  | SIMD Width                          |
-| --------------- | ------------------------- | -------------------------------------------- | ----------------------------------- |
-| **Interleave**  | `Interleave2(dst, a, b)`  | Pack two channels into interleaved stereo    | 8x (AVX) / 4x (NEON)                |
-|                 | `Deinterleave2(a, b, src)`| Split interleaved stereo into two channels   | 8x (AVX) / 4x (NEON)                |
+| Category            | Function                                | Description                                              | SIMD Width            |
+| ------------------- | --------------------------------------- | -------------------------------------------------------- | --------------------- |
+| **Interleave**      | `Interleave2(dst, a, b)`                | Pack two channels into interleaved stereo                | 8x (AVX) / 4x (NEON)  |
+|                     | `Deinterleave2(a, b, src)`              | Split interleaved stereo into two channels               | 8x (AVX) / 4x (NEON)  |
+| **Decorrelation**   | `Add(dst, a, b)`                        | Element-wise add (RIGHT_SIDE decode)                     | 8x (AVX2) / 4x (NEON) |
+|                     | `Sub(dst, a, b)`                        | Element-wise subtract (side channel / LEFT_SIDE decode)  | 8x (AVX2) / 4x (NEON) |
+|                     | `MidSideEncode(mid, side, left, right)` | Mid/side forward decorrelation                           | 8x (AVX2) / 4x (NEON) |
+|                     | `MidSideDecode(left, right, mid, side)` | Mid/side inverse (parity-bit reconstruction)             | 8x (AVX2) / 4x (NEON) |
+| **Fixed predictor** | `Diff1`..`Diff4(dst, src)`              | Order 1-4 fixed-predictor encode residual (forward diff) | 8x (AVX2) / 4x (NEON) |
+|                     | `Restore1`..`Restore4(dst, src)`        | Order 1-4 fixed-predictor decode (inverse; prefix sum)   | 8x (AVX2) / 4x (NEON) |
 
 ```go
 import "github.com/tphakala/simd/i32"
@@ -386,9 +392,13 @@ stereo := make([]int32, n*2)
 
 i32.Interleave2(stereo, left, right)   // [l0, r0, l1, r1, ...]
 i32.Deinterleave2(left, right, stereo) // inverse: split back to channels
+
+res := make([]int32, n)
+i32.Diff2(res, left)     // order-2 fixed-predictor encode residual
+i32.Restore2(left, res)  // exact inverse: reconstruct the samples
 ```
 
-Interleaving is pure 32-bit-lane movement, so the kernels reuse the proven `f32` shuffle/permute encodings (AVX `VUNPCKLPS`/`VPERM2F128`, NEON `ZIP`/`UZP` on `.4S`); the bit pattern of each lane is irrelevant, so negative values and the type extremes round-trip exactly. This is the first slice of a broader integer surface (decorrelation, fixed-predictor differences, LPC FIR) tracked in the project issues.
+Interleaving is pure 32-bit-lane movement, so those kernels reuse the proven `f32` shuffle/permute encodings (AVX `VUNPCKLPS`/`VPERM2F128`, NEON `ZIP`/`UZP` on `.4S`); the bit pattern of each lane is irrelevant, so negative values and the type extremes round-trip exactly. The decorrelation and fixed-predictor kernels do integer-ALU work on 256-bit (AVX2) / 128-bit (NEON) lanes. `RestoreK` is the exact inverse of `DiffK`: since the order-`K` fixed predictor is the `K`-th forward difference, restoration is `K` cumulative-sum passes built on one SIMD prefix-sum kernel (11x at order 1 down to ~5x at order 4 on AVX2; 6x to 3x on NEON, all zero-allocation). The remaining integer surface (LPC FIR encode/decode, Rice cost search) is tracked in the project issues.
 
 ## Performance
 
@@ -556,12 +566,16 @@ a Raspberry Pi 5):
 
 ### int32 (i32) - SIMD vs Pure Go (1000 elements)
 
-| Operation     | AMD64 (AVX)                  | ARM64 (NEON, Pi 5)            |
+| Operation     | AMD64 (AVX/AVX2)             | ARM64 (NEON, Pi 5)            |
 | ------------- | ---------------------------- | ----------------------------- |
 | Interleave2   | 121 ns vs 487 ns (**4.0x**)  | 322 ns vs 1679 ns (**5.2x**)  |
 | Deinterleave2 | 228 ns vs 482 ns (**2.1x**)  | 322 ns vs 1682 ns (**5.2x**)  |
+| Restore1      | 181 ns vs 2019 ns (**11.2x**)| 605 ns vs 3763 ns (**6.2x**)  |
+| Restore2      | 320 ns vs 2296 ns (**7.2x**) | 1101 ns vs 4592 ns (**4.2x**) |
+| Restore3      | 462 ns vs 2493 ns (**5.4x**) | 1608 ns vs 5421 ns (**3.4x**) |
+| Restore4      | 575 ns vs 2778 ns (**4.8x**) | 2093 ns vs 6245 ns (**3.0x**) |
 
-All int32 kernels are zero-allocation and bit-exact against the pure-Go reference (verified across the sign and high bits with negative values and the type extremes).
+All int32 kernels are zero-allocation and bit-exact against the pure-Go reference (verified across the sign and high bits with negative values and the type extremes). The Restore baseline is the pure-Go decode recurrence; `RestoreK` reconstructs samples as `K` SIMD prefix-sum passes (the inverse of the order-`K` forward difference).
 
 ### Performance Notes
 

--- a/i32/benchmark_test.go
+++ b/i32/benchmark_test.go
@@ -221,3 +221,72 @@ func BenchmarkDiff4Go_1000(b *testing.B) {
 		diff4Go(dst, src)
 	}
 }
+
+// Restore benchmarks pair the SIMD cumulative-sum decomposition (RestoreK)
+// against restoreKGo, the pure-Go direct decode recurrence a scalar FLAC decoder
+// would use, so the speedup of the prefix-sum kernel (and the K-pass cost at
+// higher orders) is visible honestly.
+
+func BenchmarkRestore1_1000(b *testing.B) {
+	src, dst := benchSrcDst()
+	b.SetBytes(benchN * 4 * 2)
+	for b.Loop() {
+		Restore1(dst, src)
+	}
+}
+
+func BenchmarkRestore1Go_1000(b *testing.B) {
+	src, dst := benchSrcDst()
+	b.SetBytes(benchN * 4 * 2)
+	for b.Loop() {
+		restore1Go(dst, src)
+	}
+}
+
+func BenchmarkRestore2_1000(b *testing.B) {
+	src, dst := benchSrcDst()
+	b.SetBytes(benchN * 4 * 2)
+	for b.Loop() {
+		Restore2(dst, src)
+	}
+}
+
+func BenchmarkRestore2Go_1000(b *testing.B) {
+	src, dst := benchSrcDst()
+	b.SetBytes(benchN * 4 * 2)
+	for b.Loop() {
+		restore2Go(dst, src)
+	}
+}
+
+func BenchmarkRestore3_1000(b *testing.B) {
+	src, dst := benchSrcDst()
+	b.SetBytes(benchN * 4 * 2)
+	for b.Loop() {
+		Restore3(dst, src)
+	}
+}
+
+func BenchmarkRestore3Go_1000(b *testing.B) {
+	src, dst := benchSrcDst()
+	b.SetBytes(benchN * 4 * 2)
+	for b.Loop() {
+		restore3Go(dst, src)
+	}
+}
+
+func BenchmarkRestore4_1000(b *testing.B) {
+	src, dst := benchSrcDst()
+	b.SetBytes(benchN * 4 * 2)
+	for b.Loop() {
+		Restore4(dst, src)
+	}
+}
+
+func BenchmarkRestore4Go_1000(b *testing.B) {
+	src, dst := benchSrcDst()
+	b.SetBytes(benchN * 4 * 2)
+	for b.Loop() {
+		restore4Go(dst, src)
+	}
+}

--- a/i32/example_test.go
+++ b/i32/example_test.go
@@ -69,3 +69,14 @@ func ExampleDiff1() {
 	fmt.Println(res)
 	// Output: [10 3 0 -5 12]
 }
+
+// ExampleRestore1 shows decode-side restoration: Restore1 inverts Diff1,
+// reconstructing the samples from the [warm-up | residuals] layout.
+func ExampleRestore1() {
+	res := []int32{10, 3, 0, -5, 12}
+	samples := make([]int32, len(res))
+
+	i32.Restore1(samples, res)
+	fmt.Println(samples)
+	// Output: [10 13 13 8 20]
+}

--- a/i32/i32_amd64.go
+++ b/i32/i32_amd64.go
@@ -119,6 +119,17 @@ func midSideEncodeAVX2(mid, side, left, right []int32)
 //go:noescape
 func midSideDecodeAVX2(left, right, mid, side []int32)
 
+func cumsumI32(a []int32) {
+	if hasAVX2 && len(a) >= minAVXElements {
+		cumsumAVX2(a)
+		return
+	}
+	cumsumGo(a)
+}
+
+//go:noescape
+func cumsumAVX2(a []int32)
+
 //go:noescape
 func diff1AVX2(dst, src []int32)
 

--- a/i32/i32_amd64.s
+++ b/i32/i32_amd64.s
@@ -560,3 +560,57 @@ diff4_scalar:
 diff4_done:
     VZEROUPPER
     RET
+
+// func cumsumAVX2(a []int32)
+// In-place inclusive prefix sum: a[i] += a[i-1] for i in 1..n-1 (a[0] kept).
+// This is the order-1 fixed-predictor restore and the building block the
+// Restore1..Restore4 wrappers compose. Each 256-bit block computes a standalone
+// 8-element inclusive prefix sum (two within-128 shift-adds plus one cross-128
+// carry), adds the running total of all earlier blocks, then broadcasts its own
+// last lane as the running total for the next block. The scalar tail reads the
+// previous cumulative value straight from memory, so it needs no vector carry.
+TEXT ·cumsumAVX2(SB), NOSPLIT, $0-24
+    MOVQ a_base+0(FP), DX
+    MOVQ a_len+8(FP), CX
+
+    MOVQ CX, AX
+    SHRQ $3, AX                // AX = n / 8 (block count; >=1, dispatch gates n>=8)
+    JZ   cumsum_remainder
+
+    VPXOR Y3, Y3, Y3           // Y3 = running carry (total of earlier blocks) = 0
+
+cumsum_loop8:
+    VMOVDQU (DX), Y0           // block [x0..x7]
+    VPSLLDQ $4, Y0, Y1         // shift each 128-bit half left 1 lane (zero fill)
+    VPADDD  Y1, Y0, Y0         // partial within-128 prefix
+    VPSLLDQ $8, Y0, Y1         // shift each 128-bit half left 2 lanes
+    VPADDD  Y1, Y0, Y0         // low/high halves each hold a 4-elem prefix sum
+    VPSHUFD $0xFF, Y0, Y2      // broadcast lane 3 of each half: low=[L3..], high=[H3..]
+    VPERM2I128 $0x08, Y2, Y2, Y2 // low half -> 0, high half -> [L3,L3,L3,L3]
+    VPADDD  Y2, Y0, Y0         // fold low-half total into high half: full 8-elem prefix
+    VPADDD  Y3, Y0, Y0         // add carry accumulated from earlier blocks
+    VMOVDQU Y0, (DX)
+    VPSHUFD $0xFF, Y0, Y2      // high half = [lane7 x4]
+    VPERM2I128 $0x11, Y2, Y2, Y3 // Y3 = [lane7 x8] = new running total
+    ADDQ $32, DX
+    DECQ AX
+    JNZ  cumsum_loop8
+
+cumsum_remainder:
+    ANDQ $7, CX
+    JZ   cumsum_done
+
+    MOVL -4(DX), BX            // carry = previous cumulative value (a[i-1] in memory)
+
+cumsum_scalar:
+    MOVL (DX), AX
+    ADDL BX, AX
+    MOVL AX, (DX)
+    MOVL AX, BX
+    ADDQ $4, DX
+    DECQ CX
+    JNZ  cumsum_scalar
+
+cumsum_done:
+    VZEROUPPER
+    RET

--- a/i32/i32_amd64_test.go
+++ b/i32/i32_amd64_test.go
@@ -103,9 +103,9 @@ func TestAddSubAVX2_ParityWithGo(t *testing.T) {
 		b := make([]int32, n)
 		fillPattern(a, b)
 		for _, tc := range []struct {
-			name   string
-			simd   func(dst, a, b []int32)
-			ref    func(dst, a, b []int32)
+			name string
+			simd func(dst, a, b []int32)
+			ref  func(dst, a, b []int32)
 		}{
 			{"add", addAVX2, addGo},
 			{"sub", subAVX2, subGo},
@@ -194,6 +194,52 @@ func TestDiffAVX2_ParityWithGo(t *testing.T) {
 	}
 }
 
+func TestCumsumAVX2_ParityWithGo(t *testing.T) {
+	if !cpu.X86.AVX2 {
+		t.Skip("AVX2 not available")
+	}
+	for _, n := range paritySizes {
+		if n < minAVXElements {
+			continue // the dispatch routes shorter inputs to the Go path; the
+			// kernel assumes at least one full block (its scalar tail reads the
+			// previous cumulative value from a[-1] of the tail).
+		}
+		gotAVX := make([]int32, n)
+		gotGo := make([]int32, n)
+		fillDiffSrc(gotAVX)
+		copy(gotGo, gotAVX)
+		cumsumAVX2(gotAVX)
+		cumsumGo(gotGo)
+		for i := range gotGo {
+			if gotAVX[i] != gotGo[i] {
+				t.Fatalf("n=%d: cumsumAVX2[%d] = %d, want %d (Go)", n, i, gotAVX[i], gotGo[i])
+			}
+		}
+	}
+}
+
+// TestCumsumAVX2_NoOverwrite guards the scalar tail: the in-place kernel must
+// touch exactly n elements when n is not a multiple of the block.
+func TestCumsumAVX2_NoOverwrite(t *testing.T) {
+	if !cpu.X86.AVX2 {
+		t.Skip("AVX2 not available")
+	}
+	const n = 17
+	buf := make([]int32, n+4)
+	for i := range buf {
+		buf[i] = math.MaxInt32 // sentinel
+	}
+	in := make([]int32, n)
+	fillDiffSrc(in)
+	copy(buf[:n], in)
+	cumsumAVX2(buf[:n])
+	for i := n; i < len(buf); i++ {
+		if buf[i] != math.MaxInt32 {
+			t.Errorf("cumsumAVX2 wrote past end at buf[%d] = %d", i, buf[i])
+		}
+	}
+}
+
 // TestDiff1AVX2_NoOverwrite guards the scalar tail: the kernel must write exactly
 // n elements and not run past the end when n is not a multiple of the block.
 func TestDiff1AVX2_NoOverwrite(t *testing.T) {
@@ -239,6 +285,7 @@ func TestAVX2Kernels_AllocFree(t *testing.T) {
 		{"diff2AVX2", func() { diff2AVX2(dst, a) }},
 		{"diff3AVX2", func() { diff3AVX2(dst, a) }},
 		{"diff4AVX2", func() { diff4AVX2(dst, a) }},
+		{"cumsumAVX2", func() { cumsumAVX2(dst) }},
 	}
 	for _, c := range checks {
 		if got := testing.AllocsPerRun(100, c.fn); got != 0 {

--- a/i32/i32_arm64.go
+++ b/i32/i32_arm64.go
@@ -107,6 +107,17 @@ func midSideEncodeNEON(mid, side, left, right []int32)
 //go:noescape
 func midSideDecodeNEON(left, right, mid, side []int32)
 
+func cumsumI32(a []int32) {
+	if hasNEON && len(a) >= minNEONElements {
+		cumsumNEON(a)
+		return
+	}
+	cumsumGo(a)
+}
+
+//go:noescape
+func cumsumNEON(a []int32)
+
 //go:noescape
 func diff1NEON(dst, src []int32)
 

--- a/i32/i32_arm64.s
+++ b/i32/i32_arm64.s
@@ -504,3 +504,54 @@ diff4_neon_loop1:
 
 diff4_neon_done:
     RET
+
+// func cumsumNEON(a []int32)
+// In-place inclusive prefix sum: a[i] += a[i-1] for i in 1..n-1 (a[0] kept).
+// This is the order-1 fixed-predictor restore and the building block the
+// Restore1..Restore4 wrappers compose. Each .4S block computes a standalone
+// 4-element inclusive prefix sum (two zero-filled EXT shift-adds), adds the
+// running total of earlier blocks, then broadcasts its last lane as the next
+// block's running total. The scalar tail reads the previous cumulative value
+// from memory, so it needs no vector carry. EXT/DUP/MOVI and ADD .4S are
+// hand-encoded as WORD (the Go assembler lacks these mnemonics); the trailing
+// comment is the decoded form, cross-checked by asmcheck_test.go.
+TEXT ·cumsumNEON(SB), NOSPLIT, $0-24
+    MOVD a_base+0(FP), R0
+    MOVD a_len+8(FP), R3
+
+    LSR $2, R3, R4             // R4 = n / 4 (block count; >=1, dispatch gates n>=4)
+    CBZ R4, cumsum_neon_remainder
+
+    WORD $0x4F000407           // MOVI V7.4S, #0x0   (zero source for the EXT shifts)
+    WORD $0x4F000408           // MOVI V8.4S, #0x0   (running carry = 0)
+
+cumsum_neon_loop4:
+    VLD1 (R0), [V0.S4]         // block [x0, x1, x2, x3]
+    WORD $0x6E0060E1           // EXT V1.16B, V7.16B, V0.16B, #12   ([0, x0, x1, x2])
+    WORD $0x4EA18400           // ADD V0.4S, V0.4S, V1.4S
+    WORD $0x6E0040E1           // EXT V1.16B, V7.16B, V0.16B, #8    ([0, 0, y0, y1])
+    WORD $0x4EA18400           // ADD V0.4S, V0.4S, V1.4S   (4-elem inclusive prefix)
+    WORD $0x4EA88400           // ADD V0.4S, V0.4S, V8.4S   (+ carry from earlier blocks)
+    VST1 [V0.S4], (R0)
+    WORD $0x4E1C0408           // DUP V8.4S, V0.S[3]        (carry = last lane)
+    ADD $16, R0
+    SUB $1, R4
+    CBNZ R4, cumsum_neon_loop4
+
+cumsum_neon_remainder:
+    AND $3, R3
+    CBZ R3, cumsum_neon_done
+
+    MOVW -4(R0), R5            // carry = previous cumulative value from memory
+
+cumsum_neon_loop1:
+    MOVW (R0), R6
+    ADDW R5, R6, R6
+    MOVW R6, (R0)
+    MOVW R6, R5
+    ADD $4, R0
+    SUB $1, R3
+    CBNZ R3, cumsum_neon_loop1
+
+cumsum_neon_done:
+    RET

--- a/i32/i32_arm64_test.go
+++ b/i32/i32_arm64_test.go
@@ -193,6 +193,52 @@ func TestDiffNEON_ParityWithGo(t *testing.T) {
 	}
 }
 
+func TestCumsumNEON_ParityWithGo(t *testing.T) {
+	if !cpu.ARM64.NEON {
+		t.Skip("NEON not available")
+	}
+	for _, n := range paritySizes {
+		if n < minNEONElements {
+			continue // the dispatch routes shorter inputs to the Go path; the
+			// kernel assumes at least one full block (its scalar tail reads the
+			// previous cumulative value from a[-1] of the tail).
+		}
+		gotNEON := make([]int32, n)
+		gotGo := make([]int32, n)
+		fillDiffSrc(gotNEON)
+		copy(gotGo, gotNEON)
+		cumsumNEON(gotNEON)
+		cumsumGo(gotGo)
+		for i := range gotGo {
+			if gotNEON[i] != gotGo[i] {
+				t.Fatalf("n=%d: cumsumNEON[%d] = %d, want %d (Go)", n, i, gotNEON[i], gotGo[i])
+			}
+		}
+	}
+}
+
+// TestCumsumNEON_NoOverwrite guards the scalar tail: the in-place kernel must
+// touch exactly n elements when n is not a multiple of the 4-lane block.
+func TestCumsumNEON_NoOverwrite(t *testing.T) {
+	if !cpu.ARM64.NEON {
+		t.Skip("NEON not available")
+	}
+	const n = 17
+	buf := make([]int32, n+4)
+	for i := range buf {
+		buf[i] = math.MaxInt32 // sentinel
+	}
+	in := make([]int32, n)
+	fillDiffSrc(in)
+	copy(buf[:n], in)
+	cumsumNEON(buf[:n])
+	for i := n; i < len(buf); i++ {
+		if buf[i] != math.MaxInt32 {
+			t.Errorf("cumsumNEON wrote past end at buf[%d] = %d", i, buf[i])
+		}
+	}
+}
+
 // TestNEONKernels_AllocFree asserts each NEON kernel runs allocation-free, the
 // repo's zero-allocation contract enforced directly at the kernel boundary
 // (the public-API alloc tests cover the dispatch, these cover the kernels).
@@ -217,6 +263,7 @@ func TestNEONKernels_AllocFree(t *testing.T) {
 		{"diff2NEON", func() { diff2NEON(dst, a) }},
 		{"diff3NEON", func() { diff3NEON(dst, a) }},
 		{"diff4NEON", func() { diff4NEON(dst, a) }},
+		{"cumsumNEON", func() { cumsumNEON(dst) }},
 	}
 	for _, c := range checks {
 		if got := testing.AllocsPerRun(100, c.fn); got != 0 {

--- a/i32/i32_go.go
+++ b/i32/i32_go.go
@@ -20,7 +20,6 @@ func deinterleave2Go(a, b, src []int32) {
 	}
 }
 
-
 func addGo(dst, a, b []int32) {
 	for i := range dst {
 		dst[i] = a[i] + b[i]
@@ -81,3 +80,14 @@ func diff1Go(dst, src []int32) { diffGo(dst, src, fixedCoeffs1) }
 func diff2Go(dst, src []int32) { diffGo(dst, src, fixedCoeffs2) }
 func diff3Go(dst, src []int32) { diffGo(dst, src, fixedCoeffs3) }
 func diff4Go(dst, src []int32) { diffGo(dst, src, fixedCoeffs4) }
+
+// cumsumGo is the in-place inclusive prefix sum (cumulative sum): a[i] becomes
+// a[0]+...+a[i], with a[0] left unchanged. It is the building block the
+// SIMD-accelerated Restore kernels compose: the order-K fixed predictor is the
+// K-th forward difference, so its inverse is K cumulative-sum passes. int32
+// arithmetic wraps, matching the SIMD kernels.
+func cumsumGo(a []int32) {
+	for i := 1; i < len(a); i++ {
+		a[i] += a[i-1]
+	}
+}

--- a/i32/i32_other.go
+++ b/i32/i32_other.go
@@ -11,6 +11,8 @@ func subI32(dst, a, b []int32) { subGo(dst, a, b) }
 func midSideEncodeI32(mid, side, left, right []int32) { midSideEncodeGo(mid, side, left, right) }
 func midSideDecodeI32(left, right, mid, side []int32) { midSideDecodeGo(left, right, mid, side) }
 
+func cumsumI32(a []int32) { cumsumGo(a) }
+
 func diff1I32(dst, src []int32) { diff1Go(dst, src) }
 func diff2I32(dst, src []int32) { diff2Go(dst, src) }
 func diff3I32(dst, src []int32) { diff3Go(dst, src) }

--- a/i32/restore.go
+++ b/i32/restore.go
@@ -1,0 +1,68 @@
+package i32
+
+// Fixed-predictor decode restoration for the FLAC codec.
+//
+// RestoreK is the exact inverse of DiffK (see fixed.go): given a subframe laid
+// out as [K warm-up samples | residuals], it reconstructs the original samples:
+//
+//	dst[i] = src[i]                              for i < K  (verbatim warm-up)
+//	dst[n] = src[n] - sum_{j>=1} c[j]*dst[n-j]   for n >= K (the recurrence)
+//
+// where c are the signed binomials (-1)^j*C(K,j). Each function clamps to
+// n = min(len(dst), len(src)), uses int32 wraparound, and writes only into the
+// caller's dst. Inputs of K or fewer samples are all warm-up (copied verbatim).
+//
+// Implementation: the order-K fixed predictor is the K-th forward difference, so
+// its inverse is K cumulative-sum passes. Over int32 (the ring Z/2^32) the
+// forward-difference operator and the cumulative-sum operator are exact
+// inverses, so K passes of the SIMD cumsumI32 kernel reproduce the serial
+// recurrence bit-for-bit (cross-checked against restoreGo in the tests). The
+// only wrinkle is the warm-up: DiffK stores the first K samples verbatim rather
+// than differenced, so before integrating we rewrite that prefix into the K-th
+// difference form. That fix-up is causal (it reads only the prefix), O(K^2) with
+// K <= 4, and never touches the residual region.
+
+// Restore1 inverts Diff1: dst[0]=src[0], dst[n]=src[n]+dst[n-1].
+func Restore1(dst, src []int32) { restoreI32(dst, src, fixedCoeffs1) }
+
+// Restore2 inverts Diff2: dst[n]=src[n]+2*dst[n-1]-dst[n-2].
+func Restore2(dst, src []int32) { restoreI32(dst, src, fixedCoeffs2) }
+
+// Restore3 inverts Diff3: dst[n]=src[n]+3*dst[n-1]-3*dst[n-2]+dst[n-3].
+func Restore3(dst, src []int32) { restoreI32(dst, src, fixedCoeffs3) }
+
+// Restore4 inverts Diff4: dst[n]=src[n]+4*dst[n-1]-6*dst[n-2]+4*dst[n-3]-dst[n-4].
+func Restore4(dst, src []int32) { restoreI32(dst, src, fixedCoeffs4) }
+
+// restoreI32 reconstructs samples using the cumulative-sum decomposition. It
+// takes the same fixedCoeffsK table diffGo uses and derives the predictor order
+// from it (order = len(c)-1), so Restore and Diff stay locked to matching orders
+// and are provably inverses; the cumulative-sum path needs only that order, not
+// the coefficient values. cumsumI32 dispatches to the SIMD kernel (with a
+// pure-Go fallback), so this one orchestration covers every architecture.
+func restoreI32(dst, src, c []int32) {
+	order := len(c) - 1
+	n := min(len(dst), len(src))
+	if n == 0 {
+		return
+	}
+	copy(dst[:n], src[:n])
+	if n <= order {
+		// Fewer samples than the predictor order: all warm-up, no residual to
+		// integrate. The verbatim copy above is already the answer.
+		return
+	}
+	// Rewrite the verbatim warm-up dst[0:order] into its K-th forward-difference
+	// form by applying the first difference 'order' times to the prefix. Each
+	// pass holds index 0 and differences 1..order-1 in place (backward so a
+	// value is read before it is overwritten), mirroring diffGo's boundary.
+	for range order {
+		for i := order - 1; i >= 1; i-- {
+			dst[i] -= dst[i-1]
+		}
+	}
+	// 'order' cumulative-sum passes invert the order-K forward difference.
+	for range order {
+		cumsumI32(dst[:n])
+	}
+}

--- a/i32/restore_test.go
+++ b/i32/restore_test.go
@@ -1,0 +1,181 @@
+package i32
+
+import (
+	"math"
+	"testing"
+)
+
+// Tests for the fixed-predictor decode restoration Restore1..Restore4.
+//
+// RestoreK is the exact inverse of DiffK: it reconstructs the original samples
+// from the [K warm-up | residuals] layout. The strongest check is the
+// Restore(Diff(x)) == x round-trip, since Diff (forward difference) and Restore
+// (cumulative sum) are independent kernels. Parity against restoreGo, the direct
+// decode recurrence, guards the cumulative-sum decomposition the SIMD path uses.
+
+// fillRestoreSrc fills src with values that exercise the sign bit and force
+// int32 wraparound at the extremes (matching fillDiffSrc's intent, but defined
+// here so the cross-architecture tests do not depend on the amd64/arm64-only
+// helpers).
+func fillRestoreSrc(src []int32) {
+	for i := range src {
+		src[i] = int32(i*7-3) ^ math.MinInt32
+	}
+	if len(src) > 1 {
+		src[0] = math.MaxInt32
+		src[1] = math.MinInt32
+	}
+}
+
+// restoreSizes straddle both SIMD block sizes (4 lanes on NEON, 8 on AVX) and
+// include inputs shorter than the predictor order (routed to the Go path).
+var restoreSizes = []int{1, 2, 3, 4, 5, 7, 8, 9, 15, 16, 17, 31, 33, 100, 1000, 1024, 1025}
+
+// restoreGo is the test oracle: the direct decode recurrence that inverts diffGo
+// for the order-(len(c)-1) fixed predictor. The first 'order' entries are the
+// verbatim warm-up (dst[i]=src[i]) and, for n>=order,
+//
+//	dst[n] = src[n] - sum_{j>=1} c[j]*dst[n-j]
+//
+// which solves src[n] = sum_j c[j]*dst[n-j] (the diffGo combination) for dst[n].
+// This serial recurrence is independent of the cumulative-sum decomposition the
+// package ships, so the two agreeing is a meaningful cross-check. int32 wraps.
+func restoreGo(dst, src, c []int32) {
+	order := len(c) - 1
+	n := min(len(dst), len(src))
+	w := min(order, n)
+	copy(dst[:w], src[:w])
+	for nn := order; nn < n; nn++ {
+		acc := src[nn]
+		for j := 1; j < len(c); j++ {
+			acc -= c[j] * dst[nn-j]
+		}
+		dst[nn] = acc
+	}
+}
+
+func restore1Go(dst, src []int32) { restoreGo(dst, src, fixedCoeffs1) }
+func restore2Go(dst, src []int32) { restoreGo(dst, src, fixedCoeffs2) }
+func restore3Go(dst, src []int32) { restoreGo(dst, src, fixedCoeffs3) }
+func restore4Go(dst, src []int32) { restoreGo(dst, src, fixedCoeffs4) }
+
+func TestRestoreRoundTrip(t *testing.T) {
+	diffs := []func(dst, src []int32){Diff1, Diff2, Diff3, Diff4}
+	restores := []func(dst, src []int32){Restore1, Restore2, Restore3, Restore4}
+	for _, n := range restoreSizes {
+		src := make([]int32, n)
+		fillRestoreSrc(src)
+		for order := 1; order <= 4; order++ {
+			residual := make([]int32, n)
+			diffs[order-1](residual, src)
+			got := make([]int32, n)
+			restores[order-1](got, residual)
+			for i := range src {
+				if got[i] != src[i] {
+					t.Fatalf("n=%d order=%d Restore(Diff)[%d] = %d, want %d", n, order, i, got[i], src[i])
+				}
+			}
+		}
+	}
+}
+
+func TestRestoreMatchesDirectRecurrence(t *testing.T) {
+	restores := []func(dst, src []int32){Restore1, Restore2, Restore3, Restore4}
+	refs := []func(dst, src []int32){restore1Go, restore2Go, restore3Go, restore4Go}
+	for _, n := range restoreSizes {
+		res := make([]int32, n)
+		fillRestoreSrc(res) // treat as an arbitrary residual stream
+		for order := 1; order <= 4; order++ {
+			got := make([]int32, n)
+			want := make([]int32, n)
+			restores[order-1](got, res)
+			refs[order-1](want, res)
+			for i := range want {
+				if got[i] != want[i] {
+					t.Fatalf("n=%d order=%d Restore[%d] = %d, want %d (direct recurrence)", n, order, i, got[i], want[i])
+				}
+			}
+		}
+	}
+}
+
+// TestRestore1Simple checks order-1 restoration against a hand-computed result.
+func TestRestore1Simple(t *testing.T) {
+	// Diff1 of [10,13,13,8,20] is [10,3,0,-5,12]; Restore1 inverts it.
+	src := []int32{10, 3, 0, -5, 12}
+	dst := make([]int32, len(src))
+	Restore1(dst, src)
+	want := []int32{10, 13, 13, 8, 20}
+	for i, w := range want {
+		if dst[i] != w {
+			t.Errorf("Restore1[%d] = %d, want %d", i, dst[i], w)
+		}
+	}
+}
+
+// TestRestoreWraps verifies int32 wraparound: restoring residuals at the type
+// extremes must wrap exactly like the scalar recurrence.
+func TestRestoreWraps(t *testing.T) {
+	src := []int32{math.MinInt32, math.MaxInt32, 1, math.MaxInt32, -1, 0}
+	got := make([]int32, len(src))
+	want := make([]int32, len(src))
+	Restore1(got, src)
+	restore1Go(want, src)
+	for i := range want {
+		if got[i] != want[i] {
+			t.Errorf("Restore1 wrap [%d] = %d, want %d", i, got[i], want[i])
+		}
+	}
+}
+
+func TestRestore_Clamp(t *testing.T) {
+	src := []int32{1, 1, 2, 3, 4}
+	dst := make([]int32, 100)
+	Restore1(dst, src)
+	want := []int32{1, 2, 4, 7, 11} // cumulative sum of src
+	for i, w := range want {
+		if dst[i] != w {
+			t.Errorf("Restore1 clamp dst[%d] = %d, want %d", i, dst[i], w)
+		}
+	}
+	for i := len(want); i < len(dst); i++ {
+		if dst[i] != 0 {
+			t.Errorf("Restore1 wrote past clamp at dst[%d] = %d, want untouched 0", i, dst[i])
+		}
+	}
+}
+
+// TestRestore_ShortInput checks inputs shorter than the order: with fewer than
+// K samples there is no residual, only warm-up copied verbatim.
+func TestRestore_ShortInput(t *testing.T) {
+	src := []int32{42, 7}
+	dst := make([]int32, len(src))
+	Restore4(dst, src) // order 4 but only 2 samples
+	if dst[0] != 42 || dst[1] != 7 {
+		t.Errorf("Restore4 short input = %v, want [42 7] warm-up", dst)
+	}
+}
+
+func TestRestore_Empty(t *testing.T) {
+	Restore1(nil, nil)
+	Restore2([]int32{}, []int32{})
+	Restore3(nil, nil)
+	Restore4(nil, nil)
+	dst := []int32{99}
+	Restore1(dst, nil)
+	if dst[0] != 99 {
+		t.Errorf("Restore1 wrote on empty input: %v", dst)
+	}
+}
+
+func TestRestore_AllocFree(t *testing.T) {
+	src := make([]int32, 1024)
+	fillRestoreSrc(src)
+	dst := make([]int32, 1024)
+	restores := map[string]func(dst, src []int32){"Restore1": Restore1, "Restore2": Restore2, "Restore3": Restore3, "Restore4": Restore4}
+	for name, fn := range restores {
+		if got := testing.AllocsPerRun(100, func() { fn(dst, src) }); got != 0 {
+			t.Errorf("%s allocated %v times per run, want 0", name, got)
+		}
+	}
+}


### PR DESCRIPTION
## Summary

Adds the decode-side fixed-predictor restoration kernels `Restore1..Restore4` to the `i32` package (PR5 of the integer-SIMD FLAC roadmap), the exact inverse of the `Diff1..Diff4` encode residual kernels.

The order-K fixed predictor is the K-th forward difference, so its inverse is K cumulative-sum passes. Over `int32` (the ring Z/2^32) the forward-difference and cumulative-sum operators are exact inverses, so the whole family reduces to **one new SIMD kernel**, `cumsumI32` (an in-place inclusive prefix sum), composed K times. `RestoreK` is thin orchestration: rewrite the K verbatim warm-up samples into K-th-difference form (causal, O(K^2), K<=4), then run `cumsumI32` K times. This reproduces the serial decode recurrence bit-for-bit.

### `cumsumI32`
- **AMD64 AVX2** (gated on the AVX2 feature): per 256-bit block, two within-128 shift-adds (`VPSLLDQ`/`VPADDD`) plus one cross-128 carry fold (`VPSHUFD`/`VPERM2I128`) give a standalone 8-element inclusive prefix sum; a broadcast running total carries between blocks. Mnemonics only, no hand-encoded directives.
- **ARM64 NEON**: per `.4S` block, two zero-filled `EXT` shift-adds and a `DUP`-broadcast running carry. `EXT`/`MOVI`/`DUP`/`ADD.4S` are hand-encoded as `WORD` with decoded comments cross-checked by `asmcheck_test.go`.
- **Pure-Go `cumsumGo`** fallback (and the `!amd64 && !arm64` path).

The scalar tail reads the previous cumulative value straight from memory, so it needs no vector carry.

This PR also brings the `i32` section of the README in sync with the package (the decorrelation and fixed-predictor surface added previously was undocumented), and adds the measured Restore benchmarks.

## Related Issues

Relates to #79 (integer-SIMD FLAC roadmap, PR5 of 8). Closes the Phase 2 work; PR6/PR7 (LPC FIR encode/decode) and PR8 (Rice cost search) remain.

## Performance (1000 elements, vs the pure-Go decode recurrence, zero-allocation)

| Op | amd64 AVX2 | arm64 NEON (Pi 5) |
|----|-----------|-------------------|
| Restore1 | 181 ns, 11.2x | 605 ns, 6.2x |
| Restore2 | 320 ns, 7.2x | 1101 ns, 4.2x |
| Restore3 | 462 ns, 5.4x | 1608 ns, 3.4x |
| Restore4 | 575 ns, 4.8x | 2093 ns, 3.0x |

Even order 4 (4 cumsum passes) beats the scalar recurrence handily: a blocked SIMD prefix sum has a critical path of ~N/8 chained carry adds vs the recurrence's length-N dependency chain, and at FLAC block sizes the data is L1-resident so the K-pass memory traffic is not a bottleneck.

## Test Plan

- [x] `Restore(Diff(x)) == x` round-trip against the merged encode kernels (independent kernels: forward difference vs cumulative sum)
- [x] Parity vs an independent direct-recurrence oracle across block-straddling sizes with sign/int32-extreme inputs and wraparound
- [x] Length clamping, short (`n <= order`) and empty inputs, scalar-tail no-overwrite guards
- [x] SIMD-vs-Go kernel parity; per-kernel zero-allocation
- [x] asmcheck verifies every new NEON `WORD` encoding against `arm64asm`
- [x] `ExampleRestore1` pairing `ExampleDiff1`
- [x] Verified on amd64 (AVX2) natively and arm64 (NEON) on a Raspberry Pi 5
- [x] `go vet ./...` clean, `golangci-lint run ./...` reports 0 issues

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added fixed-order restoration functions (Restore1–Restore4) for integer sample processing.

* **Documentation**
  * Expanded integer operations guide and performance benchmarks with restoration operation metrics and zero-allocation characteristics.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->