### PR TITLE
Fix non-AVX fallback paths (c128 SIGILL + f64 sigmoid accuracy)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -158,9 +158,16 @@ jobs:
           models=("Conroe" "qemu64,-pni,-ssse3,-sse4.1,-sse4.2,-avx,-avx2")
           fail=0
           for pkg in $(go list ./...); do
+            # Skip packages with no test files; a compile failure in a real test
+            # package must fail the job, not be silently swallowed.
+            read -r ntest nxtest <<<"$(go list -f '{{len .TestGoFiles}} {{len .XTestGoFiles}}' "$pkg")"
+            if [ "$ntest" -eq 0 ] && [ "$nxtest" -eq 0 ]; then continue; fi
             bin="/tmp/$(echo "$pkg" | tr '/.' '__').test"
-            CGO_ENABLED=0 go test -c -o "$bin" "$pkg" 2>/dev/null || true
-            [ -f "$bin" ] || continue   # package has no test files
+            if ! CGO_ENABLED=0 go test -c -o "$bin" "$pkg"; then
+              echo "::error::failed to compile tests for $pkg"
+              fail=1
+              continue
+            fi
             for m in "${models[@]}"; do
               echo "::group::$pkg @ qemu -cpu $m"
               if qemu-x86_64 -cpu "$m" "$bin" -test.v; then

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -127,3 +127,50 @@ jobs:
           GOOS: ${{ matrix.goos }}
           GOARCH: ${{ matrix.goarch }}
         run: go build ./...
+
+  cross-isa:
+    # Run the amd64 test suite under qemu on CPU models that lack AVX (and, for
+    # Conroe, SSE4.1) so the SSE2/SSE4.x fallback dispatch paths are actually
+    # exercised. Every CI/dev host has AVX, so without this leg the fallback
+    # kernels are never run: a fallback that issues an unsupported instruction
+    # (SIGILL) or diverges from the SIMD kernel ships undetected. qemu-x86_64
+    # v7+ enforces the -cpu feature set, raising #UD for out-of-baseline ops.
+    name: Cross-ISA (no-AVX fallbacks)
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v6
+
+      - name: Set up Go
+        uses: actions/setup-go@v6
+        with:
+          go-version: ${{ env.GO_VERSION }}
+
+      - name: Install qemu-user
+        run: sudo apt-get update && sudo apt-get install -y qemu-user
+
+      - name: Run amd64 tests under no-AVX CPU models
+        run: |
+          set -uo pipefail
+          # Conroe: SSSE3, no SSE4.1, no AVX (catches the c128 BLENDPD SIGILL).
+          # qemu64 stripped to SSE2: the amd64 baseline (catches SSE3+ ops like
+          # MOVDDUP and any non-SSE2 instruction in an SSE2-gated kernel).
+          models=("Conroe" "qemu64,-pni,-ssse3,-sse4.1,-sse4.2,-avx,-avx2")
+          fail=0
+          for pkg in $(go list ./...); do
+            bin="/tmp/$(echo "$pkg" | tr '/.' '__').test"
+            CGO_ENABLED=0 go test -c -o "$bin" "$pkg" 2>/dev/null || true
+            [ -f "$bin" ] || continue   # package has no test files
+            for m in "${models[@]}"; do
+              echo "::group::$pkg @ qemu -cpu $m"
+              if qemu-x86_64 -cpu "$m" "$bin" -test.v; then
+                echo "ok"
+              else
+                echo "::error::$pkg failed under qemu -cpu $m"
+                fail=1
+              fi
+              echo "::endgroup::"
+            done
+            rm -f "$bin"
+          done
+          exit "$fail"

--- a/c128/c128_amd64.s
+++ b/c128/c128_amd64.s
@@ -545,7 +545,7 @@ mul_sse2_loop:
     SUBPD X3, X5                 // [ar*br-ai*bi, ar*bi-ai*br]
     ADDPD X3, X2                 // [ar*br+ai*bi, ar*bi+ai*br]
 
-    BLENDPD $0x02, X2, X5        // Take lane 1 from X2 (add result)
+    SHUFPD $0x2, X2, X5          // re<-X5[0] (sub), im<-X2[1] (add); SSE2 form of BLENDPD $0x02
 
     MOVUPD X5, (DX)
 
