### PR TITLE
i32: AVX2/NEON quantized-LPC residual encode and decode kernels

### DIFF
--- a/README.md
+++ b/README.md
@@ -382,6 +382,8 @@ SIMD-accelerated integer-domain operations for codec and integer-DSP hot loops (
 |                     | `MidSideDecode(left, right, mid, side)` | Mid/side inverse (parity-bit reconstruction)             | 8x (AVX2) / 4x (NEON) |
 | **Fixed predictor** | `Diff1`..`Diff4(dst, src)`              | Order 1-4 fixed-predictor encode residual (forward diff) | 8x (AVX2) / 4x (NEON) |
 |                     | `Restore1`..`Restore4(dst, src)`        | Order 1-4 fixed-predictor decode (inverse; prefix sum)   | 8x (AVX2) / 4x (NEON) |
+| **LPC**             | `LPCResidualEncode(res, samples, coeffs, shift)` | Quantized-LPC encode residual FIR (parallel across outputs) | 8x (AVX2) / 4x (NEON) |
+|                     | `LPCRestore(out, residual, coeffs, shift)`       | Quantized-LPC decode (serial recurrence; vectorized taps)   | 8x (AVX2) / 4x (NEON) |
 
 ```go
 import "github.com/tphakala/simd/i32"
@@ -396,9 +398,13 @@ i32.Deinterleave2(left, right, stereo) // inverse: split back to channels
 res := make([]int32, n)
 i32.Diff2(res, left)     // order-2 fixed-predictor encode residual
 i32.Restore2(left, res)  // exact inverse: reconstruct the samples
+
+coeffs := []int32{...}             // quantized LPC coefficients (order = len)
+i32.LPCResidualEncode(res, left, coeffs, shift) // encode FIR residual
+i32.LPCRestore(left, res, coeffs, shift)        // exact inverse: reconstruct
 ```
 
-Interleaving is pure 32-bit-lane movement, so those kernels reuse the proven `f32` shuffle/permute encodings (AVX `VUNPCKLPS`/`VPERM2F128`, NEON `ZIP`/`UZP` on `.4S`); the bit pattern of each lane is irrelevant, so negative values and the type extremes round-trip exactly. The decorrelation and fixed-predictor kernels do integer-ALU work on 256-bit (AVX2) / 128-bit (NEON) lanes. `RestoreK` is the exact inverse of `DiffK`: since the order-`K` fixed predictor is the `K`-th forward difference, restoration is `K` cumulative-sum passes built on one SIMD prefix-sum kernel (11x at order 1 down to ~5x at order 4 on AVX2; 6x to 3x on NEON, all zero-allocation). The remaining integer surface (LPC FIR encode/decode, Rice cost search) is tracked in the project issues.
+Interleaving is pure 32-bit-lane movement, so those kernels reuse the proven `f32` shuffle/permute encodings (AVX `VUNPCKLPS`/`VPERM2F128`, NEON `ZIP`/`UZP` on `.4S`); the bit pattern of each lane is irrelevant, so negative values and the type extremes round-trip exactly. The decorrelation and fixed-predictor kernels do integer-ALU work on 256-bit (AVX2) / 128-bit (NEON) lanes. `RestoreK` is the exact inverse of `DiffK`: since the order-`K` fixed predictor is the `K`-th forward difference, restoration is `K` cumulative-sum passes built on one SIMD prefix-sum kernel (11x at order 1 down to ~5x at order 4 on AVX2; 6x to 3x on NEON, all zero-allocation). The LPC kernels accumulate the prediction sum in int64 (matching libFLAC), so they stay bit-exact for the full coefficient precision and order: `LPCResidualEncode` is a FIR that vectorizes across output samples (widening `VPMULDQ` / `SMLAL`, ~7-9x on AVX2, ~4-5x on NEON), while `LPCRestore` is a serial recurrence whose per-output tap dot product is vectorized, keeping the just-written newest samples on store-forwardable scalar loads (~1.4-3.9x on AVX2, ~1.8-3.6x on NEON, order 8 to 32). The remaining integer surface (Rice cost search) is tracked in the project issues.
 
 ## Performance
 
@@ -574,8 +580,12 @@ a Raspberry Pi 5):
 | Restore2      | 320 ns vs 2296 ns (**7.2x**) | 1101 ns vs 4592 ns (**4.2x**) |
 | Restore3      | 462 ns vs 2493 ns (**5.4x**) | 1608 ns vs 5421 ns (**3.4x**) |
 | Restore4      | 575 ns vs 2778 ns (**4.8x**) | 2093 ns vs 6245 ns (**3.0x**) |
+| LPCResidualEncode (order 8)  | 743 ns vs 5333 ns (**7.2x**)  | 2495 ns vs 10707 ns (**4.3x**) |
+| LPCResidualEncode (order 32) | 2397 ns vs 22046 ns (**9.2x**)| 8148 ns vs 40811 ns (**5.0x**) |
+| LPCRestore (order 8)         | 3583 ns vs 4944 ns (**1.4x**) | 6128 ns vs 10889 ns (**1.8x**) |
+| LPCRestore (order 32)        | 4443 ns vs 17529 ns (**3.9x**)| 11303 ns vs 41026 ns (**3.6x**) |
 
-All int32 kernels are zero-allocation and bit-exact against the pure-Go reference (verified across the sign and high bits with negative values and the type extremes). The Restore baseline is the pure-Go decode recurrence; `RestoreK` reconstructs samples as `K` SIMD prefix-sum passes (the inverse of the order-`K` forward difference).
+All int32 kernels are zero-allocation and bit-exact against the pure-Go reference (verified across the sign and high bits with negative values and the type extremes). The Restore baseline is the pure-Go decode recurrence; `RestoreK` reconstructs samples as `K` SIMD prefix-sum passes (the inverse of the order-`K` forward difference). The LPC kernels accumulate in int64 and are checked against an arbitrary-precision `math.big` oracle and the encode->decode round-trip; `LPCRestore` is the serial decode recurrence (vectorized per-output tap dot product), dispatched to SIMD only at order >= 8 where it beats the scalar path.
 
 ### Performance Notes
 

--- a/i32/benchmark_test.go
+++ b/i32/benchmark_test.go
@@ -290,3 +290,92 @@ func BenchmarkRestore4Go_1000(b *testing.B) {
 		restore4Go(dst, src)
 	}
 }
+
+// LPC benchmarks pair the dispatched path against the pure-Go reference at two
+// representative FLAC predictor orders. LPCResidualEncode is a parallel FIR;
+// LPCRestore is the serial decode recurrence (vectorized only across taps, and
+// only above minLPCRestoreOrder), benched honestly so the difference is visible.
+
+func benchLPCCoeffs(order int) []int32 {
+	c := make([]int32, order)
+	for j := range c {
+		v := int32(16000 >> (j / 4))
+		if j%2 == 1 {
+			v = -v
+		}
+		c[j] = v
+	}
+	return c
+}
+
+func BenchmarkLPCResidualEncode8_1000(b *testing.B) {
+	src, dst := benchSrcDst()
+	coeffs := benchLPCCoeffs(8)
+	b.SetBytes(benchN * 4 * 2)
+	for b.Loop() {
+		LPCResidualEncode(dst, src, coeffs, 12)
+	}
+}
+
+func BenchmarkLPCResidualEncode8Go_1000(b *testing.B) {
+	src, dst := benchSrcDst()
+	coeffs := benchLPCCoeffs(8)
+	b.SetBytes(benchN * 4 * 2)
+	for b.Loop() {
+		lpcResidualEncodeGo(dst, src, coeffs, 12)
+	}
+}
+
+func BenchmarkLPCResidualEncode32_1000(b *testing.B) {
+	src, dst := benchSrcDst()
+	coeffs := benchLPCCoeffs(32)
+	b.SetBytes(benchN * 4 * 2)
+	for b.Loop() {
+		LPCResidualEncode(dst, src, coeffs, 12)
+	}
+}
+
+func BenchmarkLPCResidualEncode32Go_1000(b *testing.B) {
+	src, dst := benchSrcDst()
+	coeffs := benchLPCCoeffs(32)
+	b.SetBytes(benchN * 4 * 2)
+	for b.Loop() {
+		lpcResidualEncodeGo(dst, src, coeffs, 12)
+	}
+}
+
+func BenchmarkLPCRestore8_1000(b *testing.B) {
+	src, dst := benchSrcDst()
+	coeffs := benchLPCCoeffs(8)
+	b.SetBytes(benchN * 4 * 2)
+	for b.Loop() {
+		LPCRestore(dst, src, coeffs, 12)
+	}
+}
+
+func BenchmarkLPCRestore8Go_1000(b *testing.B) {
+	src, dst := benchSrcDst()
+	coeffs := benchLPCCoeffs(8)
+	b.SetBytes(benchN * 4 * 2)
+	for b.Loop() {
+		lpcRestoreGo(dst, src, coeffs, 12)
+	}
+}
+
+func BenchmarkLPCRestore32_1000(b *testing.B) {
+	src, dst := benchSrcDst()
+	coeffs := benchLPCCoeffs(32)
+	b.SetBytes(benchN * 4 * 2)
+	for b.Loop() {
+		LPCRestore(dst, src, coeffs, 12)
+	}
+}
+
+func BenchmarkLPCRestore32Go_1000(b *testing.B) {
+	src, dst := benchSrcDst()
+	coeffs := benchLPCCoeffs(32)
+	b.SetBytes(benchN * 4 * 2)
+	for b.Loop() {
+		lpcRestoreGo(dst, src, coeffs, 12)
+	}
+}

--- a/i32/example_test.go
+++ b/i32/example_test.go
@@ -80,3 +80,29 @@ func ExampleRestore1() {
 	fmt.Println(samples)
 	// Output: [10 13 13 8 20]
 }
