### PR TITLE
i32: AVX2/NEON Rice zigzag cost search (RiceSums / RiceBestParam)

### DIFF
--- a/README.md
+++ b/README.md
@@ -384,6 +384,8 @@ SIMD-accelerated integer-domain operations for codec and integer-DSP hot loops (
 |                     | `Restore1`..`Restore4(dst, src)`        | Order 1-4 fixed-predictor decode (inverse; prefix sum)   | 8x (AVX2) / 4x (NEON) |
 | **LPC**             | `LPCResidualEncode(res, samples, coeffs, shift)` | Quantized-LPC encode residual FIR (parallel across outputs) | 8x (AVX2) / 4x (NEON) |
 |                     | `LPCRestore(out, residual, coeffs, shift)`       | Quantized-LPC decode (serial recurrence; vectorized taps)   | 8x (AVX2) / 4x (NEON) |
+| **Rice**            | `RiceSums(sums, res)`                   | Per-parameter zigzag unary-bit sums `Σ (zigzag(res)>>k)`  | 8x (AVX2) / 4x (NEON) |
+|                     | `RiceBestParam(res, maxParam)`          | Cost-minimizing Rice parameter + its bit count           | 8x (AVX2) / 4x (NEON) |
 
 ```go
 import "github.com/tphakala/simd/i32"
@@ -402,9 +404,11 @@ i32.Restore2(left, res)  // exact inverse: reconstruct the samples
 coeffs := []int32{...}             // quantized LPC coefficients (order = len)
 i32.LPCResidualEncode(res, left, coeffs, shift) // encode FIR residual
 i32.LPCRestore(left, res, coeffs, shift)        // exact inverse: reconstruct
+
+param, bits := i32.RiceBestParam(res, 14) // best Rice parameter and its bit cost
 ```
 
-Interleaving is pure 32-bit-lane movement, so those kernels reuse the proven `f32` shuffle/permute encodings (AVX `VUNPCKLPS`/`VPERM2F128`, NEON `ZIP`/`UZP` on `.4S`); the bit pattern of each lane is irrelevant, so negative values and the type extremes round-trip exactly. The decorrelation and fixed-predictor kernels do integer-ALU work on 256-bit (AVX2) / 128-bit (NEON) lanes. `RestoreK` is the exact inverse of `DiffK`: since the order-`K` fixed predictor is the `K`-th forward difference, restoration is `K` cumulative-sum passes built on one SIMD prefix-sum kernel (11x at order 1 down to ~5x at order 4 on AVX2; 6x to 3x on NEON, all zero-allocation). The LPC kernels accumulate the prediction sum in int64 (matching libFLAC), so they stay bit-exact for the full coefficient precision and order: `LPCResidualEncode` is a FIR that vectorizes across output samples (widening `VPMULDQ` / `SMLAL`, ~7-9x on AVX2, ~4-5x on NEON), while `LPCRestore` is a serial recurrence whose per-output tap dot product is vectorized, keeping the just-written newest samples on store-forwardable scalar loads (~1.4-3.9x on AVX2, ~1.8-3.6x on NEON, order 8 to 32). The remaining integer surface (Rice cost search) is tracked in the project issues.
+Interleaving is pure 32-bit-lane movement, so those kernels reuse the proven `f32` shuffle/permute encodings (AVX `VUNPCKLPS`/`VPERM2F128`, NEON `ZIP`/`UZP` on `.4S`); the bit pattern of each lane is irrelevant, so negative values and the type extremes round-trip exactly. The decorrelation and fixed-predictor kernels do integer-ALU work on 256-bit (AVX2) / 128-bit (NEON) lanes. `RestoreK` is the exact inverse of `DiffK`: since the order-`K` fixed predictor is the `K`-th forward difference, restoration is `K` cumulative-sum passes built on one SIMD prefix-sum kernel (11x at order 1 down to ~5x at order 4 on AVX2; 6x to 3x on NEON, all zero-allocation). The LPC kernels accumulate the prediction sum in int64 (matching libFLAC), so they stay bit-exact for the full coefficient precision and order: `LPCResidualEncode` is a FIR that vectorizes across output samples (widening `VPMULDQ` / `SMLAL`, ~7-9x on AVX2, ~4-5x on NEON), while `LPCRestore` is a serial recurrence whose per-output tap dot product is vectorized, keeping the just-written newest samples on store-forwardable scalar loads (~1.4-3.9x on AVX2, ~1.8-3.6x on NEON, order 8 to 32). The Rice cost search folds each residual to its unsigned zigzag symbol `(r<<1)^(r>>31)`, widens it to int64, and accumulates `Σ (zigzag(res)>>k)` for every Rice parameter `k` in 0..14 at once (the symbols are halved progressively, exact for the logical shift); `RiceBestParam` adds the `n*(k+1)` code overhead and picks the cheapest `k`. This is the exact bit cost, not the `sum>>k` approximation, and runs ~13x on AVX2 and ~4x on NEON, zero-allocation.
 
 ## Performance
 
@@ -584,8 +588,10 @@ a Raspberry Pi 5):
 | LPCResidualEncode (order 32) | 2397 ns vs 22046 ns (**9.2x**)| 8148 ns vs 40811 ns (**5.0x**) |
 | LPCRestore (order 8)         | 3583 ns vs 4944 ns (**1.4x**) | 6128 ns vs 10889 ns (**1.8x**) |
 | LPCRestore (order 32)        | 4443 ns vs 17529 ns (**3.9x**)| 11303 ns vs 41026 ns (**3.6x**) |
+| RiceSums (k=0..14)           | 810 ns vs 10490 ns (**13.0x**)| 4090 ns vs 17163 ns (**4.2x**) |
+| RiceBestParam (k=0..14)      | 810 ns vs 10490 ns (**13.0x**)| 4081 ns vs 17163 ns (**4.2x**) |
 
-All int32 kernels are zero-allocation and bit-exact against the pure-Go reference (verified across the sign and high bits with negative values and the type extremes). The Restore baseline is the pure-Go decode recurrence; `RestoreK` reconstructs samples as `K` SIMD prefix-sum passes (the inverse of the order-`K` forward difference). The LPC kernels accumulate in int64 and are checked against an arbitrary-precision `math.big` oracle and the encode->decode round-trip; `LPCRestore` is the serial decode recurrence (vectorized per-output tap dot product), dispatched to SIMD only at order >= 8 where it beats the scalar path.
+All int32 kernels are zero-allocation and bit-exact against the pure-Go reference (verified across the sign and high bits with negative values and the type extremes). The Restore baseline is the pure-Go decode recurrence; `RestoreK` reconstructs samples as `K` SIMD prefix-sum passes (the inverse of the order-`K` forward difference). The LPC kernels accumulate in int64 and are checked against an arbitrary-precision `math.big` oracle and the encode->decode round-trip; `LPCRestore` is the serial decode recurrence (vectorized per-output tap dot product), dispatched to SIMD only at order >= 8 where it beats the scalar path. The Rice kernels compute the exact per-parameter unary-bit sums `Σ (zigzag(res)>>k)` for all 15 FLAC parameters in one pass (15 int64 accumulators; AVX2 sweeps the data twice for its 16-register file, NEON fits one pass in its 32 registers), checked against an independent oracle and brute-force parameter scan.
 
 ### Performance Notes
 

