### PR TITLE
i32: add ZigzagSum, FixedAbsSums, and widen RiceSums to k=0..30

### DIFF
--- a/README.md
+++ b/README.md
@@ -382,10 +382,12 @@ SIMD-accelerated integer-domain operations for codec and integer-DSP hot loops (
 |                     | `MidSideDecode(left, right, mid, side)` | Mid/side inverse (parity-bit reconstruction)             | 8x (AVX2) / 4x (NEON) |
 | **Fixed predictor** | `Diff1`..`Diff4(dst, src)`              | Order 1-4 fixed-predictor encode residual (forward diff) | 8x (AVX2) / 4x (NEON) |
 |                     | `Restore1`..`Restore4(dst, src)`        | Order 1-4 fixed-predictor decode (inverse; prefix sum)   | 8x (AVX2) / 4x (NEON) |
+|                     | `FixedAbsSums(src, sums)`               | Order 0-4 residual abs-sums in one pass (predictor select) | 8x (AVX2) / 4x (NEON) |
 | **LPC**             | `LPCResidualEncode(res, samples, coeffs, shift)` | Quantized-LPC encode residual FIR (parallel across outputs) | 8x (AVX2) / 4x (NEON) |
 |                     | `LPCRestore(out, residual, coeffs, shift)`       | Quantized-LPC decode (serial recurrence; vectorized taps)   | 8x (AVX2) / 4x (NEON) |
-| **Rice**            | `RiceSums(sums, res)`                   | Per-parameter zigzag unary-bit sums `Σ (zigzag(res)>>k)`  | 8x (AVX2) / 4x (NEON) |
+| **Rice**            | `RiceSums(sums, res)`                   | Per-parameter zigzag unary-bit sums `Σ (zigzag(res)>>k)`, all FLAC params k=0..30 | 8x (AVX2) / 4x (NEON) |
 |                     | `RiceBestParam(res, maxParam)`          | Cost-minimizing Rice parameter + its bit count           | 8x (AVX2) / 4x (NEON) |
+|                     | `ZigzagSum(res)`                        | Total zigzag fold `Σ zigzag(res)` (estimate fast path)   | 8x (AVX2) / 4x (NEON) |
 
 ```go
 import "github.com/tphakala/simd/i32"
@@ -401,14 +403,18 @@ res := make([]int32, n)
 i32.Diff2(res, left)     // order-2 fixed-predictor encode residual
 i32.Restore2(left, res)  // exact inverse: reconstruct the samples
 
+var absSums [5]uint64
+i32.FixedAbsSums(left, &absSums) // order 0-4 residual abs-sums for predictor selection
+
 coeffs := []int32{...}             // quantized LPC coefficients (order = len)
 i32.LPCResidualEncode(res, left, coeffs, shift) // encode FIR residual
 i32.LPCRestore(left, res, coeffs, shift)        // exact inverse: reconstruct
 
 param, bits := i32.RiceBestParam(res, 14) // best Rice parameter and its bit cost
+total := i32.ZigzagSum(res)               // Σ zigzag(res): the k=0 Rice sum on its own
 ```
 
-Interleaving is pure 32-bit-lane movement, so those kernels reuse the proven `f32` shuffle/permute encodings (AVX `VUNPCKLPS`/`VPERM2F128`, NEON `ZIP`/`UZP` on `.4S`); the bit pattern of each lane is irrelevant, so negative values and the type extremes round-trip exactly. The decorrelation and fixed-predictor kernels do integer-ALU work on 256-bit (AVX2) / 128-bit (NEON) lanes. `RestoreK` is the exact inverse of `DiffK`: since the order-`K` fixed predictor is the `K`-th forward difference, restoration is `K` cumulative-sum passes built on one SIMD prefix-sum kernel (11x at order 1 down to ~5x at order 4 on AVX2; 6x to 3x on NEON, all zero-allocation). The LPC kernels accumulate the prediction sum in int64 (matching libFLAC), so they stay bit-exact for the full coefficient precision and order: `LPCResidualEncode` is a FIR that vectorizes across output samples (widening `VPMULDQ` / `SMLAL`, ~7-9x on AVX2, ~4-5x on NEON), while `LPCRestore` is a serial recurrence whose per-output tap dot product is vectorized, keeping the just-written newest samples on store-forwardable scalar loads (~1.4-3.9x on AVX2, ~1.8-3.6x on NEON, order 8 to 32). The Rice cost search folds each residual to its unsigned zigzag symbol `(r<<1)^(r>>31)`, widens it to int64, and accumulates `Σ (zigzag(res)>>k)` for every Rice parameter `k` in 0..14 at once (the symbols are halved progressively, exact for the logical shift); `RiceBestParam` adds the `n*(k+1)` code overhead and picks the cheapest `k`. This is the exact bit cost, not the `sum>>k` approximation, and runs ~13x on AVX2 and ~4x on NEON, zero-allocation.
+Interleaving is pure 32-bit-lane movement, so those kernels reuse the proven `f32` shuffle/permute encodings (AVX `VUNPCKLPS`/`VPERM2F128`, NEON `ZIP`/`UZP` on `.4S`); the bit pattern of each lane is irrelevant, so negative values and the type extremes round-trip exactly. The decorrelation and fixed-predictor kernels do integer-ALU work on 256-bit (AVX2) / 128-bit (NEON) lanes. `RestoreK` is the exact inverse of `DiffK`: since the order-`K` fixed predictor is the `K`-th forward difference, restoration is `K` cumulative-sum passes built on one SIMD prefix-sum kernel (11x at order 1 down to ~5x at order 4 on AVX2; 6x to 3x on NEON, all zero-allocation). The LPC kernels accumulate the prediction sum in int64 (matching libFLAC), so they stay bit-exact for the full coefficient precision and order: `LPCResidualEncode` is a FIR that vectorizes across output samples (widening `VPMULDQ` / `SMLAL`, ~7-9x on AVX2, ~4-5x on NEON), while `LPCRestore` is a serial recurrence whose per-output tap dot product is vectorized, keeping the just-written newest samples on store-forwardable scalar loads (~1.4-3.9x on AVX2, ~1.8-3.6x on NEON, order 8 to 32). `FixedAbsSums` picks the cheapest fixed predictor in one pass: it forms the order-0..4 forward finite differences in int64 (a 4th difference of int32 samples exceeds the int32 range) with a windowed sign-extending subtract cascade, sums `|e_order|` per order excluding the warm-up, and runs ~2.6x on AVX2, ~1.7x on NEON. The Rice cost search folds each residual to its unsigned zigzag symbol `(r<<1)^(r>>31)`, widens it to int64, and accumulates `Σ (zigzag(res)>>k)` for every Rice parameter at once (the symbols are halved progressively, exact for the logical shift); the kernel now covers FLAC's full range `k` in 0..30 (the 5-bit method, previously a scalar tail above 14), so a 31-column `RiceSums` runs ~13x on AVX2 and ~4x on NEON instead of falling back to scalar. `RiceBestParam` adds the `n*(k+1)` code overhead and picks the cheapest `k`; this is the exact bit cost, not the `sum>>k` approximation. `ZigzagSum` exposes just the `k=0` total `Σ zigzag(res)` for the estimate path (~3.7x AVX2, ~2.4x NEON). All zero-allocation.
 
 ### `i16` - int16 Operations
 
@@ -612,6 +618,9 @@ a Raspberry Pi 5):
 | LPCRestore (order 32)        | 4443 ns vs 17529 ns (**3.9x**)| 11303 ns vs 41026 ns (**3.6x**) |
 | RiceSums (k=0..14)           | 810 ns vs 10490 ns (**13.0x**)| 4090 ns vs 17163 ns (**4.2x**) |
 | RiceBestParam (k=0..14)      | 810 ns vs 10490 ns (**13.0x**)| 4081 ns vs 17163 ns (**4.2x**) |
+| RiceSums (k=0..30, 5-bit)    | 1685 ns vs 21401 ns (**12.7x**)| 8503 ns vs 34111 ns (**4.0x**) |
+| ZigzagSum                    | 88 ns vs 328 ns (**3.7x**)    | 476 ns vs 1124 ns (**2.4x**)  |
+| FixedAbsSums (orders 0..4)   | 752 ns vs 1952 ns (**2.6x**)  | 2881 ns vs 4777 ns (**1.7x**) |
 
 ### int16 (i16) - SIMD vs Pure Go (1000 elements)
 
@@ -622,7 +631,7 @@ a Raspberry Pi 5):
 
 Both i16 kernels are zero-allocation and bit-exact against the pure-Go reference (verified with negative values and the int16 extremes); they move whole 16-bit lanes, so the bit pattern of each sample is irrelevant to correctness.
 
-All int32 kernels are zero-allocation and bit-exact against the pure-Go reference (verified across the sign and high bits with negative values and the type extremes). The Restore baseline is the pure-Go decode recurrence; `RestoreK` reconstructs samples as `K` SIMD prefix-sum passes (the inverse of the order-`K` forward difference). The LPC kernels accumulate in int64 and are checked against an arbitrary-precision `math.big` oracle and the encode->decode round-trip; `LPCRestore` is the serial decode recurrence (vectorized per-output tap dot product), dispatched to SIMD only at order >= 8 where it beats the scalar path. The Rice kernels compute the exact per-parameter unary-bit sums `Σ (zigzag(res)>>k)` for all 15 FLAC parameters in one pass (15 int64 accumulators; AVX2 sweeps the data twice for its 16-register file, NEON fits one pass in its 32 registers), checked against an independent oracle and brute-force parameter scan.
+All int32 kernels are zero-allocation and bit-exact against the pure-Go reference (verified across the sign and high bits with negative values and the type extremes). The Restore baseline is the pure-Go decode recurrence; `RestoreK` reconstructs samples as `K` SIMD prefix-sum passes (the inverse of the order-`K` forward difference). The LPC kernels accumulate in int64 and are checked against an arbitrary-precision `math.big` oracle and the encode->decode round-trip; `LPCRestore` is the serial decode recurrence (vectorized per-output tap dot product), dispatched to SIMD only at order >= 8 where it beats the scalar path. The Rice kernels compute the exact per-parameter unary-bit sums `Σ (zigzag(res)>>k)` for FLAC's full parameter range in one sweep, checked against an independent oracle and brute-force parameter scan: the 4-bit method (k=0..14) and the 5-bit method (k=0..30, a low-15 kernel plus a pre-shifted high-16 kernel) are both fully vectorized, replacing the scalar tail that previously handled k>14. `ZigzagSum` is that sweep's k=0 column on its own (Σ zigzag), and `FixedAbsSums` computes the order-0..4 fixed-predictor residual abs-sums in one windowed int64 cascade; both are checked against independent oracles across the sign bit and the int32 extremes (where the 4th difference exceeds int32, exercising the int64 width).
 
 ### Performance Notes
 

--- a/i32/benchmark_test.go
+++ b/i32/benchmark_test.go
@@ -410,10 +410,64 @@ func BenchmarkRiceSumsGo_1000(b *testing.B) {
 	}
 }
 
+// Wide variants exercise the FLAC 5-bit range (31 columns, k=0..30): the SIMD
+// path now vectorizes all of it, where it previously fell back to scalar.
+func BenchmarkRiceSumsWide_1000(b *testing.B) {
+	res := benchRiceRes()
+	sums := make([]uint64, riceMaxParam5+1)
+	b.SetBytes(benchN * 4)
+	for b.Loop() {
+		RiceSums(sums, res)
+	}
+}
+
+func BenchmarkRiceSumsWideGo_1000(b *testing.B) {
+	res := benchRiceRes()
+	sums := make([]uint64, riceMaxParam5+1)
+	b.SetBytes(benchN * 4)
+	for b.Loop() {
+		riceSumsGo(sums, res)
+	}
+}
+
 func BenchmarkRiceBestParam_1000(b *testing.B) {
 	res := benchRiceRes()
 	b.SetBytes(benchN * 4)
 	for b.Loop() {
 		RiceBestParam(res, riceMaxParam)
+	}
+}
+
+func BenchmarkZigzagSum_1000(b *testing.B) {
+	res := benchRiceRes()
+	b.SetBytes(benchN * 4)
+	for b.Loop() {
+		ZigzagSum(res)
+	}
+}
+
+func BenchmarkZigzagSumGo_1000(b *testing.B) {
+	res := benchRiceRes()
+	b.SetBytes(benchN * 4)
+	for b.Loop() {
+		zigzagSumGo(res)
+	}
+}
+
+func BenchmarkFixedAbsSums_1000(b *testing.B) {
+	src, _ := benchSrcDst()
+	var sums [5]uint64
+	b.SetBytes(benchN * 4)
+	for b.Loop() {
+		FixedAbsSums(src, &sums)
+	}
+}
+
+func BenchmarkFixedAbsSumsGo_1000(b *testing.B) {
+	src, _ := benchSrcDst()
+	var sums [5]uint64
+	b.SetBytes(benchN * 4)
+	for b.Loop() {
+		fixedAbsSumsGo(src, &sums)
 	}
 }

--- a/i32/fixed.go
+++ b/i32/fixed.go
@@ -51,3 +51,17 @@ func Diff4(dst, src []int32) {
 	}
 	diff4I32(dst[:n], src[:n])
 }