+
+// ExampleLPCResidualEncode shows the quantized-LPC encode FIR. With order-2
+// coefficients {2,-1} and shift 1 the prediction is (2*s[i-1] - s[i-2]) >> 1;
+// res holds the order-2 warm-up samples verbatim, then samples[i] - prediction.
+func ExampleLPCResidualEncode() {
+	samples := []int32{10, 20, 34, 50}
+	coeffs := []int32{2, -1}
+	res := make([]int32, len(samples))
+
+	i32.LPCResidualEncode(res, samples, coeffs, 1)
+	fmt.Println(res)
+	// Output: [10 20 19 26]
+}
+
+// ExampleLPCRestore shows decode-side restoration: LPCRestore inverts
+// LPCResidualEncode with the same coefficients and shift, reconstructing the
+// samples from the [warm-up | residual] layout.
+func ExampleLPCRestore() {
+	res := []int32{10, 20, 19, 26}
+	coeffs := []int32{2, -1}
+	samples := make([]int32, len(res))
+
+	i32.LPCRestore(samples, res, coeffs, 1)
+	fmt.Println(samples)
+	// Output: [10 20 34 50]
+}

--- a/i32/i32_amd64.go
+++ b/i32/i32_amd64.go
@@ -43,6 +43,13 @@ func deinterleave2AVX(a, b, src []int32)
 // on AVX2 explicitly and fall back to the pure-Go reference otherwise.
 var hasAVX2 = cpu.X86.AVX2
 