--- a/doc.go
+++ b/doc.go
@@ -53,7 +53,7 @@
 //
 // Audio DSP: Interleave2, Deinterleave2, ConvolveValid, ConvolveValidMulti, ConvolveDecimate, AccumulateAdd, CumulativeSum, CubicInterpDot, Int32ToFloat32Scale, Int16ToFloat32Scale, Float32ToInt16Scale
 //
-// Integer DSP (i32): Interleave2, Deinterleave2
+// Integer DSP (i32): Interleave2, Deinterleave2, Add, Sub, MidSideEncode, MidSideDecode, Diff1..Diff4, Restore1..Restore4, LPCResidualEncode, LPCRestore, RiceSums, RiceBestParam
 //
 // Complex (c128): Add, Sub, Mul, MulConj, Conj, Abs, AbsSq, Scale
 //

--- a/i32/benchmark_test.go
+++ b/i32/benchmark_test.go
@@ -379,3 +379,41 @@ func BenchmarkLPCRestore32Go_1000(b *testing.B) {
 		lpcRestoreGo(dst, src, coeffs, 12)
 	}
 }
+
+// benchRiceRes makes a residual stream with realistic small-magnitude values so
+// the cost-minimizing Rice parameter is interior to the 0..14 scan.
+func benchRiceRes() []int32 {
+	res := make([]int32, benchN)
+	x := uint32(0x12345)
+	for i := range res {
+		x = x*1664525 + 1013904223 // LCG
+		res[i] = int32(x%4096) - 2048
+	}
+	return res
+}
+
+func BenchmarkRiceSums_1000(b *testing.B) {
+	res := benchRiceRes()
+	sums := make([]uint64, riceParamCount)
+	b.SetBytes(benchN * 4)
+	for b.Loop() {
+		RiceSums(sums, res)
+	}
+}
+
+func BenchmarkRiceSumsGo_1000(b *testing.B) {
+	res := benchRiceRes()
+	sums := make([]uint64, riceParamCount)
+	b.SetBytes(benchN * 4)
+	for b.Loop() {
+		riceSumsGo(sums, res)
+	}
+}
+
+func BenchmarkRiceBestParam_1000(b *testing.B) {
+	res := benchRiceRes()
+	b.SetBytes(benchN * 4)
+	for b.Loop() {
+		RiceBestParam(res, riceMaxParam)
+	}
+}

--- a/i32/example_test.go
+++ b/i32/example_test.go
@@ -106,3 +106,26 @@ func ExampleLPCRestore() {
 	fmt.Println(samples)
 	// Output: [10 20 34 50]
 }
+
+// ExampleRiceSums shows the per-parameter unary-bit sums. The residuals fold to
+// the zigzag symbols 0,1,2,3,4; sums[k] is the sum of those symbols shifted
+// right by k, the data-dependent part of the Rice code length for parameter k.
+func ExampleRiceSums() {
+	res := []int32{0, -1, 1, -2, 2} // zigzag -> 0,1,2,3,4
+	sums := make([]uint64, 4)
+
+	i32.RiceSums(sums, res)
+	fmt.Println(sums)
+	// Output: [10 4 1 0]
+}
+
+// ExampleRiceBestParam shows the Rice parameter search. For these residuals the
+// total code cost is minimized at parameter 1, which needs 14 bits:
+// cost(0)=15, cost(1)=14, cost(2)=16.
+func ExampleRiceBestParam() {
+	res := []int32{0, -1, 1, -2, 2}
+
+	param, bits := i32.RiceBestParam(res, 14)
+	fmt.Println(param, bits)
+	// Output: 1 14
+}

--- a/i32/i32_amd64.go
+++ b/i32/i32_amd64.go
@@ -187,3 +187,17 @@ func lpcResidualEncodeAVX2(res, samples, coeffs []int32, shift uint)
 
 //go:noescape
 func lpcRestoreAVX2(out, residual, rcoeffs []int32, shift uint)
+
+// riceSumsI32 dispatches the Rice per-parameter unary-bit sums. The AVX2 kernel
+// always writes the full riceParamCount (15) FLAC sums, so it is used only for
+// that width; other widths and short inputs use the pure-Go reference.
+func riceSumsI32(sums []uint64, res []int32) {
+	if hasAVX2 && len(sums) == riceParamCount && len(res) >= minAVXElements {
+		riceSumsAVX2(sums, res)
+		return
+	}
+	riceSumsGo(sums, res)
+}
+
+//go:noescape
+func riceSumsAVX2(sums []uint64, res []int32)

--- a/i32/i32_amd64.s
+++ b/i32/i32_amd64.s
@@ -847,3 +847,272 @@ lpcdec_pred:
 lpcdec_done:
     VZEROUPPER
     RET