@@ -589,7 +589,7 @@ mulconj_sse2_loop:
     MOVAPD X3, X6
     SUBPD X2, X6                 // [ai*bi-ar*br, ai*br-ar*bi]
 
-    BLENDPD $0x02, X6, X5        // Take lane 1 from X6
+    SHUFPD $0x2, X6, X5          // re<-X5[0] (add), im<-X6[1] (sub); SSE2 form of BLENDPD $0x02
 
     MOVUPD X5, (DX)
 
@@ -633,7 +633,7 @@ scale_sse2_loop:
     SUBPD X3, X4                 // [ar*sr-ai*si, ar*si-ai*sr]
     ADDPD X3, X2                 // [ar*sr+ai*si, ar*si+ai*sr]
 
-    BLENDPD $0x02, X2, X4
+    SHUFPD $0x2, X2, X4          // re<-X4[0] (sub), im<-X2[1] (add); SSE2 form of BLENDPD $0x02
 
     MOVUPD X4, (DX)
 
@@ -833,8 +833,8 @@ abs_sse2_loop:
     MOVUPD (SI), X0        // Load one complex128 [real, imag]
 
     // X0 = [real, imag]
-    MOVDDUP X0, X1         // X1 = [real, real]
-    SHUFPD $1, X0, X0      // X0 = [imag, imag]
+    MOVAPD X0, X1          // X1[0]=real; high lane discarded by MOVSD store (SSE2 form of MOVDDUP)
+    SHUFPD $1, X0, X0      // X0[0]=imag
 
     MULPD X1, X1           // real²
     MULPD X0, X0           // imag²
@@ -988,8 +988,8 @@ abssq_sse2_loop:
 
     MULPD X0, X0           // [r², i²]
 
-    MOVDDUP X0, X1         // [r², r²]
-    SHUFPD $1, X0, X0      // [i², i²]
+    MOVAPD X0, X1          // X1[0]=r²; high lane discarded by MOVSD store (SSE2 form of MOVDDUP)
+    SHUFPD $1, X0, X0      // X0[0]=i²
     ADDPD X0, X1           // r² + i²
 
     MOVSD X1, (DX)