+// minLPCRestoreOrder is the smallest predictor order at which the SIMD decode
+// recurrence kernel beats the scalar Go recurrence. The recurrence is serial
+// (each output feeds the next), so SIMD only helps once the per-output tap dot
+// product has enough work to amortize its horizontal reduction; below this the
+// scalar path wins. Tuned from the benchmarks.
+const minLPCRestoreOrder = 8
+
 func addI32(dst, a, b []int32) {
 	if hasAVX2 && len(dst) >= minAVXElements {
 		addAVX2(dst, a, b)
@@ -141,3 +148,42 @@ func diff3AVX2(dst, src []int32)
 
 //go:noescape
 func diff4AVX2(dst, src []int32)
+
+// lpcResidualEncodeI32 dispatches the quantized-LPC encode FIR. The kernel
+// vectorizes across output samples and accumulates the prediction in int64, so
+// it gates on AVX2 (VPMULDQ widening multiply) and needs at least one full
+// 8-output block past the warm-up.
+func lpcResidualEncodeI32(res, samples, coeffs []int32, shift uint) {
+	if hasAVX2 && len(res)-len(coeffs) >= minAVXElements {
+		lpcResidualEncodeAVX2(res, samples, coeffs, shift)
+		return
+	}
+	lpcResidualEncodeGo(res, samples, coeffs, shift)
+}
+
+// lpcRestoreI32 dispatches the quantized-LPC decode recurrence. Each output
+// feeds the next prediction, so the kernel vectorizes only the per-output tap
+// dot product and pays off only once the order is large enough to amortize the
+// horizontal reduction; below that it stays on the scalar Go recurrence.
+func lpcRestoreI32(out, residual, coeffs []int32, shift uint) {
+	order := len(coeffs)
+	if hasAVX2 && order >= minLPCRestoreOrder && order <= maxLPCRestoreOrder && len(out)-order >= 1 {
+		// The kernel dots the ascending window out[i-order..i-1] with the
+		// coefficients reversed, so it lines up two contiguous loads. Reverse
+		// once into a stack array (no heap alloc; the array does not escape
+		// through the //go:noescape kernel).
+		var rc [maxLPCRestoreOrder]int32
+		for k := range order {
+			rc[k] = coeffs[order-1-k]
+		}
+		lpcRestoreAVX2(out, residual, rc[:order], shift)
+		return
+	}
+	lpcRestoreGo(out, residual, coeffs, shift)
+}
+
+//go:noescape
+func lpcResidualEncodeAVX2(res, samples, coeffs []int32, shift uint)
+
+//go:noescape
+func lpcRestoreAVX2(out, residual, rcoeffs []int32, shift uint)

--- a/i32/i32_amd64.s
+++ b/i32/i32_amd64.s
@@ -614,3 +614,236 @@ cumsum_scalar:
 cumsum_done:
     VZEROUPPER
     RET
+
+// func lpcResidualEncodeAVX2(res, samples, coeffs []int32, shift uint)
+// Quantized-LPC encode FIR, vectorized across 8 output samples per iteration:
+//
+//	res[i] = samples[i] - int32((Σ_j coeffs[j]*samples[i-1-j]) >> shift)
+//
+// For each tap j the 8-sample window samples[i-1-j..i+6-j] is widened to int64
+// (VPMULDQ on the even int32 lanes, then again on the odd lanes shifted into
+// place) and multiply-accumulated into two int64x4 accumulators: Y0 holds output
+// lanes {0,2,4,6}, Y1 holds {1,3,5,7}. After the tap loop each accumulator is
+// arithmetic-shifted right by shift, then the low 32 bits are recombined into the
+// int32x8 prediction and subtracted from samples[i..i+7].
+//
+// AVX2 has no 64-bit arithmetic shift, so it is emulated as
+// asr(x,s) = ((x XOR 2^63) >>u s) - 2^(63-s), with VPSRLVQ supplying the logical
+// shift by the broadcast count. The first 'order' samples are the verbatim
+// warm-up; the (n-order) mod 8 trailing outputs use a scalar int64 recurrence.
+// The dispatch guarantees order >= 1 and n-order >= 8 (at least one full block).
+TEXT ·lpcResidualEncodeAVX2(SB), NOSPLIT, $0-80
+    MOVQ res_base+0(FP), DI
+    MOVQ res_len+8(FP), DX          // n
+    MOVQ samples_base+24(FP), SI
+    MOVQ coeffs_base+48(FP), R9
+    MOVQ coeffs_len+56(FP), R10      // order
+
+    // warm-up: res[0:order] = samples[0:order]
+    XORQ AX, AX
+lpcenc_warmup:
+    MOVL (SI)(AX*4), CX
+    MOVL CX, (DI)(AX*4)
+    INCQ AX
+    CMPQ AX, R10
+    JL   lpcenc_warmup
+
+    LEAQ -4(SI)(R10*4), BX           // winBase = &samples[order-1]
+    LEAQ (DI)(R10*4), DI             // DI = &res[order]
+    SUBQ R10, DX                     // residual count = n - order
+    MOVQ DX, R12
+    SHRQ $3, R12                     // R12 = full 8-blocks (>=1)
+    ANDQ $7, DX
+    MOVQ DX, R13                     // R13 = remaining tail outputs
+
+    // Build the shift constants once. Y8 = broadcast count; Y9 = 2^(63-s)
+    // offset; Y7 = 2^63 bias; Y6 = low-32 mask 0x00000000FFFFFFFF.
+    VPCMPEQD Y10, Y10, Y10           // all ones
+    VPSLLQ   $63, Y10, Y7            // bias = 0x8000000000000000 per qword
+    VPSRLQ   $32, Y10, Y6            // mask = 0x00000000FFFFFFFF per qword
+    MOVQ shift+72(FP), AX
+    MOVQ AX, X8
+    VPBROADCASTQ X8, Y8              // count vector (shift per qword)
+    MOVQ $63, CX
+    SUBQ AX, CX                      // CX = 63 - shift
+    MOVQ $1, AX
+    SHLQ CX, AX                      // AX = 1 << (63 - shift)
+    MOVQ AX, X9
+    VPBROADCASTQ X9, Y9              // offset vector
+
+lpcenc_block:
+    VPXOR Y0, Y0, Y0                 // acc_even = 0
+    VPXOR Y1, Y1, Y1                 // acc_odd  = 0
+    XORQ R11, R11                    // j = 0
+    MOVQ BX, AX                      // window ptr = winBase - j*4
+lpcenc_tap:
+    VMOVDQU (AX), Y2                 // S = samples[i-1-j .. i+6-j]
+    VPBROADCASTD (R9)(R11*4), Y3     // C = coeffs[j] in all lanes
+    VPMULDQ Y3, Y2, Y5               // Peven = S_even * C  (int64x4, lanes 0,2,4,6)
+    VPSRLQ  $32, Y2, Y4              // bring odd int32 lanes into the low halves
+    VPMULDQ Y3, Y4, Y4               // Podd  = S_odd  * C  (int64x4, lanes 1,3,5,7)
+    VPADDQ  Y5, Y0, Y0               // acc_even += Peven
+    VPADDQ  Y4, Y1, Y1               // acc_odd  += Podd
+    SUBQ $4, AX                      // window for tap j+1 starts one sample earlier
+    INCQ R11
+    CMPQ R11, R10
+    JL   lpcenc_tap
+
+    // acc_even: arithmetic shift right by shift, then keep low 32 of each qword.
+    VPXOR   Y7, Y0, Y0               // x XOR bias
+    VPSRLVQ Y8, Y0, Y0               // >>u shift (per lane)
+    VPSUBQ  Y9, Y0, Y0               // - 2^(63-shift)  => arithmetic shift result
+    VPAND   Y6, Y0, Y0               // keep low 32 (even predictions at lanes 0,2,4,6)
+    // acc_odd: same shift, then move low 32 into the high half of each qword.
+    VPXOR   Y7, Y1, Y1
+    VPSRLVQ Y8, Y1, Y1
+    VPSUBQ  Y9, Y1, Y1
+    VPSLLQ  $32, Y1, Y1              // odd predictions at lanes 1,3,5,7
+    VPOR    Y1, Y0, Y0               // pred = int32x8 [p0..p7]
+    VMOVDQU 4(BX), Y2                // samples[i..i+7]
+    VPSUBD  Y0, Y2, Y2               // res = samples - pred
+    VMOVDQU Y2, (DI)
+
+    ADDQ $32, BX
+    ADDQ $32, DI
+    DECQ R12
+    JNZ  lpcenc_block
+
+    TESTQ R13, R13
+    JZ    lpcenc_done
+    MOVQ shift+72(FP), CX            // CL = shift for the scalar SARQ
+lpcenc_tail_out:
+    XORQ R8, R8                      // acc = 0 (int64)
+    XORQ R11, R11                    // j = 0
+    MOVQ BX, AX                      // window ptr
+lpcenc_tail_tap:
+    MOVLQSX (AX), DX                 // sign-extend samples[i-1-j]
+    MOVLQSX (R9)(R11*4), SI          // sign-extend coeffs[j] (SI is free after warm-up)
+    IMULQ   SI, DX
+    ADDQ    DX, R8                   // acc += coeffs[j]*samples[i-1-j]
+    SUBQ    $4, AX
+    INCQ    R11
+    CMPQ    R11, R10
+    JL      lpcenc_tail_tap
+    MOVQ R8, AX
+    SARQ CX, AX                      // pred = acc >> shift (arithmetic)
+    MOVL 4(BX), DX                   // samples[i]
+    SUBL AX, DX                      // - pred (low 32)
+    MOVL DX, (DI)
+    ADDQ $4, BX
+    ADDQ $4, DI
+    DECQ R13
+    JNZ  lpcenc_tail_out
+
+lpcenc_done:
+    VZEROUPPER
+    RET
+
+// func lpcRestoreAVX2(out, residual, rcoeffs []int32, shift uint)
+// Quantized-LPC decode recurrence:
+//
+//	out[i] = residual[i] + int32((Σ_j coeffs[j]*out[i-1-j]) >> shift)
+//
+// Each out[i] feeds the next prediction, so this cannot vectorize across i; only
+// the per-output tap dot product is vectorized. The caller passes rcoeffs, the
+// coefficients reversed (rcoeffs[k] = coeffs[order-1-k]), so the window
+// out[i-order..i-1] and rcoeffs line up as ascending contiguous loads:
+// Σ_k rcoeffs[k]*out[i-order+k] = Σ_j coeffs[j]*out[i-1-j]. The oldest vecTaps
+// taps are widened (VPMULDQ even/odd) into int64 accumulators and horizontally
+// summed; the newest scalarTaps are added scalar.
+//
+// The split is not order mod 8: the newest samples out[i-1], out[i-2], ... were
+// just written by this loop's narrow 4-byte stores, and a wide 32-byte vector
+// load that overlaps a store still in the store buffer cannot forward and stalls
+// for ~15 cycles every output. So scalarTaps = ((order+6) & 7) + 2 always keeps
+// the newest 2..9 taps (which include out[i-1]) on forwardable scalar loads and
+// leaves vecTaps = order - scalarTaps (a multiple of 8) for the vector loop,
+// whose oldest samples have long since drained to L1. This is ~3x faster on the
+// order-is-a-multiple-of-8 cases than a naive order/8 split.
+// The dispatch gates order in [minLPCRestoreOrder, 32] and n-order >= 1.
+TEXT ·lpcRestoreAVX2(SB), NOSPLIT, $0-80
+    MOVQ out_base+0(FP), R8
+    MOVQ out_len+8(FP), R12          // n
+    MOVQ residual_base+24(FP), SI
+    MOVQ rcoeffs_base+48(FP), R9
+    MOVQ rcoeffs_len+56(FP), R10      // order
+    MOVQ shift+72(FP), CX
+
+    // warm-up: out[0:order] = residual[0:order]
+    XORQ AX, AX
+lpcdec_warmup:
+    MOVL (SI)(AX*4), DX
+    MOVL DX, (R8)(AX*4)
+    INCQ AX
+    CMPQ AX, R10
+    JL   lpcdec_warmup
+
+    LEAQ (R8)(R10*4), DI             // DI = &out[i],          i = order
+    MOVQ R8, BX                      // BX = &out[i-order],    = &out[0]
+    LEAQ (SI)(R10*4), SI             // SI = &residual[i]
+    LEAQ (R8)(R12*4), R8             // R8 = &out[n] (end sentinel; R12 still = n)
+
+    // scalarTaps = ((order+6) & 7) + 2 ; vecTaps = order - scalarTaps ; numVec = vecTaps/8.
+    // vecTaps = numVec*8, so the scalar leftover starts at tap numVec*8 (R13<<3).
+    MOVQ R10, AX
+    ADDQ $6, AX
+    ANDQ $7, AX
+    ADDQ $2, AX                      // AX = scalarTaps (2..9)
+    MOVQ R10, R13
+    SUBQ AX, R13                     // R13 = vecTaps (>=0, multiple of 8)
+    SHRQ $3, R13                     // R13 = numVec
+
+lpcdec_out:
+    CMPQ DI, R8
+    JGE  lpcdec_done
+    VPXOR Y0, Y0, Y0                 // acc_even = 0
+    VPXOR Y1, Y1, Y1                 // acc_odd  = 0
+    XORQ R11, R11                    // byte offset into window/coeffs
+    MOVQ R13, AX                     // groups remaining
+    TESTQ AX, AX
+    JZ   lpcdec_reduce
+lpcdec_vec:
+    VMOVDQU (BX)(R11*1), Y2          // W = out[i-order+gi*8 ..]
+    VMOVDQU (R9)(R11*1), Y3          // C = rcoeffs[gi*8 ..]
+    VPMULDQ Y3, Y2, Y5              // even lanes products
+    VPADDQ  Y5, Y0, Y0
+    VPSRLQ  $32, Y2, Y4             // odd int32 lanes into low halves
+    VPSRLQ  $32, Y3, Y6
+    VPMULDQ Y6, Y4, Y4             // odd lanes products
+    VPADDQ  Y4, Y1, Y1
+    ADDQ $32, R11
+    DECQ AX
+    JNZ  lpcdec_vec
+lpcdec_reduce:
+    VPADDQ Y1, Y0, Y0               // S = acc_even + acc_odd (int64x4)
+    VEXTRACTI128 $1, Y0, X2         // high 128
+    VPADDQ X2, X0, X0              // [s0,s1] = low2 + high2
+    VPSHUFD $0xEE, X0, X2          // [s1,s1,..]
+    VPADDQ X2, X0, X0             // low qword = s0 + s1
+    MOVQ X0, AX                    // AX = vector partial sum (int64)
+    // scalar leftover taps k = numVec*8 .. order-1
+    MOVQ R13, DX
+    SHLQ $3, DX                    // DX = k
+lpcdec_rem:
+    CMPQ DX, R10
+    JGE  lpcdec_pred
+    MOVLQSX (R9)(DX*4), R11        // rcoeffs[k]
+    MOVLQSX (BX)(DX*4), CX         // out[i-order+k] (CX reloaded as shift below)
+    IMULQ   CX, R11
+    ADDQ    R11, AX
+    INCQ    DX
+    JMP     lpcdec_rem
+lpcdec_pred:
+    MOVQ shift+72(FP), CX          // CL = shift
+    SARQ CX, AX                    // pred = sum >> shift (arithmetic)
+    MOVL (SI), DX                  // residual[i]
+    ADDL AX, DX                    // + pred (low 32)
+    MOVL DX, (DI)                  // out[i]
+    ADDQ $4, DI
+    ADDQ $4, BX
+    ADDQ $4, SI
+    JMP  lpcdec_out
+
+lpcdec_done:
+    VZEROUPPER
+    RET

--- a/i32/i32_amd64_test.go
+++ b/i32/i32_amd64_test.go
@@ -286,10 +286,119 @@ func TestAVX2Kernels_AllocFree(t *testing.T) {
 		{"diff3AVX2", func() { diff3AVX2(dst, a) }},
 		{"diff4AVX2", func() { diff4AVX2(dst, a) }},
 		{"cumsumAVX2", func() { cumsumAVX2(dst) }},
+		{"lpcResidualEncodeAVX2", func() { lpcResidualEncodeAVX2(dst, a, lpcAllocCoeffs, 12) }},
+		{"lpcRestoreAVX2", func() { lpcRestoreAVX2(dst, a, lpcAllocCoeffs, 12) }},
 	}
 	for _, c := range checks {
 		if got := testing.AllocsPerRun(100, c.fn); got != 0 {
 			t.Errorf("%s allocated %v times per run, want 0", c.name, got)
+		}
+	}
+}
+
+func TestLPCResidualEncodeAVX2_ParityWithGo(t *testing.T) {
+	if !cpu.X86.AVX2 {
+		t.Skip("AVX2 not available")
+	}
+	for _, n := range paritySizes {
+		samples := make([]int32, n)
+		fillLPCSamples(samples)
+		for _, coeffs := range lpcCoeffSets() {
+			order := len(coeffs)
+			if n-order < minAVXElements {
+				continue // the dispatch routes these to the Go path; the kernel
+				// assumes order >= 1 and at least one full 8-output block.
+			}
+			for _, shift := range lpcShifts {
+				gotAVX := make([]int32, n)
+				gotGo := make([]int32, n)
+				lpcResidualEncodeAVX2(gotAVX, samples, coeffs, shift)
+				lpcResidualEncodeGo(gotGo, samples, coeffs, shift)
+				for i := range gotGo {
+					if gotAVX[i] != gotGo[i] {
+						t.Fatalf("n=%d order=%d shift=%d lpcResidualEncodeAVX2[%d] = %d, want %d (Go)",
+							n, order, shift, i, gotAVX[i], gotGo[i])
+					}
+				}
+			}
+		}
+	}
+}
+
+// TestLPCResidualEncodeAVX2_NoOverwrite guards the scalar tail: an order-4
+// predictor over 23 samples is 2 full 8-output blocks plus a 3-output tail, so a
+// kernel that ran past n would be caught here.
+func TestLPCResidualEncodeAVX2_NoOverwrite(t *testing.T) {
+	if !cpu.X86.AVX2 {
+		t.Skip("AVX2 not available")
+	}
+	const n = 23
+	coeffs := []int32{8000, -5000, 2000, -512}
+	samples := make([]int32, n)
+	fillLPCSamples(samples)
+	res := make([]int32, n+4)
+	for i := range res {
+		res[i] = math.MaxInt32 // sentinel
+	}
+	lpcResidualEncodeAVX2(res[:n], samples, coeffs, 9)
+	for i := n; i < len(res); i++ {
+		if res[i] != math.MaxInt32 {
+			t.Errorf("lpcResidualEncodeAVX2 wrote past end at res[%d] = %d", i, res[i])
+		}
+	}
+}
+
+func TestLPCRestoreAVX2_ParityWithGo(t *testing.T) {
+	if !cpu.X86.AVX2 {
+		t.Skip("AVX2 not available")
+	}
+	for _, n := range paritySizes {
+		res := make([]int32, n)
+		fillLPCSamples(res) // arbitrary residual stream
+		for _, coeffs := range lpcCoeffSets() {
+			order := len(coeffs)
+			if order < minLPCRestoreOrder || order > maxLPCRestoreOrder || n-order < 1 {
+				continue // dispatch routes these to the Go recurrence
+			}
+			rc := reverseCoeffs(coeffs)
+			for _, shift := range lpcShifts {
+				gotAVX := make([]int32, n)
+				gotGo := make([]int32, n)
+				lpcRestoreAVX2(gotAVX, res, rc, shift)
+				lpcRestoreGo(gotGo, res, coeffs, shift)
+				for i := range gotGo {
+					if gotAVX[i] != gotGo[i] {
+						t.Fatalf("n=%d order=%d shift=%d lpcRestoreAVX2[%d] = %d, want %d (Go)",
+							n, order, shift, i, gotAVX[i], gotGo[i])
+					}
+				}
+			}
+		}
+	}
+}
+
+// TestLPCRestoreAVX2_NoOverwrite guards the output tail: an order-12 predictor
+// over 35 outputs exercises both the vector groups and the scalar tap remainder.
+func TestLPCRestoreAVX2_NoOverwrite(t *testing.T) {
+	if !cpu.X86.AVX2 {
+		t.Skip("AVX2 not available")
+	}
+	const n = 35
+	coeffs := make([]int32, 12)
+	for j := range coeffs {
+		coeffs[j] = int32(1000 - 137*j)
+	}
+	res := make([]int32, n)
+	fillLPCSamples(res)
+	rc := reverseCoeffs(coeffs)
+	out := make([]int32, n+4)
+	for i := range out {
+		out[i] = math.MaxInt32 // sentinel
+	}
+	lpcRestoreAVX2(out[:n], res, rc, 10)
+	for i := n; i < len(out); i++ {
+		if out[i] != math.MaxInt32 {
+			t.Errorf("lpcRestoreAVX2 wrote past end at out[%d] = %d", i, out[i])
 		}
 	}
 }

--- a/i32/i32_arm64.go
+++ b/i32/i32_arm64.go
@@ -129,3 +129,39 @@ func diff3NEON(dst, src []int32)
 
 //go:noescape
 func diff4NEON(dst, src []int32)
+
+// minNEONRestoreOrder is the smallest predictor order at which the SIMD decode
+// recurrence kernel beats the scalar Go recurrence on NEON (tuned from the
+// Raspberry Pi 5 benchmarks). Below it the serial dependency leaves too little
+// per-output tap work to amortize the horizontal reduction.
+const minNEONRestoreOrder = 8
+
+func lpcResidualEncodeI32(res, samples, coeffs []int32, shift uint) {
+	if hasNEON && len(res)-len(coeffs) >= minNEONElements {
+		lpcResidualEncodeNEON(res, samples, coeffs, shift)
+		return
+	}
+	lpcResidualEncodeGo(res, samples, coeffs, shift)
+}
+
+func lpcRestoreI32(out, residual, coeffs []int32, shift uint) {
+	order := len(coeffs)
+	if hasNEON && order >= minNEONRestoreOrder && order <= maxLPCRestoreOrder && len(out)-order >= 1 {
+		// The kernel dots the ascending window with the coefficients reversed,
+		// so reverse once into a stack array (no heap alloc; the array does not
+		// escape through the //go:noescape kernel).
+		var rc [maxLPCRestoreOrder]int32
+		for k := range order {
+			rc[k] = coeffs[order-1-k]
+		}
+		lpcRestoreNEON(out, residual, rc[:order], shift)
+		return
+	}
+	lpcRestoreGo(out, residual, coeffs, shift)
+}
+
+//go:noescape
+func lpcResidualEncodeNEON(res, samples, coeffs []int32, shift uint)
+
+//go:noescape
+func lpcRestoreNEON(out, residual, rcoeffs []int32, shift uint)

--- a/i32/i32_arm64.s
+++ b/i32/i32_arm64.s
@@ -555,3 +555,188 @@ cumsum_neon_loop1:
 
 cumsum_neon_done:
     RET
+
+// func lpcResidualEncodeNEON(res, samples, coeffs []int32, shift uint)
+// Quantized-LPC encode FIR, vectorized across 4 output samples per iteration:
+//
+//	res[i] = samples[i] - int32((Σ_j coeffs[j]*samples[i-1-j]) >> shift)
+//
+// For each tap j the 4-sample window samples[i-1-j..i+2-j] is widened to int64
+// (SMLAL on the low two lanes, SMLAL2 on the high two) and multiply-accumulated
+// into two int64x2 accumulators. After the tap loop each accumulator is
+// arithmetic-shifted right by shift (SSHL by the broadcast -shift, NEON's native
+// signed 64-bit shift), the int64 predictions are narrowed back to int32 (XTN /
+// XTN2) and subtracted from samples[i..i+3]. The first 'order' samples are the
+// verbatim warm-up; the (n-order) mod 4 trailing outputs use a scalar int64
+// recurrence. The dispatch guarantees order >= 1 and n-order >= 4.
+TEXT ·lpcResidualEncodeNEON(SB), NOSPLIT, $0-80
+    MOVD res_base+0(FP), R0
+    MOVD res_len+8(FP), R4           // n
+    MOVD samples_base+24(FP), R1
+    MOVD coeffs_base+48(FP), R2
+    MOVD coeffs_len+56(FP), R3       // order
+    MOVD shift+72(FP), R6
+
+    // warm-up: res[0:order] = samples[0:order]
+    MOVD R1, R10
+    MOVD R0, R11
+    MOVD R3, R9
+lpcenc_neon_warmup:
+    MOVW.P 4(R10), R12
+    MOVW.P R12, 4(R11)
+    SUB $1, R9
+    CBNZ R9, lpcenc_neon_warmup
+
+    SUB $1, R3, R10
+    LSL $2, R10, R10
+    ADD R1, R10, R5                  // winBase = &samples[order-1]
+    LSL $2, R3, R10
+    ADD R0, R10, R0                  // R0 = &res[order]
+    SUB R3, R4, R4                   // residual count = n - order
+    LSR $2, R4, R7                   // R7 = full 4-blocks
+    AND $3, R4, R8                   // R8 = remaining tail outputs
+    NEG R6, R12
+    WORD $0x4e080d84                 // DUP V4.2D, X12   (-shift, for the SSHL)
+
+    CBZ R7, lpcenc_neon_tail
+lpcenc_neon_block:
+    WORD $0x6f00e400                 // MOVI V0.2D, #0x0   (acc_lo = 0)
+    WORD $0x6f00e401                 // MOVI V1.2D, #0x0   (acc_hi = 0)
+    MOVD R5, R10                     // window ptr = winBase - j*4
+    MOVD R2, R11                     // coeff ptr
+    MOVD R3, R9                      // j = order
+lpcenc_neon_tap:
+    VLD1 (R10), [V2.S4]              // S = samples[i-1-j..i+2-j]
+    MOVW (R11), R12                  // coeff[j]
+    WORD $0x4e040d83                 // DUP V3.4S, W12
+    WORD $0x0ea38040                 // SMLAL V0.2D, V2.2S, V3.2S
+    WORD $0x4ea38041                 // SMLAL2 V1.2D, V2.4S, V3.4S
+    ADD $4, R11
+    SUB $4, R10
+    SUB $1, R9
+    CBNZ R9, lpcenc_neon_tap
+
+    WORD $0x4ee44400                 // SSHL V0.2D, V0.2D, V4.2D   (>>shift arithmetic)
+    WORD $0x4ee44421                 // SSHL V1.2D, V1.2D, V4.2D
+    WORD $0x0ea12805                 // XTN V5.2S, V0.2D
+    WORD $0x4ea12825                 // XTN2 V5.4S, V1.2D
+    ADD $4, R5, R10                  // &samples[i]
+    VLD1 (R10), [V6.S4]              // samples[i..i+3]
+    WORD $0x6ea584c6                 // SUB V6.4S, V6.4S, V5.4S    (res = samples - pred)
+    VST1.P [V6.S4], 16(R0)
+    ADD $16, R5                      // winBase += 4 samples
+    SUB $1, R7
+    CBNZ R7, lpcenc_neon_block
+
+lpcenc_neon_tail:
+    CBZ R8, lpcenc_neon_done
+lpcenc_neon_tail_out:
+    MOVD ZR, R4                      // acc = 0 (int64)
+    MOVD R5, R10                     // window ptr
+    MOVD R2, R11                     // coeff ptr
+    MOVD R3, R9                      // j = order
+lpcenc_neon_tail_tap:
+    MOVW (R10), R12                  // sign-extend samples[i-1-j]
+    MOVW (R11), R13                  // sign-extend coeff[j]
+    MUL R12, R13, R13
+    ADD R13, R4, R4                  // acc += coeff[j]*samples[i-1-j]
+    ADD $4, R11
+    SUB $4, R10
+    SUB $1, R9
+    CBNZ R9, lpcenc_neon_tail_tap
+    ASR R6, R4, R4                   // pred = acc >> shift (arithmetic)
+    ADD $4, R5, R10
+    MOVW (R10), R12                  // samples[i]
+    SUBW R4, R12, R12                // - pred
+    MOVW.P R12, 4(R0)
+    ADD $4, R5                       // winBase += 1 sample
+    SUB $1, R8
+    CBNZ R8, lpcenc_neon_tail_out
+
+lpcenc_neon_done:
+    RET
+
+// func lpcRestoreNEON(out, residual, rcoeffs []int32, shift uint)
+// Quantized-LPC decode recurrence:
+//
+//	out[i] = residual[i] + int32((Σ_j coeffs[j]*out[i-1-j]) >> shift)
+//
+// Serial across i, so only the per-output tap dot product is vectorized. The
+// caller passes rcoeffs (coeffs reversed), so the ascending window out[i-order..]
+// and rcoeffs line up. The newest scalarTaps taps (which include the just-stored
+// out[i-1]) are summed scalar to keep them on forwardable narrow loads; the
+// oldest vecTaps (a multiple of 4) are widened (SMLAL/SMLAL2) into int64
+// accumulators, summed (ADD.2D), and folded to a scalar (ADDP). scalarTaps =
+// ((order+2) & 3) + 2 keeps the newest 2..5 taps scalar. The dispatch gates order
+// in [minNEONRestoreOrder, 32] and n-order >= 1.
+TEXT ·lpcRestoreNEON(SB), NOSPLIT, $0-80
+    MOVD out_base+0(FP), R5
+    MOVD out_len+8(FP), R4           // n
+    MOVD residual_base+24(FP), R1
+    MOVD rcoeffs_base+48(FP), R2
+    MOVD rcoeffs_len+56(FP), R3      // order
+    MOVD shift+72(FP), R6
+
+    // warm-up: out[0:order] = residual[0:order]
+    MOVD R5, R10
+    MOVD R1, R11
+    MOVD R3, R9
+lpcdec_neon_warmup:
+    MOVW.P 4(R11), R12
+    MOVW.P R12, 4(R10)
+    SUB $1, R9
+    CBNZ R9, lpcdec_neon_warmup
+
+    LSL $2, R4, R10
+    ADD R5, R10, R0                  // R0 = &out[n] (end sentinel)
+    MOVD R5, R7                      // R7 = &out[i-order] (window base, i=order -> &out[0])
+    LSL $2, R3, R10
+    ADD R5, R10, R5                  // R5 = &out[order]
+    ADD R1, R10, R1                  // R1 = &residual[order]
+    // scalarTaps = ((order+2) & 3) + 2 ; vecTaps = order - scalarTaps ; numVec = vecTaps/4
+    ADD $2, R3, R10
+    AND $3, R10, R10
+    ADD $2, R10, R10                 // scalarTaps (2..5)
+    SUB R10, R3, R8                  // vecTaps (multiple of 4)
+    LSR $2, R8, R8                   // R8 = numVec
+
+lpcdec_neon_out:
+    CMP R0, R5
+    BHS lpcdec_neon_done
+    WORD $0x6f00e400                 // MOVI V0.2D, #0x0   (acc_lo)
+    WORD $0x6f00e401                 // MOVI V1.2D, #0x0   (acc_hi)
+    MOVD R7, R10                     // window ptr = &out[i-order]
+    MOVD R2, R11                     // rcoeffs ptr
+    MOVD R8, R13                     // groups remaining = numVec
+    CBZ R13, lpcdec_neon_reduce
+lpcdec_neon_vec:
+    VLD1.P 16(R10), [V2.S4]          // W = out[i-order + g*4 ..]
+    VLD1.P 16(R11), [V3.S4]          // rcoeffs[g*4 ..]
+    WORD $0x0ea38040                 // SMLAL V0.2D, V2.2S, V3.2S
+    WORD $0x4ea38041                 // SMLAL2 V1.2D, V2.4S, V3.4S
+    SUB $1, R13
+    CBNZ R13, lpcdec_neon_vec
+lpcdec_neon_reduce:
+    WORD $0x4ee18400                 // ADD V0.2D, V0.2D, V1.2D
+    WORD $0x5ef1b800                 // ADDP D0, V0.2D
+    FMOVD F0, R12                    // R12 = vector partial sum (int64)
+    // scalar leftover taps: R10/R11 already advanced to tap = vecTaps
+lpcdec_neon_rem:
+    CMP R5, R10
+    BHS lpcdec_neon_pred
+    MOVW.P 4(R10), R13               // out[i-order+k]
+    MOVW.P 4(R11), R9                // rcoeffs[k]
+    MUL R13, R9, R13
+    ADD R13, R12, R12                // acc += rcoeffs[k]*out[i-order+k]
+    B   lpcdec_neon_rem
+lpcdec_neon_pred:
+    ASR R6, R12, R12                 // pred = acc >> shift (arithmetic)
+    MOVW (R1), R13                   // residual[i]
+    ADDW R12, R13, R13               // + pred
+    MOVW.P R13, 4(R5)                // out[i]
+    ADD $4, R1                       // &residual[i]++
+    ADD $4, R7                       // window base++
+    B   lpcdec_neon_out
+
+lpcdec_neon_done:
+    RET

--- a/i32/i32_arm64_test.go
+++ b/i32/i32_arm64_test.go
@@ -264,10 +264,117 @@ func TestNEONKernels_AllocFree(t *testing.T) {
 		{"diff3NEON", func() { diff3NEON(dst, a) }},
 		{"diff4NEON", func() { diff4NEON(dst, a) }},
 		{"cumsumNEON", func() { cumsumNEON(dst) }},
+		{"lpcResidualEncodeNEON", func() { lpcResidualEncodeNEON(dst, a, lpcAllocCoeffs, 12) }},
+		{"lpcRestoreNEON", func() { lpcRestoreNEON(dst, a, lpcAllocCoeffs, 12) }},
 	}
 	for _, c := range checks {
 		if got := testing.AllocsPerRun(100, c.fn); got != 0 {
 			t.Errorf("%s allocated %v times per run, want 0", c.name, got)
+		}
+	}
+}
+
+func TestLPCResidualEncodeNEON_ParityWithGo(t *testing.T) {
+	if !cpu.ARM64.NEON {
+		t.Skip("NEON not available")
+	}
+	for _, n := range paritySizes {
+		samples := make([]int32, n)
+		fillLPCSamples(samples)
+		for _, coeffs := range lpcCoeffSets() {
+			order := len(coeffs)
+			if n-order < minNEONElements {
+				continue // the dispatch routes these to the Go path
+			}
+			for _, shift := range lpcShifts {
+				gotNEON := make([]int32, n)
+				gotGo := make([]int32, n)
+				lpcResidualEncodeNEON(gotNEON, samples, coeffs, shift)
+				lpcResidualEncodeGo(gotGo, samples, coeffs, shift)
+				for i := range gotGo {
+					if gotNEON[i] != gotGo[i] {
+						t.Fatalf("n=%d order=%d shift=%d lpcResidualEncodeNEON[%d] = %d, want %d (Go)",
+							n, order, shift, i, gotNEON[i], gotGo[i])
+					}
+				}
+			}
+		}
+	}
+}
+
+func TestLPCRestoreNEON_ParityWithGo(t *testing.T) {
+	if !cpu.ARM64.NEON {
+		t.Skip("NEON not available")
+	}
+	for _, n := range paritySizes {
+		res := make([]int32, n)
+		fillLPCSamples(res)
+		for _, coeffs := range lpcCoeffSets() {
+			order := len(coeffs)
+			if order < minNEONRestoreOrder || order > maxLPCRestoreOrder || n-order < 1 {
+				continue
+			}
+			rc := reverseCoeffs(coeffs)
+			for _, shift := range lpcShifts {
+				gotNEON := make([]int32, n)
+				gotGo := make([]int32, n)
+				lpcRestoreNEON(gotNEON, res, rc, shift)
+				lpcRestoreGo(gotGo, res, coeffs, shift)
+				for i := range gotGo {
+					if gotNEON[i] != gotGo[i] {
+						t.Fatalf("n=%d order=%d shift=%d lpcRestoreNEON[%d] = %d, want %d (Go)",
+							n, order, shift, i, gotNEON[i], gotGo[i])
+					}
+				}
+			}
+		}
+	}
+}
+
+// TestLPCResidualEncodeNEON_NoOverwrite guards the scalar tail: an order-4
+// predictor over 23 outputs is 4 full 4-output blocks plus a 3-output tail.
+func TestLPCResidualEncodeNEON_NoOverwrite(t *testing.T) {
+	if !cpu.ARM64.NEON {
+		t.Skip("NEON not available")
+	}
+	const n = 23
+	coeffs := []int32{8000, -5000, 2000, -512}
+	samples := make([]int32, n)
+	fillLPCSamples(samples)
+	res := make([]int32, n+4)
+	for i := range res {
+		res[i] = math.MaxInt32 // sentinel
+	}
+	lpcResidualEncodeNEON(res[:n], samples, coeffs, 9)
+	for i := n; i < len(res); i++ {
+		if res[i] != math.MaxInt32 {
+			t.Errorf("lpcResidualEncodeNEON wrote past end at res[%d] = %d", i, res[i])
+		}
+	}
+}
+
+// TestLPCRestoreNEON_NoOverwrite guards the output tail: an order-12 predictor
+// over 35 outputs exercises both the vector groups and the scalar tap remainder.
+func TestLPCRestoreNEON_NoOverwrite(t *testing.T) {
+	if !cpu.ARM64.NEON {
+		t.Skip("NEON not available")
+	}
+	const n = 35
+	coeffs := make([]int32, 12)
+	for j := range coeffs {
+		coeffs[j] = int32(1000 - 137*j)
+	}
+	res := make([]int32, n)
+	fillLPCSamples(res)
+	rc := reverseCoeffs(coeffs)
+	out := make([]int32, n+4)
+	for i := range out {
+		out[i] = math.MaxInt32 // sentinel
+	}
+	lpcRestoreNEON(out[:n], res, rc, 10)
+	for i := n; i < len(out); i++ {
+		if out[i] != math.MaxInt32 {
+			t.Errorf("lpcRestoreNEON wrote past end at out[%d] = %d", i, out[i])
 		}
 	}
 }