+
+// func riceSumsAVX2(sums []uint64, res []int32)
+// Rice per-parameter unary-bit sums, sums[k] = Σ_i (zigzag(res[i]) >> k) for
+// k = 0..14 (the fixed FLAC 4-bit range; the dispatch guarantees len(sums)==15).
+//
+// Each residual is folded to its unsigned Rice symbol with
+// zigzag(r) = (r<<1) ^ (r>>31) (VPSLLD / VPSRAD / VPXOR), then zero-extended to
+// int64 (VPMOVZXDQ on the low and high 128-bit halves) so the per-k right shifts
+// and the running totals never overflow. The 15 sums need more 64-bit
+// accumulators than the 16 YMM registers allow in one pass, so the data is swept
+// twice: group A computes k=0..7, group B k=8..14. Within a sweep the widened
+// symbols are halved progressively (u>>k is u>>(k-1) shifted once more, exact for
+// the logical VPSRLQ), accumulating into one int64x4 register per k. After each
+// sweep every accumulator's four lanes are folded to a scalar and stored. The
+// (n mod 8) trailing residuals are then added to all 15 sums with a scalar
+// progressive-halving tail. The dispatch gates len(res) >= 8 (>=1 full block).
+TEXT ·riceSumsAVX2(SB), NOSPLIT, $0-48
+    MOVQ sums_base+0(FP), DI
+    MOVQ res_base+24(FP), R8
+    MOVQ res_len+32(FP), CX          // n
+    MOVQ CX, R9
+    SHRQ $3, R9                      // R9 = full 8-element blocks (>=1)
+
+    // ---- group A: k = 0..7 (accumulators Y8..Y15) ----
+    VPXOR Y8, Y8, Y8
+    VPXOR Y9, Y9, Y9
+    VPXOR Y10, Y10, Y10
+    VPXOR Y11, Y11, Y11
+    VPXOR Y12, Y12, Y12
+    VPXOR Y13, Y13, Y13
+    VPXOR Y14, Y14, Y14
+    VPXOR Y15, Y15, Y15
+    MOVQ R8, SI                      // working res ptr
+    MOVQ R9, AX                      // block counter
+riceA_loop:
+    VMOVDQU (SI), Y0                 // v = res[i..i+7]
+    VPSLLD  $1, Y0, Y1               // r<<1
+    VPSRAD  $31, Y0, Y2              // r>>31 (arithmetic)
+    VPXOR   Y2, Y1, Y1               // u = zigzag(r) (int32x8, as uint32)
+    VPMOVZXDQ X1, Y2                 // ulo = zero-extend lanes 0..3 -> int64x4
+    VEXTRACTI128 $1, Y1, X3          // high 128 of u (lanes 4..7)
+    VPMOVZXDQ X3, Y3                 // uhi = zero-extend lanes 4..7 -> int64x4
+    VPADDQ Y2, Y8, Y8               // k=0
+    VPADDQ Y3, Y8, Y8
+    VPSRLQ $1, Y2, Y2
+    VPSRLQ $1, Y3, Y3
+    VPADDQ Y2, Y9, Y9               // k=1
+    VPADDQ Y3, Y9, Y9
+    VPSRLQ $1, Y2, Y2
+    VPSRLQ $1, Y3, Y3
+    VPADDQ Y2, Y10, Y10            // k=2
+    VPADDQ Y3, Y10, Y10
+    VPSRLQ $1, Y2, Y2
+    VPSRLQ $1, Y3, Y3
+    VPADDQ Y2, Y11, Y11            // k=3
+    VPADDQ Y3, Y11, Y11
+    VPSRLQ $1, Y2, Y2
+    VPSRLQ $1, Y3, Y3
+    VPADDQ Y2, Y12, Y12            // k=4
+    VPADDQ Y3, Y12, Y12
+    VPSRLQ $1, Y2, Y2
+    VPSRLQ $1, Y3, Y3
+    VPADDQ Y2, Y13, Y13            // k=5
+    VPADDQ Y3, Y13, Y13
+    VPSRLQ $1, Y2, Y2
+    VPSRLQ $1, Y3, Y3
+    VPADDQ Y2, Y14, Y14            // k=6
+    VPADDQ Y3, Y14, Y14
+    VPSRLQ $1, Y2, Y2
+    VPSRLQ $1, Y3, Y3
+    VPADDQ Y2, Y15, Y15            // k=7
+    VPADDQ Y3, Y15, Y15
+    ADDQ $32, SI
+    DECQ AX
+    JNZ  riceA_loop
+
+    // fold each int64x4 accumulator to a scalar and store sums[0..7]
+    VEXTRACTI128 $1, Y8, X0
+    VPADDQ X0, X8, X0
+    MOVQ X0, AX
+    VPEXTRQ $1, X0, DX
+    ADDQ DX, AX
+    MOVQ AX, 0(DI)
+    VEXTRACTI128 $1, Y9, X0
+    VPADDQ X0, X9, X0
+    MOVQ X0, AX
+    VPEXTRQ $1, X0, DX
+    ADDQ DX, AX
+    MOVQ AX, 8(DI)
+    VEXTRACTI128 $1, Y10, X0
+    VPADDQ X0, X10, X0
+    MOVQ X0, AX
+    VPEXTRQ $1, X0, DX
+    ADDQ DX, AX
+    MOVQ AX, 16(DI)
+    VEXTRACTI128 $1, Y11, X0
+    VPADDQ X0, X11, X0
+    MOVQ X0, AX
+    VPEXTRQ $1, X0, DX
+    ADDQ DX, AX
+    MOVQ AX, 24(DI)
+    VEXTRACTI128 $1, Y12, X0
+    VPADDQ X0, X12, X0
+    MOVQ X0, AX
+    VPEXTRQ $1, X0, DX
+    ADDQ DX, AX
+    MOVQ AX, 32(DI)
+    VEXTRACTI128 $1, Y13, X0
+    VPADDQ X0, X13, X0
+    MOVQ X0, AX
+    VPEXTRQ $1, X0, DX
+    ADDQ DX, AX
+    MOVQ AX, 40(DI)
+    VEXTRACTI128 $1, Y14, X0
+    VPADDQ X0, X14, X0
+    MOVQ X0, AX
+    VPEXTRQ $1, X0, DX
+    ADDQ DX, AX
+    MOVQ AX, 48(DI)
+    VEXTRACTI128 $1, Y15, X0
+    VPADDQ X0, X15, X0
+    MOVQ X0, AX
+    VPEXTRQ $1, X0, DX
+    ADDQ DX, AX
+    MOVQ AX, 56(DI)
+
+    // ---- group B: k = 8..14 (accumulators Y8..Y14) ----
+    VPXOR Y8, Y8, Y8
+    VPXOR Y9, Y9, Y9
+    VPXOR Y10, Y10, Y10
+    VPXOR Y11, Y11, Y11
+    VPXOR Y12, Y12, Y12
+    VPXOR Y13, Y13, Y13
+    VPXOR Y14, Y14, Y14
+    MOVQ R8, SI
+    MOVQ R9, AX
+riceB_loop:
+    VMOVDQU (SI), Y0
+    VPSLLD  $1, Y0, Y1
+    VPSRAD  $31, Y0, Y2
+    VPXOR   Y2, Y1, Y1               // u = zigzag(r)
+    VPMOVZXDQ X1, Y2                 // ulo
+    VEXTRACTI128 $1, Y1, X3
+    VPMOVZXDQ X3, Y3                 // uhi
+    VPSRLQ $8, Y2, Y2               // start at k=8
+    VPSRLQ $8, Y3, Y3
+    VPADDQ Y2, Y8, Y8              // k=8
+    VPADDQ Y3, Y8, Y8
+    VPSRLQ $1, Y2, Y2
+    VPSRLQ $1, Y3, Y3
+    VPADDQ Y2, Y9, Y9             // k=9
+    VPADDQ Y3, Y9, Y9
+    VPSRLQ $1, Y2, Y2
+    VPSRLQ $1, Y3, Y3
+    VPADDQ Y2, Y10, Y10          // k=10
+    VPADDQ Y3, Y10, Y10
+    VPSRLQ $1, Y2, Y2
+    VPSRLQ $1, Y3, Y3
+    VPADDQ Y2, Y11, Y11          // k=11
+    VPADDQ Y3, Y11, Y11
+    VPSRLQ $1, Y2, Y2
+    VPSRLQ $1, Y3, Y3
+    VPADDQ Y2, Y12, Y12          // k=12
+    VPADDQ Y3, Y12, Y12
+    VPSRLQ $1, Y2, Y2
+    VPSRLQ $1, Y3, Y3
+    VPADDQ Y2, Y13, Y13          // k=13
+    VPADDQ Y3, Y13, Y13
+    VPSRLQ $1, Y2, Y2
+    VPSRLQ $1, Y3, Y3
+    VPADDQ Y2, Y14, Y14          // k=14
+    VPADDQ Y3, Y14, Y14
+    ADDQ $32, SI
+    DECQ AX
+    JNZ  riceB_loop
+
+    VEXTRACTI128 $1, Y8, X0
+    VPADDQ X0, X8, X0
+    MOVQ X0, AX
+    VPEXTRQ $1, X0, DX
+    ADDQ DX, AX
+    MOVQ AX, 64(DI)
+    VEXTRACTI128 $1, Y9, X0
+    VPADDQ X0, X9, X0
+    MOVQ X0, AX
+    VPEXTRQ $1, X0, DX
+    ADDQ DX, AX
+    MOVQ AX, 72(DI)
+    VEXTRACTI128 $1, Y10, X0
+    VPADDQ X0, X10, X0
+    MOVQ X0, AX
+    VPEXTRQ $1, X0, DX
+    ADDQ DX, AX
+    MOVQ AX, 80(DI)
+    VEXTRACTI128 $1, Y11, X0
+    VPADDQ X0, X11, X0
+    MOVQ X0, AX
+    VPEXTRQ $1, X0, DX
+    ADDQ DX, AX
+    MOVQ AX, 88(DI)
+    VEXTRACTI128 $1, Y12, X0
+    VPADDQ X0, X12, X0
+    MOVQ X0, AX
+    VPEXTRQ $1, X0, DX
+    ADDQ DX, AX
+    MOVQ AX, 96(DI)
+    VEXTRACTI128 $1, Y13, X0
+    VPADDQ X0, X13, X0
+    MOVQ X0, AX
+    VPEXTRQ $1, X0, DX
+    ADDQ DX, AX
+    MOVQ AX, 104(DI)
+    VEXTRACTI128 $1, Y14, X0
+    VPADDQ X0, X14, X0
+    MOVQ X0, AX
+    VPEXTRQ $1, X0, DX
+    ADDQ DX, AX
+    MOVQ AX, 112(DI)
+
+    // ---- scalar tail: (n mod 8) residuals, add to all 15 sums ----
+    MOVQ CX, AX
+    ANDQ $7, AX                      // tail count
+    JZ   rice_done
+    MOVQ R9, DX
+    SHLQ $5, DX                      // fullBlocks * 32 bytes
+    ADDQ R8, DX                      // tail ptr = &res[fullBlocks*8]
+rice_tail:
+    MOVL (DX), BX                    // r (zero-extended into RBX)
+    MOVL BX, R10
+    SHLL $1, BX                      // r<<1
+    SARL $31, R10                    // r>>31 (arithmetic)
+    XORL R10, BX                     // BX = zigzag(r), RBX zero-extended
+    MOVQ BX, R10                     // cur = u
+    ADDQ R10, 0(DI)
+    SHRQ $1, R10
+    ADDQ R10, 8(DI)
+    SHRQ $1, R10
+    ADDQ R10, 16(DI)
+    SHRQ $1, R10
+    ADDQ R10, 24(DI)
+    SHRQ $1, R10
+    ADDQ R10, 32(DI)
+    SHRQ $1, R10
+    ADDQ R10, 40(DI)
+    SHRQ $1, R10
+    ADDQ R10, 48(DI)
+    SHRQ $1, R10
+    ADDQ R10, 56(DI)
+    SHRQ $1, R10
+    ADDQ R10, 64(DI)
+    SHRQ $1, R10
+    ADDQ R10, 72(DI)
+    SHRQ $1, R10
+    ADDQ R10, 80(DI)
+    SHRQ $1, R10
+    ADDQ R10, 88(DI)
+    SHRQ $1, R10
+    ADDQ R10, 96(DI)
+    SHRQ $1, R10
+    ADDQ R10, 104(DI)
+    SHRQ $1, R10
+    ADDQ R10, 112(DI)
+    ADDQ $4, DX
+    DECQ AX
+    JNZ  rice_tail
+
+rice_done:
+    VZEROUPPER
+    RET