--- a/c128/sse2_baseline_test.go
+++ b/c128/sse2_baseline_test.go
@@ -1,0 +1,122 @@
+//go:build amd64
+
+package c128
+
+import (
+	"os"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"testing"
+)
+
+// postSSE2Mnemonics lists legacy (non-VEX) x86 instruction mnemonics that are
+// NOT part of the SSE2 baseline: they require SSE3, SSSE3, SSE4.1 or SSE4.2.
+// VEX-encoded forms (V-prefixed, e.g. VBLENDPD) are AVX and never appear in an
+// SSE2 kernel, so exact-token matching against this set does not flag them.
+var postSSE2Mnemonics = map[string]string{
+	// SSE3
+	"ADDSUBPD": "SSE3", "ADDSUBPS": "SSE3",
+	"HADDPD": "SSE3", "HADDPS": "SSE3", "HSUBPD": "SSE3", "HSUBPS": "SSE3",
+	"MOVDDUP": "SSE3", "MOVSHDUP": "SSE3", "MOVSLDUP": "SSE3",
+	"LDDQU": "SSE3", "FISTTP": "SSE3",
+	// SSSE3
+	"PABSB": "SSSE3", "PABSW": "SSSE3", "PABSD": "SSSE3", "PALIGNR": "SSSE3",
+	"PHADDW": "SSSE3", "PHADDD": "SSSE3", "PHADDSW": "SSSE3",
+	"PHSUBW": "SSSE3", "PHSUBD": "SSSE3", "PHSUBSW": "SSSE3",
+	"PMADDUBSW": "SSSE3", "PMULHRSW": "SSSE3", "PSHUFB": "SSSE3",
+	"PSIGNB": "SSSE3", "PSIGNW": "SSSE3", "PSIGND": "SSSE3",
+	// SSE4.1
+	"BLENDPD": "SSE4.1", "BLENDPS": "SSE4.1", "BLENDVPD": "SSE4.1", "BLENDVPS": "SSE4.1",
+	"DPPD": "SSE4.1", "DPPS": "SSE4.1", "EXTRACTPS": "SSE4.1", "INSERTPS": "SSE4.1",
+	"MOVNTDQA": "SSE4.1", "MPSADBW": "SSE4.1", "PACKUSDW": "SSE4.1",
+	"PBLENDVB": "SSE4.1", "PBLENDW": "SSE4.1", "PCMPEQQ": "SSE4.1",
+	"PEXTRB": "SSE4.1", "PEXTRD": "SSE4.1", "PEXTRQ": "SSE4.1", "PEXTRW": "SSE4.1",
+	"PHMINPOSUW": "SSE4.1", "PINSRB": "SSE4.1", "PINSRD": "SSE4.1", "PINSRQ": "SSE4.1",
+	"PMAXSB": "SSE4.1", "PMAXSD": "SSE4.1", "PMAXUD": "SSE4.1", "PMAXUW": "SSE4.1",
+	"PMINSB": "SSE4.1", "PMINSD": "SSE4.1", "PMINUD": "SSE4.1", "PMINUW": "SSE4.1",
+	"PMOVSXBW": "SSE4.1", "PMOVSXBD": "SSE4.1", "PMOVSXBQ": "SSE4.1",
+	"PMOVSXWD": "SSE4.1", "PMOVSXWQ": "SSE4.1", "PMOVSXDQ": "SSE4.1",
+	"PMOVZXBW": "SSE4.1", "PMOVZXBD": "SSE4.1", "PMOVZXBQ": "SSE4.1",
+	"PMOVZXWD": "SSE4.1", "PMOVZXWQ": "SSE4.1", "PMOVZXDQ": "SSE4.1",
+	"PMULDQ": "SSE4.1", "PMULLD": "SSE4.1", "PTEST": "SSE4.1",
+	"ROUNDPD": "SSE4.1", "ROUNDPS": "SSE4.1", "ROUNDSD": "SSE4.1", "ROUNDSS": "SSE4.1",
+	// SSE4.2
+	"PCMPGTQ": "SSE4.2", "PCMPESTRI": "SSE4.2", "PCMPESTRM": "SSE4.2",
+	"PCMPISTRI": "SSE4.2", "PCMPISTRM": "SSE4.2", "CRC32": "SSE4.2", "POPCNT": "SSE4.2",
+}
+
+// TestSSE2KernelsAreBaselineSSE2 guards the c128 dispatch contract: c128_amd64.go
+// routes the *SSE2 kernels through `case cpu.X86.SSE2` (genuine SSE2 baseline),
+// unlike c64 which gates its similarly named kernels on SSE4.1. So every
+// instruction in a c128 *SSE2 TEXT block must be SSE2 (or older). A post-SSE2
+// instruction here SIGILLs on a CPU that lacks the feature (reproduced under
+// `qemu-x86_64 -cpu Conroe`), which is the regression this test prevents.
+func TestSSE2KernelsAreBaselineSSE2(t *testing.T) {
+	// Locate the .s file relative to this test's source, not the working
+	// directory: when this test runs from a precompiled binary (e.g. the
+	// qemu cross-ISA CI leg, run from the repo root) the cwd is not the
+	// package dir, so a bare relative open would spuriously fail.
+	_, thisFile, _, ok := runtime.Caller(0)
+	if !ok {
+		t.Fatal("runtime.Caller(0) failed; cannot locate source dir")
+	}
+	asmFile := filepath.Join(filepath.Dir(thisFile), "c128_amd64.s")
+	src, err := os.ReadFile(asmFile)
+	if err != nil {
+		t.Fatalf("read %s: %v", asmFile, err)
+	}
+
+	var curFunc string
+	inSSE2 := false
+	scanned := 0
+	for lineNo, raw := range strings.Split(string(src), "\n") {
+		line := raw
+		// Strip line comment, then trim.
+		if idx := strings.Index(line, "//"); idx >= 0 {
+			line = line[:idx]
+		}
+		line = strings.TrimSpace(line)
+		if line == "" {
+			continue
+		}
+
+		if name, ok := textSymbol(line); ok {
+			curFunc = name
+			inSSE2 = strings.HasSuffix(name, "SSE2")
+			if inSSE2 {
+				scanned++
+			}
+			continue
+		}
+		if !inSSE2 {
+			continue
+		}
+
+		mnemonic := strings.Fields(line)[0]
+		if strings.HasSuffix(mnemonic, ":") { // label
+			continue
+		}
+		if isa, bad := postSSE2Mnemonics[mnemonic]; bad {
+			t.Errorf("%s:%d: %s uses %s (%s); c128 dispatches *SSE2 kernels on plain SSE2, so this SIGILLs on CPUs without %s",
+				asmFile, lineNo+1, curFunc, mnemonic, isa, isa)
+		}
+	}
+	if scanned == 0 {
+		t.Fatalf("scanned no *SSE2 TEXT blocks in %s; parser likely broken", asmFile)
+	}
+}
+
+// textSymbol returns the function name from a Plan9 `TEXT ·name(SB), ...` line.
+func textSymbol(line string) (string, bool) {
+	if !strings.HasPrefix(line, "TEXT") {
+		return "", false
+	}
+	rest := strings.TrimSpace(strings.TrimPrefix(line, "TEXT"))
+	rest = strings.TrimPrefix(rest, "·") // middle dot prefixes the symbol
+	idx := strings.Index(rest, "(")
+	if idx <= 0 {
+		return "", false
+	}
+	return rest[:idx], true
+}

