### PR TITLE
i32: add MinMax, a signed int32 per-slice min/max reduction kernel

### DIFF
--- a/i32/benchmark_test.go
+++ b/i32/benchmark_test.go
@@ -471,3 +471,19 @@ func BenchmarkFixedAbsSumsGo_1000(b *testing.B) {
 		fixedAbsSumsGo(src, &sums)
 	}
 }
+
+func BenchmarkMinMax_1000(b *testing.B) {
+	res := benchRiceRes()
+	b.SetBytes(benchN * 4)
+	for b.Loop() {
+		MinMax(res)
+	}
+}
+
+func BenchmarkMinMaxGo_1000(b *testing.B) {
+	res := benchRiceRes()
+	b.SetBytes(benchN * 4)
+	for b.Loop() {
+		minMaxGo(res)
+	}
+}

--- a/i32/i32_amd64.go
+++ b/i32/i32_amd64.go
@@ -249,3 +249,17 @@ func riceSumsWideI32(sums []uint64, res []int32) {
 
 //go:noescape
 func riceSumsHighAVX2(sums []uint64, res []int32)
+
+// minMaxI32 dispatches the signed int32 min/max reduction. The AVX2 kernel does
+// the reduction in 8-wide VPMINSD/VPMAXSD lanes with a scalar tail, so it gates
+// on AVX2 and at least one full 8-element block; shorter slices use the pure-Go
+// reference. res is non-empty (the public MinMax guards the empty case).
+func minMaxI32(res []int32) (minVal, maxVal int32) {
+	if hasAVX2 && len(res) >= minAVXElements {
+		return minMaxAVX2(res)
+	}
+	return minMaxGo(res)
+}
+
+//go:noescape
+func minMaxAVX2(res []int32) (minVal, maxVal int32)

--- a/i32/i32_amd64.s
+++ b/i32/i32_amd64.s
@@ -1672,8 +1672,10 @@ TEXT ·minMaxAVX2(SB), NOSPLIT, $0-32
     SHRQ $3, R9                      // R9 = full 8-element blocks (>=1)
     VMOVDQU (R8), Y0                 // min acc = block 0
     VMOVDQU (R8), Y1                 // max acc = block 0
-    MOVQ R8, SI                      // working res ptr
     MOVQ R9, AX                      // block counter
+    DECQ AX                          // blocks remaining after block 0
+    JZ   mm_reduce                   // single block: accumulators already hold it
+    LEAQ 32(R8), SI                  // working res ptr at block 1
 mm_loop:
     VMOVDQU (SI), Y2
     VPMINSD Y2, Y0, Y0               // Y0 = lanewise min(Y2, Y0)
@@ -1681,6 +1683,8 @@ mm_loop:
     ADDQ $32, SI
     DECQ AX
     JNZ  mm_loop
+
+mm_reduce:
 
     // horizontal min of Y0 -> AX (low 32 bits), max of Y1 -> DX (low 32 bits)
     VEXTRACTI128 $1, Y0, X3

--- a/i32/i32_amd64.s
+++ b/i32/i32_amd64.s
@@ -1657,3 +1657,71 @@ riceHi_tail:
 riceHi_done:
     VZEROUPPER
     RET
+
+// func minMaxAVX2(res []int32) (minVal, maxVal int32)
+// Signed int32 min and max over res in one pass. The dispatch gates len(res) >=
+// 8, so at least one full 8-element block exists: the min and max accumulators
+// start from block 0 and fold the remaining full blocks with VPMINSD/VPMAXSD,
+// then a horizontal reduce collapses the 8 lanes to a scalar and a scalar tail
+// folds the (n mod 8) remainder. Every compare is signed (VPMINSD/VPMAXSD and
+// the CMPL tail), so the int32 sign bit is honored exactly like minMaxGo.
+TEXT ·minMaxAVX2(SB), NOSPLIT, $0-32
+    MOVQ res_base+0(FP), R8
+    MOVQ res_len+8(FP), CX           // n (>=8)
+    MOVQ CX, R9
+    SHRQ $3, R9                      // R9 = full 8-element blocks (>=1)
+    VMOVDQU (R8), Y0                 // min acc = block 0
+    VMOVDQU (R8), Y1                 // max acc = block 0
+    MOVQ R8, SI                      // working res ptr
+    MOVQ R9, AX                      // block counter
+mm_loop:
+    VMOVDQU (SI), Y2
+    VPMINSD Y2, Y0, Y0               // Y0 = lanewise min(Y2, Y0)
+    VPMAXSD Y2, Y1, Y1               // Y1 = lanewise max(Y2, Y1)
+    ADDQ $32, SI
+    DECQ AX
+    JNZ  mm_loop
+
+    // horizontal min of Y0 -> AX (low 32 bits), max of Y1 -> DX (low 32 bits)
+    VEXTRACTI128 $1, Y0, X3
+    VPMINSD X3, X0, X0               // fold lanes 4..7 into 0..3
+    VPSHUFD $0x4E, X0, X3           // swap 64-bit halves
+    VPMINSD X3, X0, X0
+    VPSHUFD $0xB1, X0, X3           // swap 32-bit within pairs
+    VPMINSD X3, X0, X0              // lane0 = min over all 8 lanes
+    MOVQ X0, AX                      // EAX = running min
+
+    VEXTRACTI128 $1, Y1, X3
+    VPMAXSD X3, X1, X1
+    VPSHUFD $0x4E, X1, X3
+    VPMAXSD X3, X1, X1
+    VPSHUFD $0xB1, X1, X3
+    VPMAXSD X3, X1, X1
+    MOVQ X1, DX                      // EDX = running max
+
+    // scalar tail: (n mod 8) residuals at &res[fullBlocks*8]
+    MOVQ CX, BX
+    ANDQ $7, BX
+    JZ   mm_done
+    MOVQ R9, R10
+    SHLQ $5, R10                     // fullBlocks * 32 bytes
+    ADDQ R8, R10                     // tail ptr
+mm_tail:
+    MOVL (R10), R11                  // r (32-bit)
+    CMPL R11, AX
+    JGE  mm_tail_max
+    MOVL R11, AX                     // r < min -> new min
+mm_tail_max:
+    CMPL R11, DX
+    JLE  mm_tail_next
+    MOVL R11, DX                     // r > max -> new max
+mm_tail_next:
+    ADDQ $4, R10
+    DECQ BX
+    JNZ  mm_tail
+
+mm_done:
+    MOVL AX, minVal+24(FP)
+    MOVL DX, maxVal+28(FP)
+    VZEROUPPER
+    RET

--- a/i32/i32_amd64_test.go
+++ b/i32/i32_amd64_test.go
@@ -289,6 +289,7 @@ func TestAVX2Kernels_AllocFree(t *testing.T) {
 		{"diff4AVX2", func() { diff4AVX2(dst, a) }},
 		{"cumsumAVX2", func() { cumsumAVX2(dst) }},
 		{"zigzagSumAVX2", func() { _ = zigzagSumAVX2(a) }},
+		{"minMaxAVX2", func() { _, _ = minMaxAVX2(a) }},
 		{"fixedAbsSumsAVX2", func() { fixedAbsSumsAVX2(a, &fasSums) }},
 		{"riceSumsHighAVX2", func() { riceSumsHighAVX2(riceHi, a) }},
 		{"lpcResidualEncodeAVX2", func() { lpcResidualEncodeAVX2(dst, a, lpcAllocCoeffs, 12) }},
@@ -491,6 +492,39 @@ func TestZigzagSumAVX2_ParityWithGo(t *testing.T) {
 		want := zigzagSumGo(res)
 		if got != want {
 			t.Fatalf("n=%d: zigzagSumAVX2 = %d, want %d (Go)", n, got, want)
+		}
+	}
+}
+
+func TestMinMaxAVX2_ParityWithGo(t *testing.T) {
+	if !cpu.X86.AVX2 {
+		t.Skip("AVX2 not available")
+	}
+	// A tame in-range body keeps the planted extremes the unique min/max, so a
+	// kernel that drops a vector lane or skips the scalar tail is caught: one
+	// variant plants the extremes in a mid-block lane and in the tail, the other
+	// swaps them, covering both a dropped lane and a dropped tail on both reduces.
+	for _, n := range paritySizes {
+		if n < minAVXElements {
+			continue // dispatch routes these to Go; the kernel is not called
+		}
+		for _, swap := range []bool{false, true} {
+			res := make([]int32, n)
+			for i := range res {
+				res[i] = int32(i%13) - 6
+			}
+			mid, tail := int32(math.MinInt32), int32(math.MaxInt32)
+			if swap {
+				mid, tail = tail, mid
+			}
+			res[n/2] = mid
+			res[n-1] = tail
+			gotMin, gotMax := minMaxAVX2(res)
+			wantMin, wantMax := minMaxGo(res)
+			if gotMin != wantMin || gotMax != wantMax {
+				t.Fatalf("n=%d swap=%v: minMaxAVX2 = (%d, %d), want (%d, %d) (Go)",
+					n, swap, gotMin, gotMax, wantMin, wantMax)
+			}
 		}
 	}
 }

--- a/i32/i32_arm64.go
+++ b/i32/i32_arm64.go
@@ -227,3 +227,18 @@ func riceSumsWideI32(sums []uint64, res []int32) {
 
 //go:noescape
 func riceSumsHighNEON(sums []uint64, res []int32)
+
+// minMaxI32 dispatches the signed int32 min/max reduction. The NEON kernel does
+// the reduction in 4-wide SMIN/SMAX lanes with a single-instruction SMINV/SMAXV
+// across-vector fold and a scalar tail, so it gates on NEON and at least one full
+// 4-element block; shorter slices use the pure-Go reference. res is non-empty
+// (the public MinMax guards the empty case).
+func minMaxI32(res []int32) (minVal, maxVal int32) {
+	if hasNEON && len(res) >= minNEONElements {
+		return minMaxNEON(res)
+	}
+	return minMaxGo(res)
+}
+
+//go:noescape
+func minMaxNEON(res []int32) (minVal, maxVal int32)

--- a/i32/i32_arm64.s
+++ b/i32/i32_arm64.s
@@ -1327,3 +1327,47 @@ rice_neon_hi_tail_k:
 
 rice_neon_hi_done:
     RET
+
+// func minMaxNEON(res []int32) (minVal, maxVal int32)
+// Signed int32 min and max over res in one pass. The dispatch gates len(res) >=
+// 4, so at least one full 4-element (.4S) block exists: the min and max
+// accumulators start from block 0 and fold the remaining full blocks with
+// SMIN/SMAX, then SMINV/SMAXV reduce each accumulator across its 4 lanes to a
+// scalar and a scalar tail folds the (n mod 4) remainder. SMIN/SMAX/SMINV/SMAXV
+// have no Go assembler mnemonic, so they are hand-encoded WORD directives (the
+// trailing comment is the decoded form, cross-checked by asmcheck_test.go).
+// Every compare is signed, matching minMaxGo exactly.
+TEXT ·minMaxNEON(SB), NOSPLIT, $0-32
+    MOVD res_base+0(FP), R2
+    MOVD res_len+8(FP), R3
+    LSR  $2, R3, R4                  // R4 = full 4-element blocks (>=1)
+    VLD1 (R2), [V0.S4]               // V0 = block 0 (min acc)
+    VLD1 (R2), [V1.S4]               // V1 = block 0 (max acc)
+mm_neon_loop:
+    VLD1.P 16(R2), [V2.S4]           // load block + advance
+    WORD $0x4EA26C00                 // SMIN V0.4S, V0.4S, V2.4S
+    WORD $0x4EA26421                 // SMAX V1.4S, V1.4S, V2.4S
+    SUB  $1, R4
+    CBNZ R4, mm_neon_loop
+
+    WORD $0x4EB1A803                 // SMINV S3, V0.4S
+    WORD $0x4EB0A824                 // SMAXV S4, V1.4S
+    FMOVS F3, R5                     // R5 = running min (low 32 = int32)
+    FMOVS F4, R6                     // R6 = running max (low 32 = int32)
+
+    // scalar tail: (n mod 4) residuals (R2 already at &res[fullBlocks*4])
+    AND  $3, R3, R4
+    CBZ  R4, mm_neon_done
+mm_neon_tail:
+    MOVW.P 4(R2), R7                 // r (sign-extended; low 32 = int32)
+    CMPW R5, R7                      // (R7 - R5), signed 32-bit
+    CSEL LT, R7, R5, R5             // R5 = min(r, R5)
+    CMPW R6, R7
+    CSEL GT, R7, R6, R6             // R6 = max(r, R6)
+    SUB  $1, R4
+    CBNZ R4, mm_neon_tail
+
+mm_neon_done:
+    MOVW R5, minVal+24(FP)
+    MOVW R6, maxVal+28(FP)
+    RET

--- a/i32/i32_arm64.s
+++ b/i32/i32_arm64.s
@@ -1341,8 +1341,10 @@ TEXT ·minMaxNEON(SB), NOSPLIT, $0-32
     MOVD res_base+0(FP), R2
     MOVD res_len+8(FP), R3
     LSR  $2, R3, R4                  // R4 = full 4-element blocks (>=1)
-    VLD1 (R2), [V0.S4]               // V0 = block 0 (min acc)
-    VLD1 (R2), [V1.S4]               // V1 = block 0 (max acc)
+    VLD1 (R2), [V0.S4]               // V0 = block 0 (min acc), no advance
+    VLD1.P 16(R2), [V1.S4]           // V1 = block 0 (max acc), advance to block 1
+    SUB  $1, R4                      // blocks remaining after block 0
+    CBZ  R4, mm_neon_reduce          // single block: accumulators hold it; R2 at tail
 mm_neon_loop:
     VLD1.P 16(R2), [V2.S4]           // load block + advance
     WORD $0x4EA26C00                 // SMIN V0.4S, V0.4S, V2.4S
@@ -1350,6 +1352,7 @@ mm_neon_loop:
     SUB  $1, R4
     CBNZ R4, mm_neon_loop
 
+mm_neon_reduce:
     WORD $0x4EB1A803                 // SMINV S3, V0.4S
     WORD $0x4EB0A824                 // SMAXV S4, V1.4S
     FMOVS F3, R5                     // R5 = running min (low 32 = int32)

--- a/i32/i32_arm64_test.go
+++ b/i32/i32_arm64_test.go
@@ -267,6 +267,7 @@ func TestNEONKernels_AllocFree(t *testing.T) {
 		{"diff4NEON", func() { diff4NEON(dst, a) }},
 		{"cumsumNEON", func() { cumsumNEON(dst) }},
 		{"zigzagSumNEON", func() { _ = zigzagSumNEON(a) }},
+		{"minMaxNEON", func() { _, _ = minMaxNEON(a) }},
 		{"fixedAbsSumsNEON", func() { fixedAbsSumsNEON(a, &fasSums) }},
 		{"riceSumsHighNEON", func() { riceSumsHighNEON(riceHi, a) }},
 		{"lpcResidualEncodeNEON", func() { lpcResidualEncodeNEON(dst, a, lpcAllocCoeffs, 12) }},
@@ -461,6 +462,39 @@ func TestZigzagSumNEON_ParityWithGo(t *testing.T) {
 		want := zigzagSumGo(res)
 		if got != want {
 			t.Fatalf("n=%d: zigzagSumNEON = %d, want %d (Go)", n, got, want)
+		}
+	}
+}
+
+func TestMinMaxNEON_ParityWithGo(t *testing.T) {
+	if !cpu.ARM64.NEON {
+		t.Skip("NEON not available")
+	}
+	// A tame in-range body keeps the planted extremes the unique min/max, so a
+	// kernel that drops a vector lane or skips the scalar tail is caught: one
+	// variant plants the extremes in a mid-block lane and in the tail, the other
+	// swaps them, covering both a dropped lane and a dropped tail on both reduces.
+	for _, n := range paritySizes {
+		if n < minNEONElements {
+			continue // dispatch routes these to Go; the kernel is not called
+		}
+		for _, swap := range []bool{false, true} {
+			res := make([]int32, n)
+			for i := range res {
+				res[i] = int32(i%13) - 6
+			}
+			mid, tail := int32(math.MinInt32), int32(math.MaxInt32)
+			if swap {
+				mid, tail = tail, mid
+			}
+			res[n/2] = mid
+			res[n-1] = tail
+			gotMin, gotMax := minMaxNEON(res)
+			wantMin, wantMax := minMaxGo(res)
+			if gotMin != wantMin || gotMax != wantMax {
+				t.Fatalf("n=%d swap=%v: minMaxNEON = (%d, %d), want (%d, %d) (Go)",
+					n, swap, gotMin, gotMax, wantMin, wantMax)
+			}
 		}
 	}
 }

--- a/i32/i32_go.go
+++ b/i32/i32_go.go
@@ -155,6 +155,22 @@ func zigzagSumGo(res []int32) uint64 {
 	return s
 }
 
+// minMaxGo returns the smallest and largest int32 in res via a single signed
+// scan. res must be non-empty (the public MinMax guards the empty case); it is
+// the bit-exact source of truth the SIMD MinMax kernels are validated against.
+func minMaxGo(res []int32) (minVal, maxVal int32) {
+	lo, hi := res[0], res[0]
+	for _, r := range res[1:] {
+		if r < lo {
+			lo = r
+		}
+		if r > hi {
+			hi = r
+		}
+	}
+	return lo, hi
+}
+
 // absU64 returns the absolute value of v as a uint64. v is bounded well inside
 // the int64 range here (at most a 4th finite difference of int32 samples, ~2^35),
 // so the math.MinInt64 edge case (where -v overflows) cannot arise.

--- a/i32/i32_other.go
+++ b/i32/i32_other.go
@@ -33,3 +33,5 @@ func zigzagSumI32(res []int32) uint64 { return zigzagSumGo(res) }
 func fixedAbsSumsI32(src []int32, sums *[5]uint64) { fixedAbsSumsGo(src, sums) }
 
 func riceSumsWideI32(sums []uint64, res []int32) { riceSumsGo(sums, res) }
+
+func minMaxI32(res []int32) (minVal, maxVal int32) { return minMaxGo(res) }

--- a/i32/minmax.go
+++ b/i32/minmax.go
@@ -1,0 +1,22 @@
+package i32
+
+// MinMax returns the smallest and largest int32 in res:
+//
+//	minVal = min_i res[i],  maxVal = max_i res[i]
+//
+// Both are signed comparisons. An empty res returns (0, 0). res is read-only;
+// the call allocates nothing.
+//
+// This is the reduction the FLAC Rice planner runs per finest partition to find
+// each partition's largest-magnitude residual (the escape-code cost input): the
+// largest zigzag fold over a partition is reached at its most-negative or
+// most-positive sample, so max(zigzag(minVal), zigzag(maxVal)) is that extreme.
+// The SIMD fast path uses signed-min/max vector instructions (VPMINSD/VPMAXSD on
+// amd64, SMIN/SMAX on arm64) with a scalar tail; both are bit-exact against the
+// pure-Go reference.
+func MinMax(res []int32) (minVal, maxVal int32) {
+	if len(res) == 0 {
+		return 0, 0
+	}
+	return minMaxI32(res)
+}

--- a/i32/minmax_test.go
+++ b/i32/minmax_test.go
@@ -1,0 +1,109 @@
+package i32
+
+import (
+	"math"
+	"math/rand"
+	"testing"
+)
+
+// Tests for MinMax, the signed int32 per-slice min/max reduction.
+//
+// The interesting cases mirror the other i32 reductions: the int32 sign-bit
+// extremes (MinInt32/MaxInt32), the block-straddling sizes that exercise both
+// the vector body and the scalar tail, and the degenerate length-1 and empty
+// slices.
+
+// TestMinMaxMatchesOracle checks MinMax against an independent min/max scan
+// across the block-straddling sizes.
+func TestMinMaxMatchesOracle(t *testing.T) {
+	rng := rand.New(rand.NewSource(11))
+	for _, n := range []int{1, 2, 3, 7, 8, 9, 15, 16, 17, 31, 33, 100, 1000, 1024, 1025} {
+		res := make([]int32, n)
+		for i := range res {
+			res[i] = int32(rng.Uint32())
+		}
+		wantMin, wantMax := res[0], res[0]
+		for _, r := range res {
+			if r < wantMin {
+				wantMin = r
+			}
+			if r > wantMax {
+				wantMax = r
+			}
+		}
+		gotMin, gotMax := MinMax(res)
+		if gotMin != wantMin || gotMax != wantMax {
+			t.Fatalf("n=%d MinMax = (%d, %d), want (%d, %d)", n, gotMin, gotMax, wantMin, wantMax)
+		}
+	}
+}
+
+// TestMinMaxExtremes pins the int32 sign-bit extremes so a kernel that mishandles
+// signedness (an unsigned compare, or a lane-corrupting move) is caught.
+func TestMinMaxExtremes(t *testing.T) {
+	res := []int32{math.MinInt32, math.MaxInt32, -1, 0, 1, math.MinInt32, math.MaxInt32}
+	gotMin, gotMax := MinMax(res)
+	if gotMin != math.MinInt32 || gotMax != math.MaxInt32 {
+		t.Errorf("MinMax extremes = (%d, %d), want (%d, %d)", gotMin, gotMax, math.MinInt32, math.MaxInt32)
+	}
+}
+
+// TestMinMaxTailPlacement puts the unique extreme at the last index so the
+// scalar tail (n mod vector-width) must be folded in for the answer to be right.
+// Sizes straddle both the 4-lane (NEON) and 8-lane (AVX) widths.
+func TestMinMaxTailPlacement(t *testing.T) {
+	for _, n := range []int{1, 2, 4, 5, 8, 9, 12, 16, 17, 31, 33, 100, 1023, 1025} {
+		// Baseline values are a tame mid-range; the extremes live only at the end.
+		res := make([]int32, n)
+		for i := range res {
+			res[i] = int32(i % 7)
+		}
+		res[n-1] = math.MaxInt32
+		if n >= 2 {
+			res[n-2] = math.MinInt32
+		}
+		wantMin, wantMax := res[0], res[0]
+		for _, r := range res {
+			if r < wantMin {
+				wantMin = r
+			}
+			if r > wantMax {
+				wantMax = r
+			}
+		}
+		gotMin, gotMax := MinMax(res)
+		if gotMin != wantMin || gotMax != wantMax {
+			t.Fatalf("n=%d MinMax = (%d, %d), want (%d, %d)", n, gotMin, gotMax, wantMin, wantMax)
+		}
+	}
+}
+
+// TestMinMaxSingle covers the length-1 slice (min == max == the element).
+func TestMinMaxSingle(t *testing.T) {
+	gotMin, gotMax := MinMax([]int32{-42})
+	if gotMin != -42 || gotMax != -42 {
+		t.Errorf("MinMax([-42]) = (%d, %d), want (-42, -42)", gotMin, gotMax)
+	}
+}
+
+// TestMinMaxEmpty pins the documented empty-input contract: (0, 0), no panic.
+func TestMinMaxEmpty(t *testing.T) {
+	gotMin, gotMax := MinMax(nil)
+	if gotMin != 0 || gotMax != 0 {
+		t.Errorf("MinMax(nil) = (%d, %d), want (0, 0)", gotMin, gotMax)
+	}
+	gotMin, gotMax = MinMax([]int32{})
+	if gotMin != 0 || gotMax != 0 {
+		t.Errorf("MinMax([]) = (%d, %d), want (0, 0)", gotMin, gotMax)
+	}
+}
+
+func TestMinMaxAllocFree(t *testing.T) {
+	res := make([]int32, 1024)
+	for i := range res {
+		res[i] = int32(i*7 - 3)
+	}
+	if got := testing.AllocsPerRun(100, func() { _, _ = MinMax(res) }); got != 0 {
+		t.Errorf("MinMax allocated %v times per run, want 0", got)
+	}
+}


### PR DESCRIPTION
## Summary

Adds `i32.MinMax(res []int32) (minVal, maxVal int32)`: the smallest and largest int32 in `res`, computed in one signed pass.

This is the reduction a pure-Go FLAC encoder's Rice planner runs per finest partition to find each partition's largest-magnitude residual (the escape-code cost input). The largest zigzag fold over a partition is reached at its most-negative or most-positive sample, so `max(zigzag(minVal), zigzag(maxVal))` is that extreme. Exposing it as a primitive lets the planner drop its last scalar min/max hot loop.

## Implementation

Five plug-in points, mirroring the existing i32 reductions (ZigzagSum, FixedAbsSums):

- **pure-Go `minMaxGo`** reference, the bit-exact parity source of truth.
- **AVX2 kernel**: 8-wide `VPMINSD`/`VPMAXSD` accumulators, horizontal reduce (`VEXTRACTI128` + `VPSHUFD` folds), scalar tail. ~10x over pure-Go on 1000 int32.
- **NEON kernel**: 4-wide `SMIN`/`SMAX` accumulators, single-instruction `SMINV`/`SMAXV` across-vector fold, scalar tail (`CSEL`). ~5x over pure-Go on a Raspberry Pi 5. `SMIN`/`SMAX`/`SMINV`/`SMAXV` have no Go assembler mnemonic, so they are hand-encoded `WORD` directives whose comments are cross-checked against `arm64asm` by `asmcheck_test.go`.
- **`i32_other.go`** pure-Go fallback dispatch for non-amd64/arm64.
- runtime dispatch gating on AVX2/NEON and the vector width; shorter-than-vector and empty slices use the pure-Go reference.

## Correctness

Unlike the sum kernels, min/max of int32 is exact (no accumulation order or integer wrapping), so the SIMD paths are bit-identical to the pure-Go reference by construction. Empty input returns `(0, 0)`; zero alloc.

Parity tests plant the int32 sign extremes (`MinInt32`/`MaxInt32`) in a mid-block lane and in the scalar tail, in both orderings, so a dropped vector lane or a skipped tail is caught. Block-straddling sizes cover the vector body and the `n mod width` tail on both the 4-lane (NEON) and 8-lane (AVX) widths.

## Validation

- amd64: `go test ./i32/` (AVX2 and `GODEBUG=cpu.avx2=off`), `go vet`, `golangci-lint` clean.
- arm64: cross-built test binary run natively on a Raspberry Pi 5; full i32 suite + MinMax parity green. `asmcheck` verifies the four WORD encodings decode to the claimed instructions.

## Benchmarks

```
BenchmarkMinMax_1000-16        47.11 ns/op    84903 MB/s   (AVX2)
BenchmarkMinMaxGo_1000-16     480.5  ns/op     8324 MB/s
BenchmarkMinMax_1000-4        215.8  ns/op    18536 MB/s   (NEON, Pi 5)
BenchmarkMinMaxGo_1000-4     1103    ns/op     3626 MB/s
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added `MinMax()` function to efficiently compute both minimum and maximum int32 values from a slice in one pass
  * Zero-allocation design for high-performance workloads
  * Safe handling of empty or nil slices (returns `0, 0`)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->