--- a/i32/i32_amd64_test.go
+++ b/i32/i32_amd64_test.go
@@ -428,3 +428,46 @@ func TestMidSideEncodeAVX2_NoOverwrite(t *testing.T) {
 		}
 	}
 }
+
+func TestRiceSumsAVX2_ParityWithGo(t *testing.T) {
+	if !cpu.X86.AVX2 {
+		t.Skip("AVX2 not available")
+	}
+	for _, n := range paritySizes {
+		if n < minAVXElements {
+			continue // dispatch routes these to Go; the kernel is not called
+		}
+		res := make([]int32, n)
+		fillRiceRes(res)
+		gotAVX := make([]uint64, riceParamCount)
+		gotGo := make([]uint64, riceParamCount)
+		riceSumsAVX2(gotAVX, res)
+		riceSumsGo(gotGo, res)
+		for k := range gotGo {
+			if gotAVX[k] != gotGo[k] {
+				t.Fatalf("n=%d: riceSumsAVX2[%d] = %d, want %d (Go)", n, k, gotAVX[k], gotGo[k])
+			}
+		}
+	}
+}
+
+// TestRiceSumsAVX2_NoOverwrite guards the fixed 15-wide write: the kernel must
+// fill exactly riceParamCount sums and touch nothing past them.
+func TestRiceSumsAVX2_NoOverwrite(t *testing.T) {
+	if !cpu.X86.AVX2 {
+		t.Skip("AVX2 not available")
+	}
+	const n = 100
+	res := make([]int32, n)
+	fillRiceRes(res)
+	sums := make([]uint64, riceParamCount+4)
+	for i := range sums {
+		sums[i] = math.MaxUint64 // sentinel
+	}
+	riceSumsAVX2(sums[:riceParamCount], res)
+	for i := riceParamCount; i < len(sums); i++ {
+		if sums[i] != math.MaxUint64 {
+			t.Errorf("riceSumsAVX2 wrote past end at sums[%d] = %d", i, sums[i])
+		}
+	}
+}

--- a/i32/i32_arm64.go
+++ b/i32/i32_arm64.go
@@ -165,3 +165,17 @@ func lpcResidualEncodeNEON(res, samples, coeffs []int32, shift uint)
 
 //go:noescape
 func lpcRestoreNEON(out, residual, rcoeffs []int32, shift uint)
+
+// riceSumsI32 dispatches the Rice per-parameter unary-bit sums. The NEON kernel
+// always writes the full riceParamCount (15) FLAC sums, so it is used only for
+// that width; other widths and short inputs use the pure-Go reference.
+func riceSumsI32(sums []uint64, res []int32) {
+	if hasNEON && len(sums) == riceParamCount && len(res) >= minNEONElements {
+		riceSumsNEON(sums, res)
+		return
+	}
+	riceSumsGo(sums, res)
+}
+
+//go:noescape
+func riceSumsNEON(sums []uint64, res []int32)

--- a/i32/i32_arm64.s
+++ b/i32/i32_arm64.s
@@ -740,3 +740,182 @@ lpcdec_neon_pred:
 
 lpcdec_neon_done:
     RET