--- a/i32/i32_go.go
+++ b/i32/i32_go.go
@@ -91,3 +91,47 @@ func cumsumGo(a []int32) {
 		a[i] += a[i-1]
 	}
 }
+
+// lpcResidualEncodeGo writes the quantized-LPC residual for an order-len(coeffs)
+// predictor. The first order entries are the verbatim warm-up; for i >= order,
+//
+//	res[i] = samples[i] - int32((Σ_j coeffs[j]*samples[i-1-j]) >> shift)
+//
+// The prediction sum is accumulated in int64 (matching libFLAC) so it does not
+// overflow for FLAC's coefficient precision and order; only the shifted result
+// is truncated to int32. res and samples are the caller-clamped equal-length
+// slices; res must not alias samples. int32 truncation wraps, matching the SIMD
+// kernels.
+func lpcResidualEncodeGo(res, samples, coeffs []int32, shift uint) {
+	order := len(coeffs)
+	w := min(order, len(res))
+	copy(res[:w], samples[:w])
+	for i := order; i < len(res); i++ {
+		var acc int64
+		for j, c := range coeffs {
+			acc += int64(c) * int64(samples[i-1-j])
+		}
+		res[i] = samples[i] - int32(acc>>shift)
+	}
+}
+
+// lpcRestoreGo is the exact inverse of lpcResidualEncodeGo: it reconstructs the
+// samples from the [order warm-up | residual] layout via the serial recurrence
+//
+//	out[i] = residual[i] + int32((Σ_j coeffs[j]*out[i-1-j]) >> shift)
+//
+// Each out[i] depends on the order previously reconstructed outputs, so unlike
+// the encode FIR this cannot be vectorized across i. out and residual are the
+// caller-clamped equal-length slices; out must not alias residual.
+func lpcRestoreGo(out, residual, coeffs []int32, shift uint) {
+	order := len(coeffs)
+	w := min(order, len(out))
+	copy(out[:w], residual[:w])
+	for i := order; i < len(out); i++ {
+		var acc int64
+		for j, c := range coeffs {
+			acc += int64(c) * int64(out[i-1-j])
+		}
+		out[i] = residual[i] + int32(acc>>shift)
+	}
+}