--- a/c128/sse2_baseline_test.go
+++ b/c128/sse2_baseline_test.go
@@ -97,9 +97,22 @@ func TestSSE2KernelsAreBaselineSSE2(t *testing.T) {
 		if strings.HasSuffix(mnemonic, ":") { // label
 			continue
 		}
-		if isa, bad := postSSE2Mnemonics[mnemonic]; bad {
-			t.Errorf("%s:%d: %s uses %s (%s); c128 dispatches *SSE2 kernels on plain SSE2, so this SIGILLs on CPUs without %s",
-				asmFile, lineNo+1, curFunc, mnemonic, isa, isa)
+		// VEX/EVEX (V-prefixed) and AVX-512 opmask (K-prefixed) instructions
+		// require AVX / AVX-512 and SIGILL on plain SSE2. No SSE2 mnemonic or
+		// Plan9 pseudo-op starts with V or K, so a blanket prefix check catches
+		// any AVX instruction the named denylist below would miss.
+		switch {
+		case strings.HasPrefix(mnemonic, "V"):
+			t.Errorf("%s:%d: %s uses VEX/EVEX instruction %s; an SSE2 kernel must not use AVX (SIGILLs on CPUs without AVX)",
+				asmFile, lineNo+1, curFunc, mnemonic)
+		case strings.HasPrefix(mnemonic, "K"):
+			t.Errorf("%s:%d: %s uses AVX-512 opmask instruction %s; an SSE2 kernel must not use AVX-512 (SIGILLs on CPUs without AVX-512)",
+				asmFile, lineNo+1, curFunc, mnemonic)
+		default:
+			if isa, bad := postSSE2Mnemonics[mnemonic]; bad {
+				t.Errorf("%s:%d: %s uses %s (%s); c128 dispatches *SSE2 kernels on plain SSE2, so this SIGILLs on CPUs without %s",
+					asmFile, lineNo+1, curFunc, mnemonic, isa, isa)
+			}
 		}
 	}
 	if scanned == 0 {

--- a/f64/f64_go.go
+++ b/f64/f64_go.go
@@ -10,9 +10,8 @@ const (
 
 // Numerical stability thresholds
 const (
-	sigmoidClampThreshold = 20.0  // sigmoid(±20) ≈ 1.0 - 2e-9 (float64 precision limit)
-	tanhClampThreshold    = 2.5   // fast approximation threshold: tanh(±2.5) saturates to ±1
-	expOverflowThreshold  = 709.0 // exp(709.78) = max float64; clamp to prevent overflow
+	tanhClampThreshold   = 2.5   // fast approximation threshold: tanh(±2.5) saturates to ±1
+	expOverflowThreshold = 709.0 // exp(709.78) = max float64; clamp to prevent overflow
 )
 
 // Pure Go implementations - used as fallback on all architectures
@@ -452,16 +451,21 @@ func sigmoid64Go(dst, src []float64) {
 	}
 	_ = src[len(dst)-1]
 	for i := range dst {
-		x := src[i]
-		// Clamp extreme values for numerical stability
+		// sigmoid(x) = 1/(1+e^-x). Clamp the exponent to ±expOverflowThreshold so
+		// e^z cannot overflow to +Inf; the quotient then saturates smoothly to 0
+		// (x -> -inf) or 1 (x -> +inf). This matches the accurate exp-based SIMD
+		// kernels (issue #33) within tolerance. The previous hard flush to 0 for
+		// x < -20 diverged from those kernels (sigmoid(-25) is ~1.4e-11, not 0),
+		// so TestSigmoidAccuracy failed on the scalar fallback path that runs on
+		// CPUs without AVX2.
+		z := -src[i]
 		switch {
-		case x > sigmoidClampThreshold:
-			dst[i] = 1.0
-		case x < -sigmoidClampThreshold:
-			dst[i] = 0.0
-		default:
-			dst[i] = 1.0 / (1.0 + math.Exp(-x))
+		case z > expOverflowThreshold:
+			z = expOverflowThreshold
+		case z < -expOverflowThreshold:
+			z = -expOverflowThreshold
 		}
+		dst[i] = 1.0 / (1.0 + math.Exp(z))
 	}
 }
 

--- a/f64/go_impl_newops_test.go
+++ b/f64/go_impl_newops_test.go
@@ -71,20 +71,46 @@ func TestSubFromScalarGo_EmptyDst(_ *testing.T) {
 	subFromScalarGo(nil, []float64{1, 2}, 0)
 }
 
-// TestSigmoid64Go_Saturation hits both saturation branches (x > +threshold
-// and x < -threshold) in the new BCE-hinted sigmoid64Go fallback.
+// TestSigmoid64Go_Saturation hits both exponent-clamp branches (|x| beyond
+// expOverflowThreshold) in the sigmoid64Go fallback and confirms it saturates
+// smoothly: +large -> 1, -large -> a tiny positive value (NOT a hard 0).
 func TestSigmoid64Go_Saturation(t *testing.T) {
-	src := []float64{sigmoidClampThreshold + 1, -sigmoidClampThreshold - 1, 0}
+	src := []float64{expOverflowThreshold + 1, -(expOverflowThreshold + 1), 0}
 	dst := make([]float64, len(src))
 	sigmoid64Go(dst, src)
 	if dst[0] != 1.0 {
 		t.Errorf("sigmoid64Go(+large) = %v, want 1", dst[0])
 	}
-	if dst[1] != 0.0 {
-		t.Errorf("sigmoid64Go(-large) = %v, want 0", dst[1])
+	// With z = -x clamped to expOverflowThreshold, sigmoid(-large) is
+	// 1/(1+exp(709)) ~ 1.2e-308: vanishingly small but strictly positive.
+	wantNeg := 1.0 / (1.0 + math.Exp(expOverflowThreshold))
+	if dst[1] != wantNeg {
+		t.Errorf("sigmoid64Go(-large) = %v, want %v", dst[1], wantNeg)
 	}
 	if dst[2] != 0.5 {
 		t.Errorf("sigmoid64Go(0) = %v, want 0.5", dst[2])
+	}
+}
+
+// TestSigmoid64Go_NoFlushToZero guards the regression fixed here: the scalar
+// fallback used to hard-clamp to 0 for x < -20, diverging from the accurate
+// exp-based SIMD kernels (issue #33). It calls sigmoid64Go directly so it runs
+// on every host, unlike the dispatched TestSigmoidAccuracy which only exercises
+// whichever kernel the CPU selects (the AVX2 kernel on CI, never this fallback).
+// sigmoid(-25) is ~1.39e-11; flushing it to 0 is a relative error of 1.
+func TestSigmoid64Go_NoFlushToZero(t *testing.T) {
+	src := []float64{-30, -27.5, -25, -22, -20.5}
+	dst := make([]float64, len(src))
+	sigmoid64Go(dst, src)
+	for i, x := range src {
+		want := 1.0 / (1.0 + math.Exp(-x))
+		if dst[i] <= 0 {
+			t.Errorf("sigmoid64Go(%v) = %v, want positive ~%v", x, dst[i], want)
+			continue
+		}
+		if relErr := math.Abs(dst[i]-want) / want; relErr > 1e-9 {
+			t.Errorf("sigmoid64Go(%v) = %v, want %v (relErr %v)", x, dst[i], want, relErr)
+		}
 	}
 }
 


### PR DESCRIPTION
## Summary

Two fallback-correctness bugs that only manifest on x86 CPUs without AVX, found
during a fallback audit and confirmed empirically under qemu. Every CI and dev
host has AVX, so these paths were never exercised and the bugs reached `main`.

**1. `c128` SSE2 kernels SIGILL on CPUs without SSE4.1.** The c128 init switch
dispatches the `*SSE2` kernels on `cpu.X86.SSE2` (the amd64 baseline), but five
of them used post-SSE2 instructions:

- `mulSSE2` / `mulConjSSE2` / `scaleSSE2` used `BLENDPD` (SSE4.1)
- `absSSE2` / `absSqSSE2` used `MOVDDUP` (SSE3)

On a CPU advertising no SSE4.1 (e.g. Core 2 / Conroe, or a default `qemu64` VM)
the `BLENDPD` kernels fault with SIGILL; on a genuine SSE2-only CPU the
`MOVDDUP` kernels fault too. Replaced with bit-identical SSE2 forms:
`BLENDPD $0x02, Xs, Xd` -> `SHUFPD $0x2, Xs, Xd` (both yield `[Xd.lo, Xs.hi]`),
and `MOVDDUP X0, X1` -> `MOVAPD X0, X1` (only the low lane is stored). `c64` was
already correct (it gates its similarly named kernels on `cpu.X86.SSE41`).

**2. `f64` sigmoid scalar fallback diverged from the SIMD kernel.** `sigmoid64Go`
hard-clamped to `0` for `x < -20` (a leftover from the pre-#33 rational
approximation), while the AVX/AVX-512 kernels compute the accurate
`1/(1+e^-x)`. `TestSigmoidAccuracy` asserts that accuracy across `-30..30` but
only runs the dispatched path, so on AVX2 CI the inaccurate fallback was never
checked. `sigmoid(-25)` is ~1.4e-11, not 0. Now computes `1/(1+e^-x)` with the
exponent clamped to `+/-expOverflowThreshold` (no overflow to +Inf), matching
the kernels within tolerance.

## Regression guards

- `TestSSE2KernelsAreBaselineSSE2` (c128): scans the `*SSE2` TEXT blocks and
  fails on any post-SSE2 mnemonic. Runs on normal CI, no qemu needed.
- `TestSigmoid64Go_NoFlushToZero` (f64): calls the scalar fallback directly so
  it runs on every host, unlike the dispatched accuracy test.
- New `cross-isa` CI job: runs the amd64 suite under `qemu-x86_64 -cpu Conroe`
  (SSSE3, no SSE4.1, no AVX) and a stripped SSE2-only `qemu64` model. qemu v7+
  enforces the `-cpu` feature set and raises #UD for out-of-baseline ops, so
  these models reproduce real-hardware faults. This is what would have caught
  both bugs.

## Test Plan

- [x] `go test -race ./...` passes natively
- [x] `go vet ./...` clean for amd64 and arm64
- [x] `golangci-lint run ./...` clean
- [x] Full suite passes under `qemu-x86_64` `-cpu Conroe`, SSE2-only, `Nehalem`, `Penryn` (all no-AVX)
- [x] c128 numerical results bit-identical to before (verified native)
- [x] Regression tests verified red against the old code, green after the fix

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added QEMU-based cross-ISA CPU compatibility testing to validate system behavior across processors without AVX and extended SSE instruction support.

* **Improvements**
  * Enhanced sigmoid function numerical stability through exponent-clamping logic, replacing hard cutoffs with smooth saturation behavior for extreme input values.
  * Optimized assembly implementations for improved instruction compatibility and performance.

* **Tests**
  * Added baseline validation test and regression test to prevent numerical edge-case issues.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->