+
+// func riceSumsNEON(sums []uint64, res []int32)
+// Rice per-parameter unary-bit sums, sums[k] = Σ_i (zigzag(res[i]) >> k) for
+// k = 0..14 (the fixed FLAC 4-bit range; the dispatch guarantees len(sums)==15).
+//
+// Each residual is folded to its unsigned Rice symbol with
+// zigzag(r) = (r<<1) ^ (r>>31): VSHL gives r<<1 and the arithmetic r>>31 is built
+// without a signed-shift mnemonic as -(r>>>31), the logical sign bit negated
+// (VUSHR then VSUB from zero). The fold is zero-extended to int64 (VUSHLL /
+// VUSHLL2 on the low and high S-lane pairs) so the per-k shifts and running
+// totals never overflow. ARM64's 32 vector registers hold all 15 int64x2
+// accumulators in a single sweep: each 4-lane block contributes its low pair
+// (V2) and high pair (V3), which are halved progressively (u>>k is u>>(k-1)
+// shifted once more, exact for the logical VUSHR) and added to one accumulator
+// per k. After the loop each accumulator's two lanes are folded (VADDP) and
+// stored. The (n mod 4) trailing residuals are then added to all 15 sums with a
+// scalar progressive-halving tail. The dispatch gates len(res) >= 4 (>=1 block).
+TEXT ·riceSumsNEON(SB), NOSPLIT, $0-48
+    MOVD sums_base+0(FP), R0
+    MOVD res_base+24(FP), R2
+    MOVD res_len+32(FP), R3
+    LSR  $2, R3, R4                  // R4 = full 4-element blocks (>=1)
+    VEOR V7.B16, V7.B16, V7.B16      // V7 = 0 (zero source for the sign negate)
+    VEOR V8.B16, V8.B16, V8.B16
+    VEOR V9.B16, V9.B16, V9.B16
+    VEOR V10.B16, V10.B16, V10.B16
+    VEOR V11.B16, V11.B16, V11.B16
+    VEOR V12.B16, V12.B16, V12.B16
+    VEOR V13.B16, V13.B16, V13.B16
+    VEOR V14.B16, V14.B16, V14.B16
+    VEOR V15.B16, V15.B16, V15.B16
+    VEOR V16.B16, V16.B16, V16.B16
+    VEOR V17.B16, V17.B16, V17.B16
+    VEOR V18.B16, V18.B16, V18.B16
+    VEOR V19.B16, V19.B16, V19.B16
+    VEOR V20.B16, V20.B16, V20.B16
+    VEOR V21.B16, V21.B16, V21.B16
+    VEOR V22.B16, V22.B16, V22.B16
+
+rice_neon_loop:
+    VLD1.P 16(R2), [V0.S4]           // v = res[i..i+3]
+    VSHL   $1, V0.S4, V1.S4          // r<<1
+    VUSHR  $31, V0.S4, V4.S4         // (uint32)r >> 31  (sign bit, 0 or 1)
+    VSUB   V4.S4, V7.S4, V4.S4       // mask = 0 - signbit = (r>>31 arithmetic)
+    VEOR   V4.B16, V1.B16, V1.B16    // u = zigzag(r)
+    VUSHLL  $0, V1.S2, V2.D2         // cur_lo = zero-extend lanes 0,1 -> int64x2
+    VUSHLL2 $0, V1.S4, V3.D2         // cur_hi = zero-extend lanes 2,3 -> int64x2
+    VADD V2.D2, V8.D2, V8.D2          // k=0
+    VADD V3.D2, V8.D2, V8.D2
+    VUSHR $1, V2.D2, V2.D2
+    VUSHR $1, V3.D2, V3.D2
+    VADD V2.D2, V9.D2, V9.D2          // k=1
+    VADD V3.D2, V9.D2, V9.D2
+    VUSHR $1, V2.D2, V2.D2
+    VUSHR $1, V3.D2, V3.D2
+    VADD V2.D2, V10.D2, V10.D2          // k=2
+    VADD V3.D2, V10.D2, V10.D2
+    VUSHR $1, V2.D2, V2.D2
+    VUSHR $1, V3.D2, V3.D2
+    VADD V2.D2, V11.D2, V11.D2          // k=3
+    VADD V3.D2, V11.D2, V11.D2
+    VUSHR $1, V2.D2, V2.D2
+    VUSHR $1, V3.D2, V3.D2
+    VADD V2.D2, V12.D2, V12.D2          // k=4
+    VADD V3.D2, V12.D2, V12.D2
+    VUSHR $1, V2.D2, V2.D2
+    VUSHR $1, V3.D2, V3.D2
+    VADD V2.D2, V13.D2, V13.D2          // k=5
+    VADD V3.D2, V13.D2, V13.D2
+    VUSHR $1, V2.D2, V2.D2
+    VUSHR $1, V3.D2, V3.D2
+    VADD V2.D2, V14.D2, V14.D2          // k=6
+    VADD V3.D2, V14.D2, V14.D2
+    VUSHR $1, V2.D2, V2.D2
+    VUSHR $1, V3.D2, V3.D2
+    VADD V2.D2, V15.D2, V15.D2          // k=7
+    VADD V3.D2, V15.D2, V15.D2
+    VUSHR $1, V2.D2, V2.D2
+    VUSHR $1, V3.D2, V3.D2
+    VADD V2.D2, V16.D2, V16.D2          // k=8
+    VADD V3.D2, V16.D2, V16.D2
+    VUSHR $1, V2.D2, V2.D2
+    VUSHR $1, V3.D2, V3.D2
+    VADD V2.D2, V17.D2, V17.D2          // k=9
+    VADD V3.D2, V17.D2, V17.D2
+    VUSHR $1, V2.D2, V2.D2
+    VUSHR $1, V3.D2, V3.D2
+    VADD V2.D2, V18.D2, V18.D2          // k=10
+    VADD V3.D2, V18.D2, V18.D2
+    VUSHR $1, V2.D2, V2.D2
+    VUSHR $1, V3.D2, V3.D2
+    VADD V2.D2, V19.D2, V19.D2          // k=11
+    VADD V3.D2, V19.D2, V19.D2
+    VUSHR $1, V2.D2, V2.D2
+    VUSHR $1, V3.D2, V3.D2
+    VADD V2.D2, V20.D2, V20.D2          // k=12
+    VADD V3.D2, V20.D2, V20.D2
+    VUSHR $1, V2.D2, V2.D2
+    VUSHR $1, V3.D2, V3.D2
+    VADD V2.D2, V21.D2, V21.D2          // k=13
+    VADD V3.D2, V21.D2, V21.D2
+    VUSHR $1, V2.D2, V2.D2
+    VUSHR $1, V3.D2, V3.D2
+    VADD V2.D2, V22.D2, V22.D2          // k=14
+    VADD V3.D2, V22.D2, V22.D2
+    SUB  $1, R4
+    CBNZ R4, rice_neon_loop
+
+    // fold each int64x2 accumulator to a scalar and store sums[0..14]
+    VADDP V8.D2, V8.D2, V1.D2
+    FMOVD F1, R5
+    MOVD  R5, 0(R0)
+    VADDP V9.D2, V9.D2, V1.D2
+    FMOVD F1, R5
+    MOVD  R5, 8(R0)
+    VADDP V10.D2, V10.D2, V1.D2
+    FMOVD F1, R5
+    MOVD  R5, 16(R0)
+    VADDP V11.D2, V11.D2, V1.D2
+    FMOVD F1, R5
+    MOVD  R5, 24(R0)
+    VADDP V12.D2, V12.D2, V1.D2
+    FMOVD F1, R5
+    MOVD  R5, 32(R0)
+    VADDP V13.D2, V13.D2, V1.D2
+    FMOVD F1, R5
+    MOVD  R5, 40(R0)
+    VADDP V14.D2, V14.D2, V1.D2
+    FMOVD F1, R5
+    MOVD  R5, 48(R0)
+    VADDP V15.D2, V15.D2, V1.D2
+    FMOVD F1, R5
+    MOVD  R5, 56(R0)
+    VADDP V16.D2, V16.D2, V1.D2
+    FMOVD F1, R5
+    MOVD  R5, 64(R0)
+    VADDP V17.D2, V17.D2, V1.D2
+    FMOVD F1, R5
+    MOVD  R5, 72(R0)
+    VADDP V18.D2, V18.D2, V1.D2
+    FMOVD F1, R5
+    MOVD  R5, 80(R0)
+    VADDP V19.D2, V19.D2, V1.D2
+    FMOVD F1, R5
+    MOVD  R5, 88(R0)
+    VADDP V20.D2, V20.D2, V1.D2
+    FMOVD F1, R5
+    MOVD  R5, 96(R0)
+    VADDP V21.D2, V21.D2, V1.D2
+    FMOVD F1, R5
+    MOVD  R5, 104(R0)
+    VADDP V22.D2, V22.D2, V1.D2
+    FMOVD F1, R5
+    MOVD  R5, 112(R0)
+
+    // scalar tail: (n mod 4) residuals, add to all 15 sums
+    AND  $3, R3, R4
+    CBZ  R4, rice_neon_done
+rice_neon_tail_out:
+    MOVW (R2), R5                    // sign-extend r
+    ADDW R5, R5, R6                  // r<<1
+    ASRW $31, R5, R7                 // r>>31 (arithmetic)
+    EORW R7, R6, R6                  // u = zigzag(r) (zero-extended)
+    MOVD R0, R8                      // sums ptr
+    MOVD $15, R9                     // k counter
+rice_neon_tail_k:
+    MOVD (R8), R7
+    ADD  R6, R7, R7
+    MOVD R7, (R8)
+    LSR  $1, R6, R6
+    ADD  $8, R8
+    SUB  $1, R9
+    CBNZ R9, rice_neon_tail_k
+    ADD  $4, R2
+    SUB  $1, R4
+    CBNZ R4, rice_neon_tail_out
+
+rice_neon_done:
+    RET