--- a/i32/i32_other.go
+++ b/i32/i32_other.go
@@ -17,3 +17,11 @@ func diff1I32(dst, src []int32) { diff1Go(dst, src) }
 func diff2I32(dst, src []int32) { diff2Go(dst, src) }
 func diff3I32(dst, src []int32) { diff3Go(dst, src) }
 func diff4I32(dst, src []int32) { diff4Go(dst, src) }
+
+func lpcResidualEncodeI32(res, samples, coeffs []int32, shift uint) {
+	lpcResidualEncodeGo(res, samples, coeffs, shift)
+}
+
+func lpcRestoreI32(out, residual, coeffs []int32, shift uint) {
+	lpcRestoreGo(out, residual, coeffs, shift)
+}

--- a/i32/lpc.go
+++ b/i32/lpc.go
@@ -23,6 +23,12 @@ package i32
 // less parallel. Both have SIMD kernels where they pay off, with a pure-Go
 // fallback that is the bit-exact source of truth.
 
+// maxLPCShift is the largest shift the kernels handle. A 64-bit accumulator
+// shifted by 63 already saturates to 0 or -1, and the SIMD kernels' emulated
+// arithmetic shift (and x86's shift-count masking) are only correct for counts
+// in [0, 63], so the public functions clamp shift to this value.
+const maxLPCShift = 63
+
 // maxLPCRestoreOrder caps the predictor order the SIMD decode kernels accept. It
 // matches FLAC's maximum LPC order (32) and sizes the stack array the dispatch
 // reverses the coefficients into, so the reversal stays allocation-free. Orders
