### PR TITLE
f64: add Autocorrelate, a bit-exact lag-vectorized autocorrelation kernel

### DIFF
--- a/f64/autocorrelate_test.go
+++ b/f64/autocorrelate_test.go
@@ -1,0 +1,115 @@
+package f64
+
+import (
+	"math"
+	"math/rand"
+	"testing"
+)
+
+// autocorrNaive is an independent, maximally simple reference: the textbook
+// double loop. autocorrelateGo must equal it, and Autocorrelate (AVX2/NEON on
+// capable hosts) must equal autocorrelateGo bit-for-bit.
+func autocorrNaive(x []float64, maxLag int) []float64 {
+	out := make([]float64, maxLag+1)
+	n := len(x)
+	for lag := 0; lag <= maxLag; lag++ {
+		var s float64
+		for i := lag; i < n; i++ {
+			s += x[i] * x[i-lag]
+		}
+		out[lag] = s
+	}
+	return out
+}
+
+func randWindowed(rng *rand.Rand, n int) []float64 {
+	x := make([]float64, n)
+	for i := range x {
+		// Windowed integer PCM: a sample magnitude scaled by a [0,1] weight.
+		amp := float64(rng.Intn(1<<21) - (1 << 20))
+		x[i] = amp * rng.Float64()
+	}
+	return x
+}
+
+func bitsDiff(a, b []float64) (int, bool) {
+	if len(a) != len(b) {
+		return -1, false
+	}
+	for i := range a {
+		if math.Float64bits(a[i]) != math.Float64bits(b[i]) {
+			return i, false
+		}
+	}
+	return -1, true
+}
+
+// TestAutocorrelateBitIdentical asserts the dispatched implementation (AVX2 on
+// this host) reproduces the scalar reference bit-for-bit across block sizes and
+// lag counts, including the partial-final-group and short-block fallback paths.
+func TestAutocorrelateBitIdentical(t *testing.T) {
+	rng := rand.New(rand.NewSource(0xA17C0))
+	blockSizes := []int{1, 2, 3, 4, 5, 7, 8, 15, 16, 17, 31, 32, 33, 35, 36, 63, 64, 256, 1024, 4096}
+	maxLags := []int{0, 1, 2, 3, 4, 5, 7, 8, 11, 12, 15, 16, 31, 32}
+	cases := 0
+	for range 60 {
+		for _, n := range blockSizes {
+			x := randWindowed(rng, n)
+			for _, maxLag := range maxLags {
+				if maxLag >= n {
+					continue
+				}
+				want := autocorrNaive(x, maxLag)
+
+				gotGo := make([]float64, maxLag+1)
+				autocorrelateGo(gotGo, x, maxLag)
+				if i, ok := bitsDiff(want, gotGo); !ok {
+					t.Fatalf("autocorrelateGo != naive: n=%d maxLag=%d lag=%d", n, maxLag, i)
+				}
+
+				gotDisp := make([]float64, maxLag+1)
+				Autocorrelate(gotDisp, x, maxLag)
+				if i, ok := bitsDiff(gotGo, gotDisp); !ok {
+					t.Fatalf("Autocorrelate != reference: n=%d maxLag=%d lag=%d\n want=%v (%#x)\n got =%v (%#x)",
+						n, maxLag, i, gotGo[i], math.Float64bits(gotGo[i]),
+						gotDisp[i], math.Float64bits(gotDisp[i]))
+				}
+				cases++
+			}
+		}
+	}
+	t.Logf("bit-identical across %d (n, maxLag) cases", cases)
+}
+
+// TestAutocorrelateGuards covers the public-API precondition clamps.
+func TestAutocorrelateGuards(t *testing.T) {
+	autoc := make([]float64, 4)
+	x := []float64{1, 2, 3, 4, 5}
+
+	// Negative maxLag and empty x are no-ops.
+	Autocorrelate(autoc, x, -1)
+	Autocorrelate(autoc, nil, 3)
+
+	// maxLag clamped to len(autoc)-1; lag 0 still computed.
+	for i := range autoc {
+		autoc[i] = -123
+	}
+	Autocorrelate(autoc, x, 99)
+	want := autocorrNaive(x, len(autoc)-1)
+	if i, ok := bitsDiff(want, autoc); !ok {
+		t.Fatalf("clamped maxLag mismatch at lag %d: got %v want %v", i, autoc, want)
+	}
+}
+
+// TestAutocorrelateZeroInput keeps the all-zero block (silence) well-defined:
+// every lag is exactly 0.
+func TestAutocorrelateZeroInput(t *testing.T) {
+	x := make([]float64, 512)
+	autoc := make([]float64, 13)
+	Autocorrelate(autoc, x, 12)
+	for lag, v := range autoc {
+		if v != 0 {
+			t.Fatalf("lag %d = %v, want 0", lag, v)
+		}
+	}
+}