--- a/i32/i32_arm64_test.go
+++ b/i32/i32_arm64_test.go
@@ -398,3 +398,46 @@ func TestDiff1NEON_NoOverwrite(t *testing.T) {
 		}
 	}
 }
+
+func TestRiceSumsNEON_ParityWithGo(t *testing.T) {
+	if !cpu.ARM64.NEON {
+		t.Skip("NEON not available")
+	}
+	for _, n := range paritySizes {
+		if n < minNEONElements {
+			continue // dispatch routes these to Go; the kernel is not called
+		}
+		res := make([]int32, n)
+		fillRiceRes(res)
+		gotNEON := make([]uint64, riceParamCount)
+		gotGo := make([]uint64, riceParamCount)
+		riceSumsNEON(gotNEON, res)
+		riceSumsGo(gotGo, res)
+		for k := range gotGo {
+			if gotNEON[k] != gotGo[k] {
+				t.Fatalf("n=%d: riceSumsNEON[%d] = %d, want %d (Go)", n, k, gotNEON[k], gotGo[k])
+			}
+		}
+	}
+}
+
+// TestRiceSumsNEON_NoOverwrite guards the fixed 15-wide write: the kernel must
+// fill exactly riceParamCount sums and touch nothing past them.
+func TestRiceSumsNEON_NoOverwrite(t *testing.T) {
+	if !cpu.ARM64.NEON {
+		t.Skip("NEON not available")
+	}
+	const n = 100
+	res := make([]int32, n)
+	fillRiceRes(res)
+	sums := make([]uint64, riceParamCount+4)
+	for i := range sums {
+		sums[i] = math.MaxUint64 // sentinel
+	}
+	riceSumsNEON(sums[:riceParamCount], res)
+	for i := riceParamCount; i < len(sums); i++ {
+		if sums[i] != math.MaxUint64 {
+			t.Errorf("riceSumsNEON wrote past end at sums[%d] = %d", i, sums[i])
+		}
+	}
+}

--- a/i32/i32_go.go
+++ b/i32/i32_go.go
@@ -115,6 +115,32 @@ func lpcResidualEncodeGo(res, samples, coeffs []int32, shift uint) {
 	}
 }
 
+// int32SignShift sign-extends an int32 to its all-zero/all-one mask: r>>31
+// (arithmetic) is 0 for non-negative r and -1 (0xFFFFFFFF) for negative r, the
+// sign-mask half of the zigzag fold.
+const int32SignShift = 31
+
+// riceSumsGo writes the per-parameter Rice unary-bit sums into sums:
+//
+//	sums[k] = Σ_i (zigzag(res[i]) >> k)   for k in [0, len(sums))
+//
+// where zigzag(r) = (r<<1) ^ (r>>31) folds a signed residual to its unsigned
+// Rice symbol. It fully overwrites sums and is the bit-exact source of truth the
+// SIMD kernels are validated against. The fold uses int32 arithmetic (matching
+// the kernels): r<<1 wraps and r>>31 is the arithmetic sign-extension, so a
+// math.MinInt32 residual folds to 2^32-1 before the unsigned widen.
+func riceSumsGo(sums []uint64, res []int32) {
+	for k := range sums {
+		sums[k] = 0
+	}
+	for _, r := range res {
+		u := uint64(uint32((r << 1) ^ (r >> int32SignShift)))
+		for k := range sums {
+			sums[k] += u >> uint(k)
+		}
+	}
+}
+
 // lpcRestoreGo is the exact inverse of lpcResidualEncodeGo: it reconstructs the
 // samples from the [order warm-up | residual] layout via the serial recurrence
 //