@@ -37,6 +43,11 @@ const maxLPCRestoreOrder = 32
 // where order = len(coeffs). It processes n = min(len(res), len(samples)) and
 // leaves any trailing capacity in res untouched. An empty coeffs (order 0) or
 // fewer than order+1 samples yields all warm-up (res is samples verbatim).
+//
+// shift is the quantization right-shift (FLAC uses 0..31). It is clamped to 63
+// so the result stays consistent across the Go and SIMD paths: a shift of 63 or
+// more of a 64-bit accumulator already yields 0 or -1, and the SIMD kernels'
+// emulated shift is only valid for counts in [0, 63].
 func LPCResidualEncode(res, samples, coeffs []int32, shift uint) {
 	n := min(len(res), len(samples))
 	if n == 0 {
@@ -45,6 +56,9 @@ func LPCResidualEncode(res, samples, coeffs []int32, shift uint) {
 	if order := len(coeffs); order == 0 || order >= n {
 		copy(res[:n], samples[:n])
 		return
+	}
+	if shift > maxLPCShift {
+		shift = maxLPCShift
 	}
 	lpcResidualEncodeI32(res[:n], samples[:n], coeffs, shift)
 }
@@ -57,7 +71,8 @@ func LPCResidualEncode(res, samples, coeffs []int32, shift uint) {
 //
 // where order = len(coeffs). It processes n = min(len(out), len(residual)) and
 // leaves any trailing capacity in out untouched. Given the same coeffs and shift,
-// LPCRestore(LPCResidualEncode(samples)) == samples.
+// LPCRestore(LPCResidualEncode(samples)) == samples. shift is clamped to 63, as
+// in LPCResidualEncode, so encode and decode stay matched across all paths.
 func LPCRestore(out, residual, coeffs []int32, shift uint) {
 	n := min(len(out), len(residual))
 	if n == 0 {
@@ -66,6 +81,9 @@ func LPCRestore(out, residual, coeffs []int32, shift uint) {
 	if order := len(coeffs); order == 0 || order >= n {
 		copy(out[:n], residual[:n])
 		return
+	}
+	if shift > maxLPCShift {
+		shift = maxLPCShift
 	}
 	lpcRestoreI32(out[:n], residual[:n], coeffs, shift)
 }

--- a/i32/lpc.go
+++ b/i32/lpc.go
@@ -1,0 +1,71 @@
+package i32
+
+// Quantized-LPC residual encode and restore for the FLAC codec.
+//
+// FLAC's LPC subframes predict each sample from a fixed-point linear
+// combination of the preceding `order` samples, using integer coefficients
+// quantized to a shared right-shift. The encoder Rice-codes the residual
+// LPCResidualEncode produces; the decoder reconstructs the samples with
+// LPCRestore. The predictor order is taken from len(coeffs) (FLAC allows 1..32),
+// and shift is the quantization right-shift applied to the prediction sum.
+//
+// Both functions lay the data out as a FLAC subframe stores it: the first
+// `order` entries are the verbatim warm-up samples and the rest are the residual
+// (encode) or the reconstructed samples (decode). The prediction sum is
+// accumulated in int64 so it does not overflow for FLAC's coefficient precision
+// and order; only the final shifted prediction is truncated to int32. Each
+// function clamps to n = min of its two slice lengths, writes only into the
+// caller's destination, and uses int32 wraparound. The destination must not
+// alias the source.
+//
+// LPCResidualEncode is a FIR that vectorizes across output samples; LPCRestore
+// is a serial recurrence (each output feeds the next prediction) and so is far
+// less parallel. Both have SIMD kernels where they pay off, with a pure-Go
+// fallback that is the bit-exact source of truth.
+
+// maxLPCRestoreOrder caps the predictor order the SIMD decode kernels accept. It
+// matches FLAC's maximum LPC order (32) and sizes the stack array the dispatch
+// reverses the coefficients into, so the reversal stays allocation-free. Orders
+// above it fall back to the pure-Go recurrence.
+const maxLPCRestoreOrder = 32
+
+// LPCResidualEncode writes the quantized-LPC residual into res:
+//
+//	res[i] = samples[i]                                              for i < order
+//	res[i] = samples[i] - int32((Σ_j coeffs[j]*samples[i-1-j]) >> shift) for i >= order
+//
+// where order = len(coeffs). It processes n = min(len(res), len(samples)) and
+// leaves any trailing capacity in res untouched. An empty coeffs (order 0) or
+// fewer than order+1 samples yields all warm-up (res is samples verbatim).
+func LPCResidualEncode(res, samples, coeffs []int32, shift uint) {
+	n := min(len(res), len(samples))
+	if n == 0 {
+		return
+	}
+	if order := len(coeffs); order == 0 || order >= n {
+		copy(res[:n], samples[:n])
+		return
+	}
+	lpcResidualEncodeI32(res[:n], samples[:n], coeffs, shift)
+}
+
+// LPCRestore reconstructs the samples LPCResidualEncode encoded, inverting it
+// with the serial recurrence:
+//
+//	out[i] = residual[i]                                            for i < order
+//	out[i] = residual[i] + int32((Σ_j coeffs[j]*out[i-1-j]) >> shift)   for i >= order
+//
+// where order = len(coeffs). It processes n = min(len(out), len(residual)) and
+// leaves any trailing capacity in out untouched. Given the same coeffs and shift,
+// LPCRestore(LPCResidualEncode(samples)) == samples.
+func LPCRestore(out, residual, coeffs []int32, shift uint) {
+	n := min(len(out), len(residual))
+	if n == 0 {
+		return
+	}
+	if order := len(coeffs); order == 0 || order >= n {
+		copy(out[:n], residual[:n])
+		return
+	}
+	lpcRestoreI32(out[:n], residual[:n], coeffs, shift)
+}

--- a/i32/lpc_test.go
+++ b/i32/lpc_test.go
@@ -1,0 +1,337 @@
+package i32
+
+import (
+	"math"
+	"math/big"
+	"testing"
+)
+
+// Tests for the quantized-LPC encode FIR (LPCResidualEncode) and its decode
+// inverse (LPCRestore), the Phase 3 kernels of the FLAC integer roadmap.
+//
+// LPCResidualEncode writes the residual a FLAC LPC subframe Rice-codes:
+//
+//	res[i] = samples[i]                                       for i < order
+//	res[i] = samples[i] - int32((Σ_j coeffs[j]*samples[i-1-j]) >> shift) for i >= order
+//
+// LPCRestore inverts it with the serial recurrence:
+//
+//	out[i] = residual[i]                                      for i < order
+//	out[i] = residual[i] + int32((Σ_j coeffs[j]*out[i-1-j]) >> shift)   for i >= order
+//
+// The prediction sum is accumulated in int64 (matching libFLAC); only the
+// final >>shift result is truncated to int32. The strongest correctness check
+// is the LPCRestore(LPCResidualEncode(x)) == x round-trip, because the forward
+// FIR and the backward recurrence are independent kernels. lpcPredictOracle is
+// a math/big reference that depends on neither the int64 accumulation width nor
+// the package's shift handling, so its agreement pins the exact semantics.
+
+// lpcPredictOracle returns int32((Σ_j coeffs[j]*window[j]) >> shift) computed in
+// arbitrary precision. window[j] is the sample multiplied by coeffs[j]; for the
+// encode/decode loops window[j] = src[i-1-j]. big.Int Rsh is floor division by
+// 2^shift, matching Go's arithmetic >> on a signed integer, and masking the low
+// 32 bits then reinterpreting reproduces the int32() truncation exactly, without
+// assuming the running sum fits in int64.
+func lpcPredictOracle(coeffs, window []int32, shift uint) int32 {
+	acc := new(big.Int)
+	term := new(big.Int)
+	for j := range coeffs {
+		term.Mul(big.NewInt(int64(coeffs[j])), big.NewInt(int64(window[j])))
+		acc.Add(acc, term)
+	}
+	acc.Rsh(acc, shift) // arithmetic shift right = floor(acc / 2^shift)
+	low := new(big.Int).And(acc, big.NewInt(0xFFFFFFFF))
+	return int32(uint32(low.Uint64()))
+}
+
+// lpcEncodeOracle is the independent encode reference built on lpcPredictOracle.
+func lpcEncodeOracle(res, samples, coeffs []int32, shift uint) {
+	order := len(coeffs)
+	n := min(len(res), len(samples))
+	w := min(order, n)
+	copy(res[:w], samples[:w])
+	window := make([]int32, order)
+	for i := order; i < n; i++ {
+		for j := range order {
+			window[j] = samples[i-1-j]
+		}
+		res[i] = samples[i] - lpcPredictOracle(coeffs, window, shift)
+	}
+}
+
+// lpcRestoreOracle is the independent decode reference built on lpcPredictOracle.
+func lpcRestoreOracle(out, residual, coeffs []int32, shift uint) {
+	order := len(coeffs)
+	n := min(len(out), len(residual))
+	w := min(order, n)
+	copy(out[:w], residual[:w])
+	window := make([]int32, order)
+	for i := order; i < n; i++ {
+		for j := range order {
+			window[j] = out[i-1-j]
+		}
+		out[i] = residual[i] + lpcPredictOracle(coeffs, window, shift)
+	}
+}
+
+// lpcSizes straddle both SIMD block sizes (4 lanes on NEON, 8 on AVX) and
+// include inputs at or below the predictor order (all warm-up, Go path).
+var lpcSizes = []int{1, 2, 3, 4, 5, 7, 8, 9, 15, 16, 17, 31, 32, 33, 64, 100, 1000, 1024, 1025}
+
+// lpcCoeffSets are representative quantized-LPC coefficient vectors. Orders span
+// 1..32 (FLAC's range), values stay within ~15-bit qlp precision, and the signs
+// vary so the int64 accumulation and the >>shift sign handling are exercised.
+func lpcCoeffSets() [][]int32 {
+	// An order-12 and an order-32 set with alternating-sign, decaying magnitudes.
+	orders := []int{12, 32}
+	sets := make([][]int32, 0, 4+len(orders))
+	sets = append(sets,
+		[]int32{4096},
+		[]int32{7000, -3000},
+		[]int32{8000, -5000, 2000, -512},
+		[]int32{6000, -4000, 3000, -2000, 1500, -1000, 700, -300},
+	)
+	for _, order := range orders {
+		c := make([]int32, order)
+		for j := range c {
+			v := int32(16000 >> (j / 4))
+			if j%2 == 1 {
+				v = -v
+			}
+			c[j] = v
+		}
+		sets = append(sets, c)
+	}
+	return sets
+}
+
+var lpcShifts = []uint{0, 1, 9, 14, 15}
+
+// lpcAllocCoeffs is an order-8 coefficient vector for the kernel allocation-free
+// assertions (the per-architecture *_test.go files reference it).
+var lpcAllocCoeffs = []int32{6000, -4000, 3000, -2000, 1500, -1000, 700, -300}
+
+// reverseCoeffs returns coeffs reversed, the layout the SIMD restore kernels
+// consume (rcoeffs[k] = coeffs[order-1-k]).
+func reverseCoeffs(coeffs []int32) []int32 {
+	rc := make([]int32, len(coeffs))
+	for k := range coeffs {
+		rc[k] = coeffs[len(coeffs)-1-k]
+	}
+	return rc
+}
+
+// fillLPCSamples fills src with values that exercise the sign bit and the int32
+// extremes. Round-trip holds for any int32 input because encode and decode use
+// identical arithmetic, so extreme inputs are fair game and stress wraparound.
+func fillLPCSamples(src []int32) {
+	for i := range src {
+		src[i] = int32(uint32(i)*2654435761) ^ (int32(i) << 20)
+	}
+	if len(src) > 2 {
+		src[0] = math.MaxInt32
+		src[1] = math.MinInt32
+		src[2] = -1
+	}
+}
+
+func TestLPCRoundTrip(t *testing.T) {
+	for _, n := range lpcSizes {
+		samples := make([]int32, n)
+		fillLPCSamples(samples)
+		for _, coeffs := range lpcCoeffSets() {
+			for _, shift := range lpcShifts {
+				res := make([]int32, n)
+				LPCResidualEncode(res, samples, coeffs, shift)
+				got := make([]int32, n)
+				LPCRestore(got, res, coeffs, shift)
+				for i := range samples {
+					if got[i] != samples[i] {
+						t.Fatalf("n=%d order=%d shift=%d LPCRestore(LPCResidualEncode)[%d] = %d, want %d",
+							n, len(coeffs), shift, i, got[i], samples[i])
+					}
+				}
+			}
+		}
+	}
+}
+
+func TestLPCEncodeMatchesOracle(t *testing.T) {
+	for _, n := range lpcSizes {
+		samples := make([]int32, n)
+		fillLPCSamples(samples)
+		for _, coeffs := range lpcCoeffSets() {
+			for _, shift := range lpcShifts {
+				got := make([]int32, n)
+				want := make([]int32, n)
+				LPCResidualEncode(got, samples, coeffs, shift)
+				lpcEncodeOracle(want, samples, coeffs, shift)
+				for i := range want {
+					if got[i] != want[i] {
+						t.Fatalf("n=%d order=%d shift=%d LPCResidualEncode[%d] = %d, want %d (big.Int oracle)",
+							n, len(coeffs), shift, i, got[i], want[i])
+					}
+				}
+			}
+		}
+	}
+}
+
+func TestLPCRestoreMatchesOracle(t *testing.T) {
+	for _, n := range lpcSizes {
+		res := make([]int32, n)
+		fillLPCSamples(res) // treat as an arbitrary residual stream
+		for _, coeffs := range lpcCoeffSets() {
+			for _, shift := range lpcShifts {
+				got := make([]int32, n)
+				want := make([]int32, n)
+				LPCRestore(got, res, coeffs, shift)
+				lpcRestoreOracle(want, res, coeffs, shift)
+				for i := range want {
+					if got[i] != want[i] {
+						t.Fatalf("n=%d order=%d shift=%d LPCRestore[%d] = %d, want %d (big.Int oracle)",
+							n, len(coeffs), shift, i, got[i], want[i])
+					}
+				}
+			}
+		}
+	}
+}
+
+// TestLPCEncodeSimple checks a hand-computed order-2 case with shift.
+func TestLPCEncodeSimple(t *testing.T) {
+	// coeffs={2,-1}, shift=1. pred[i] = (2*s[i-1] - s[i-2]) >> 1.
+	samples := []int32{10, 20, 34, 50}
+	// i=2: pred=(2*20-10)>>1=(30)>>1=15; res=34-15=19
+	// i=3: pred=(2*34-20)>>1=(48)>>1=24; res=50-24=26
+	want := []int32{10, 20, 19, 26}
+	res := make([]int32, len(samples))
+	LPCResidualEncode(res, samples, []int32{2, -1}, 1)
+	for i, w := range want {
+		if res[i] != w {
+			t.Errorf("LPCResidualEncode[%d] = %d, want %d", i, res[i], w)
+		}
+	}
+}
+
+// TestLPCRestoreSimple inverts TestLPCEncodeSimple's residual.
+func TestLPCRestoreSimple(t *testing.T) {
+	res := []int32{10, 20, 19, 26}
+	want := []int32{10, 20, 34, 50}
+	out := make([]int32, len(res))
+	LPCRestore(out, res, []int32{2, -1}, 1)
+	for i, w := range want {
+		if out[i] != w {
+			t.Errorf("LPCRestore[%d] = %d, want %d", i, out[i], w)
+		}
+	}
+}
+
+// TestLPCWraps verifies int32 truncation of the prediction matches the oracle at
+// the type extremes.
+func TestLPCWraps(t *testing.T) {
+	samples := []int32{math.MaxInt32, math.MinInt32, math.MaxInt32, math.MinInt32, 1, -1, 0, 7, 11, 13}
+	coeffs := []int32{12345, -6789}
+	got := make([]int32, len(samples))
+	want := make([]int32, len(samples))
+	LPCResidualEncode(got, samples, coeffs, 3)
+	lpcEncodeOracle(want, samples, coeffs, 3)
+	for i := range want {
+		if got[i] != want[i] {
+			t.Errorf("LPCResidualEncode wrap [%d] = %d, want %d", i, got[i], want[i])
+		}
+	}
+}
+
+func TestLPC_Clamp(t *testing.T) {
+	samples := []int32{1, 2, 4, 7, 11, 16, 22, 29, 37, 46}
+	coeffs := []int32{2, -1}
+	res := make([]int32, 100)
+	LPCResidualEncode(res, samples, coeffs, 0)
+	want := make([]int32, len(samples))
+	lpcEncodeOracle(want, samples, coeffs, 0)
+	for i, w := range want {
+		if res[i] != w {
+			t.Errorf("LPCResidualEncode clamp res[%d] = %d, want %d", i, res[i], w)
+		}
+	}
+	for i := len(want); i < len(res); i++ {
+		if res[i] != 0 {
+			t.Errorf("LPCResidualEncode wrote past clamp at res[%d] = %d, want untouched 0", i, res[i])
+		}
+	}
+}
+
+// TestLPC_ShortInput checks inputs at or below the order: with order or fewer
+// samples there is no residual, only warm-up copied verbatim.
+func TestLPC_ShortInput(t *testing.T) {
+	coeffs := []int32{1, 2, 3, 4} // order 4
+	samples := []int32{42, 7, 9}  // only 3 samples
+	res := make([]int32, len(samples))
+	LPCResidualEncode(res, samples, coeffs, 2)
+	if res[0] != 42 || res[1] != 7 || res[2] != 9 {
+		t.Errorf("LPCResidualEncode short input = %v, want [42 7 9] warm-up", res)
+	}
+	out := make([]int32, len(res))
+	LPCRestore(out, res, coeffs, 2)
+	if out[0] != 42 || out[1] != 7 || out[2] != 9 {
+		t.Errorf("LPCRestore short input = %v, want [42 7 9] warm-up", out)
+	}
+}
+
+// TestLPC_ZeroOrder treats an empty coefficient vector as identity: no predictor,
+// every output is warm-up.
+func TestLPC_ZeroOrder(t *testing.T) {
+	samples := []int32{3, 1, 4, 1, 5}
+	res := make([]int32, len(samples))
+	LPCResidualEncode(res, samples, nil, 4)
+	for i := range samples {
+		if res[i] != samples[i] {
+			t.Errorf("LPCResidualEncode zero order res[%d] = %d, want %d", i, res[i], samples[i])
+		}
+	}
+}
+
+func TestLPC_Empty(t *testing.T) {
+	coeffs := []int32{1, -1}
+	LPCResidualEncode(nil, nil, coeffs, 0)
+	LPCResidualEncode([]int32{}, []int32{}, coeffs, 0)
+	LPCRestore(nil, nil, coeffs, 0)
+	res := []int32{99}
+	LPCResidualEncode(res, nil, coeffs, 0)
+	if res[0] != 99 {
+		t.Errorf("LPCResidualEncode wrote on empty input: %v", res)
+	}
+}
+
+func TestLPC_AllocFree(t *testing.T) {
+	const n = 1024
+	samples := make([]int32, n)
+	fillLPCSamples(samples)
+	res := make([]int32, n)
+	out := make([]int32, n)
+	for _, coeffs := range lpcCoeffSets() {
+		name := "order" + itoa(len(coeffs))
+		if got := testing.AllocsPerRun(50, func() { LPCResidualEncode(res, samples, coeffs, 12) }); got != 0 {
+			t.Errorf("LPCResidualEncode %s allocated %v times per run, want 0", name, got)
+		}
+		if got := testing.AllocsPerRun(50, func() { LPCRestore(out, res, coeffs, 12) }); got != 0 {
+			t.Errorf("LPCRestore %s allocated %v times per run, want 0", name, got)
+		}
+	}
+}
+
+// itoa is a tiny allocation-free-friendly int formatter for subtest labels.
+func itoa(n int) string {
+	if n == 0 {
+		return "0"
+	}
+	var b [12]byte
+	i := len(b)
+	for n > 0 {
+		i--
+		b[i] = byte('0' + n%10)
+		n /= 10
+	}
+	return string(b[i:])
+}

--- a/i32/lpc_test.go
+++ b/i32/lpc_test.go
@@ -292,6 +292,36 @@ func TestLPC_ZeroOrder(t *testing.T) {
 	}
 }
 
+// TestLPC_ShiftClamp checks that an out-of-range shift (>= 64) is clamped to 63
+// at the public boundary, so the Go and SIMD paths stay consistent (FLAC never
+// uses such shifts; this guards a caller passing a bad value). It also confirms
+// the round-trip still holds and that shift 64..67 all behave like 63.
+func TestLPC_ShiftClamp(t *testing.T) {
+	const n = 200
+	samples := make([]int32, n)
+	fillLPCSamples(samples)
+	coeffs := []int32{6000, -4000, 3000, -2000, 1500, -1000, 700, -300}
+
+	ref := make([]int32, n)
+	LPCResidualEncode(ref, samples, coeffs, 63)
+	for _, shift := range []uint{64, 65, 100, 1 << 20} {
+		got := make([]int32, n)
+		LPCResidualEncode(got, samples, coeffs, shift)
+		for i := range got {
+			if got[i] != ref[i] {
+				t.Fatalf("shift=%d not clamped to 63: res[%d] = %d, want %d", shift, i, got[i], ref[i])
+			}
+		}
+		out := make([]int32, n)
+		LPCRestore(out, got, coeffs, shift)
+		for i := range samples {
+			if out[i] != samples[i] {
+				t.Fatalf("shift=%d round-trip[%d] = %d, want %d", shift, i, out[i], samples[i])
+			}
+		}
+	}
+}
+
 func TestLPC_Empty(t *testing.T) {
 	coeffs := []int32{1, -1}
 	LPCResidualEncode(nil, nil, coeffs, 0)


### PR DESCRIPTION
## Summary

Implements Phase 3 PR6 + PR7 of the integer-SIMD FLAC roadmap, batched because the encode FIR and decode recurrence share the `(coeffs, shift)` API shape and give an encode->decode round-trip test, the same way `Diff`/`Restore` do.

New `i32` API:
- `LPCResidualEncode(res, samples, coeffs, shift)`: the quantized-LPC encode residual, `res[i] = samples[i] - int32((sum_j coeffs[j]*samples[i-1-j]) >> shift)` for `i >= order`, first `order` samples verbatim. A FIR that vectorizes across output samples.
- `LPCRestore(out, residual, coeffs, shift)`: the exact decode inverse, a serial recurrence `out[i] = residual[i] + int32((sum_j coeffs[j]*out[i-1-j]) >> shift)`.

The prediction sum is accumulated in **int64**, matching libFLAC, so the kernels stay bit-exact for FLAC's full coefficient precision and order. int32 accumulation would overflow and balloon the residual (it still round-trips, but defeats compression), so the issue's `VPMULLD` sketch is replaced with int64 widening. Order is taken from `len(coeffs)`; order 0 or fewer than `order+1` samples is all warm-up.

## Kernels

- **AMD64 AVX2** (gated on the AVX2 feature). Encode widens each tap via `VPMULDQ` on the even and odd int32 lanes into two int64x4 accumulators, emulates the 64-bit arithmetic shift AVX2 lacks (`(x^2^63) >>u s - 2^(63-s)` with `VPSRLVQ`), and recombines the low 32 bits into the int32 prediction. Decode vectorizes only the per-output tap dot product; the newest taps (which include the just-stored `out[i-1]`) stay on store-forwardable scalar loads so a wide vector load never stalls on a pending narrow store, which is ~3x faster on order-is-a-multiple-of-8 cases.
- **ARM64 NEON**. Encode uses `SMLAL`/`SMLAL2` widening with `SSHL` for the native signed 64-bit shift and `XTN`/`XTN2` to narrow; decode mirrors the AVX2 structure with the same store-forward-aware tap split. NEON ops are hand-encoded as `WORD` and cross-checked by asmcheck.
- **Pure-Go** reference is the bit-exact source of truth and the fallback.

`LPCRestore` dispatches to SIMD only at order >= 8 (where it beats the scalar recurrence) and order <= 32 (FLAC's max; the dispatch reverses the coefficients into a stack array, no heap alloc).

## Benchmarks (1000 elements, vs pure Go, zero-alloc)

| Op | amd64 AVX2 | arm64 NEON (Pi 5) |
|----|-----------|-------------------|
| LPCResidualEncode (order 8)  | 743 ns, 7.2x  | 2495 ns, 4.3x  |
| LPCResidualEncode (order 32) | 2397 ns, 9.2x | 8148 ns, 5.0x  |
| LPCRestore (order 8)         | 3583 ns, 1.4x | 6128 ns, 1.8x  |
| LPCRestore (order 32)        | 4443 ns, 3.9x | 11303 ns, 3.6x |

## Related issue

Part of #79. Closes Phase 3 except PR8 (Rice zigzag cost search), which is standalone.

## Test plan

- [x] SIMD-vs-Go kernel parity across block-straddling sizes with sign and int32-extreme inputs
- [x] arbitrary-precision `math/big` oracle for both directions
- [x] `LPCRestore(LPCResidualEncode(x)) == x` round-trip
- [x] length clamping, short/empty/zero-order inputs, scalar-tail no-overwrite guards
- [x] per-kernel zero-alloc assertions
- [x] asmcheck for every NEON `WORD` encoding
- [x] `go vet`, `go test -race`, whole-tree `golangci-lint`
- [x] verified natively on amd64 (AVX2) and on a Raspberry Pi 5 (arm64 NEON)