--- a/f64/benchmark_test.go
+++ b/f64/benchmark_test.go
@@ -558,6 +558,37 @@ func BenchmarkDotProductBatch(b *testing.B) {
 	}
 }
 
+func BenchmarkAutocorrelate(b *testing.B) {
+	// FLAC LPC analysis: a windowed block (typically 4096 samples) correlated
+	// at lags 0..maxOrder. maxLag 8 mirrors libFLAC -l 8 (compression level 5);
+	// 32 is the subset maximum.
+	blockSizes := []int{4096}
+	maxLags := []int{8, 12, 32}
+
+	for _, n := range blockSizes {
+		x := make([]float64, n)
+		for i := range x {
+			x[i] = (float64((i*2654435761)%65536) - 32768) * 0.7
+		}
+		for _, maxLag := range maxLags {
+			autoc := make([]float64, maxLag+1)
+			name := fmt.Sprintf("n%d_lag%d", n, maxLag)
+			b.Run(fmt.Sprintf("SIMD_%s", name), func(b *testing.B) {
+				for i := 0; i < b.N; i++ {
+					Autocorrelate(autoc, x, maxLag)
+				}
+				b.SetBytes(int64(n * 8))
+			})
+			b.Run(fmt.Sprintf("Go_%s", name), func(b *testing.B) {
+				for i := 0; i < b.N; i++ {
+					autocorrelateGo(autoc, x, maxLag)
+				}
+				b.SetBytes(int64(n * 8))
+			})
+		}
+	}
+}
+
 func BenchmarkConvolveValid(b *testing.B) {
 	signalSizes := []int{1024, 4096, 16384}
 	kernelSizes := []int{16, 64, 256}

--- a/f64/f64.go
+++ b/f64/f64.go
@@ -321,6 +321,33 @@ func DotProductBatch(results []float64, rows [][]float64, vec []float64) {
 	dotProductBatch64(results[:n], rows[:n], vec)
 }
 
+// Autocorrelate computes the autocorrelation of x at lags 0..maxLag:
+//
+//	autoc[lag] = Σ x[i]*x[i-lag]  for i in lag..len(x)-1
+//
+// summed left to right with separate multiply and add. The AVX2 and NEON
+// kernels vectorize ACROSS lags (one accumulator lane per lag, never fusing the
+// multiply-add), so every build produces byte-identical results to the pure-Go
+// reference. This is the LPC autocorrelation step used by FLAC-style encoders,
+// where the quantized predictor coefficients (hence the output bytes) depend on
+// the exact rounding of this reduction.
+//
+// Preconditions: maxLag >= 0 and len(autoc) >= maxLag+1. Lags beyond len(x)-1
+// (whose sums are empty) are written as 0. Processes lags 0..min(maxLag,
+// len(autoc)-1).
+func Autocorrelate(autoc, x []float64, maxLag int) {
+	if maxLag < 0 || len(x) == 0 {
+		return
+	}
+	if maxLag > len(autoc)-1 {
+		maxLag = len(autoc) - 1
+	}
+	if maxLag < 0 {
+		return
+	}
+	autocorrelate64(autoc, x, maxLag)
+}
+
 // ConvolveValid computes valid convolution of signal with kernel.
 // dst[i] = sum(signal[i+j] * kernel[j]) for j in 0..len(kernel)-1.
 // Output length is len(signal) - len(kernel) + 1.

--- a/f64/f64_amd64.go
+++ b/f64/f64_amd64.go
@@ -20,6 +20,10 @@ const (
 // Used by min64/max64 to determine when to fall back to scalar code.
 var minSIMDElements = minAVXElements
 
+// hasAVX2 gates the autocorrelation kernel, which needs VPERMPD (AVX2). It uses
+// a direct dispatch rather than the init-time function pointers above.
+var hasAVX2 = cpu.X86.AVX2
+
 // Function pointer types for SIMD operations
 type (
 	dotProductFunc        func(a, b []float64) float64
@@ -390,6 +394,48 @@ func dotProductBatchKernel(useAVX512 bool, results []float64, rows [][]float64, 
 	}
 }
 
+// autocorrelate64 computes autoc[lag] for lag in 0..maxLag. On AVX2 it
+// vectorizes ACROSS lags: four consecutive lags share one accumulator register,
+// each lane summing its lag's x[i]*x[i-lag] terms in increasing-i order with
+// separate VMULPD+VADDPD (never FMA), so the result is bit-identical to
+// autocorrelateGo. The triangular prologue (i < pmax) is seeded in scalar Go;
+// the kernel then sweeps the rectangular steady region i in pmax..n-1 where
+// every per-lag window load is in bounds. Without AVX2, or when the block is
+// too short to have a steady region, it falls back to the scalar reference.
+func autocorrelate64(autoc, x []float64, maxLag int) {
+	const lanes = 4
+	n := len(x)
+	groups := (maxLag + lanes) / lanes // ceil((maxLag+1)/lanes)
+	pmax := groups*lanes - 1           // steady-region start = padded max lag
+	if !hasAVX2 || n <= pmax {
+		autocorrelateGo(autoc, x, maxLag)
+		return
+	}
+	autocorrTriangularSeed(autoc, x, maxLag, pmax)
+	count := n - pmax
+	bcast := &x[pmax]
+	for g := range groups {
+		base := g * lanes
+		// window points at x[pmax-base-(lanes-1)]; the kernel loads `lanes`
+		// ascending elements there and reverses them so lane j accumulates lag
+		// base+j. Both pmax-base-(lanes-1) >= 0 and the final read index
+		// n-1-base stay in bounds for every group.
+		window := &x[pmax-base-(lanes-1)]
+		if base+lanes-1 <= maxLag {
+			autocorrStep4AVX(&autoc[base], bcast, window, count)
+			continue
+		}
+		// Final partial group (maxLag+1 not a multiple of lanes): run the kernel
+		// over a padded stack buffer and copy back only the real lags. The pad
+		// lanes accumulate valid-but-unused lags and are discarded.
+		var buf [lanes]float64
+		realLanes := maxLag + 1 - base
+		copy(buf[:realLanes], autoc[base:maxLag+1])
+		autocorrStep4AVX(&buf[0], bcast, window, count)
+		copy(autoc[base:maxLag+1], buf[:realLanes])
+	}
+}
+
 func convolveValid64(dst, signal, kernel []float64) {
 	kLen := len(kernel)
 	for i := range dst {
@@ -651,6 +697,16 @@ func dotProductAVX(a, b []float64) float64
 
 //go:noescape
 func dotProduct4AVX(results, row0, row1, row2, row3, vec *float64, n int)
+
+// autocorrStep4AVX accumulates the steady region of four autocorrelation lags.
+// acc points at four contiguous seeded accumulators (lags base..base+3);
+// broadcast at x[pmax] and window at x[pmax-base-3] advance one element per
+// iteration for count iterations. Each step does acc += x[i] * reverse(window)
+// with separate VMULPD+VADDPD so the per-lag sum order matches the scalar
+// reference exactly. See autocorrelate64.
+//
+//go:noescape
+func autocorrStep4AVX(acc, broadcast, window *float64, count int)
 
 //go:noescape
 func convolveDecimateAVX(dst, signal, kernel []float64, factor, phase int)

--- a/f64/f64_amd64.s
+++ b/f64/f64_amd64.s
@@ -1330,6 +1330,40 @@ dot4_avx_done:
     VZEROUPPER
     RET
 
+// func autocorrStep4AVX(acc, broadcast, window *float64, count int)
+// Steady-region accumulation for four autocorrelation lags at once. Y0 holds
+// the four seeded accumulators (lanes = lags base..base+3). Each iteration
+// broadcasts x[i], loads the four ascending window samples, reverses them with
+// VPERMPD so lane j carries x[i-(base+j)], multiplies, and adds. Separate
+// VMULPD + VADDPD (no FMA) keep each lane's sum bit-identical to the scalar
+// reference. broadcast and window advance one float64 (8 bytes) per iteration.
+TEXT ·autocorrStep4AVX(SB), NOSPLIT, $0-32
+    MOVQ acc+0(FP), DX
+    MOVQ broadcast+8(FP), SI
+    MOVQ window+16(FP), DI
+    MOVQ count+24(FP), CX
+
+    VMOVUPD (DX), Y0           // Y0 = seeded accumulators (lags base..base+3)
+    TESTQ CX, CX
+    JZ    autocorr4_done
+
+autocorr4_loop:
+    VBROADCASTSD (SI), Y1      // Y1 = x[i] in all four lanes
+    VMOVUPD (DI), Y2           // Y2 = [x[i-base-3], x[i-base-2], x[i-base-1], x[i-base]]
+    VPERMPD $0x1B, Y2, Y2      // reverse -> [x[i-base], x[i-base-1], x[i-base-2], x[i-base-3]]
+    VMULPD Y1, Y2, Y2          // Y2 = x[i] * window         (separate multiply)
+    VADDPD Y2, Y0, Y0          // Y0 += Y2                   (separate add, no FMA)
+    ADDQ $8, SI
+    ADDQ $8, DI
+    DECQ CX
+    JNZ  autocorr4_loop
+
+    VMOVUPD Y0, (DX)           // store the four lag accumulators back
+
+autocorr4_done:
+    VZEROUPPER
+    RET
+
 // func dotProduct4AVX512(results, row0, row1, row2, row3, vec *float64, n int)
 // Computes four dot products against the same vec, reusing each vec load.
 // Two accumulator banks per row (a/b); 32 doubles per row per main iteration

--- a/f64/f64_arm64.go
+++ b/f64/f64_arm64.go
@@ -180,6 +180,47 @@ func dotProductBatch64(results []float64, rows [][]float64, vec []float64) {
 	}
 }
 
+// autocorrelate64 computes autoc[lag] for lag in 0..maxLag. On NEON it
+// vectorizes ACROSS lags (two consecutive lags per accumulator register), each
+// lane summing its lag's x[i]*x[i-lag] terms in increasing-i order. The kernel
+// uses fused FMLA because Go's arm64 compiler fuses the scalar reference's
+// multiply-add into FMADDD, so FMLA is what reproduces autocorrelateGo
+// bit-for-bit on arm64 (the amd64 AVX2 path instead uses separate mul+add to
+// match its own non-fused fallback). The triangular prologue (i < pmax) is
+// seeded in scalar Go; the kernel sweeps the rectangular steady region
+// i in pmax..n-1. Mirrors the amd64 orchestrator with two lanes instead of four.
+func autocorrelate64(autoc, x []float64, maxLag int) {
+	const lanes = 2
+	n := len(x)
+	groups := (maxLag + lanes) / lanes // ceil((maxLag+1)/lanes)
+	pmax := groups*lanes - 1           // steady-region start = padded max lag
+	if !hasNEON || n <= pmax {
+		autocorrelateGo(autoc, x, maxLag)
+		return
+	}
+	autocorrTriangularSeed(autoc, x, maxLag, pmax)
+	count := n - pmax
+	bcast := &x[pmax]
+	for g := range groups {
+		base := g * lanes
+		window := &x[pmax-base-(lanes-1)]
+		if base+lanes-1 <= maxLag {
+			autocorrStep2NEON(&autoc[base], bcast, window, count)
+			continue
+		}
+		// Final partial group (odd lag count): run the kernel over a padded
+		// stack buffer; the pad lane accumulates a valid-but-unused lag.
+		var buf [lanes]float64
+		realLanes := maxLag + 1 - base
+		copy(buf[:realLanes], autoc[base:maxLag+1])
+		autocorrStep2NEON(&buf[0], bcast, window, count)
+		copy(autoc[base:maxLag+1], buf[:realLanes])
+	}
+}
+
+//go:noescape
+func autocorrStep2NEON(acc, broadcast, window *float64, count int)
+
 func convolveValid64(dst, signal, kernel []float64) {
 	// Convolution as sliding dot products
 	kLen := len(kernel)

--- a/f64/f64_arm64.s
+++ b/f64/f64_arm64.s
@@ -1686,3 +1686,40 @@ cd_neon_store:
 
 cd_neon_done:
     RET
+
+// func autocorrStep2NEON(acc, broadcast, window *float64, count int)
+// Steady-region accumulation for two autocorrelation lags at once. V0 holds the
+// two seeded accumulators (lanes = lags base..base+1). Each iteration broadcasts
+// x[i] (LD1R), loads the two ascending window samples, swaps them with EXT #8 so
+// lane j carries x[i-(base+j)], then fuses the multiply-add with FMLA.
+//
+// FMLA (one rounding) is deliberate: Go's arm64 compiler fuses the scalar
+// reference's `sum += x[i]*x[i-lag]` into FMADDD, so the fused kernel is what
+// reproduces autocorrelateGo bit-for-bit on arm64. (The amd64 backend does not
+// fuse, so the AVX2 kernel uses separate VMULPD+VADDPD to match its own
+// fallback.) broadcast (X1) and window (X2) advance one float64 per iteration.
+// Registers are fixed by the hand-encoded WORDs: X0=acc, X1=broadcast,
+// X2=window; V0=acc, V1=x[i], V2=window/temp.
+TEXT ·autocorrStep2NEON(SB), NOSPLIT, $0-32
+    MOVD acc+0(FP), R0
+    MOVD broadcast+8(FP), R1
+    MOVD window+16(FP), R2
+    MOVD count+24(FP), R3
+
+    WORD $0x4C407C00           // LD1 {V0.2D}, [X0]   seeded accumulators (lags base, base+1)
+    CBZ R3, autocorr2_done
+
+autocorr2_loop:
+    WORD $0x4D40CC21           // LD1R {V1.2D}, [X1]  V1 = x[i] in both lanes
+    WORD $0x4C407C42           // LD1 {V2.2D}, [X2]   V2 = [x[i-base-1], x[i-base]]
+    WORD $0x6E024042           // EXT V2.16B, V2.16B, V2.16B, #8   swap -> [x[i-base], x[i-base-1]]
+    WORD $0x4E61CC40           // FMLA V0.2D, V2.2D, V1.2D   V0 += x[i]*window (fused, matches Go FMADDD)
+    ADD $8, R1
+    ADD $8, R2
+    SUB $1, R3
+    CBNZ R3, autocorr2_loop
+
+    WORD $0x4C007C00           // ST1 {V0.2D}, [X0]   store the two lag accumulators
+
+autocorr2_done:
+    RET

--- a/f64/f64_go.go
+++ b/f64/f64_go.go
@@ -319,6 +319,40 @@ func accumulateAdd64Go(dst, src []float64) {
 	}
 }
 
+// autocorrelateGo is the pure-Go reference autocorrelation. For each lag in
+// 0..maxLag it sums x[i]*x[i-lag] over i in lag..len(x)-1, left to right with
+// separate multiply and add. It is the bit-exact contract the AVX2 and NEON
+// kernels reproduce: each lag is an independent accumulator fed in increasing-i
+// order, so vectorizing ACROSS lags (one lane per lag, separate mul+add, never
+// FMA) yields identical bytes to this loop on every build.
+func autocorrelateGo(autoc, x []float64, maxLag int) {
+	n := len(x)
+	for lag := 0; lag <= maxLag; lag++ {
+		var sum float64
+		for i := lag; i < n; i++ {
+			sum += x[i] * x[i-lag]
+		}
+		autoc[lag] = sum
+	}
+}
+
+// autocorrTriangularSeed fills autoc[lag] (lag in 0..maxLag) with the partial
+// sum over the prologue samples i in lag..pmax-1, left to right. The SIMD
+// kernels then continue each lag's accumulator over the steady region
+// i in pmax..n-1, so the complete sum is accumulated in the same order as
+// autocorrelateGo and stays bit-identical. pmax is the padded steady-region
+// start (a multiple-of-lanes boundary) chosen so every vectorized load is in
+// bounds. Shared by the amd64 and arm64 orchestrators.
+func autocorrTriangularSeed(autoc, x []float64, maxLag, pmax int) {
+	for lag := 0; lag <= maxLag; lag++ {
+		var s float64
+		for i := lag; i < pmax; i++ {
+			s += x[i] * x[i-lag]
+		}
+		autoc[lag] = s
+	}
+}
+
 func interleave2Go(dst, a, b []float64) {
 	for i := range a {
 		dst[i*2] = a[i]

--- a/f64/f64_other.go
+++ b/f64/f64_other.go
@@ -32,7 +32,10 @@ func convolveValid64(dst, signal, kernel []float64) { convolveValid64Go(dst, sig
 func convolveDecimate64(dst, signal, kernel []float64, factor, phase int) {
 	convolveDecimate64Go(dst, signal, kernel, factor, phase)
 }
-func accumulateAdd64(dst, src []float64)   { accumulateAdd64Go(dst, src) }
+func accumulateAdd64(dst, src []float64) { accumulateAdd64Go(dst, src) }
+func autocorrelate64(autoc, x []float64, maxLag int) {
+	autocorrelateGo(autoc, x, maxLag)
+}
 func interleave2_64(dst, a, b []float64)   { interleave2Go(dst, a, b) }
 func deinterleave2_64(a, b, src []float64) { deinterleave2Go(a, b, src) }
 func interleaveN64(dst []float64, srcs [][]float64, n int) {


### PR DESCRIPTION
## Summary

Adds `f64.Autocorrelate(autoc, x, maxLag)`, the LPC autocorrelation step used by FLAC-style encoders:

```
autoc[lag] = Σ x[i]*x[i-lag]  for i in lag..len(x)-1
```

This is the largest remaining single-core hotspot in the go-flac encoder (~16% mono / ~27% stereo self time), currently a naive scalar `float64` double loop.

## Why this can be byte-identical

The natural SIMD framing (a per-lag dot product reduced across samples) reassociates the sum and changes `float64` rounding. For FLAC that perturbs the quantized LPC coefficients and therefore the output bytes, which is why SIMD autocorrelation has historically been considered output-changing.

The trick here is to vectorize **across lags** instead: one accumulator lane per lag, so each lag's sum is accumulated in the exact left-to-right order of the scalar loop. Parallel lanes never change any single lane's addition sequence, so the result is bit-for-bit identical to the scalar reference.

## Per-arch fusion

Each kernel matches its own platform's scalar fallback so SIMD and non-SIMD builds emit identical bytes:

- **amd64 AVX2**: four lags per YMM accumulator, contiguous load reversed with `VPERMPD`, **separate `VMULPD`+`VADDPD`** (Go's amd64 backend does not fuse `a*b+c`).
- **arm64 NEON**: two lags per V register, swapped with `EXT`, **fused `FMLA`** (Go's arm64 backend *does* fuse `a*b+c` into `FMADDD`, so `FMLA` is what reproduces the scalar loop bit-for-bit).
- **pure-Go fallback** and the short-block path use the scalar reference.

A scalar triangular prologue seeds each lag's accumulator so the vectorized steady region only touches in-bounds samples; the final partial lane group runs over a zero-alloc stack buffer.

## Validation

- Bit-identical to the scalar reference across **11,880 (block size, lag) cases** on both amd64 (AVX2) and arm64 (NEON, validated natively on real hardware).
- New WORD encodings pass the `asmcheck` cross-check in strict objdump mode (`SIMD_REQUIRE_OBJDUMP=1`).
- Full `go test ./...` green on amd64 and arm64; `go vet` clean.

## Kernel speedup over the Go fallback (n=4096)

| lag | amd64 (AVX2) | arm64 (NEON) |
|----:|-------------:|-------------:|
| 8   | 2.9x | 2.4x |
| 12  | 3.0x | 2.4x |
| 32  | 3.5x | 2.7x |