--- a/i32/i32_other.go
+++ b/i32/i32_other.go
@@ -25,3 +25,5 @@ func lpcResidualEncodeI32(res, samples, coeffs []int32, shift uint) {
 func lpcRestoreI32(out, residual, coeffs []int32, shift uint) {
 	lpcRestoreGo(out, residual, coeffs, shift)
 }
+
+func riceSumsI32(sums []uint64, res []int32) { riceSumsGo(sums, res) }

--- a/i32/i32_simd_test.go
+++ b/i32/i32_simd_test.go
@@ -23,3 +23,18 @@ func fillPattern(a, b []int32) {
 // paritySizes straddle both SIMD block sizes (4 lanes on NEON, 8 on AVX) so the
 // vector body and the scalar tail are both covered on either architecture.
 var paritySizes = []int{0, 1, 2, 3, 7, 8, 9, 15, 16, 17, 31, 32, 33, 100, 1000, 1023, 1024, 1025}
+
+// fillRiceRes fills res with sign-exercising values, pinning the extremes so the
+// zigzag overflow at math.MinInt32 (-> 2^32-1) and the unsigned widening are
+// covered alongside the block-straddling sizes.
+func fillRiceRes(res []int32) {
+	for i := range res {
+		res[i] = int32(i*7-3) ^ math.MinInt32
+	}
+	if len(res) > 3 {
+		res[0] = math.MinInt32
+		res[1] = math.MaxInt32
+		res[2] = -1
+		res[3] = 0
+	}
+}

--- a/i32/rice.go
+++ b/i32/rice.go
@@ -1,0 +1,100 @@
+package i32
+
+// Rice zigzag cost search for the FLAC codec.
+//
+// FLAC Rice-codes each residual by mapping it to an unsigned symbol with the
+// zigzag fold zigzag(r) = (r<<1) ^ (r>>31) (0,-1,1,-2,2 -> 0,1,2,3,4) and then
+// writing that symbol in a Rice code with parameter k: the high bits u>>k in
+// unary (u>>k zero bits plus a stop bit) followed by the low k bits verbatim.
+// One symbol therefore costs (u>>k) + 1 + k bits, so a block of n residuals
+// costs
+//
+//	bits(k) = Σ_i (zigzag(res[i]) >> k) + n*(k+1)
+//
+// The encoder picks the k minimizing bits(k). The data-dependent term is the
+// per-parameter unary-bit sum Σ_i (zigzag(res[i]) >> k); computing it for every
+// candidate k is the hot loop RiceSums vectorizes. RiceBestParam wraps it with
+// the scalar k scan, which is cheap (a handful of parameters).
+
+const (
+	// riceMaxParam is the largest Rice parameter the SIMD fast path scans,
+	// matching FLAC's 4-bit Rice partition method (k = 0..14; parameter 15 is
+	// the escape code). riceParamCount is the corresponding sum count.
+	riceMaxParam   = 14
+	riceParamCount = riceMaxParam + 1
+
+	// riceMaxParam5 is the largest parameter FLAC's 5-bit partition method can
+	// encode (k = 0..30; 31 is the escape). RiceBestParam clamps maxParam to it
+	// and serves parameters above riceMaxParam from the pure-Go path.
+	riceMaxParam5 = 30
+)
+
+// RiceSums fills sums[k] with the per-parameter unary-bit total
+//
+//	sums[k] = Σ_i (zigzag(res[i]) >> k)   for k in [0, len(sums))
+//
+// where zigzag(r) = (r<<1) ^ (r>>31) is the FLAC residual fold. Each sum is
+// accumulated in uint64 (it cannot overflow for any realistic block length).
+// The total Rice-coded bit cost of res with parameter k is sums[k] + n*(k+1),
+// n = len(res); see RiceBestParam.
+//
+// sums is fully overwritten (not accumulated into). res is read-only. The SIMD
+// fast path covers the FLAC parameter range (len(sums) <= riceParamCount = 15);
+// wider requests fall back to the pure-Go reference.
+func RiceSums(sums []uint64, res []int32) {
+	switch m := len(sums); {
+	case m == 0:
+		return
+	case m == riceParamCount:
+		riceSumsI32(sums, res)
+	case m < riceParamCount:
+		// The SIMD kernel writes exactly riceParamCount sums; compute the full
+		// set on the stack and copy the requested prefix. The array does not
+		// escape, so this stays allocation-free.
+		var full [riceParamCount]uint64
+		riceSumsI32(full[:], res)
+		copy(sums, full[:m])
+	default: // m > riceParamCount
+		riceSumsGo(sums, res)
+	}
+}
+
+// RiceBestParam scans Rice parameters k in [0, maxParam] and returns the k that
+// minimizes the total Rice-coded bit count of res, together with that bit count
+//
+//	bits(k) = Σ_i (zigzag(res[i]) >> k) + n*(k+1),   n = len(res)
+//
+// On a tie the smallest k wins. maxParam is clamped to riceMaxParam5 (30),
+// FLAC's largest encodable parameter. An empty res returns (0, 0).
+func RiceBestParam(res []int32, maxParam uint) (bestParam uint, bits uint64) {
+	n := len(res)
+	if n == 0 {
+		return 0, 0
+	}
+	if maxParam > riceMaxParam5 {
+		maxParam = riceMaxParam5
+	}
+	var sums [riceMaxParam5 + 1]uint64
+	if maxParam < riceParamCount {
+		// SIMD fast path: the kernel always computes the 15-wide FLAC range;
+		// the scan below only reads sums[:maxParam+1].
+		riceSumsI32(sums[:riceParamCount], res)
+	} else {
+		riceSumsGo(sums[:maxParam+1], res)
+	}
+	return riceScan(sums[:maxParam+1], n)
+}
+
+// riceScan returns the cost-minimizing Rice parameter over sums and its bit
+// cost, where bits(k) = sums[k] + n*(k+1). The smallest k wins ties.
+func riceScan(sums []uint64, n int) (bestParam uint, bits uint64) {
+	bits = sums[0] + uint64(n) // n*(0+1)
+	for k := 1; k < len(sums); k++ {
+		c := sums[k] + uint64(n)*uint64(k+1)
+		if c < bits {
+			bits = c
+			bestParam = uint(k)
+		}
+	}
+	return bestParam, bits
+}

--- a/i32/rice_test.go
+++ b/i32/rice_test.go
@@ -113,6 +113,28 @@ func TestRiceBestParamMatchesBruteForce(t *testing.T) {
 	}
 }
 
+// TestRiceSumsWide covers the pure-Go path for parameter counts beyond the
+// SIMD fast path's fixed 15-wide range (FLAC's 5-bit method scans k up to 30).
+func TestRiceSumsWide(t *testing.T) {
+	rng := rand.New(rand.NewSource(3))
+	for _, params := range []int{20, 31} {
+		for _, n := range []int{0, 1, 8, 9, 100, 1000} {
+			res := make([]int32, n)
+			for i := range res {
+				res[i] = int32(rng.Uint32())
+			}
+			sums := make([]uint64, params)
+			RiceSums(sums, res)
+			want := riceSumsOracle(res, params)
+			for k := range want {
+				if sums[k] != want[k] {
+					t.Fatalf("params=%d n=%d RiceSums[%d] = %d, want %d", params, n, k, sums[k], want[k])
+				}
+			}
+		}
+	}
+}
+
 func TestRiceBestParamEmpty(t *testing.T) {
 	k, bits := RiceBestParam(nil, 14)
 	if k != 0 || bits != 0 {

--- a/i32/rice_test.go
+++ b/i32/rice_test.go
@@ -1,0 +1,151 @@
+package i32
+
+import (
+	"math"
+	"math/rand"
+	"testing"
+)
+
+// Tests for the Rice zigzag cost search (RiceSums / RiceBestParam).
+//
+// zigzag maps a signed residual to its unsigned Rice symbol,
+// zigzag(r) = (r<<1) ^ (r>>31): 0,-1,1,-2,2 -> 0,1,2,3,4. RiceSums returns
+// sums[k] = Σ_i (zigzag(res[i]) >> k), the unary-bit total for Rice parameter k;
+// the full code cost of parameter k over n residuals is sums[k] + n*(k+1).
+// RiceBestParam scans k and returns the cost-minimizing parameter.
+
+// zigzag is the scalar reference fold used by the oracle below.
+func zigzag(r int32) uint64 {
+	return uint64(uint32((r << 1) ^ (r >> 31)))
+}
+
+// riceSumsOracle is an independent, obviously-correct implementation of the
+// per-parameter unary-bit sums, written separately from riceSumsGo so the two
+// agreeing is a real cross-check rather than a tautology.
+func riceSumsOracle(res []int32, params int) []uint64 {
+	sums := make([]uint64, params)
+	for _, r := range res {
+		u := zigzag(r)
+		for k := range params {
+			sums[k] += u >> uint(k)
+		}
+	}
+	return sums
+}
+
+func TestRiceSumsSmall(t *testing.T) {
+	res := []int32{0, -1, 1, -2, 2} // zigzag -> 0,1,2,3,4
+	sums := make([]uint64, 4)
+	RiceSums(sums, res)
+	want := []uint64{10, 4, 1, 0}
+	for k := range want {
+		if sums[k] != want[k] {
+			t.Errorf("RiceSums[%d] = %d, want %d", k, sums[k], want[k])
+		}
+	}
+}
+
+func TestRiceBestParamSmall(t *testing.T) {
+	res := []int32{0, -1, 1, -2, 2}
+	// cost(0)=10+5=15, cost(1)=4+10=14, cost(2)=1+15=16, cost(3)=0+20=20.
+	gotK, gotBits := RiceBestParam(res, 14)
+	if gotK != 1 || gotBits != 14 {
+		t.Errorf("RiceBestParam = (%d, %d), want (1, 14)", gotK, gotBits)
+	}
+}
+
+func TestRiceSumsMatchesOracle(t *testing.T) {
+	rng := rand.New(rand.NewSource(1))
+	for _, n := range []int{0, 1, 2, 3, 7, 8, 9, 15, 16, 17, 31, 33, 100, 1000, 1024, 1025} {
+		res := make([]int32, n)
+		for i := range res {
+			res[i] = int32(rng.Uint32())
+		}
+		sums := make([]uint64, riceParamCount)
+		RiceSums(sums, res)
+		want := riceSumsOracle(res, riceParamCount)
+		for k := range want {
+			if sums[k] != want[k] {
+				t.Fatalf("n=%d RiceSums[%d] = %d, want %d", n, k, sums[k], want[k])
+			}
+		}
+	}
+}
+
+// TestRiceSumsExtremes exercises the int32 sign bit and the zigzag overflow at
+// math.MinInt32 (zigzag = 2^32-1), the worst case for the unsigned widening.
+func TestRiceSumsExtremes(t *testing.T) {
+	res := []int32{math.MinInt32, math.MaxInt32, -1, 0, math.MinInt32, math.MaxInt32, 1, -2, 3}
+	sums := make([]uint64, riceParamCount)
+	RiceSums(sums, res)
+	want := riceSumsOracle(res, riceParamCount)
+	for k := range want {
+		if sums[k] != want[k] {
+			t.Errorf("RiceSums extremes [%d] = %d, want %d", k, sums[k], want[k])
+		}
+	}
+}
+
+func TestRiceBestParamMatchesBruteForce(t *testing.T) {
+	rng := rand.New(rand.NewSource(2))
+	for _, n := range []int{1, 8, 9, 17, 100, 1000} {
+		res := make([]int32, n)
+		// Bias toward small magnitudes so the optimum parameter is interior.
+		for i := range res {
+			res[i] = int32(rng.Intn(2000) - 1000)
+		}
+		for _, maxParam := range []uint{0, 5, 14, 30} {
+			gotK, gotBits := RiceBestParam(res, maxParam)
+			// brute force over the same range using the oracle
+			sums := riceSumsOracle(res, int(maxParam)+1)
+			wantK, wantBits := uint(0), sums[0]+uint64(n)
+			for k := 1; k <= int(maxParam); k++ {
+				c := sums[k] + uint64(n)*uint64(k+1)
+				if c < wantBits {
+					wantBits = c
+					wantK = uint(k)
+				}
+			}
+			if gotK != wantK || gotBits != wantBits {
+				t.Errorf("n=%d maxParam=%d RiceBestParam=(%d,%d), want (%d,%d)", n, maxParam, gotK, gotBits, wantK, wantBits)
+			}
+		}
+	}
+}
+
+func TestRiceBestParamEmpty(t *testing.T) {
+	k, bits := RiceBestParam(nil, 14)
+	if k != 0 || bits != 0 {
+		t.Errorf("RiceBestParam(nil) = (%d, %d), want (0, 0)", k, bits)
+	}
+}
+
+func TestRiceSumsClearsDst(t *testing.T) {
+	// RiceSums must fully overwrite sums, not accumulate into existing content.
+	res := []int32{1, 2, 3}
+	sums := make([]uint64, riceParamCount)
+	for i := range sums {
+		sums[i] = 999
+	}
+	RiceSums(sums, res)
+	want := riceSumsOracle(res, riceParamCount)
+	for k := range want {
+		if sums[k] != want[k] {
+			t.Errorf("RiceSums did not clear dst [%d] = %d, want %d", k, sums[k], want[k])
+		}
+	}
+}
+
+func TestRiceAllocFree(t *testing.T) {
+	res := make([]int32, 1024)
+	for i := range res {
+		res[i] = int32(i*7 - 3)
+	}
+	sums := make([]uint64, riceParamCount)
+	if got := testing.AllocsPerRun(100, func() { RiceSums(sums, res) }); got != 0 {
+		t.Errorf("RiceSums allocated %v times per run, want 0", got)
+	}
+	if got := testing.AllocsPerRun(100, func() { RiceBestParam(res, 14) }); got != 0 {
+		t.Errorf("RiceBestParam allocated %v times per run, want 0", got)
+	}
+}


### PR DESCRIPTION
## Summary

Adds the Rice parameter cost search, the last integer primitive the FLAC codec needs. This completes Phase 3 and the full integer SIMD surface from #79.

- `RiceSums(sums, res)` fills `sums[k] = Σ_i (zigzag(res[i]) >> k)` for `k = 0..14`, the data-dependent part of the Rice code length per parameter. `zigzag(r) = (r<<1) ^ (r>>31)` folds a signed residual to its unsigned symbol; the total code cost of parameter `k` over `n` residuals is `sums[k] + n*(k+1)`.
- `RiceBestParam(res, maxParam)` returns the cost-minimizing Rice parameter and its **exact** bit count (not the `sum>>k` approximation). `maxParam` is clamped to FLAC's 5-bit ceiling of 30; the 0..14 range is served by SIMD, higher parameters by the pure-Go path.

## Implementation

Each residual is folded, zero-extended to int64 so the per-k right shifts and running totals never overflow, then the symbols are halved progressively (`u>>k` is `u>>(k-1)` shifted once more, exact for the logical shift) into one int64 accumulator per `k`.

- **AMD64 AVX2:** the 15 accumulators exceed the 16-YMM register file for a single pass, so the data is swept twice (k=0..7, then k=8..14), with a scalar 15-wide progressive-halving tail.
- **ARM64 NEON:** ARM64's 32 vector registers fit all 15 accumulators in one pass. The kernel uses only assembler-validated mnemonics (no hand-encoded `WORD` directives); the arithmetic `r>>31` is built as the negated logical sign bit since the Go assembler has no signed-shift-right NEON mnemonic.
- Pure-Go reference is the bit-exact source of truth and the fallback.

## Related Issues

Closes the final task (Rice zigzag cost search) of #79; with this the integer SIMD surface for the FLAC codec is complete.

## Test Plan

- [x] SIMD-vs-Go parity across block-straddling sizes (0,1,2,3,7,8,9,15,16,17,31,32,33,100,1000,1023,1024,1025)
- [x] Sign and int32-extreme inputs (zigzag of MinInt32 is 2^32-1, the worst case for the unsigned widen)
- [x] Independent oracle and brute-force parameter scan cross-checks
- [x] Fixed 15-wide no-overwrite guard, per-kernel zero-allocation, examples
- [x] `go vet` + `golangci-lint run ./...` clean; asmcheck (`SIMD_REQUIRE_OBJDUMP=1`) green
- [x] Verified on amd64 (AVX2) natively and arm64 (NEON) on a Raspberry Pi 5

Benchmarks (1000 elements, vs pure Go, zero-alloc): RiceSums / RiceBestParam ~810 ns (**13.0x**) on amd64 AVX2; ~4090 ns (**4.2x**) on arm64 NEON (Pi 5).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added `RiceSums` and `RiceBestParam` functions for Rice parameter selection on 32-bit residuals.
  * Optimized implementations for AMD64 and ARM64 architectures.

* **Documentation**
  * Updated README with Rice kernel operations and performance benchmarks.
  * Expanded package documentation with additional DSP operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->