+
+// FixedAbsSums writes into sums the absolute-value totals of the order-0 through
+// order-4 fixed-predictor residuals of src:
+//
+//	sums[order] = Σ_{i>=order} |e_order[i]|
+//
+// where e_order is the order-th forward finite difference of src (order 0 is src
+// itself). Each total is accumulated in int64 (the differences exceed the int32
+// range) and excludes the first order warm-up samples, matching the cost FLAC
+// uses to choose a fixed predictor order in one pass. sums is fully overwritten;
+// src is read-only. An empty src yields all-zero sums.
+func FixedAbsSums(src []int32, sums *[5]uint64) {
+	fixedAbsSumsI32(src, sums)
+}

--- a/i32/fixed_test.go
+++ b/i32/fixed_test.go
@@ -2,6 +2,7 @@ package i32
 
 import (
 	"math"
+	"math/rand"
 	"testing"
 )
 
@@ -131,5 +132,117 @@ func TestDiff_AllocFree(t *testing.T) {
 		if got := testing.AllocsPerRun(100, func() { fn(dst, src) }); got != 0 {
 			t.Errorf("%s allocated %v times per run, want 0", name, got)
 		}
+	}
+}
+
+// Tests for FixedAbsSums, the five fixed-predictor residual abs-sums.
+//
+// sums[order] = Σ_{i>=order} |e_order[i]| where e_order is the order-th forward
+// finite difference of src (orders 0..4), computed in int64 and excluding the
+// first order warm-up samples.
+
+// fixedAbsSumsOracle is an independent implementation that derives each order's
+// finite difference by repeated first-differencing in int64 (the algorithm
+// diffResidualRepeated uses, widened), then sums |diff| over the non-warm-up
+// range [order, n). Written separately from fixedAbsSumsGo so the two agreeing
+// is a real cross-check rather than a restatement.
+func fixedAbsSumsOracle(src []int32) [5]uint64 {
+	cur := make([]int64, len(src))
+	for i, v := range src {
+		cur[i] = int64(v)
+	}
+	abs := func(v int64) uint64 {
+		if v < 0 {
+			return uint64(-v)
+		}
+		return uint64(v)
+	}
+	var sums [5]uint64
+	for order := 0; order <= 4; order++ {
+		for i := order; i < len(cur); i++ {
+			sums[order] += abs(cur[i])
+		}
+		if order < 4 {
+			next := make([]int64, len(cur))
+			for i := len(cur) - 1; i >= 1; i-- {
+				next[i] = cur[i] - cur[i-1] // next[0] is warm-up, never read for order+1
+			}
+			cur = next
+		}
+	}
+	return sums
+}
+
+// TestFixedAbsSumsSmall checks a hand-computed case including the warm-up
+// exclusions for orders that have no full window yet.
+func TestFixedAbsSumsSmall(t *testing.T) {
+	src := []int32{3, 7, 2}
+	// order0: 3+7+2 = 12
+	// order1 (i>=1): |7-3| + |2-7| = 4 + 5 = 9
+	// order2 (i>=2): |(2-7)-(7-3)| = |-9| = 9
+	// order3,4: no terms (n<4, n<5) -> 0
+	var got [5]uint64
+	FixedAbsSums(src, &got)
+	want := [5]uint64{12, 9, 9, 0, 0}
+	if got != want {
+		t.Fatalf("FixedAbsSums small = %v, want %v", got, want)
+	}
+}
+
+func TestFixedAbsSumsMatchesOracle(t *testing.T) {
+	rng := rand.New(rand.NewSource(11))
+	for _, n := range []int{0, 1, 2, 3, 4, 5, 7, 8, 9, 15, 16, 17, 31, 33, 100, 1000, 1024, 1025} {
+		src := make([]int32, n)
+		for i := range src {
+			src[i] = int32(rng.Uint32())
+		}
+		var got [5]uint64
+		FixedAbsSums(src, &got)
+		want := fixedAbsSumsOracle(src)
+		if got != want {
+			t.Fatalf("n=%d FixedAbsSums = %v, want %v", n, got, want)
+		}
+	}
+}
+
+// TestFixedAbsSumsExtremes drives the int64 width: MinInt32/MaxInt32 differences
+// reach ~2^35, so an int32-wrapping cascade would diverge from the reference.
+func TestFixedAbsSumsExtremes(t *testing.T) {
+	src := []int32{math.MinInt32, math.MaxInt32, math.MinInt32, math.MaxInt32, math.MinInt32, math.MaxInt32, 0, -1, 1, math.MinInt32, math.MaxInt32, 0}
+	var got [5]uint64
+	FixedAbsSums(src, &got)
+	want := fixedAbsSumsOracle(src)
+	if got != want {
+		t.Fatalf("FixedAbsSums extremes = %v, want %v", got, want)
+	}
+}
+
+// TestFixedAbsSumsOverwrites confirms sums is fully written, not accumulated into.
+func TestFixedAbsSumsOverwrites(t *testing.T) {
+	src := []int32{1, 2, 3, 4, 5, 6, 7, 8, 9}
+	got := [5]uint64{999, 999, 999, 999, 999}
+	FixedAbsSums(src, &got)
+	want := fixedAbsSumsOracle(src)
+	if got != want {
+		t.Fatalf("FixedAbsSums did not overwrite: %v, want %v", got, want)
+	}
+}
+
+func TestFixedAbsSumsEmpty(t *testing.T) {
+	got := [5]uint64{7, 7, 7, 7, 7}
+	FixedAbsSums(nil, &got)
+	if got != ([5]uint64{}) {
+		t.Errorf("FixedAbsSums(nil) = %v, want all zero", got)
+	}
+}
+
+func TestFixedAbsSumsAllocFree(t *testing.T) {
+	src := make([]int32, 1024)
+	for i := range src {
+		src[i] = int32(i*7 - 3)
+	}
+	var sums [5]uint64
+	if got := testing.AllocsPerRun(100, func() { FixedAbsSums(src, &sums) }); got != 0 {
+		t.Errorf("FixedAbsSums allocated %v times per run, want 0", got)
 	}
 }

--- a/i32/i32_amd64.go
+++ b/i32/i32_amd64.go
@@ -199,5 +199,50 @@ func riceSumsI32(sums []uint64, res []int32) {
 	riceSumsGo(sums, res)
 }
 
+// zigzagSumI32 dispatches the residual zigzag-fold sum (RiceSums' k=0 column).
+// The AVX2 kernel widens to int64 lanes; it gates on AVX2 and at least one full
+// 8-element block, falling back to the pure-Go reference otherwise.
+func zigzagSumI32(res []int32) uint64 {
+	if hasAVX2 && len(res) >= minAVXElements {
+		return zigzagSumAVX2(res)
+	}
+	return zigzagSumGo(res)
+}
+
+//go:noescape
+func zigzagSumAVX2(res []int32) uint64
+
+// fixedAbsSumsI32 dispatches the five fixed-predictor residual abs-sums. The
+// AVX2 kernel computes the order-0..4 finite differences in int64 lanes via a
+// windowed sign-extending cascade, so it gates on AVX2 and at least one full
+// 8-element block (the kernel handles the first 4 warm-up samples and the tail
+// scalar). Shorter inputs use the pure-Go reference.
+func fixedAbsSumsI32(src []int32, sums *[5]uint64) {
+	if hasAVX2 && len(src) >= minAVXElements {
+		fixedAbsSumsAVX2(src, sums)
+		return
+	}
+	fixedAbsSumsGo(src, sums)
+}
+
+//go:noescape
+func fixedAbsSumsAVX2(src []int32, sums *[5]uint64)
+
 //go:noescape
 func riceSumsAVX2(sums []uint64, res []int32)
+
+// riceSumsWideI32 dispatches the FLAC 5-bit Rice sums (len(sums) ==
+// riceMaxParam5+1 = 31). The AVX2 path reuses the 15-wide kernel for columns
+// 0..14 and a high kernel for columns 15..30, so the whole range is vectorized
+// instead of falling to the scalar tail; both gate on AVX2 and one full block.
+func riceSumsWideI32(sums []uint64, res []int32) {
+	if hasAVX2 && len(res) >= minAVXElements {
+		riceSumsAVX2(sums[:riceParamCount], res)     // columns 0..14
+		riceSumsHighAVX2(sums[riceParamCount:], res) // columns 15..30
+		return
+	}
+	riceSumsGo(sums, res)
+}
+
+//go:noescape
+func riceSumsHighAVX2(sums []uint64, res []int32)

--- a/i32/i32_amd64.go
+++ b/i32/i32_amd64.go
@@ -236,7 +236,10 @@ func riceSumsAVX2(sums []uint64, res []int32)
 // 0..14 and a high kernel for columns 15..30, so the whole range is vectorized
 // instead of falling to the scalar tail; both gate on AVX2 and one full block.
 func riceSumsWideI32(sums []uint64, res []int32) {
-	if hasAVX2 && len(res) >= minAVXElements {
+	// The exact-width gate mirrors riceSumsI32: riceSumsHighAVX2 is a fixed
+	// 16-column writer, so only dispatch it when sums is the full 31-wide slice;
+	// any other length goes to the pure-Go reference (which handles all widths).
+	if hasAVX2 && len(sums) == riceMaxParam5+1 && len(res) >= minAVXElements {
 		riceSumsAVX2(sums[:riceParamCount], res)     // columns 0..14
 		riceSumsHighAVX2(sums[riceParamCount:], res) // columns 15..30
 		return

--- a/i32/i32_amd64.s
+++ b/i32/i32_amd64.s
@@ -1116,3 +1116,544 @@ rice_tail:
 rice_done:
     VZEROUPPER
     RET
+
+// func zigzagSumAVX2(res []int32) uint64
+// Returns Σ_i zigzag(res[i]) where zigzag(r) = (r<<1) ^ (r>>31), the k=0 column
+// of riceSumsAVX2 exposed on its own. Each 8-int32 block is folded
+// (VPSLLD / VPSRAD / VPXOR), zero-extended to int64 (VPMOVZXDQ on each 128-bit
+// half) and added into two int64x4 accumulators (the low and high lanes form
+// independent chains for ILP). After the loop the two accumulators are combined
+// and the four lanes folded to a scalar; the (n mod 8) trailing residuals are
+// then folded in with a scalar tail. The dispatch gates len(res) >= 8.
+TEXT ·zigzagSumAVX2(SB), NOSPLIT, $0-32
+    MOVQ res_base+0(FP), R8
+    MOVQ res_len+8(FP), CX           // n
+    MOVQ CX, R9
+    SHRQ $3, R9                      // R9 = full 8-element blocks (>=1)
+    VPXOR Y8, Y8, Y8                 // acc for lanes 0..3
+    VPXOR Y9, Y9, Y9                 // acc for lanes 4..7
+    MOVQ R8, SI                      // working res ptr
+    MOVQ R9, AX                      // block counter
+zzsum_loop:
+    VMOVDQU (SI), Y0                 // v = res[i..i+7]
+    VPSLLD  $1, Y0, Y1               // r<<1
+    VPSRAD  $31, Y0, Y2              // r>>31 (arithmetic)
+    VPXOR   Y2, Y1, Y1               // u = zigzag(r) (int32x8, as uint32)
+    VPMOVZXDQ X1, Y2                 // zero-extend lanes 0..3 -> int64x4
+    VEXTRACTI128 $1, Y1, X3          // high 128 of u (lanes 4..7)
+    VPMOVZXDQ X3, Y3                 // zero-extend lanes 4..7 -> int64x4
+    VPADDQ Y2, Y8, Y8
+    VPADDQ Y3, Y9, Y9
+    ADDQ $32, SI
+    DECQ AX
+    JNZ  zzsum_loop
+
+    // combine the two accumulators, then fold the four int64 lanes to a scalar
+    VPADDQ Y9, Y8, Y8
+    VEXTRACTI128 $1, Y8, X0
+    VPADDQ X0, X8, X0
+    MOVQ X0, AX
+    VPEXTRQ $1, X0, DX
+    ADDQ DX, AX                      // AX = sum over all full blocks
+
+    // scalar tail: (n mod 8) residuals
+    MOVQ CX, BX
+    ANDQ $7, BX                      // tail count
+    JZ   zzsum_done
+    MOVQ R9, DX
+    SHLQ $5, DX                      // fullBlocks * 32 bytes
+    ADDQ R8, DX                      // tail ptr = &res[fullBlocks*8]
+zzsum_tail:
+    MOVL (DX), R10                   // r (zero-extended into R10)
+    MOVL R10, R11
+    SHLL $1, R10                     // r<<1
+    SARL $31, R11                    // r>>31 (arithmetic)
+    XORL R11, R10                    // R10 = zigzag(r), zero-extended
+    ADDQ R10, AX
+    ADDQ $4, DX
+    DECQ BX
+    JNZ  zzsum_tail
+
+zzsum_done:
+    MOVQ AX, ret+24(FP)
+    VZEROUPPER
+    RET
+
+// func fixedAbsSumsAVX2(src []int32, sums *[5]uint64)
+// Five fixed-predictor residual abs-sums in one pass:
+//
+//	sums[order] = Σ_{i>=order} |e_order[i]|   for order in 0..4
+//
+// where e_order is the order-th forward finite difference of src, computed in
+// int64 (a 4th difference of int32 samples reaches ~2^35, beyond int32). The
+// first 4 warm-up samples (where the higher orders are not yet active) are done
+// with a scalar p-recurrence prologue that matches the reference's masking. From
+// index 4 the differences are well-defined for every order, so the vector body
+// reads five overlapping sign-extending windows (VPMOVSXDQ at byte offsets
+// 0,-4,-8,-12,-16 around &src[i]) and forms e0..e4 with a triangular subtract
+// cascade (each level differences the one above it). int64 abs is built as
+// (x XOR m) - m with m = (0 > x) from VPCMPGTQ. The four lanes of each of the
+// five accumulators are folded and added into sums after the loop; the (n-4) mod
+// 4 trailing samples use a scalar windowed cascade. The dispatch gates
+// len(src) >= 8 so the prologue's 4 samples and >=1 vector block always exist.
+TEXT ·fixedAbsSumsAVX2(SB), NOSPLIT, $0-32
+    MOVQ src_base+0(FP), R8
+    MOVQ src_len+8(FP), CX           // n
+    MOVQ sums+24(FP), DI
+
+    // zero the five sums (the body/tail accumulate into memory via RMW)
+    XORQ AX, AX
+    MOVQ AX, 0(DI)
+    MOVQ AX, 8(DI)
+    MOVQ AX, 16(DI)
+    MOVQ AX, 24(DI)
+    MOVQ AX, 32(DI)
+
+    // ---- prologue: i = 0,1,2,3 (scalar p-recurrence; n>=8 so all four exist) ----
+    // p1..p4 = R9,R10,R11 (p4 never needed: e4 is inactive for i<4). DX = abs mask.
+
+    // i=0: e0=src[0]; s0+=|e0|; p1=e0
+    MOVLQSX 0(R8), AX
+    MOVQ AX, R9                      // p1 = e0
+    MOVQ AX, BX
+    MOVQ BX, DX; SARQ $63, DX; XORQ DX, BX; SUBQ DX, BX
+    ADDQ BX, 0(DI)
+
+    // i=1: e0=src[1]; e1=e0-p1; s0,s1; p1=e0; p2=e1
+    MOVLQSX 4(R8), AX
+    MOVQ AX, BX; SUBQ R9, BX         // e1
+    MOVQ AX, R9                      // p1 = e0
+    MOVQ BX, R10                     // p2 = e1
+    MOVQ AX, DX; SARQ $63, DX; XORQ DX, AX; SUBQ DX, AX; ADDQ AX, 0(DI)
+    MOVQ BX, DX; SARQ $63, DX; XORQ DX, BX; SUBQ DX, BX; ADDQ BX, 8(DI)
+
+    // i=2: e0=src[2]; e1=e0-p1; e2=e1-p2; s0,s1,s2; p1,p2,p3
+    MOVLQSX 8(R8), AX
+    MOVQ AX, BX; SUBQ R9, BX         // e1
+    MOVQ BX, SI; SUBQ R10, SI        // e2
+    MOVQ SI, R11                     // p3 = e2
+    MOVQ BX, R10                     // p2 = e1
+    MOVQ AX, R9                      // p1 = e0
+    MOVQ AX, DX; SARQ $63, DX; XORQ DX, AX; SUBQ DX, AX; ADDQ AX, 0(DI)
+    MOVQ BX, DX; SARQ $63, DX; XORQ DX, BX; SUBQ DX, BX; ADDQ BX, 8(DI)
+    MOVQ SI, DX; SARQ $63, DX; XORQ DX, SI; SUBQ DX, SI; ADDQ SI, 16(DI)
+
+    // i=3: e0=src[3]; e1; e2; e3; s0,s1,s2,s3 (p's discarded after)
+    MOVLQSX 12(R8), AX
+    MOVQ AX, BX; SUBQ R9, BX         // e1
+    MOVQ BX, SI; SUBQ R10, SI        // e2
+    MOVQ SI, R13; SUBQ R11, R13      // e3
+    MOVQ AX, DX; SARQ $63, DX; XORQ DX, AX; SUBQ DX, AX; ADDQ AX, 0(DI)
+    MOVQ BX, DX; SARQ $63, DX; XORQ DX, BX; SUBQ DX, BX; ADDQ BX, 8(DI)
+    MOVQ SI, DX; SARQ $63, DX; XORQ DX, SI; SUBQ DX, SI; ADDQ SI, 16(DI)
+    MOVQ R13, DX; SARQ $63, DX; XORQ DX, R13; SUBQ DX, R13; ADDQ R13, 24(DI)
+
+    // ---- vector body: nBlocks = (n-4)/4 blocks of 4 lanes from i=4 ----
+    MOVQ CX, AX
+    SUBQ $4, AX
+    SHRQ $2, AX                      // nBlocks (>=1 since n>=8)
+    LEAQ 16(R8), SI                  // window base = &src[4]
+    VPXOR Y10, Y10, Y10              // zero (abs compare source)
+    VPXOR Y11, Y11, Y11              // s0
+    VPXOR Y12, Y12, Y12              // s1
+    VPXOR Y13, Y13, Y13              // s2
+    VPXOR Y14, Y14, Y14              // s3
+    VPXOR Y15, Y15, Y15              // s4
+    MOVQ AX, R9                      // block counter
+fas_body:
+    VPMOVSXDQ   (SI), Y0             // a0 = src[i..i+3]
+    VPMOVSXDQ  -4(SI), Y1            // a1
+    VPMOVSXDQ  -8(SI), Y2            // a2
+    VPMOVSXDQ -12(SI), Y3            // a3
+    VPMOVSXDQ -16(SI), Y4            // a4
+    // order 0: e0 = a0
+    VPCMPGTQ Y0, Y10, Y5             // mask = (0 > a0)
+    VPXOR Y5, Y0, Y6
+    VPSUBQ Y5, Y6, Y6                // |e0|
+    VPADDQ Y6, Y11, Y11
+    // level 1: b0=a0-a1, b1=a1-a2, b2=a2-a3, b3=a3-a4  (b0 = e1)
+    VPSUBQ Y1, Y0, Y5
+    VPSUBQ Y2, Y1, Y6
+    VPSUBQ Y3, Y2, Y7
+    VPSUBQ Y4, Y3, Y8
+    VPCMPGTQ Y5, Y10, Y0             // mask(b0)
+    VPXOR Y0, Y5, Y9
+    VPSUBQ Y0, Y9, Y9                // |e1|
+    VPADDQ Y9, Y12, Y12
+    // level 2: c0=b0-b1, c1=b1-b2, c2=b2-b3  (c0 = e2)
+    VPSUBQ Y6, Y5, Y0
+    VPSUBQ Y7, Y6, Y1
+    VPSUBQ Y8, Y7, Y2
+    VPCMPGTQ Y0, Y10, Y3             // mask(c0)
+    VPXOR Y3, Y0, Y4
+    VPSUBQ Y3, Y4, Y4                // |e2|
+    VPADDQ Y4, Y13, Y13
+    // level 3: d0=c0-c1, d1=c1-c2  (d0 = e3)
+    VPSUBQ Y1, Y0, Y5
+    VPSUBQ Y2, Y1, Y6
+    VPCMPGTQ Y5, Y10, Y7             // mask(d0)
+    VPXOR Y7, Y5, Y8
+    VPSUBQ Y7, Y8, Y8                // |e3|
+    VPADDQ Y8, Y14, Y14
+    // level 4: e4 = d0 - d1
+    VPSUBQ Y6, Y5, Y0
+    VPCMPGTQ Y0, Y10, Y1             // mask(e4)
+    VPXOR Y1, Y0, Y2
+    VPSUBQ Y1, Y2, Y2                // |e4|
+    VPADDQ Y2, Y15, Y15
+    ADDQ $16, SI
+    DECQ R9
+    JNZ  fas_body
+
+    // fold each accumulator's 4 lanes and add into sums[order]
+    VEXTRACTI128 $1, Y11, X0
+    VPADDQ X0, X11, X0
+    MOVQ X0, AX
+    VPEXTRQ $1, X0, DX
+    ADDQ DX, AX
+    ADDQ AX, 0(DI)
+    VEXTRACTI128 $1, Y12, X0
+    VPADDQ X0, X12, X0
+    MOVQ X0, AX
+    VPEXTRQ $1, X0, DX
+    ADDQ DX, AX
+    ADDQ AX, 8(DI)
+    VEXTRACTI128 $1, Y13, X0
+    VPADDQ X0, X13, X0
+    MOVQ X0, AX
+    VPEXTRQ $1, X0, DX
+    ADDQ DX, AX
+    ADDQ AX, 16(DI)
+    VEXTRACTI128 $1, Y14, X0
+    VPADDQ X0, X14, X0
+    MOVQ X0, AX
+    VPEXTRQ $1, X0, DX
+    ADDQ DX, AX
+    ADDQ AX, 24(DI)
+    VEXTRACTI128 $1, Y15, X0
+    VPADDQ X0, X15, X0
+    MOVQ X0, AX
+    VPEXTRQ $1, X0, DX
+    ADDQ DX, AX
+    ADDQ AX, 32(DI)
+
+    // ---- scalar tail: (n-4) mod 4 samples from i=bodyEnd, all orders active ----
+    MOVQ CX, AX
+    SUBQ $4, AX
+    ANDQ $3, AX                      // tail count
+    JZ   fas_done
+    MOVQ AX, R9                      // tail counter (SI already = &src[bodyEnd])
+fas_tail:
+    MOVLQSX   0(SI), AX              // a0
+    MOVLQSX  -4(SI), BX              // a1
+    MOVLQSX  -8(SI), DX              // a2
+    MOVLQSX -12(SI), R10            // a3
+    MOVLQSX -16(SI), R11            // a4
+    // e0 = a0
+    MOVQ AX, R12
+    MOVQ R12, R13; SARQ $63, R13; XORQ R13, R12; SUBQ R13, R12; ADDQ R12, 0(DI)
+    // e1 = a0 - a1
+    MOVQ AX, R12; SUBQ BX, R12
+    MOVQ R12, R13; SARQ $63, R13; XORQ R13, R12; SUBQ R13, R12; ADDQ R12, 8(DI)
+    // e2 = a0 - 2a1 + a2
+    MOVQ AX, R12; ADDQ DX, R12; SUBQ BX, R12; SUBQ BX, R12
+    MOVQ R12, R13; SARQ $63, R13; XORQ R13, R12; SUBQ R13, R12; ADDQ R12, 16(DI)
+    // e3 = (a0 - a3) + 3*(a2 - a1)
+    MOVQ DX, R12; SUBQ BX, R12       // a2 - a1
+    LEAQ (R12)(R12*2), R12           // 3*(a2-a1)
+    ADDQ AX, R12; SUBQ R10, R12      // + a0 - a3
+    MOVQ R12, R13; SARQ $63, R13; XORQ R13, R12; SUBQ R13, R12; ADDQ R12, 24(DI)
+    // e4 = (a0 + a4) + 6*a2 - 4*(a1 + a3)
+    MOVQ AX, R12; ADDQ R11, R12      // a0 + a4
+    MOVQ DX, CX; SHLQ $1, CX         // 2*a2     (CX free in tail; n no longer needed)
+    MOVQ DX, R13; SHLQ $2, R13       // 4*a2
+    ADDQ R13, CX                     // 6*a2
+    ADDQ CX, R12
+    MOVQ BX, CX; ADDQ R10, CX        // a1 + a3
+    SHLQ $2, CX                      // 4*(a1+a3)
+    SUBQ CX, R12                     // e4
+    MOVQ R12, R13; SARQ $63, R13; XORQ R13, R12; SUBQ R13, R12; ADDQ R12, 32(DI)
+    ADDQ $4, SI
+    DECQ R9
+    JNZ  fas_tail
+
+fas_done:
+    VZEROUPPER
+    RET
+
+// func riceSumsHighAVX2(sums []uint64, res []int32)
+// The upper half of the FLAC 5-bit Rice sweep: sums[j] = Σ_i (zigzag(res[i]) >>
+// (15+j)) for j = 0..15 (columns k=15..30; the dispatch guarantees len(sums)==16).
+// Identical in shape to riceSumsAVX2's group B, but pre-shifted to start at k=15:
+// group 1 covers k=15..22, group 2 k=23..30, each progressively halving one
+// int64x4 accumulator per column. The (n mod 8) trailing residuals are added to
+// all 16 columns with a scalar progressive-halving tail starting at >>15. The
+// dispatch gates len(res) >= 8.
+TEXT ·riceSumsHighAVX2(SB), NOSPLIT, $0-48
+    MOVQ sums_base+0(FP), DI
+    MOVQ res_base+24(FP), R8
+    MOVQ res_len+32(FP), CX          // n
+    MOVQ CX, R9
+    SHRQ $3, R9                      // full 8-element blocks (>=1)
+
+    // ---- group 1: k = 15..22 (accumulators Y8..Y15) ----
+    VPXOR Y8, Y8, Y8
+    VPXOR Y9, Y9, Y9
+    VPXOR Y10, Y10, Y10
+    VPXOR Y11, Y11, Y11
+    VPXOR Y12, Y12, Y12
+    VPXOR Y13, Y13, Y13
+    VPXOR Y14, Y14, Y14
+    VPXOR Y15, Y15, Y15
+    MOVQ R8, SI
+    MOVQ R9, AX
+riceHi1_loop:
+    VMOVDQU (SI), Y0
+    VPSLLD  $1, Y0, Y1
+    VPSRAD  $31, Y0, Y2
+    VPXOR   Y2, Y1, Y1               // u = zigzag(r)
+    VPMOVZXDQ X1, Y2                 // ulo
+    VEXTRACTI128 $1, Y1, X3
+    VPMOVZXDQ X3, Y3                 // uhi
+    VPSRLQ $15, Y2, Y2              // start at k=15
+    VPSRLQ $15, Y3, Y3
+    VPADDQ Y2, Y8, Y8              // k=15
+    VPADDQ Y3, Y8, Y8
+    VPSRLQ $1, Y2, Y2
+    VPSRLQ $1, Y3, Y3
+    VPADDQ Y2, Y9, Y9             // k=16
+    VPADDQ Y3, Y9, Y9
+    VPSRLQ $1, Y2, Y2
+    VPSRLQ $1, Y3, Y3
+    VPADDQ Y2, Y10, Y10          // k=17
+    VPADDQ Y3, Y10, Y10
+    VPSRLQ $1, Y2, Y2
+    VPSRLQ $1, Y3, Y3
+    VPADDQ Y2, Y11, Y11          // k=18
+    VPADDQ Y3, Y11, Y11
+    VPSRLQ $1, Y2, Y2
+    VPSRLQ $1, Y3, Y3
+    VPADDQ Y2, Y12, Y12          // k=19
+    VPADDQ Y3, Y12, Y12
+    VPSRLQ $1, Y2, Y2
+    VPSRLQ $1, Y3, Y3
+    VPADDQ Y2, Y13, Y13          // k=20
+    VPADDQ Y3, Y13, Y13
+    VPSRLQ $1, Y2, Y2
+    VPSRLQ $1, Y3, Y3
+    VPADDQ Y2, Y14, Y14          // k=21
+    VPADDQ Y3, Y14, Y14
+    VPSRLQ $1, Y2, Y2
+    VPSRLQ $1, Y3, Y3
+    VPADDQ Y2, Y15, Y15          // k=22
+    VPADDQ Y3, Y15, Y15
+    ADDQ $32, SI
+    DECQ AX
+    JNZ  riceHi1_loop
+
+    VEXTRACTI128 $1, Y8, X0
+    VPADDQ X0, X8, X0
+    MOVQ X0, AX
+    VPEXTRQ $1, X0, DX
+    ADDQ DX, AX
+    MOVQ AX, 0(DI)
+    VEXTRACTI128 $1, Y9, X0
+    VPADDQ X0, X9, X0
+    MOVQ X0, AX
+    VPEXTRQ $1, X0, DX
+    ADDQ DX, AX
+    MOVQ AX, 8(DI)
+    VEXTRACTI128 $1, Y10, X0
+    VPADDQ X0, X10, X0
+    MOVQ X0, AX
+    VPEXTRQ $1, X0, DX
+    ADDQ DX, AX
+    MOVQ AX, 16(DI)
+    VEXTRACTI128 $1, Y11, X0
+    VPADDQ X0, X11, X0
+    MOVQ X0, AX
+    VPEXTRQ $1, X0, DX
+    ADDQ DX, AX
+    MOVQ AX, 24(DI)
+    VEXTRACTI128 $1, Y12, X0
+    VPADDQ X0, X12, X0
+    MOVQ X0, AX
+    VPEXTRQ $1, X0, DX
+    ADDQ DX, AX
+    MOVQ AX, 32(DI)
+    VEXTRACTI128 $1, Y13, X0
+    VPADDQ X0, X13, X0
+    MOVQ X0, AX
+    VPEXTRQ $1, X0, DX
+    ADDQ DX, AX
+    MOVQ AX, 40(DI)
+    VEXTRACTI128 $1, Y14, X0
+    VPADDQ X0, X14, X0
+    MOVQ X0, AX
+    VPEXTRQ $1, X0, DX
+    ADDQ DX, AX
+    MOVQ AX, 48(DI)
+    VEXTRACTI128 $1, Y15, X0
+    VPADDQ X0, X15, X0
+    MOVQ X0, AX
+    VPEXTRQ $1, X0, DX
+    ADDQ DX, AX
+    MOVQ AX, 56(DI)
+
+    // ---- group 2: k = 23..30 (accumulators Y8..Y15) ----
+    VPXOR Y8, Y8, Y8
+    VPXOR Y9, Y9, Y9
+    VPXOR Y10, Y10, Y10
+    VPXOR Y11, Y11, Y11
+    VPXOR Y12, Y12, Y12
+    VPXOR Y13, Y13, Y13
+    VPXOR Y14, Y14, Y14
+    VPXOR Y15, Y15, Y15
+    MOVQ R8, SI
+    MOVQ R9, AX
+riceHi2_loop:
+    VMOVDQU (SI), Y0
+    VPSLLD  $1, Y0, Y1
+    VPSRAD  $31, Y0, Y2
+    VPXOR   Y2, Y1, Y1
+    VPMOVZXDQ X1, Y2
+    VEXTRACTI128 $1, Y1, X3
+    VPMOVZXDQ X3, Y3
+    VPSRLQ $23, Y2, Y2             // start at k=23
+    VPSRLQ $23, Y3, Y3
+    VPADDQ Y2, Y8, Y8             // k=23
+    VPADDQ Y3, Y8, Y8
+    VPSRLQ $1, Y2, Y2
+    VPSRLQ $1, Y3, Y3
+    VPADDQ Y2, Y9, Y9            // k=24
+    VPADDQ Y3, Y9, Y9
+    VPSRLQ $1, Y2, Y2
+    VPSRLQ $1, Y3, Y3
+    VPADDQ Y2, Y10, Y10         // k=25
+    VPADDQ Y3, Y10, Y10
+    VPSRLQ $1, Y2, Y2
+    VPSRLQ $1, Y3, Y3
+    VPADDQ Y2, Y11, Y11         // k=26
+    VPADDQ Y3, Y11, Y11
+    VPSRLQ $1, Y2, Y2
+    VPSRLQ $1, Y3, Y3
+    VPADDQ Y2, Y12, Y12         // k=27
+    VPADDQ Y3, Y12, Y12
+    VPSRLQ $1, Y2, Y2
+    VPSRLQ $1, Y3, Y3
+    VPADDQ Y2, Y13, Y13         // k=28
+    VPADDQ Y3, Y13, Y13
+    VPSRLQ $1, Y2, Y2
+    VPSRLQ $1, Y3, Y3
+    VPADDQ Y2, Y14, Y14         // k=29
+    VPADDQ Y3, Y14, Y14
+    VPSRLQ $1, Y2, Y2
+    VPSRLQ $1, Y3, Y3
+    VPADDQ Y2, Y15, Y15         // k=30
+    VPADDQ Y3, Y15, Y15
+    ADDQ $32, SI
+    DECQ AX
+    JNZ  riceHi2_loop
+
+    VEXTRACTI128 $1, Y8, X0
+    VPADDQ X0, X8, X0
+    MOVQ X0, AX
+    VPEXTRQ $1, X0, DX
+    ADDQ DX, AX
+    MOVQ AX, 64(DI)
+    VEXTRACTI128 $1, Y9, X0
+    VPADDQ X0, X9, X0
+    MOVQ X0, AX
+    VPEXTRQ $1, X0, DX
+    ADDQ DX, AX
+    MOVQ AX, 72(DI)
+    VEXTRACTI128 $1, Y10, X0
+    VPADDQ X0, X10, X0
+    MOVQ X0, AX
+    VPEXTRQ $1, X0, DX
+    ADDQ DX, AX
+    MOVQ AX, 80(DI)
+    VEXTRACTI128 $1, Y11, X0
+    VPADDQ X0, X11, X0
+    MOVQ X0, AX
+    VPEXTRQ $1, X0, DX
+    ADDQ DX, AX
+    MOVQ AX, 88(DI)
+    VEXTRACTI128 $1, Y12, X0
+    VPADDQ X0, X12, X0
+    MOVQ X0, AX
+    VPEXTRQ $1, X0, DX
+    ADDQ DX, AX
+    MOVQ AX, 96(DI)
+    VEXTRACTI128 $1, Y13, X0
+    VPADDQ X0, X13, X0
+    MOVQ X0, AX
+    VPEXTRQ $1, X0, DX
+    ADDQ DX, AX
+    MOVQ AX, 104(DI)
+    VEXTRACTI128 $1, Y14, X0
+    VPADDQ X0, X14, X0
+    MOVQ X0, AX
+    VPEXTRQ $1, X0, DX
+    ADDQ DX, AX
+    MOVQ AX, 112(DI)
+    VEXTRACTI128 $1, Y15, X0
+    VPADDQ X0, X15, X0
+    MOVQ X0, AX
+    VPEXTRQ $1, X0, DX
+    ADDQ DX, AX
+    MOVQ AX, 120(DI)
+
+    // ---- scalar tail: (n mod 8) residuals, add to all 16 columns ----
+    MOVQ CX, AX
+    ANDQ $7, AX
+    JZ   riceHi_done
+    MOVQ R9, DX
+    SHLQ $5, DX
+    ADDQ R8, DX                      // tail ptr = &res[fullBlocks*8]
+riceHi_tail:
+    MOVL (DX), BX
+    MOVL BX, R10
+    SHLL $1, BX
+    SARL $31, R10
+    XORL R10, BX                     // BX = zigzag(r), RBX zero-extended
+    MOVQ BX, R10
+    SHRQ $15, R10                    // u >> 15 (k=15)
+    ADDQ R10, 0(DI)
+    SHRQ $1, R10
+    ADDQ R10, 8(DI)
+    SHRQ $1, R10
+    ADDQ R10, 16(DI)
+    SHRQ $1, R10
+    ADDQ R10, 24(DI)
+    SHRQ $1, R10
+    ADDQ R10, 32(DI)
+    SHRQ $1, R10
+    ADDQ R10, 40(DI)
+    SHRQ $1, R10
+    ADDQ R10, 48(DI)
+    SHRQ $1, R10
+    ADDQ R10, 56(DI)
+    SHRQ $1, R10
+    ADDQ R10, 64(DI)
+    SHRQ $1, R10
+    ADDQ R10, 72(DI)
+    SHRQ $1, R10
+    ADDQ R10, 80(DI)
+    SHRQ $1, R10
+    ADDQ R10, 88(DI)
+    SHRQ $1, R10
+    ADDQ R10, 96(DI)
+    SHRQ $1, R10
+    ADDQ R10, 104(DI)
+    SHRQ $1, R10
+    ADDQ R10, 112(DI)
+    SHRQ $1, R10
+    ADDQ R10, 120(DI)
+    ADDQ $4, DX
+    DECQ AX
+    JNZ  riceHi_tail
+
+riceHi_done:
+    VZEROUPPER
+    RET

--- a/i32/i32_amd64_test.go
+++ b/i32/i32_amd64_test.go
@@ -273,6 +273,8 @@ func TestAVX2Kernels_AllocFree(t *testing.T) {
 	b := make([]int32, n)
 	dst := make([]int32, n)
 	dst2 := make([]int32, n)
+	var fasSums [5]uint64
+	riceHi := make([]uint64, riceMaxParam5+1-riceParamCount)
 	checks := []struct {
 		name string
 		fn   func()
@@ -286,6 +288,9 @@ func TestAVX2Kernels_AllocFree(t *testing.T) {
 		{"diff3AVX2", func() { diff3AVX2(dst, a) }},
 		{"diff4AVX2", func() { diff4AVX2(dst, a) }},
 		{"cumsumAVX2", func() { cumsumAVX2(dst) }},
+		{"zigzagSumAVX2", func() { _ = zigzagSumAVX2(a) }},
+		{"fixedAbsSumsAVX2", func() { fixedAbsSumsAVX2(a, &fasSums) }},
+		{"riceSumsHighAVX2", func() { riceSumsHighAVX2(riceHi, a) }},
 		{"lpcResidualEncodeAVX2", func() { lpcResidualEncodeAVX2(dst, a, lpcAllocCoeffs, 12) }},
 		{"lpcRestoreAVX2", func() { lpcRestoreAVX2(dst, a, lpcAllocCoeffs, 12) }},
 	}
@@ -468,6 +473,90 @@ func TestRiceSumsAVX2_NoOverwrite(t *testing.T) {
 	for i := riceParamCount; i < len(sums); i++ {
 		if sums[i] != math.MaxUint64 {
 			t.Errorf("riceSumsAVX2 wrote past end at sums[%d] = %d", i, sums[i])
+		}
+	}
+}
+
+func TestZigzagSumAVX2_ParityWithGo(t *testing.T) {
+	if !cpu.X86.AVX2 {
+		t.Skip("AVX2 not available")
+	}
+	for _, n := range paritySizes {
+		if n < minAVXElements {
+			continue // dispatch routes these to Go; the kernel is not called
+		}
+		res := make([]int32, n)
+		fillRiceRes(res)
+		got := zigzagSumAVX2(res)
+		want := zigzagSumGo(res)
+		if got != want {
+			t.Fatalf("n=%d: zigzagSumAVX2 = %d, want %d (Go)", n, got, want)
+		}
+	}
+}
+
+func TestFixedAbsSumsAVX2_ParityWithGo(t *testing.T) {
+	if !cpu.X86.AVX2 {
+		t.Skip("AVX2 not available")
+	}
+	for _, n := range paritySizes {
+		if n < minAVXElements {
+			continue // dispatch routes these to Go; the kernel is not called
+		}
+		src := make([]int32, n)
+		fillDiffSrc(src) // sign-exercising values incl. MinInt32/MaxInt32 extremes
+		var gotAVX, gotGo [5]uint64
+		fixedAbsSumsAVX2(src, &gotAVX)
+		fixedAbsSumsGo(src, &gotGo)
+		if gotAVX != gotGo {
+			t.Fatalf("n=%d: fixedAbsSumsAVX2 = %v, want %v (Go)", n, gotAVX, gotGo)
+		}
+	}
+}
+
+// TestRiceSumsHighAVX2_ParityWithGo checks the upper-half kernel (columns
+// 15..30) against the pure-Go reference's matching columns.
+func TestRiceSumsHighAVX2_ParityWithGo(t *testing.T) {
+	if !cpu.X86.AVX2 {
+		t.Skip("AVX2 not available")
+	}
+	const lo = riceParamCount         // 15
+	const hi = riceMaxParam5 + 1 - lo // 16 columns: k=15..30
+	for _, n := range paritySizes {
+		if n < minAVXElements {
+			continue // dispatch routes these to Go; the kernel is not called
+		}
+		res := make([]int32, n)
+		fillRiceRes(res)
+		gotHigh := make([]uint64, hi)
+		riceSumsHighAVX2(gotHigh, res)
+		full := make([]uint64, riceMaxParam5+1)
+		riceSumsGo(full, res)
+		for j := range gotHigh {
+			if gotHigh[j] != full[lo+j] {
+				t.Fatalf("n=%d: riceSumsHighAVX2[%d] (k=%d) = %d, want %d (Go)", n, j, lo+j, gotHigh[j], full[lo+j])
+			}
+		}
+	}
+}
+
+// TestRiceSumsHighAVX2_NoOverwrite guards the fixed 16-wide write.
+func TestRiceSumsHighAVX2_NoOverwrite(t *testing.T) {
+	if !cpu.X86.AVX2 {
+		t.Skip("AVX2 not available")
+	}
+	const hi = riceMaxParam5 + 1 - riceParamCount // 16
+	const n = 100
+	res := make([]int32, n)
+	fillRiceRes(res)
+	sums := make([]uint64, hi+4)
+	for i := range sums {
+		sums[i] = math.MaxUint64 // sentinel
+	}
+	riceSumsHighAVX2(sums[:hi], res)
+	for i := hi; i < len(sums); i++ {
+		if sums[i] != math.MaxUint64 {
+			t.Errorf("riceSumsHighAVX2 wrote past end at sums[%d] = %d", i, sums[i])
 		}
 	}
 }

--- a/i32/i32_arm64.go
+++ b/i32/i32_arm64.go
@@ -214,7 +214,10 @@ func riceSumsNEON(sums []uint64, res []int32)
 // 0..14 and a high kernel for columns 15..30, so the whole range is vectorized
 // instead of falling to the scalar tail; both gate on NEON and one full block.
 func riceSumsWideI32(sums []uint64, res []int32) {
-	if hasNEON && len(res) >= minNEONElements {
+	// The exact-width gate mirrors riceSumsI32: riceSumsHighNEON is a fixed
+	// 16-column writer, so only dispatch it when sums is the full 31-wide slice;
+	// any other length goes to the pure-Go reference (which handles all widths).
+	if hasNEON && len(sums) == riceMaxParam5+1 && len(res) >= minNEONElements {
 		riceSumsNEON(sums[:riceParamCount], res)     // columns 0..14
 		riceSumsHighNEON(sums[riceParamCount:], res) // columns 15..30
 		return

--- a/i32/i32_arm64.go
+++ b/i32/i32_arm64.go
@@ -177,5 +177,50 @@ func riceSumsI32(sums []uint64, res []int32) {
 	riceSumsGo(sums, res)
 }
 
+// zigzagSumI32 dispatches the residual zigzag-fold sum (RiceSums' k=0 column).
+// The NEON kernel widens to int64 lanes; it gates on NEON and at least one full
+// 4-element block, falling back to the pure-Go reference otherwise.
+func zigzagSumI32(res []int32) uint64 {
+	if hasNEON && len(res) >= minNEONElements {
+		return zigzagSumNEON(res)
+	}
+	return zigzagSumGo(res)
+}
+
+//go:noescape
+func zigzagSumNEON(res []int32) uint64
+
+// fixedAbsSumsI32 dispatches the five fixed-predictor residual abs-sums. The
+// NEON kernel computes the order-0..4 finite differences in int64 lanes via a
+// windowed sign-extending cascade; it handles the first 4 warm-up samples and
+// the tail scalar, so it only needs the warm-up samples to exist. Shorter inputs
+// use the pure-Go reference.
+func fixedAbsSumsI32(src []int32, sums *[5]uint64) {
+	if hasNEON && len(src) >= minNEONElements {
+		fixedAbsSumsNEON(src, sums)
+		return
+	}
+	fixedAbsSumsGo(src, sums)
+}
+
+//go:noescape
+func fixedAbsSumsNEON(src []int32, sums *[5]uint64)
+
 //go:noescape
 func riceSumsNEON(sums []uint64, res []int32)
+
+// riceSumsWideI32 dispatches the FLAC 5-bit Rice sums (len(sums) ==
+// riceMaxParam5+1 = 31). The NEON path reuses the 15-wide kernel for columns
+// 0..14 and a high kernel for columns 15..30, so the whole range is vectorized
+// instead of falling to the scalar tail; both gate on NEON and one full block.
+func riceSumsWideI32(sums []uint64, res []int32) {
+	if hasNEON && len(res) >= minNEONElements {
+		riceSumsNEON(sums[:riceParamCount], res)     // columns 0..14
+		riceSumsHighNEON(sums[riceParamCount:], res) // columns 15..30
+		return
+	}
+	riceSumsGo(sums, res)
+}
+
+//go:noescape
+func riceSumsHighNEON(sums []uint64, res []int32)

--- a/i32/i32_arm64.s
+++ b/i32/i32_arm64.s
@@ -919,3 +919,411 @@ rice_neon_tail_k:
 
 rice_neon_done:
     RET
+
+// func zigzagSumNEON(res []int32) uint64
+// Returns Σ_i zigzag(res[i]) where zigzag(r) = (r<<1) ^ (r>>31), the k=0 column
+// of riceSumsNEON exposed on its own. VSHL gives r<<1 and the arithmetic r>>31
+// is built without a signed-shift mnemonic as -(r>>>31), the logical sign bit
+// negated (VUSHR then VSUB from zero). The fold is zero-extended to int64
+// (VUSHLL / VUSHLL2 on the low and high S-lane pairs) and added into two
+// int64x2 accumulators (the low and high lanes form independent chains for ILP).
+// After the loop the accumulators are combined and the two lanes folded (VADDP)
+// to a scalar; the (n mod 4) trailing residuals are folded in with a scalar
+// tail. The dispatch gates len(res) >= 4.
+TEXT ·zigzagSumNEON(SB), NOSPLIT, $0-32
+    MOVD res_base+0(FP), R2
+    MOVD res_len+8(FP), R3
+    LSR  $2, R3, R4                  // R4 = full 4-element blocks (>=1)
+    VEOR V7.B16, V7.B16, V7.B16      // V7 = 0 (zero source for the sign negate)
+    VEOR V8.B16, V8.B16, V8.B16      // acc for lanes 0,1
+    VEOR V9.B16, V9.B16, V9.B16      // acc for lanes 2,3
+zzsum_neon_loop:
+    VLD1.P 16(R2), [V0.S4]           // v = res[i..i+3]
+    VSHL   $1, V0.S4, V1.S4          // r<<1
+    VUSHR  $31, V0.S4, V4.S4         // (uint32)r >> 31  (sign bit, 0 or 1)
+    VSUB   V4.S4, V7.S4, V4.S4       // mask = 0 - signbit = (r>>31 arithmetic)
+    VEOR   V4.B16, V1.B16, V1.B16    // u = zigzag(r)
+    VUSHLL  $0, V1.S2, V2.D2         // zero-extend lanes 0,1 -> int64x2
+    VUSHLL2 $0, V1.S4, V3.D2         // zero-extend lanes 2,3 -> int64x2
+    VADD V2.D2, V8.D2, V8.D2
+    VADD V3.D2, V9.D2, V9.D2
+    SUB  $1, R4
+    CBNZ R4, zzsum_neon_loop
+
+    VADD  V9.D2, V8.D2, V8.D2        // combine the two accumulators
+    VADDP V8.D2, V8.D2, V1.D2        // fold the two lanes -> lane 0
+    FMOVD F1, R5                     // R5 = sum over all full blocks
+
+    // scalar tail: (n mod 4) residuals
+    AND  $3, R3, R4
+    CBZ  R4, zzsum_neon_done
+zzsum_neon_tail:
+    MOVW (R2), R6                    // sign-extend r
+    ADDW R6, R6, R7                  // r<<1
+    ASRW $31, R6, R8                 // r>>31 (arithmetic)
+    EORW R8, R7, R7                  // u = zigzag(r) (zero-extended)
+    ADD  R7, R5, R5                  // sum += u
+    ADD  $4, R2
+    SUB  $1, R4
+    CBNZ R4, zzsum_neon_tail
+
+zzsum_neon_done:
+    MOVD R5, ret+24(FP)
+    RET
+
+// func fixedAbsSumsNEON(src []int32, sums *[5]uint64)
+// Five fixed-predictor residual abs-sums in one pass:
+//
+//	sums[order] = Σ_{i>=order} |e_order[i]|   for order in 0..4
+//
+// where e_order is the order-th forward finite difference of src, computed in
+// int64 (a 4th difference of int32 samples reaches ~2^35, beyond int32). The
+// first 4 warm-up samples (where the higher orders are not yet active) are done
+// with a scalar p-recurrence prologue matching the reference's masking. From
+// index 4 the differences are well-defined for every order, so the vector body
+// reads five overlapping windows (FMOVD loads two int32 then SXTL sign-extends to
+// int64x2) and forms e0..e4 with a triangular subtract cascade; int64 abs is the
+// single ABS .2D op. SXTL and ABS .2D have no Go assembler mnemonic, so they are
+// hand-encoded WORD directives (comment cross-checked against arm64asm). The two
+// lanes of each of the five accumulators are folded (VADDP) and added into sums;
+// the (n-4) mod 2 trailing sample uses a scalar windowed cascade. The dispatch
+// gates len(src) >= 4 so the prologue's 4 samples always exist.
+TEXT ·fixedAbsSumsNEON(SB), NOSPLIT, $0-32
+    MOVD src_base+0(FP), R2
+    MOVD src_len+8(FP), R1           // n
+    MOVD sums+24(FP), R0
+
+    // zero the five sums (prologue/body/tail accumulate into memory via RMW)
+    MOVD ZR, 0(R0)
+    MOVD ZR, 8(R0)
+    MOVD ZR, 16(R0)
+    MOVD ZR, 24(R0)
+    MOVD ZR, 32(R0)
+
+    // ---- prologue: i = 0,1,2,3 (scalar p-recurrence; n>=4 so they exist) ----
+    // p1,p2,p3 = R5,R6,R7. abs-and-add uses R12 (value), R13 (mask), R14 (mem).
+
+    // i=0: e0=src[0]; p1=e0; s0+=|e0|
+    MOVW 0(R2), R8
+    MOVD R8, R5                      // p1 = e0
+    MOVD R8, R12
+    ASR $63, R12, R13; EOR R13, R12, R12; SUB R13, R12, R12
+    MOVD 0(R0), R14; ADD R12, R14, R14; MOVD R14, 0(R0)
+
+    // i=1: e0=src[1]; e1=e0-p1; p1=e0; p2=e1; s0,s1
+    MOVW 4(R2), R8
+    SUB R5, R8, R9                   // e1
+    MOVD R8, R5                      // p1 = e0
+    MOVD R9, R6                      // p2 = e1
+    MOVD R8, R12; ASR $63, R12, R13; EOR R13, R12, R12; SUB R13, R12, R12
+    MOVD 0(R0), R14; ADD R12, R14, R14; MOVD R14, 0(R0)
+    MOVD R9, R12; ASR $63, R12, R13; EOR R13, R12, R12; SUB R13, R12, R12
+    MOVD 8(R0), R14; ADD R12, R14, R14; MOVD R14, 8(R0)
+
+    // i=2: e0=src[2]; e1=e0-p1; e2=e1-p2; p1,p2,p3; s0,s1,s2
+    MOVW 8(R2), R8
+    SUB R5, R8, R9                   // e1
+    SUB R6, R9, R10                  // e2
+    MOVD R10, R7                     // p3 = e2
+    MOVD R9, R6                      // p2 = e1
+    MOVD R8, R5                      // p1 = e0
+    MOVD R8, R12; ASR $63, R12, R13; EOR R13, R12, R12; SUB R13, R12, R12
+    MOVD 0(R0), R14; ADD R12, R14, R14; MOVD R14, 0(R0)
+    MOVD R9, R12; ASR $63, R12, R13; EOR R13, R12, R12; SUB R13, R12, R12
+    MOVD 8(R0), R14; ADD R12, R14, R14; MOVD R14, 8(R0)
+    MOVD R10, R12; ASR $63, R12, R13; EOR R13, R12, R12; SUB R13, R12, R12
+    MOVD 16(R0), R14; ADD R12, R14, R14; MOVD R14, 16(R0)
+
+    // i=3: e0=src[3]; e1; e2; e3; s0,s1,s2,s3 (p's discarded after)
+    MOVW 12(R2), R8
+    SUB R5, R8, R9                   // e1
+    SUB R6, R9, R10                  // e2
+    SUB R7, R10, R11                 // e3
+    MOVD R8, R12; ASR $63, R12, R13; EOR R13, R12, R12; SUB R13, R12, R12
+    MOVD 0(R0), R14; ADD R12, R14, R14; MOVD R14, 0(R0)
+    MOVD R9, R12; ASR $63, R12, R13; EOR R13, R12, R12; SUB R13, R12, R12
+    MOVD 8(R0), R14; ADD R12, R14, R14; MOVD R14, 8(R0)
+    MOVD R10, R12; ASR $63, R12, R13; EOR R13, R12, R12; SUB R13, R12, R12
+    MOVD 16(R0), R14; ADD R12, R14, R14; MOVD R14, 16(R0)
+    MOVD R11, R12; ASR $63, R12, R13; EOR R13, R12, R12; SUB R13, R12, R12
+    MOVD 24(R0), R14; ADD R12, R14, R14; MOVD R14, 24(R0)
+
+    // ---- vector body: nBlocks = (n-4)/2 blocks of 2 lanes from i=4 ----
+    ADD $16, R2, R2                  // window base = &src[4]
+    SUB $4, R1, R1                   // n-4
+    LSR $1, R1, R3                   // nBlocks
+    AND $1, R1, R4                   // tailCount = (n-4) mod 2
+    VEOR V8.B16, V8.B16, V8.B16      // s0
+    VEOR V9.B16, V9.B16, V9.B16      // s1
+    VEOR V10.B16, V10.B16, V10.B16   // s2
+    VEOR V11.B16, V11.B16, V11.B16   // s3
+    VEOR V12.B16, V12.B16, V12.B16   // s4
+    CBZ  R3, fas_neon_reduce
+fas_neon_body:
+    FMOVD   0(R2), F0; WORD $0x0F20A400 // sxtl v0.2d, v0.2s   (a0 = src[i..i+1])
+    FMOVD  -4(R2), F1; WORD $0x0F20A421 // sxtl v1.2d, v1.2s   (a1)
+    FMOVD  -8(R2), F2; WORD $0x0F20A442 // sxtl v2.2d, v2.2s   (a2)
+    FMOVD -12(R2), F3; WORD $0x0F20A463 // sxtl v3.2d, v3.2s   (a3)
+    FMOVD -16(R2), F4; WORD $0x0F20A484 // sxtl v4.2d, v4.2s   (a4)
+    // order 0: e0 = a0
+    WORD $0x4EE0B807                     // abs v7.2d, v0.2d
+    VADD V7.D2, V8.D2, V8.D2
+    // level 1: b0=a0-a1, b1=a1-a2, b2=a2-a3, b3=a3-a4  (b0=e1)
+    VSUB V1.D2, V0.D2, V5.D2             // b0
+    VSUB V2.D2, V1.D2, V6.D2             // b1
+    VSUB V3.D2, V2.D2, V0.D2             // b2 (a0 dead)
+    VSUB V4.D2, V3.D2, V1.D2             // b3 (a1 dead)
+    WORD $0x4EE0B8A7                     // abs v7.2d, v5.2d   (|e1|)
+    VADD V7.D2, V9.D2, V9.D2
+    // level 2: c0=b0-b1, c1=b1-b2, c2=b2-b3  (c0=e2)
+    VSUB V6.D2, V5.D2, V2.D2             // c0 (a2 dead)
+    VSUB V0.D2, V6.D2, V3.D2             // c1 (a3 dead; V0=b2)
+    VSUB V1.D2, V0.D2, V4.D2             // c2 (a4 dead; V1=b3, V0=b2)
+    WORD $0x4EE0B847                     // abs v7.2d, v2.2d   (|e2|)
+    VADD V7.D2, V10.D2, V10.D2
+    // level 3: d0=c0-c1, d1=c1-c2  (d0=e3)
+    VSUB V3.D2, V2.D2, V5.D2             // d0 (V2=c0, V3=c1)
+    VSUB V4.D2, V3.D2, V6.D2             // d1 (V3=c1, V4=c2)
+    WORD $0x4EE0B8A7                     // abs v7.2d, v5.2d   (|e3|)
+    VADD V7.D2, V11.D2, V11.D2
+    // level 4: e4 = d0 - d1
+    VSUB V6.D2, V5.D2, V0.D2             // e4 (V5=d0, V6=d1)
+    WORD $0x4EE0B807                     // abs v7.2d, v0.2d   (|e4|)
+    VADD V7.D2, V12.D2, V12.D2
+    ADD  $8, R2
+    SUB  $1, R3
+    CBNZ R3, fas_neon_body
+
+fas_neon_reduce:
+    // fold each accumulator's two lanes and add into sums[order]
+    VADDP V8.D2, V8.D2, V0.D2
+    FMOVD F0, R12; MOVD 0(R0), R14; ADD R12, R14, R14; MOVD R14, 0(R0)
+    VADDP V9.D2, V9.D2, V0.D2
+    FMOVD F0, R12; MOVD 8(R0), R14; ADD R12, R14, R14; MOVD R14, 8(R0)
+    VADDP V10.D2, V10.D2, V0.D2
+    FMOVD F0, R12; MOVD 16(R0), R14; ADD R12, R14, R14; MOVD R14, 16(R0)
+    VADDP V11.D2, V11.D2, V0.D2
+    FMOVD F0, R12; MOVD 24(R0), R14; ADD R12, R14, R14; MOVD R14, 24(R0)
+    VADDP V12.D2, V12.D2, V0.D2
+    FMOVD F0, R12; MOVD 32(R0), R14; ADD R12, R14, R14; MOVD R14, 32(R0)
+
+    // ---- scalar tail: (n-4) mod 2 sample from i=bodyEnd, all orders active ----
+    CBZ  R4, fas_neon_done           // R2 = &src[bodyEnd]
+fas_neon_tail:
+    MOVW   0(R2), R5                 // a0
+    MOVW  -4(R2), R6                 // a1
+    MOVW  -8(R2), R7                 // a2
+    MOVW -12(R2), R8                 // a3
+    MOVW -16(R2), R9                 // a4
+    // e0 = a0
+    MOVD R5, R10; ASR $63, R10, R11; EOR R11, R10, R10; SUB R11, R10, R10
+    MOVD 0(R0), R14; ADD R10, R14, R14; MOVD R14, 0(R0)
+    // e1 = a0 - a1
+    SUB R6, R5, R10
+    ASR $63, R10, R11; EOR R11, R10, R10; SUB R11, R10, R10
+    MOVD 8(R0), R14; ADD R10, R14, R14; MOVD R14, 8(R0)
+    // e2 = a0 - 2a1 + a2
+    ADD R7, R5, R10; SUB R6, R10, R10; SUB R6, R10, R10
+    ASR $63, R10, R11; EOR R11, R10, R10; SUB R11, R10, R10
+    MOVD 16(R0), R14; ADD R10, R14, R14; MOVD R14, 16(R0)
+    // e3 = (a0 - a3) + 3*(a2 - a1)
+    SUB R6, R7, R10                  // a2 - a1
+    LSL $1, R10, R12; ADD R10, R12, R10  // 3*(a2-a1)
+    ADD R5, R10, R10; SUB R8, R10, R10   // + a0 - a3
+    ASR $63, R10, R11; EOR R11, R10, R10; SUB R11, R10, R10
+    MOVD 24(R0), R14; ADD R10, R14, R14; MOVD R14, 24(R0)
+    // e4 = (a0 + a4) + 6*a2 - 4*(a1 + a3)
+    ADD R9, R5, R10                  // a0 + a4
+    LSL $1, R7, R12; ADD R12, R10, R10   // + 2*a2
+    LSL $2, R7, R12; ADD R12, R10, R10   // + 4*a2
+    ADD R8, R6, R12; LSL $2, R12, R12; SUB R12, R10, R10  // - 4*(a1+a3)
+    ASR $63, R10, R11; EOR R11, R10, R10; SUB R11, R10, R10
+    MOVD 32(R0), R14; ADD R10, R14, R14; MOVD R14, 32(R0)
+    ADD  $4, R2
+    SUB  $1, R4
+    CBNZ R4, fas_neon_tail
+
+fas_neon_done:
+    RET
+
+// func riceSumsHighNEON(sums []uint64, res []int32)
+// The upper half of the FLAC 5-bit Rice sweep: sums[j] = Σ_i (zigzag(res[i]) >>
+// (15+j)) for j = 0..15 (columns k=15..30; the dispatch guarantees len(sums)==16).
+// Identical in shape to riceSumsNEON, but the widened symbols are pre-shifted by
+// 15 so the 16 progressively halved int64x2 accumulators (V8..V23, which fit in
+// one sweep) hold k=15..30. The (n mod 4) trailing residuals are added to all 16
+// columns with a scalar progressive-halving tail starting at >>15. The dispatch
+// gates len(res) >= 4.
+TEXT ·riceSumsHighNEON(SB), NOSPLIT, $0-48
+    MOVD sums_base+0(FP), R0
+    MOVD res_base+24(FP), R2
+    MOVD res_len+32(FP), R3
+    LSR  $2, R3, R4                  // R4 = full 4-element blocks (>=1)
+    VEOR V7.B16, V7.B16, V7.B16      // V7 = 0 (sign negate source)
+    VEOR V8.B16, V8.B16, V8.B16
+    VEOR V9.B16, V9.B16, V9.B16
+    VEOR V10.B16, V10.B16, V10.B16
+    VEOR V11.B16, V11.B16, V11.B16
+    VEOR V12.B16, V12.B16, V12.B16
+    VEOR V13.B16, V13.B16, V13.B16
+    VEOR V14.B16, V14.B16, V14.B16
+    VEOR V15.B16, V15.B16, V15.B16
+    VEOR V16.B16, V16.B16, V16.B16
+    VEOR V17.B16, V17.B16, V17.B16
+    VEOR V18.B16, V18.B16, V18.B16
+    VEOR V19.B16, V19.B16, V19.B16
+    VEOR V20.B16, V20.B16, V20.B16
+    VEOR V21.B16, V21.B16, V21.B16
+    VEOR V22.B16, V22.B16, V22.B16
+    VEOR V23.B16, V23.B16, V23.B16
+
+rice_neon_hi_loop:
+    VLD1.P 16(R2), [V0.S4]
+    VSHL   $1, V0.S4, V1.S4
+    VUSHR  $31, V0.S4, V4.S4
+    VSUB   V4.S4, V7.S4, V4.S4
+    VEOR   V4.B16, V1.B16, V1.B16    // u = zigzag(r)
+    VUSHLL  $0, V1.S2, V2.D2         // ulo
+    VUSHLL2 $0, V1.S4, V3.D2         // uhi
+    VUSHR $15, V2.D2, V2.D2          // start at k=15
+    VUSHR $15, V3.D2, V3.D2
+    VADD V2.D2, V8.D2, V8.D2          // k=15
+    VADD V3.D2, V8.D2, V8.D2
+    VUSHR $1, V2.D2, V2.D2
+    VUSHR $1, V3.D2, V3.D2
+    VADD V2.D2, V9.D2, V9.D2          // k=16
+    VADD V3.D2, V9.D2, V9.D2
+    VUSHR $1, V2.D2, V2.D2
+    VUSHR $1, V3.D2, V3.D2
+    VADD V2.D2, V10.D2, V10.D2        // k=17
+    VADD V3.D2, V10.D2, V10.D2
+    VUSHR $1, V2.D2, V2.D2
+    VUSHR $1, V3.D2, V3.D2
+    VADD V2.D2, V11.D2, V11.D2        // k=18
+    VADD V3.D2, V11.D2, V11.D2
+    VUSHR $1, V2.D2, V2.D2
+    VUSHR $1, V3.D2, V3.D2
+    VADD V2.D2, V12.D2, V12.D2        // k=19
+    VADD V3.D2, V12.D2, V12.D2
+    VUSHR $1, V2.D2, V2.D2
+    VUSHR $1, V3.D2, V3.D2
+    VADD V2.D2, V13.D2, V13.D2        // k=20
+    VADD V3.D2, V13.D2, V13.D2
+    VUSHR $1, V2.D2, V2.D2
+    VUSHR $1, V3.D2, V3.D2
+    VADD V2.D2, V14.D2, V14.D2        // k=21
+    VADD V3.D2, V14.D2, V14.D2
+    VUSHR $1, V2.D2, V2.D2
+    VUSHR $1, V3.D2, V3.D2
+    VADD V2.D2, V15.D2, V15.D2        // k=22
+    VADD V3.D2, V15.D2, V15.D2
+    VUSHR $1, V2.D2, V2.D2
+    VUSHR $1, V3.D2, V3.D2
+    VADD V2.D2, V16.D2, V16.D2        // k=23
+    VADD V3.D2, V16.D2, V16.D2
+    VUSHR $1, V2.D2, V2.D2
+    VUSHR $1, V3.D2, V3.D2
+    VADD V2.D2, V17.D2, V17.D2        // k=24
+    VADD V3.D2, V17.D2, V17.D2
+    VUSHR $1, V2.D2, V2.D2
+    VUSHR $1, V3.D2, V3.D2
+    VADD V2.D2, V18.D2, V18.D2        // k=25
+    VADD V3.D2, V18.D2, V18.D2
+    VUSHR $1, V2.D2, V2.D2
+    VUSHR $1, V3.D2, V3.D2
+    VADD V2.D2, V19.D2, V19.D2        // k=26
+    VADD V3.D2, V19.D2, V19.D2
+    VUSHR $1, V2.D2, V2.D2
+    VUSHR $1, V3.D2, V3.D2
+    VADD V2.D2, V20.D2, V20.D2        // k=27
+    VADD V3.D2, V20.D2, V20.D2
+    VUSHR $1, V2.D2, V2.D2
+    VUSHR $1, V3.D2, V3.D2
+    VADD V2.D2, V21.D2, V21.D2        // k=28
+    VADD V3.D2, V21.D2, V21.D2
+    VUSHR $1, V2.D2, V2.D2
+    VUSHR $1, V3.D2, V3.D2
+    VADD V2.D2, V22.D2, V22.D2        // k=29
+    VADD V3.D2, V22.D2, V22.D2
+    VUSHR $1, V2.D2, V2.D2
+    VUSHR $1, V3.D2, V3.D2
+    VADD V2.D2, V23.D2, V23.D2        // k=30
+    VADD V3.D2, V23.D2, V23.D2
+    SUB  $1, R4
+    CBNZ R4, rice_neon_hi_loop
+
+    // fold each int64x2 accumulator and store sums[0..15] (k=15..30)
+    VADDP V8.D2, V8.D2, V1.D2
+    FMOVD F1, R5
+    MOVD  R5, 0(R0)
+    VADDP V9.D2, V9.D2, V1.D2
+    FMOVD F1, R5
+    MOVD  R5, 8(R0)
+    VADDP V10.D2, V10.D2, V1.D2
+    FMOVD F1, R5
+    MOVD  R5, 16(R0)
+    VADDP V11.D2, V11.D2, V1.D2
+    FMOVD F1, R5
+    MOVD  R5, 24(R0)
+    VADDP V12.D2, V12.D2, V1.D2
+    FMOVD F1, R5
+    MOVD  R5, 32(R0)
+    VADDP V13.D2, V13.D2, V1.D2
+    FMOVD F1, R5
+    MOVD  R5, 40(R0)
+    VADDP V14.D2, V14.D2, V1.D2
+    FMOVD F1, R5
+    MOVD  R5, 48(R0)
+    VADDP V15.D2, V15.D2, V1.D2
+    FMOVD F1, R5
+    MOVD  R5, 56(R0)
+    VADDP V16.D2, V16.D2, V1.D2
+    FMOVD F1, R5
+    MOVD  R5, 64(R0)
+    VADDP V17.D2, V17.D2, V1.D2
+    FMOVD F1, R5
+    MOVD  R5, 72(R0)
+    VADDP V18.D2, V18.D2, V1.D2
+    FMOVD F1, R5
+    MOVD  R5, 80(R0)
+    VADDP V19.D2, V19.D2, V1.D2
+    FMOVD F1, R5
+    MOVD  R5, 88(R0)
+    VADDP V20.D2, V20.D2, V1.D2
+    FMOVD F1, R5
+    MOVD  R5, 96(R0)
+    VADDP V21.D2, V21.D2, V1.D2
+    FMOVD F1, R5
+    MOVD  R5, 104(R0)
+    VADDP V22.D2, V22.D2, V1.D2
+    FMOVD F1, R5
+    MOVD  R5, 112(R0)
+    VADDP V23.D2, V23.D2, V1.D2
+    FMOVD F1, R5
+    MOVD  R5, 120(R0)
+
+    // scalar tail: (n mod 4) residuals, add to all 16 columns from >>15
+    AND  $3, R3, R4
+    CBZ  R4, rice_neon_hi_done
+rice_neon_hi_tail_out:
+    MOVW (R2), R5
+    ADDW R5, R5, R6                  // r<<1
+    ASRW $31, R5, R7                 // r>>31 (arithmetic)
+    EORW R7, R6, R6                  // u = zigzag(r) (zero-extended)
+    LSR  $15, R6, R6                 // u >> 15 (k=15 start)
+    MOVD R0, R8                      // sums ptr
+    MOVD $16, R9                     // column counter
+rice_neon_hi_tail_k:
+    MOVD (R8), R7
+    ADD  R6, R7, R7
+    MOVD R7, (R8)
+    LSR  $1, R6, R6
+    ADD  $8, R8
+    SUB  $1, R9
+    CBNZ R9, rice_neon_hi_tail_k
+    ADD  $4, R2
+    SUB  $1, R4
+    CBNZ R4, rice_neon_hi_tail_out
+
+rice_neon_hi_done:
+    RET

--- a/i32/i32_arm64_test.go
+++ b/i32/i32_arm64_test.go
@@ -251,6 +251,8 @@ func TestNEONKernels_AllocFree(t *testing.T) {
 	b := make([]int32, n)
 	dst := make([]int32, n)
 	dst2 := make([]int32, n)
+	var fasSums [5]uint64
+	riceHi := make([]uint64, riceMaxParam5+1-riceParamCount)
 	checks := []struct {
 		name string
 		fn   func()
@@ -264,6 +266,9 @@ func TestNEONKernels_AllocFree(t *testing.T) {
 		{"diff3NEON", func() { diff3NEON(dst, a) }},
 		{"diff4NEON", func() { diff4NEON(dst, a) }},
 		{"cumsumNEON", func() { cumsumNEON(dst) }},
+		{"zigzagSumNEON", func() { _ = zigzagSumNEON(a) }},
+		{"fixedAbsSumsNEON", func() { fixedAbsSumsNEON(a, &fasSums) }},
+		{"riceSumsHighNEON", func() { riceSumsHighNEON(riceHi, a) }},
 		{"lpcResidualEncodeNEON", func() { lpcResidualEncodeNEON(dst, a, lpcAllocCoeffs, 12) }},
 		{"lpcRestoreNEON", func() { lpcRestoreNEON(dst, a, lpcAllocCoeffs, 12) }},
 	}
@@ -438,6 +443,90 @@ func TestRiceSumsNEON_NoOverwrite(t *testing.T) {
 	for i := riceParamCount; i < len(sums); i++ {
 		if sums[i] != math.MaxUint64 {
 			t.Errorf("riceSumsNEON wrote past end at sums[%d] = %d", i, sums[i])
+		}
+	}
+}
+
+func TestZigzagSumNEON_ParityWithGo(t *testing.T) {
+	if !cpu.ARM64.NEON {
+		t.Skip("NEON not available")
+	}
+	for _, n := range paritySizes {
+		if n < minNEONElements {
+			continue // dispatch routes these to Go; the kernel is not called
+		}
+		res := make([]int32, n)
+		fillRiceRes(res)
+		got := zigzagSumNEON(res)
+		want := zigzagSumGo(res)
+		if got != want {
+			t.Fatalf("n=%d: zigzagSumNEON = %d, want %d (Go)", n, got, want)
+		}
+	}
+}
+
+func TestFixedAbsSumsNEON_ParityWithGo(t *testing.T) {
+	if !cpu.ARM64.NEON {
+		t.Skip("NEON not available")
+	}
+	for _, n := range paritySizes {
+		if n < minNEONElements {
+			continue // dispatch routes these to Go; the kernel is not called
+		}
+		src := make([]int32, n)
+		fillDiffSrc(src) // sign-exercising values incl. MinInt32/MaxInt32 extremes
+		var gotNEON, gotGo [5]uint64
+		fixedAbsSumsNEON(src, &gotNEON)
+		fixedAbsSumsGo(src, &gotGo)
+		if gotNEON != gotGo {
+			t.Fatalf("n=%d: fixedAbsSumsNEON = %v, want %v (Go)", n, gotNEON, gotGo)
+		}
+	}
+}
+
+// TestRiceSumsHighNEON_ParityWithGo checks the upper-half kernel (columns
+// 15..30) against the pure-Go reference's matching columns.
+func TestRiceSumsHighNEON_ParityWithGo(t *testing.T) {
+	if !cpu.ARM64.NEON {
+		t.Skip("NEON not available")
+	}
+	const lo = riceParamCount         // 15
+	const hi = riceMaxParam5 + 1 - lo // 16 columns: k=15..30
+	for _, n := range paritySizes {
+		if n < minNEONElements {
+			continue // dispatch routes these to Go; the kernel is not called
+		}
+		res := make([]int32, n)
+		fillRiceRes(res)
+		gotHigh := make([]uint64, hi)
+		riceSumsHighNEON(gotHigh, res)
+		full := make([]uint64, riceMaxParam5+1)
+		riceSumsGo(full, res)
+		for j := range gotHigh {
+			if gotHigh[j] != full[lo+j] {
+				t.Fatalf("n=%d: riceSumsHighNEON[%d] (k=%d) = %d, want %d (Go)", n, j, lo+j, gotHigh[j], full[lo+j])
+			}
+		}
+	}
+}
+
+// TestRiceSumsHighNEON_NoOverwrite guards the fixed 16-wide write.
+func TestRiceSumsHighNEON_NoOverwrite(t *testing.T) {
+	if !cpu.ARM64.NEON {
+		t.Skip("NEON not available")
+	}
+	const hi = riceMaxParam5 + 1 - riceParamCount // 16
+	const n = 100
+	res := make([]int32, n)
+	fillRiceRes(res)
+	sums := make([]uint64, hi+4)
+	for i := range sums {
+		sums[i] = math.MaxUint64 // sentinel
+	}
+	riceSumsHighNEON(sums[:hi], res)
+	for i := hi; i < len(sums); i++ {
+		if sums[i] != math.MaxUint64 {
+			t.Errorf("riceSumsHighNEON wrote past end at sums[%d] = %d", i, sums[i])
 		}
 	}
 }

--- a/i32/i32_go.go
+++ b/i32/i32_go.go
@@ -141,6 +141,81 @@ func riceSumsGo(sums []uint64, res []int32) {
 	}
 }
 
+// zigzagSumGo returns Σ_i zigzag(res[i]), the FLAC residual zigzag fold summed
+// in uint64. It is exactly the k=0 column of riceSumsGo and the bit-exact source
+// of truth the SIMD kernels are validated against. The fold uses int32
+// arithmetic (matching the kernels): r<<1 wraps and r>>31 is the arithmetic
+// sign-extension, so a math.MinInt32 residual folds to 2^32-1 before the
+// unsigned widen.
+func zigzagSumGo(res []int32) uint64 {
+	var s uint64
+	for _, r := range res {
+		s += uint64(uint32((r << 1) ^ (r >> int32SignShift)))
+	}
+	return s
+}
+
+// absU64 returns the absolute value of v as a uint64. v is bounded well inside
+// the int64 range here (at most a 4th finite difference of int32 samples, ~2^35),
+// so the math.MinInt64 edge case (where -v overflows) cannot arise.
+func absU64(v int64) uint64 {
+	if v < 0 {
+		return uint64(-v)
+	}
+	return uint64(v)
+}
+
+// fixedAbsSumsGo writes the five fixed-predictor residual abs-sums into sums:
+//
+//	sums[order] = Σ_{i>=order} |e_order[i]|   for order in 0..4
+//
+// where e_order is the order-th forward finite difference of src (order 0 is src
+// itself, order 1 the first difference, and so on). The differences are computed
+// in int64 (a 4th difference of int32 samples can reach ~2^35, beyond int32), and
+// sums[order] excludes the first order warm-up samples, matching the cost FLAC
+// uses to choose a fixed predictor order. It fully overwrites sums and is the
+// bit-exact source of truth the SIMD kernels are validated against.
+//
+// The accumulators are kept in a local array and stored once at the end: writing
+// through *sums each iteration would force them to memory (the compiler cannot
+// prove sums does not alias src). This mirrors go-flac's FixedAbsSums exactly so
+// swapping it for the SIMD path leaves the encoded stream byte-identical.
+func fixedAbsSumsGo(src []int32, sums *[5]uint64) {
+	var s [5]uint64
+	var p1, p2, p3, p4 int64 // p1=prev e0, p2=prev e1, p3=prev e2, p4=prev e3
+	n := len(src)
+	// Warm-up: order o's difference e_o is first defined at sample index o, so at
+	// position i only orders 0..i are active. Handled in this short bounded loop
+	// (len(s)-1 = 4 samples at most) so the main loop below can stay branchless.
+	w := min(n, len(s)-1)
+	for i := range w {
+		e0 := int64(src[i])
+		e1 := e0 - p1
+		e2 := e1 - p2
+		e3 := e2 - p3
+		e := [4]int64{e0, e1, e2, e3}
+		for o := 0; o <= i; o++ {
+			s[o] += absU64(e[o])
+		}
+		p1, p2, p3, p4 = e0, e1, e2, e3
+	}
+	// Main region i >= len(s)-1: every order is active, so this is branchless.
+	for i := w; i < n; i++ {
+		e0 := int64(src[i])
+		e1 := e0 - p1
+		e2 := e1 - p2
+		e3 := e2 - p3
+		e4 := e3 - p4
+		s[0] += absU64(e0)
+		s[1] += absU64(e1)
+		s[2] += absU64(e2)
+		s[3] += absU64(e3)
+		s[4] += absU64(e4)
+		p1, p2, p3, p4 = e0, e1, e2, e3
+	}
+	*sums = s
+}
+
 // lpcRestoreGo is the exact inverse of lpcResidualEncodeGo: it reconstructs the
 // samples from the [order warm-up | residual] layout via the serial recurrence
 //

--- a/i32/i32_other.go
+++ b/i32/i32_other.go
@@ -27,3 +27,9 @@ func lpcRestoreI32(out, residual, coeffs []int32, shift uint) {
 }
 
 func riceSumsI32(sums []uint64, res []int32) { riceSumsGo(sums, res) }
+
+func zigzagSumI32(res []int32) uint64 { return zigzagSumGo(res) }
+
+func fixedAbsSumsI32(src []int32, sums *[5]uint64) { fixedAbsSumsGo(src, sums) }
+
+func riceSumsWideI32(sums []uint64, res []int32) { riceSumsGo(sums, res) }

--- a/i32/rice.go
+++ b/i32/rice.go
@@ -24,8 +24,9 @@ const (
 	riceParamCount = riceMaxParam + 1
 
 	// riceMaxParam5 is the largest parameter FLAC's 5-bit partition method can
-	// encode (k = 0..30; 31 is the escape). RiceBestParam clamps maxParam to it
-	// and serves parameters above riceMaxParam from the pure-Go path.
+	// encode (k = 0..30; 31 is the escape). RiceBestParam clamps maxParam to it;
+	// parameters above riceMaxParam are served by the wide SIMD path
+	// (riceSumsWideI32), falling back to pure-Go only off the SIMD architectures.
 	riceMaxParam5 = 30
 )
 
@@ -101,7 +102,9 @@ func RiceBestParam(res []int32, maxParam uint) (bestParam uint, bits uint64) {
 		// the scan below only reads sums[:maxParam+1].
 		riceSumsI32(sums[:riceParamCount], res)
 	} else {
-		riceSumsGo(sums[:maxParam+1], res)
+		// 5-bit range: the wide kernel computes the full 31-column range on the
+		// SIMD path; the scan below only reads sums[:maxParam+1].
+		riceSumsWideI32(sums[:], res)
 	}
 	return riceScan(sums[:maxParam+1], n)
 }

--- a/i32/rice.go
+++ b/i32/rice.go
@@ -41,6 +41,19 @@ const (
 // sums is fully overwritten (not accumulated into). res is read-only. The SIMD
 // fast path covers the FLAC parameter range (len(sums) <= riceParamCount = 15);
 // wider requests fall back to the pure-Go reference.
+// RiceSums fills sums[k] with the per-parameter unary-bit total
+//
+//	sums[k] = Σ_i (zigzag(res[i]) >> k)   for k in [0, len(sums))
+//
+// where zigzag(r) = (r<<1) ^ (r>>31) is the FLAC residual fold. Each sum is
+// accumulated in uint64 (it cannot overflow for any realistic block length).
+// The total Rice-coded bit cost of res with parameter k is sums[k] + n*(k+1),
+// n = len(res); see RiceBestParam.
+//
+// sums is fully overwritten (not accumulated into). res is read-only. The SIMD
+// fast path covers FLAC's full parameter range: the 4-bit method (len(sums) <=
+// riceParamCount = 15) and the 5-bit method (up to riceMaxParam5+1 = 31). Wider
+// requests fall back to the pure-Go reference.
 func RiceSums(sums []uint64, res []int32) {
 	switch m := len(sums); {
 	case m == 0:
@@ -48,15 +61,35 @@ func RiceSums(sums []uint64, res []int32) {
 	case m == riceParamCount:
 		riceSumsI32(sums, res)
 	case m < riceParamCount:
-		// The SIMD kernel writes exactly riceParamCount sums; compute the full
+		// The 15-wide kernel writes exactly riceParamCount sums; compute the full
 		// set on the stack and copy the requested prefix. The array does not
 		// escape, so this stays allocation-free.
 		var full [riceParamCount]uint64
 		riceSumsI32(full[:], res)
 		copy(sums, full[:m])
-	default: // m > riceParamCount
+	case m <= riceMaxParam5+1:
+		// FLAC 5-bit range (16..31 columns): vectorize all of it. The wide path
+		// always writes riceMaxParam5+1 sums; compute on the stack (no escape) and
+		// copy the requested prefix.
+		var full [riceMaxParam5 + 1]uint64
+		riceSumsWideI32(full[:], res)
+		copy(sums, full[:m])
+	default: // m > riceMaxParam5+1
 		riceSumsGo(sums, res)
 	}
+}
+
+// ZigzagSum returns the sum of the FLAC residual zigzag fold over res:
+//
+//	Σ_i zigzag(res[i]),   zigzag(r) = (r<<1) ^ (r>>31)
+//
+// Each residual is folded to its unsigned Rice symbol and accumulated in uint64
+// (it cannot overflow for any realistic block length). This is exactly the k=0
+// column of RiceSums, exposed separately for the estimate path that needs only
+// that total and not the full per-parameter sweep. res is read-only; an empty
+// res returns 0.
+func ZigzagSum(res []int32) uint64 {
+	return zigzagSumI32(res)
 }
 
 // RiceBestParam scans Rice parameters k in [0, maxParam] and returns the k that

--- a/i32/rice.go
+++ b/i32/rice.go
@@ -39,18 +39,6 @@ const (
 // n = len(res); see RiceBestParam.
 //
 // sums is fully overwritten (not accumulated into). res is read-only. The SIMD
-// fast path covers the FLAC parameter range (len(sums) <= riceParamCount = 15);
-// wider requests fall back to the pure-Go reference.
-// RiceSums fills sums[k] with the per-parameter unary-bit total
-//
-//	sums[k] = Σ_i (zigzag(res[i]) >> k)   for k in [0, len(sums))
-//
-// where zigzag(r) = (r<<1) ^ (r>>31) is the FLAC residual fold. Each sum is
-// accumulated in uint64 (it cannot overflow for any realistic block length).
-// The total Rice-coded bit cost of res with parameter k is sums[k] + n*(k+1),
-// n = len(res); see RiceBestParam.
-//
-// sums is fully overwritten (not accumulated into). res is read-only. The SIMD
 // fast path covers FLAC's full parameter range: the 4-bit method (len(sums) <=
 // riceParamCount = 15) and the 5-bit method (up to riceMaxParam5+1 = 31). Wider
 // requests fall back to the pure-Go reference.

--- a/i32/rice_test.go
+++ b/i32/rice_test.go
@@ -167,8 +167,15 @@ func TestRiceAllocFree(t *testing.T) {
 	if got := testing.AllocsPerRun(100, func() { RiceSums(sums, res) }); got != 0 {
 		t.Errorf("RiceSums allocated %v times per run, want 0", got)
 	}
+	wideSums := make([]uint64, riceMaxParam5+1)
+	if got := testing.AllocsPerRun(100, func() { RiceSums(wideSums, res) }); got != 0 {
+		t.Errorf("RiceSums (5-bit width) allocated %v times per run, want 0", got)
+	}
 	if got := testing.AllocsPerRun(100, func() { RiceBestParam(res, 14) }); got != 0 {
 		t.Errorf("RiceBestParam allocated %v times per run, want 0", got)
+	}
+	if got := testing.AllocsPerRun(100, func() { RiceBestParam(res, riceMaxParam5) }); got != 0 {
+		t.Errorf("RiceBestParam (5-bit range) allocated %v times per run, want 0", got)
 	}
 }
 

--- a/i32/rice_test.go
+++ b/i32/rice_test.go
@@ -171,3 +171,69 @@ func TestRiceAllocFree(t *testing.T) {
 		t.Errorf("RiceBestParam allocated %v times per run, want 0", got)
 	}
 }
+
+// TestZigzagSumMatchesOracle checks ZigzagSum against an independent sum of the
+// zigzag fold across the block-straddling sizes.
+func TestZigzagSumMatchesOracle(t *testing.T) {
+	rng := rand.New(rand.NewSource(7))
+	for _, n := range []int{0, 1, 2, 3, 7, 8, 9, 15, 16, 17, 31, 33, 100, 1000, 1024, 1025} {
+		res := make([]int32, n)
+		for i := range res {
+			res[i] = int32(rng.Uint32())
+		}
+		var want uint64
+		for _, r := range res {
+			want += zigzag(r)
+		}
+		if got := ZigzagSum(res); got != want {
+			t.Fatalf("n=%d ZigzagSum = %d, want %d", n, got, want)
+		}
+	}
+}
+
+// TestZigzagSumExtremes exercises the int32 sign bit and the zigzag overflow at
+// math.MinInt32 (zigzag = 2^32-1), the worst case for the unsigned widening.
+func TestZigzagSumExtremes(t *testing.T) {
+	res := []int32{math.MinInt32, math.MaxInt32, -1, 0, math.MinInt32, math.MaxInt32, 1, -2, 3}
+	var want uint64
+	for _, r := range res {
+		want += zigzag(r)
+	}
+	if got := ZigzagSum(res); got != want {
+		t.Errorf("ZigzagSum extremes = %d, want %d", got, want)
+	}
+}
+
+// TestZigzagSumEqualsRiceSums0 pins the invariant that ZigzagSum is exactly the
+// k=0 column of RiceSums (Σ_i zigzag(res[i]) >> 0), so the two kernels cannot
+// drift apart.
+func TestZigzagSumEqualsRiceSums0(t *testing.T) {
+	rng := rand.New(rand.NewSource(8))
+	for _, n := range []int{0, 1, 8, 9, 100, 1000, 1025} {
+		res := make([]int32, n)
+		for i := range res {
+			res[i] = int32(rng.Uint32())
+		}
+		sums := make([]uint64, riceParamCount)
+		RiceSums(sums, res)
+		if got := ZigzagSum(res); got != sums[0] {
+			t.Fatalf("n=%d ZigzagSum = %d, want RiceSums[0] = %d", n, got, sums[0])
+		}
+	}
+}
+
+func TestZigzagSumEmpty(t *testing.T) {
+	if got := ZigzagSum(nil); got != 0 {
+		t.Errorf("ZigzagSum(nil) = %d, want 0", got)
+	}
+}
+
+func TestZigzagSumAllocFree(t *testing.T) {
+	res := make([]int32, 1024)
+	for i := range res {
+		res[i] = int32(i*7 - 3)
+	}
+	if got := testing.AllocsPerRun(100, func() { ZigzagSum(res) }); got != 0 {
+		t.Errorf("ZigzagSum allocated %v times per run, want 0", got)
+	}
+}

--- a/i32/rice_test.go
+++ b/i32/rice_test.go
@@ -237,3 +237,26 @@ func TestZigzagSumAllocFree(t *testing.T) {
 		t.Errorf("ZigzagSum allocated %v times per run, want 0", got)
 	}
 }
+
+// TestRiceSumsWideDispatchGuard exercises riceSumsWideI32's exact-width gate:
+// only a full 31-wide slice may reach the fixed-width SIMD kernels (which write
+// exactly riceParamCount and 16 columns), so any other width must fall back to
+// the pure-Go reference and still be correct. A regression here would surface as
+// an out-of-bounds asm write rather than a wrong value.
+func TestRiceSumsWideDispatchGuard(t *testing.T) {
+	rng := rand.New(rand.NewSource(9))
+	res := make([]int32, 64)
+	for i := range res {
+		res[i] = int32(rng.Uint32())
+	}
+	for _, m := range []int{16, 20, riceMaxParam5 + 1} {
+		got := make([]uint64, m)
+		riceSumsWideI32(got, res)
+		want := riceSumsOracle(res, m)
+		for k := range want {
+			if got[k] != want[k] {
+				t.Fatalf("m=%d riceSumsWideI32[%d] = %d, want %d", m, k, got[k], want[k])
+			}
+		}
+	}
+}


### PR DESCRIPTION
## Summary

Three SIMD primitives for the FLAC encoder estimate path, each bit-identical to its pure-Go reference across AVX2, NEON, and the scalar fallback (verified with `GODEBUG=cpu.avx2=off` parity tests), all zero-allocation.

- **`ZigzagSum(res []int32) uint64`** - the k=0 Rice column on its own, the total zigzag fold `Sigma zigzag(res)`. ~3.7x AVX2, ~2.4x NEON.
- **`FixedAbsSums(src []int32, sums *[5]uint64)`** - the order-0..4 fixed-predictor residual abs-sums in one pass, for choosing the fixed predictor order. The differences are formed in int64 via a windowed sign-extending subtract cascade (a 4th finite difference of int32 samples exceeds the int32 range, so the kernels widen to int64). ~2.6x AVX2, ~1.7x NEON.
- **`RiceSums` widening** - the kernel now vectorizes FLAC's full 5-bit parameter range (k=0..30) instead of only the 4-bit range (k=0..14). A pre-shifted high-16 kernel covers k=15..30, so a 31-column `RiceSums` runs ~13x AVX2 / ~4x NEON where it previously fell back to the scalar reference above k=14.

## Implementation notes

- The pure-Go reference for each primitive is the source of truth; every SIMD kernel is validated for bit-exact parity against it, plus an independent oracle, across lengths 0/1/block-1/exact-multiple/large/tail-remainder and the int32 sign-bit and `MinInt32`/`MaxInt32` extremes.
- NEON `SXTL` and `ABS` (`.2D`) have no Go assembler mnemonic, so they are hand-encoded `WORD` directives. Their comments are cross-checked against `golang.org/x/arch/arm64asm` by the existing `asmcheck` test, and no goroutine-pointer register is touched.
- `FixedAbsSums`'s pure-Go fallback uses a branchless main loop (warm-up handled in a short bounded prologue), so the non-SIMD path stays fast too.

## Test Plan

- [x] `go test ./...` green on amd64 (native)
- [x] Full `i32` suite green on arm64 (Raspberry Pi 5, cross-compiled)
- [x] `GODEBUG=cpu.avx2=off` parity tests (scalar == SIMD) for all three primitives
- [x] `go vet ./...` clean on amd64 and arm64
- [x] `golangci-lint run ./...` clean (0 issues)
- [x] `TestArm64WordEncodings` verifies the new SXTL/ABS encodings
- [x] Allocation-free assertions for every new kernel and public function

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added `ZigzagSum` helper function for computing residual sums
  * Extended `RiceSums` to support full 5-bit parameter range (k=0–30)

* **Performance**
  * Optimized performance on x86-64 and ARM64 platforms

* **Documentation**
  * Updated documentation with new helper functions and extended parameter coverage

<!-- end of auto-generated comment: release notes by coderabbit.ai -->