### PR TITLE
f32: add Round; c128: add FromReal (f64/c64 API parity)

### DIFF
--- a/README.md
+++ b/README.md
@@ -314,6 +314,7 @@ SIMD-accelerated complex number operations for FFT-based signal processing:
 | **Unary**      | `Abs(dst, a)`        | Complex magnitude \|a + bi\|       | 4x (AVX-512) / 2x (AVX) |
 |                | `AbsSq(dst, a)`      | Magnitude squared \|a + bi\|²      | 4x / 2x                 |
 |                | `Conj(dst, a)`       | Complex conjugate: a - bi          | 4x / 2x                 |
+| **Conversion** | `FromReal(dst, src)` | Real to complex: src → src+0i      | 2x (AVX-512/AVX) / 2x (NEON) |
 
 These operations are designed for FFT-based signal processing pipelines:
 

--- a/c128/c128.go
+++ b/c128/c128.go
@@ -4,6 +4,7 @@
 // - Mul: Complex multiplication for frequency-domain convolution
 // - MulConj: Multiply by conjugate for correlation
 // - Scale: Scale by complex scalar
+// - FromReal: Convert real float64 to complex128 (FFT input preparation)
 //
 // All functions automatically select the optimal implementation based on
 // runtime CPU feature detection. Functions gracefully fall back to pure Go
@@ -109,6 +110,19 @@ func Conj(dst, a []complex128) {
 		return
 	}
 	conj128(dst[:n], a[:n])
+}
+
+
+// FromReal converts real float64 values to complex128: dst[i] = complex(src[i], 0).
+// Processes min(len(dst), len(src)) elements.
+//
+// This is used to convert real-valued signals to complex for FFT input.
+func FromReal(dst []complex128, src []float64) {
+	n := min(len(dst), len(src))
+	if n == 0 {
+		return
+	}
+	fromReal128(dst[:n], src[:n])
 }
 
 func minLen(a, b, c int) int {

--- a/c128/c128_amd64.go
+++ b/c128/c128_amd64.go
@@ -18,18 +18,20 @@ type (
 	scaleFunc     func(dst, a []complex128, s complex128)
 	unaryAbsFunc  func(dst []float64, a []complex128)
 	unaryConjFunc func(dst, a []complex128)
+	fromRealFunc  func(dst []complex128, src []float64)
 )
 
 // Function pointers - assigned at init time based on CPU features
 var (
-	mulImpl     binaryOpFunc
-	mulConjImpl binaryOpFunc
-	scaleImpl   scaleFunc
-	addImpl     binaryOpFunc
-	subImpl     binaryOpFunc
-	absImpl     unaryAbsFunc
-	absSqImpl   unaryAbsFunc
-	conjImpl    unaryConjFunc
+	mulImpl      binaryOpFunc
+	mulConjImpl  binaryOpFunc
+	scaleImpl    scaleFunc
+	addImpl      binaryOpFunc
+	subImpl      binaryOpFunc
+	absImpl      unaryAbsFunc
+	absSqImpl    unaryAbsFunc
+	conjImpl     unaryConjFunc
+	fromRealImpl fromRealFunc
 )
 
 func init() {
@@ -69,6 +71,7 @@ func initAVX512() {
 	absImpl = absAVX512
 	absSqImpl = absSqAVX512
 	conjImpl = conjAVX512
+	fromRealImpl = fromRealAVX512
 }
 
 func initAVX() {
@@ -80,6 +83,7 @@ func initAVX() {
 	absImpl = absAVX
 	absSqImpl = absSqAVX
 	conjImpl = conjAVX
+	fromRealImpl = fromRealAVX
 }
 
 // initAVXNoFMA runs on AVX-capable CPUs that lack FMA (rare but possible:
@@ -95,6 +99,8 @@ func initAVXNoFMA() {
 	absImpl = absAVX
 	absSqImpl = absSqAVX
 	conjImpl = conjAVX
+	// FromReal is pure interleaving (no FMA), so the AVX kernel is safe here.
+	fromRealImpl = fromRealAVX
 }
 
 func initSSE2() {
@@ -106,6 +112,7 @@ func initSSE2() {
 	absImpl = absSSE2
 	absSqImpl = absSqSSE2
 	conjImpl = conjSSE2
+	fromRealImpl = fromRealSSE2
 }
 
 func initGo() {
@@ -117,6 +124,7 @@ func initGo() {
 	absImpl = absGo
 	absSqImpl = absSqGo
 	conjImpl = conjGo
+	fromRealImpl = fromRealGo
 }
 
 // Dispatch functions - call function pointers (zero overhead after init)
@@ -151,6 +159,10 @@ func absSq128(dst []float64, a []complex128) {
 
 func conj128(dst, a []complex128) {
 	conjImpl(dst, a)
+}
+
+func fromReal128(dst []complex128, src []float64) {
+	fromRealImpl(dst, src)
 }
 
 // AVX+FMA assembly function declarations (2x complex128 per iteration)
@@ -236,3 +248,14 @@ func conjAVX(dst, a []complex128)
 
 //go:noescape
 func conjSSE2(dst, a []complex128)
+
+// FromReal assembly function declarations
+
+//go:noescape
+func fromRealAVX512(dst []complex128, src []float64)
+
+//go:noescape
+func fromRealAVX(dst []complex128, src []float64)
+
+//go:noescape
+func fromRealSSE2(dst []complex128, src []float64)

--- a/c128/c128_amd64.s
+++ b/c128/c128_amd64.s
@@ -1125,3 +1125,100 @@ conj_sse2_loop:
 
 conj_sse2_done:
     RET
+
+// ============================================================================
+// FROMREAL - CONVERT REAL TO COMPLEX: complex(x, 0)
+// ============================================================================
+
+// func fromRealAVX512(dst []complex128, src []float64)
+// Processes 2 complex128 per iteration using YMM. Mirrors fromRealAVX: a
+// dedicated ZMM kernel buys nothing for this store-bandwidth-bound interleave,
+// exactly as c64's fromRealAVX512 reuses the YMM approach.
+TEXT ·fromRealAVX512(SB), NOSPLIT, $0-48
+    MOVQ dst_base+0(FP), DX
+    MOVQ dst_len+8(FP), CX
+    MOVQ src_base+24(FP), SI
+
+    MOVQ CX, AX
+    SHRQ $1, AX
+    JZ   fromreal_avx512_remainder
+
+    VXORPD Y15, Y15, Y15          // zero for interleaving
+
+fromreal_avx512_loop2:
+    VMOVUPD (SI), X0              // X0 = [r0, r1]
+    VUNPCKLPD X15, X0, X1         // X1 = [r0, 0]
+    VUNPCKHPD X15, X0, X2         // X2 = [r1, 0]
+    VINSERTF128 $1, X2, Y1, Y0    // Y0 = [r0, 0, r1, 0]
+    VMOVUPD Y0, (DX)             // store 2 complex128 = 32 bytes
+    ADDQ $16, SI                 // 2 float64 = 16 bytes
+    ADDQ $32, DX                 // 2 complex128 = 32 bytes
+    DECQ AX
+    JNZ  fromreal_avx512_loop2
+
+fromreal_avx512_remainder:
+    ANDQ $1, CX
+    JZ   fromreal_avx512_done
+
+    VMOVSD (SI), X0              // X0 = [r, 0] (load form zeros the high 64)
+    VMOVUPD X0, (DX)            // store one complex128
+
+fromreal_avx512_done:
+    VZEROUPPER
+    RET
+
+// func fromRealAVX(dst []complex128, src []float64)
+TEXT ·fromRealAVX(SB), NOSPLIT, $0-48
+    MOVQ dst_base+0(FP), DX
+    MOVQ dst_len+8(FP), CX
+    MOVQ src_base+24(FP), SI
+
+    MOVQ CX, AX
+    SHRQ $1, AX
+    JZ   fromreal_avx_remainder
+
+    VXORPD Y15, Y15, Y15
+
+fromreal_avx_loop2:
+    VMOVUPD (SI), X0              // X0 = [r0, r1]
+    VUNPCKLPD X15, X0, X1         // X1 = [r0, 0]
+    VUNPCKHPD X15, X0, X2         // X2 = [r1, 0]
+    VINSERTF128 $1, X2, Y1, Y0    // Y0 = [r0, 0, r1, 0]
+    VMOVUPD Y0, (DX)
+    ADDQ $16, SI
+    ADDQ $32, DX
+    DECQ AX
+    JNZ  fromreal_avx_loop2
+
+fromreal_avx_remainder:
+    ANDQ $1, CX
+    JZ   fromreal_avx_done
+
+    VMOVSD (SI), X0
+    VMOVUPD X0, (DX)
+
+fromreal_avx_done:
+    VZEROUPPER
+    RET
+
+// func fromRealSSE2(dst []complex128, src []float64)
+// Each complex128 fills a full XMM, so MOVSD's load-form zeroing of the upper
+// 64 bits yields [r, 0.0] directly; one element per iteration.
+TEXT ·fromRealSSE2(SB), NOSPLIT, $0-48
+    MOVQ dst_base+0(FP), DX
+    MOVQ dst_len+8(FP), CX
+    MOVQ src_base+24(FP), SI
+
+    TESTQ CX, CX
+    JZ   fromreal_sse2_done
+
+fromreal_sse2_loop:
+    MOVSD (SI), X0               // X0 = [r, 0.0] (load form zeros the high 64)
+    MOVUPS X0, (DX)             // store one complex128 = 16 bytes
+    ADDQ $8, SI
+    ADDQ $16, DX
+    DECQ CX
+    JNZ  fromreal_sse2_loop
+
+fromreal_sse2_done:
+    RET

--- a/c128/c128_amd64_test.go
+++ b/c128/c128_amd64_test.go
@@ -230,3 +230,46 @@ func TestAbsSqKernels(t *testing.T) {
 		})
 	}
 }
+
+
+// TestFromRealKernels compares each available FromReal assembly kernel against
+// the Go reference across sizes that exercise the wide loop and the scalar
+// remainder, including odd lengths so the 2-element YMM stride and its tail both
+// run. AVX-512 is skipped on hosts without it (verified in CI), but its logic is
+// identical to the AVX kernel exercised here.
+func TestFromRealKernels(t *testing.T) {
+	sizes := []int{0, 1, 2, 3, 4, 5, 7, 8, 9, 16, 17}
+
+	kernels := []struct {
+		name string
+		fn   fromRealFunc
+		skip bool
+	}{
+		{"SSE2", fromRealSSE2, !cpu.X86.SSE2},
+		{"AVX", fromRealAVX, !cpu.X86.AVX},
+		{"AVX512", fromRealAVX512, !cpu.X86.AVX512F || !cpu.X86.AVX512VL},
+	}
+
+	for _, k := range kernels {
+		if k.skip {
+			continue
+		}
+		t.Run(k.name, func(t *testing.T) {
+			for _, n := range sizes {
+				src := make([]float64, n)
+				for i := range src {
+					src[i] = float64(i+1) - 5
+				}
+				got := make([]complex128, n)
+				want := make([]complex128, n)
+				k.fn(got, src)
+				fromRealGo(want, src)
+				for i := range got {
+					if got[i] != want[i] {
+						t.Errorf("%s n=%d: FromReal[%d] = %v, want %v", k.name, n, i, got[i], want[i])
+					}
+				}
+			}
+		})
+	}
+}

--- a/c128/c128_arm64.go
+++ b/c128/c128_arm64.go
@@ -72,6 +72,14 @@ func conj128(dst, a []complex128) {
 	conjGo(dst, a)
 }
 
+func fromReal128(dst []complex128, src []float64) {
+	if hasNEON && len(dst) >= 1 {
+		fromRealNEON(dst, src)
+		return
+	}
+	fromRealGo(dst, src)
+}
+
 //go:noescape
 func mulNEON(dst, a, b []complex128)
 
@@ -95,3 +103,6 @@ func absSqNEON(dst []float64, a []complex128)
 
 //go:noescape
 func conjNEON(dst, a []complex128)
+
+//go:noescape
+func fromRealNEON(dst []complex128, src []float64)

--- a/c128/c128_arm64.s
+++ b/c128/c128_arm64.s
@@ -552,3 +552,54 @@ conj_neon_tail:
 
 conj_neon_done:
     RET
+
+// ============================================================================
+// FROMREAL - CONVERT REAL TO COMPLEX: complex(x, 0)
+// ============================================================================
+
+// func fromRealNEON(dst []complex128, src []float64)
+TEXT ·fromRealNEON(SB), NOSPLIT, $0-48
+    MOVD dst_base+0(FP), R0
+    MOVD dst_len+8(FP), R1
+    MOVD src_base+24(FP), R2
+
+    CBZ  R1, fromreal_neon_done
+
+    CMP  $2, R1
+    BLT  fromreal_neon_tail
+
+    // Zero register for interleaving
+    VEOR V15.B16, V15.B16, V15.B16
+
+fromreal_neon_loop2:
+    // Load 2 float64: V0 = [r0, r1]
+    VLD1.P 16(R2), [V0.D2]
+
+    // Interleave with zeros: V1=[r0,0], V2=[r1,0]
+    WORD $0x4ECF3801             // ZIP1 V1.2D, V0.2D, V15.2D
+    WORD $0x4ECF7802             // ZIP2 V2.2D, V0.2D, V15.2D
+
+    // Store 2 complex128 = 32 bytes
+    VST1.P [V1.D2], 16(R0)
+    VST1.P [V2.D2], 16(R0)
+
+    SUB  $2, R1
+    CMP  $2, R1
+    BGE  fromreal_neon_loop2
+
+    CBZ  R1, fromreal_neon_done
+
+fromreal_neon_tail:
+    FMOVD (R2), F0               // r
+    FMOVD ZR, F1                 // 0
+
+    FMOVD F0, (R0)
+    FMOVD F1, 8(R0)
+
+    ADD  $8, R2
+    ADD  $16, R0
+    SUB  $1, R1
+    CBNZ R1, fromreal_neon_tail
+
+fromreal_neon_done:
+    RET

--- a/c128/c128_go.go
+++ b/c128/c128_go.go
@@ -108,3 +108,17 @@ func conjGo(dst, a []complex128) {
 		dst[i] = complex(real(a[i]), -imag(a[i]))
 	}
 }
+
+
+// fromRealGo converts real float64 values to complex128: dst[i] = complex(src[i], 0).
+// This is the trusted reference and the path that runs on architectures without
+// SIMD.
+func fromRealGo(dst []complex128, src []float64) {
+	if len(dst) == 0 {
+		return
+	}
+	_ = src[len(dst)-1]
+	for i := range dst {
+		dst[i] = complex(src[i], 0)
+	}
+}

--- a/c128/c128_other.go
+++ b/c128/c128_other.go
@@ -9,4 +9,7 @@ func mulConj128(dst, a, b []complex128)           { mulConjGo(dst, a, b) }
 func scale128(dst, a []complex128, s complex128)  { scaleGo(dst, a, s) }
 func add128(dst, a, b []complex128)               { addGo(dst, a, b) }
 func sub128(dst, a, b []complex128)               { subGo(dst, a, b) }
+func abs128(dst []float64, a []complex128)        { absGo(dst, a) }
+func absSq128(dst []float64, a []complex128)      { absSqGo(dst, a) }
+func conj128(dst, a []complex128)                 { conjGo(dst, a) }
 func fromReal128(dst []complex128, src []float64) { fromRealGo(dst, src) }

--- a/c128/c128_other.go
+++ b/c128/c128_other.go
@@ -4,8 +4,9 @@ package c128
 
 // Fallback implementations for unsupported architectures
 
-func mul128(dst, a, b []complex128)              { mulGo(dst, a, b) }
-func mulConj128(dst, a, b []complex128)          { mulConjGo(dst, a, b) }
-func scale128(dst, a []complex128, s complex128) { scaleGo(dst, a, s) }
-func add128(dst, a, b []complex128)              { addGo(dst, a, b) }
-func sub128(dst, a, b []complex128)              { subGo(dst, a, b) }
+func mul128(dst, a, b []complex128)               { mulGo(dst, a, b) }
+func mulConj128(dst, a, b []complex128)           { mulConjGo(dst, a, b) }
+func scale128(dst, a []complex128, s complex128)  { scaleGo(dst, a, s) }
+func add128(dst, a, b []complex128)               { addGo(dst, a, b) }
+func sub128(dst, a, b []complex128)               { subGo(dst, a, b) }
+func fromReal128(dst []complex128, src []float64) { fromRealGo(dst, src) }

--- a/c128/fromreal_test.go
+++ b/c128/fromreal_test.go
@@ -1,0 +1,65 @@
+package c128
+
+import "testing"
+
+func TestFromReal(t *testing.T) {
+	tests := []struct {
+		name string
+		src  []float64
+		want []complex128
+	}{
+		{"empty", nil, nil},
+		{"single", []float64{1}, []complex128{1 + 0i}},
+		{"pair", []float64{1, 2}, []complex128{1 + 0i, 2 + 0i}},
+		{"negative", []float64{-1, -2}, []complex128{-1 + 0i, -2 + 0i}},
+		{"zero", []float64{0, 0}, []complex128{0 + 0i, 0 + 0i}},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if len(tt.src) == 0 {
+				dst := make([]complex128, 0)
+				FromReal(dst, tt.src)
+				return
+			}
+			dst := make([]complex128, len(tt.src))
+			FromReal(dst, tt.src)
+			for i := range dst {
+				if !complexClose(dst[i], tt.want[i]) {
+					t.Errorf("FromReal()[%d] = %v, want %v", i, dst[i], tt.want[i])
+				}
+			}
+		})
+	}
+}
+
+func TestFromReal_Large(t *testing.T) {
+	n := 100
+	src := make([]float64, n)
+	for i := range n {
+		src[i] = float64(i + 1)
+	}
+
+	dst := make([]complex128, n)
+	FromReal(dst, src)
+
+	for i := range n {
+		expected := complex(src[i], 0)
+		if !complexClose(dst[i], expected) {
+			t.Errorf("FromReal_Large()[%d] = %v, want %v", i, dst[i], expected)
+		}
+	}
+}
+
+// TestFromReal_AllocFree pins the zero-allocation contract: FromReal writes into
+// the caller-provided destination and must not allocate.
+func TestFromReal_AllocFree(t *testing.T) {
+	src := make([]float64, 1024)
+	dst := make([]complex128, 1024)
+	for i := range src {
+		src[i] = float64(i%2400 - 1200)
+	}
+	if a := testing.AllocsPerRun(50, func() { FromReal(dst, src) }); a != 0 {
+		t.Errorf("FromReal allocated %v times per run, want 0", a)
+	}
+}

--- a/c128/vector_path_test.go
+++ b/c128/vector_path_test.go
@@ -137,3 +137,28 @@ func TestVectorPathToRealC128(t *testing.T) {
 		}
 	}
 }
+
+
+// vpMakeF64 builds a deterministic float64 source slice for FromReal sweeps.
+func vpMakeF64(n, seed int) []float64 {
+	s := make([]float64, n)
+	for i := range s {
+		s[i] = float64((i*7+seed)%23) - 11
+	}
+	return s
+}
+
+func TestVectorPathFromRealC128(t *testing.T) {
+	for _, n := range vpLens {
+		src := vpMakeF64(n, 6)
+		got := make([]complex128, n)
+		want := make([]complex128, n)
+		FromReal(got, src)
+		fromRealGo(want, src)
+		for i := range got {
+			if got[i] != want[i] {
+				t.Errorf("FromReal n=%d [%d] = %v, want %v (Go fallback)", n, i, got[i], want[i])
+			}
+		}
+	}
+}

--- a/f32/f32.go
+++ b/f32/f32.go
@@ -410,6 +410,17 @@ func Sqrt(dst, a []float32) {
 	sqrt32(dst[:n], a[:n])
 }
 
+
+// Round rounds each element to the nearest integer, half away from zero:
+// dst[i] = round(src[i]). Processes min(len(dst), len(src)) elements.
+func Round(dst, src []float32) {
+	n := min(len(dst), len(src))
+	if n == 0 {
+		return
+	}
+	round32(dst[:n], src[:n])
+}
+
 // Reciprocal computes element-wise reciprocal: dst[i] = 1/a[i].
 // Processes min(len(dst), len(a)) elements.
 func Reciprocal(dst, a []float32) {

--- a/f32/f32_amd64.go
+++ b/f32/f32_amd64.go
@@ -52,6 +52,7 @@ var (
 	negImpl              unaryOpFunc
 	sqrtImpl             unaryOpFunc
 	reciprocalImpl       unaryOpFunc
+	roundImpl            unaryOpFunc
 	fmaImpl              fmaFunc
 	clampImpl            clampFunc
 	minIdxImpl           reduceIdxFunc
@@ -93,6 +94,7 @@ func initAVX512() {
 	negImpl = negAVX512
 	sqrtImpl = sqrtAVX512
 	reciprocalImpl = reciprocalAVX512
+	roundImpl = roundAVX
 	fmaImpl = fmaAVX512
 	clampImpl = clampAVX512
 	minIdxImpl = minIdxGo
@@ -118,6 +120,7 @@ func initAVX() {
 	negImpl = negAVX
 	sqrtImpl = sqrtAVX
 	reciprocalImpl = reciprocalAVX
+	roundImpl = roundAVX
 	fmaImpl = fmaAVX
 	clampImpl = clampAVX
 	minIdxImpl = minIdxGo
@@ -142,6 +145,7 @@ func initSSE() {
 	negImpl = negSSE
 	sqrtImpl = sqrtSSE
 	reciprocalImpl = reciprocalSSE
+	roundImpl = round32Go
 	fmaImpl = fmaSSE
 	clampImpl = clampSSE
 	minIdxImpl = minIdxGo
@@ -168,6 +172,7 @@ func initGo() {
 	negImpl = negGo
 	sqrtImpl = sqrt32Go
 	reciprocalImpl = reciprocal32Go
+	roundImpl = round32Go
 	fmaImpl = fmaGo
 	clampImpl = clampGo
 	minIdxImpl = minIdxGo
@@ -259,6 +264,11 @@ func sqrt32(dst, a []float32) {
 
 func reciprocal32(dst, a []float32) {
 	reciprocalImpl(dst, a)
+}
+
+
+func round32(dst, src []float32) {
+	roundImpl(dst, src)
 }
 
 func minIdx32(a []float32) int {
@@ -704,6 +714,9 @@ func clampScaleAVX(dst, src []float32, minVal, maxVal, scale float32)
 
 //go:noescape
 func sqrtAVX(dst, a []float32)
+
+//go:noescape
+func roundAVX(dst, src []float32)
 
 //go:noescape
 func reciprocalAVX(dst, a []float32)

--- a/f32/f32_amd64.s
+++ b/f32/f32_amd64.s
@@ -13,6 +13,38 @@ DATA absf32mask<>+0x18(SB)/4, $0x7fffffff
 DATA absf32mask<>+0x1c(SB)/4, $0x7fffffff
 GLOBL absf32mask<>(SB), RODATA|NOPTR, $32
 
+// Constants for roundAVX (round-half-away-from-zero). absf32mask above doubles
+// as the |frac| mask; these supply the sign bit, the 0.5 threshold and 1.0.
+DATA roundf32_signmask<>+0x00(SB)/4, $0x80000000
+DATA roundf32_signmask<>+0x04(SB)/4, $0x80000000
+DATA roundf32_signmask<>+0x08(SB)/4, $0x80000000
+DATA roundf32_signmask<>+0x0c(SB)/4, $0x80000000
+DATA roundf32_signmask<>+0x10(SB)/4, $0x80000000
+DATA roundf32_signmask<>+0x14(SB)/4, $0x80000000
+DATA roundf32_signmask<>+0x18(SB)/4, $0x80000000
+DATA roundf32_signmask<>+0x1c(SB)/4, $0x80000000
+GLOBL roundf32_signmask<>(SB), RODATA|NOPTR, $32
+
+DATA roundf32_half<>+0x00(SB)/4, $0x3f000000
+DATA roundf32_half<>+0x04(SB)/4, $0x3f000000
+DATA roundf32_half<>+0x08(SB)/4, $0x3f000000
+DATA roundf32_half<>+0x0c(SB)/4, $0x3f000000
+DATA roundf32_half<>+0x10(SB)/4, $0x3f000000
+DATA roundf32_half<>+0x14(SB)/4, $0x3f000000
+DATA roundf32_half<>+0x18(SB)/4, $0x3f000000
+DATA roundf32_half<>+0x1c(SB)/4, $0x3f000000
+GLOBL roundf32_half<>(SB), RODATA|NOPTR, $32
+
+DATA roundf32_one<>+0x00(SB)/4, $0x3f800000
+DATA roundf32_one<>+0x04(SB)/4, $0x3f800000
+DATA roundf32_one<>+0x08(SB)/4, $0x3f800000
+DATA roundf32_one<>+0x0c(SB)/4, $0x3f800000
+DATA roundf32_one<>+0x10(SB)/4, $0x3f800000
+DATA roundf32_one<>+0x14(SB)/4, $0x3f800000
+DATA roundf32_one<>+0x18(SB)/4, $0x3f800000
+DATA roundf32_one<>+0x1c(SB)/4, $0x3f800000
+GLOBL roundf32_one<>(SB), RODATA|NOPTR, $32
+
 // func dotProductAVX(a, b []float32) float32
 // Optimized with 4 independent accumulators to hide FMA latency.
 // Processes 32 float32s per iteration (4 vectors × 8 floats).
@@ -2928,6 +2960,76 @@ sqrt32_avx_scalar:
     JNZ  sqrt32_avx_scalar
 
 sqrt32_avx_done:
+    VZEROUPPER
+    RET
+
+// roundAVX: round-half-away-from-zero, the float32 analogue of f64's roundAVX.
+// There is no single AVX instruction for round-half-away (VROUNDPS $0 rounds
+// half-to-even), so it is emulated:
+//   t   = trunc(x)
+//   f   = x - t                     // signed fractional part in (-1, 1)
+//   inc = (|f| >= 0.5) ? sign(x)*1.0 : 0
+//   result = t + inc
+// This avoids the trunc(|x|+0.5) overcounting at |x|=nextafter(0.5,0), where the
+// FP add rounds up to exactly 1.0.
+//
+// func roundAVX(dst, src []float32)
+TEXT ·roundAVX(SB), NOSPLIT, $0-48
+    MOVQ dst_base+0(FP), DX
+    MOVQ dst_len+8(FP), CX
+    MOVQ src_base+24(FP), SI
+
+    VMOVUPS absf32mask<>(SB), Y3      // |frac| mask (0x7fffffff per lane)
+    VMOVUPS roundf32_signmask<>(SB), Y4
+    VMOVUPS roundf32_half<>(SB), Y5
+    VMOVUPS roundf32_one<>(SB), Y11
+
+    MOVQ CX, AX
+    SHRQ $3, AX
+    JZ   round32_avx_remainder
+
+round32_avx_loop8:
+    VMOVUPS (SI), Y0                  // Y0 = x
+    VROUNDPS $3, Y0, Y1               // Y1 = trunc(x)
+    VSUBPS Y1, Y0, Y2                 // Y2 = x - trunc(x) = signed frac
+    VANDPS Y3, Y2, Y6                 // Y6 = |frac|
+    VCMPPS $5, Y5, Y6, Y7             // Y7 = mask: |frac| NLT 0.5  (|frac| >= 0.5)
+    VANDPS Y11, Y7, Y8                // Y8 = 1.0 where mask, else 0
+    VANDPS Y4, Y0, Y9                 // Y9 = signbit(x)
+    VORPS Y9, Y8, Y8                  // Y8 = ±1.0 (or ±0.0 when no increment)
+    VADDPS Y8, Y1, Y1                 // Y1 = trunc(x) + ±1 or +0
+    VMOVUPS Y1, (DX)
+    ADDQ $32, SI
+    ADDQ $32, DX
+    DECQ AX
+    JNZ  round32_avx_loop8
+
+round32_avx_remainder:
+    ANDQ $7, CX
+    JZ   round32_avx_done
+
+    VMOVSS absf32mask<>(SB), X3
+    VMOVSS roundf32_signmask<>(SB), X4
+    VMOVSS roundf32_half<>(SB), X5
+    VMOVSS roundf32_one<>(SB), X11
+
+round32_avx_scalar:
+    VMOVSS (SI), X0                   // X0 = x
+    VROUNDSS $3, X0, X0, X1           // X1 = trunc(x)
+    VSUBSS X1, X0, X2                 // X2 = signed frac
+    VANDPS X3, X2, X6                 // X6 = |frac|
+    VCMPSS $5, X5, X6, X7             // X7 = mask: |frac| NLT 0.5
+    VANDPS X11, X7, X8                // X8 = 1.0 where mask else 0
+    VANDPS X4, X0, X9                 // X9 = signbit(x)
+    VORPS X9, X8, X8                  // X8 = ±1 or ±0
+    VADDSS X8, X1, X1                 // X1 = trunc(x) + inc
+    VMOVSS X1, (DX)
+    ADDQ $4, SI
+    ADDQ $4, DX
+    DECQ CX
+    JNZ  round32_avx_scalar
+
+round32_avx_done:
     VZEROUPPER
     RET
 

--- a/f32/f32_arm64.go
+++ b/f32/f32_arm64.go
@@ -465,6 +465,15 @@ func sqrt32(dst, a []float32) {
 	sqrt32Go(dst, a)
 }
 
+
+func round32(dst, src []float32) {
+	if hasNEON && len(dst) >= 4 {
+		roundNEON(dst, src)
+		return
+	}
+	round32Go(dst, src)
+}
+
 func reciprocal32(dst, a []float32) {
 	if hasNEON && len(dst) >= 4 {
 		reciprocalNEON(dst, a)
@@ -495,6 +504,9 @@ func cumulativeSum32(dst, a []float32) {
 
 //go:noescape
 func sqrtNEON(dst, a []float32)
+
+//go:noescape
+func roundNEON(dst, src []float32)
 
 //go:noescape
 func reciprocalNEON(dst, a []float32)

--- a/f32/f32_arm64.s
+++ b/f32/f32_arm64.s
@@ -976,6 +976,42 @@ sqrt32_loop1:
 sqrt32_done:
     RET
 
+// roundNEON: round-half-away-from-zero using FRINTA (round to nearest, ties to
+// away), which matches math.Round exactly. The float32 analogue of f64's
+// roundNEON.
+//
+// func roundNEON(dst, src []float32)
+TEXT ·roundNEON(SB), NOSPLIT, $0-48
+    MOVD dst_base+0(FP), R0
+    MOVD dst_len+8(FP), R2
+    MOVD src_base+24(FP), R1
+
+    LSR $2, R2, R3
+    CBZ R3, round32_scalar
+
+round32_loop4:
+    VLD1.P 16(R1), [V0.S4]
+    WORD $0x6E218800           // FRINTA V0.4S, V0.4S
+    VST1.P [V0.S4], 16(R0)
+    SUB $1, R3
+    CBNZ R3, round32_loop4
+
+round32_scalar:
+    AND $3, R2
+    CBZ R2, round32_done
+
+round32_loop1:
+    FMOVS (R1), F0
+    WORD $0x1E264000           // FRINTA S0, S0
+    FMOVS F0, (R0)
+    ADD $4, R0
+    ADD $4, R1
+    SUB $1, R2
+    CBNZ R2, round32_loop1
+
+round32_done:
+    RET
+
 // func reciprocalNEON(dst, a []float32)
 // Uses full precision division (FRECPE is only approximate)
 TEXT ·reciprocalNEON(SB), NOSPLIT, $0-48

--- a/f32/f32_go.go
+++ b/f32/f32_go.go
@@ -389,6 +389,20 @@ func sqrt32Go(dst, a []float32) {
 	}
 }
 
+
+// round32Go rounds each element to the nearest integer, half away from zero,
+// matching math.Round. This is the trusted reference and the path that runs on
+// architectures without SIMD.
+func round32Go(dst, src []float32) {
+	if len(dst) == 0 {
+		return
+	}
+	_ = src[len(dst)-1]
+	for i := range dst {
+		dst[i] = float32(math.Round(float64(src[i])))
+	}
+}
+
 func reciprocal32Go(dst, a []float32) {
 	if len(dst) == 0 {
 		return

--- a/f32/f32_other.go
+++ b/f32/f32_other.go
@@ -40,6 +40,7 @@ func deinterleaveN32(dsts [][]float32, src []float32, n int) {
 	deinterleaveNGo(dsts, src, n)
 }
 func sqrt32(dst, a []float32)                               { sqrt32Go(dst, a) }
+func round32(dst, src []float32)                            { round32Go(dst, src) }
 func reciprocal32(dst, a []float32)                         { reciprocal32Go(dst, a) }
 func minIdx32(a []float32) int                              { return minIdxGo(a) }
 func maxIdx32(a []float32) int                              { return maxIdxGo(a) }

--- a/f32/go_impl_newops_test.go
+++ b/f32/go_impl_newops_test.go
@@ -1,6 +1,9 @@
 package f32
 
-import "testing"
+import (
+	"math"
+	"testing"
+)
 
 // Exercises the Go fallback for the subFromScalar composition directly, so the
 // pure-Go path is covered on AVX/NEON-capable test hosts too.
@@ -15,4 +18,25 @@ func TestSubFromScalarGo(t *testing.T) {
 			t.Errorf("subFromScalarGo[%d] = %v, want %v", i, dst[i], want[i])
 		}
 	}
+}
+
+// TestRound32Go exercises the Go fallback for Round directly, so the pure-Go
+// path (and its BCE-hint bounds line) is covered on AVX/NEON-capable test hosts
+// too, where Round dispatches to the assembly kernel instead.
+func TestRound32Go(t *testing.T) {
+	src := []float32{-2.5, -1.5, -0.5, 0.4, 0.5, 1.5, 2.5}
+	dst := make([]float32, len(src))
+	round32Go(dst, src)
+	for i, v := range src {
+		want := float32(math.Round(float64(v)))
+		if dst[i] != want {
+			t.Errorf("round32Go[%d](%v) = %v, want %v", i, v, dst[i], want)
+		}
+	}
+}
+
+// TestRound32Go_EmptyDst hits the `if len(dst) == 0 { return }` guard with a
+// non-empty src argument.
+func TestRound32Go_EmptyDst(_ *testing.T) {
+	round32Go(nil, []float32{1, 2})
 }

--- a/f32/round_test.go
+++ b/f32/round_test.go
@@ -1,0 +1,107 @@
+package f32
+
+import (
+	"math"
+	"testing"
+)
+
+func TestRound(t *testing.T) {
+	src := []float32{-2.5, -1.5, -0.5, 0.4, 0.5, 1.5, 2.5, 3.49, 3.5}
+	dst := make([]float32, len(src))
+
+	Round(dst, src)
+
+	for i := range src {
+		want := float32(math.Round(float64(src[i])))
+		if dst[i] != want {
+			t.Errorf("Round()[%d] = %v, want %v", i, dst[i], want)
+		}
+	}
+}
+
+func TestRound_SpecialValues(t *testing.T) {
+	src := []float32{float32(math.NaN()), float32(math.Inf(1)), float32(math.Inf(-1))}
+	dst := make([]float32, len(src))
+
+	Round(dst, src)
+
+	if !math.IsNaN(float64(dst[0])) {
+		t.Errorf("Round(NaN) = %v, want NaN", dst[0])
+	}
+	if !math.IsInf(float64(dst[1]), 1) {
+		t.Errorf("Round(+Inf) = %v, want +Inf", dst[1])
+	}
+	if !math.IsInf(float64(dst[2]), -1) {
+		t.Errorf("Round(-Inf) = %v, want -Inf", dst[2])
+	}
+}
+
+func TestRound_EmptySlices(_ *testing.T) {
+	Round(nil, nil)
+	Round([]float32{}, []float32{1, 2, 3})
+	Round([]float32{1, 2, 3}, nil)
+}
+
+func TestRound_FPEdgeCases(t *testing.T) {
+	// Inputs that would break a naive trunc(abs(x)+0.5) implementation because
+	// abs(x)+0.5 rounds to a value whose trunc is one too large. Nextafter is
+	// computed in float64 then narrowed; the narrowing stays below the tie so
+	// the float32 value is still strictly below 0.5/1.5.
+	belowHalf := math.Float32frombits(math.Float32bits(0.5) - 1)        // largest float32 < 0.5
+	negBelowHalf := math.Float32frombits(math.Float32bits(-0.5) - 1)    // smallest-magnitude float32 > -0.5
+	belowOneHalf := math.Float32frombits(math.Float32bits(1.5) - 1)     // largest float32 < 1.5
+	negBelowOneHalf := math.Float32frombits(math.Float32bits(-1.5) - 1) // smallest-magnitude float32 > -1.5
+
+	src := []float32{
+		belowHalf,
+		negBelowHalf,
+		belowOneHalf,
+		negBelowOneHalf,
+		0.5,
+		-0.5,
+		1.5,
+		-1.5,
+		float32(math.Copysign(0, 1)),
+		float32(math.Copysign(0, -1)),
+	}
+	dst := make([]float32, len(src))
+	Round(dst, src)
+
+	for i, v := range src {
+		want := float32(math.Round(float64(v)))
+		if dst[i] != want || math.Signbit(float64(dst[i])) != math.Signbit(float64(want)) {
+			t.Errorf("Round(%g)=%g (signbit=%v), want %g (signbit=%v)",
+				v, dst[i], math.Signbit(float64(dst[i])), want, math.Signbit(float64(want)))
+		}
+	}
+}
+
+func TestRound_LongerInputs(t *testing.T) {
+	for _, n := range []int{1, 3, 4, 7, 8, 15, 16, 17, 31, 32, 33, 64, 65, 127, 128} {
+		src := make([]float32, n)
+		for i := range src {
+			src[i] = float32(i)*0.5 - 4
+		}
+		dst := make([]float32, n)
+		Round(dst, src)
+		for i, v := range src {
+			want := float32(math.Round(float64(v)))
+			if dst[i] != want {
+				t.Fatalf("n=%d: Round[%d]=%v, want %v", n, i, dst[i], want)
+			}
+		}
+	}
+}
+
+// TestRound_AllocFree pins the zero-allocation contract: Round writes into the
+// caller-provided destination and must not allocate.
+func TestRound_AllocFree(t *testing.T) {
+	src := make([]float32, 1024)
+	dst := make([]float32, 1024)
+	for i := range src {
+		src[i] = float32(i%2400-1200) / 7.0
+	}
+	if a := testing.AllocsPerRun(50, func() { Round(dst, src) }); a != 0 {
+		t.Errorf("Round allocated %v times per run, want 0", a)
+	}
+}

--- a/f32/vector_path_test.go
+++ b/f32/vector_path_test.go
@@ -140,6 +140,30 @@ func TestVectorPathUnary32(t *testing.T) {
 	}
 }
 
+// TestVectorPathRound32 uses non-tie fractional inputs so the result is identical
+// regardless of the half-way rounding rule, and an exact match is required.
+func TestVectorPathRound32(t *testing.T) {
+	for _, n := range vpLens {
+		src := make([]float32, n)
+		for i := range src {
+			frac := float32(0.3)
+			if i%2 == 1 {
+				frac = 0.7
+			}
+			src[i] = float32((i*3+1)%17-8) + frac
+		}
+		got := make([]float32, n)
+		want := make([]float32, n)
+		Round(got, src)
+		round32Go(want, src)
+		for i := range got {
+			if got[i] != want[i] {
+				t.Errorf("Round n=%d [%d] = %v, want %v (in %v)", n, i, got[i], want[i], src[i])
+			}
+		}
+	}
+}
+
 // TestVectorPathActivations32 covers the (dst, src) activation kernels. ReLU is
 // exact; Sigmoid/Tanh/Exp use the looser approximation tolerance.
 func TestVectorPathActivations32(t *testing.T) {


### PR DESCRIPTION
## Summary

Closes the two remaining f32/c128 API-parity gaps with their f64/c64 siblings, plus a cross-architecture build fix discovered along the way.

### `f32.Round` (parity with `f64.Round`)
f32 advertised "Same API as f64" but lacked `Round`. The kernels mirror f64 exactly:
- **ARM64 (NEON):** `FRINTA` (round to nearest, ties to away) which is `math.Round` in one instruction.
- **AMD64 (AVX/AVX-512):** `VROUNDPS` truncate plus a manual half-away-from-zero correction (no single AVX instruction rounds half away from zero; `VROUNDPS $0` is half-to-even). SSE2 and the Go path use the scalar reference, matching f64 (ROUNDPS is SSE4.1, not in the SSE2 baseline).

Bit-identical to `float32(math.Round(float64(x)))`, allocation-free.

### `c128.FromReal` (parity with `c64.FromReal`)
Real to complex with a zero imaginary part (FFT input prep). Kernels mirror c64:
- **AMD64:** AVX-512/AVX use a YMM unpack (2 complex128/iter); SSE2 uses `MOVSD`'s load-form upper-64 zeroing to produce `[r, 0.0]` directly.
- **ARM64 (NEON):** `ZIP1/ZIP2 .2D` against a zero register.

The AVX-512 kernel reuses the YMM approach (this op is store-bandwidth-bound), exactly as c64's `fromRealAVX512` does. Allocation-free.

### Fix: `c128` non-SIMD build
`abs128`/`absSq128`/`conj128` were only defined for amd64/arm64; `c128_other.go` was never updated when those ops landed, so the package failed to compile on riscv64, wasm, ppc64, mips64, s390x, etc. (despite the package doc promising a pure-Go fallback). Wired the three to their existing Go references.

## Test Plan
- [x] Full suite green on AMD64 (AVX2+FMA)
- [x] Full f32 + c128 suites green on a real ARM64 Raspberry Pi 5 (NEON), incl. FP edge cases
- [x] Every hand-encoded ARM64 `WORD` cross-validated against `arm64asm` (`SIMD_REQUIRE_OBJDUMP=1`); pre-checked with `aarch64-linux-gnu-as`
- [x] SSE2 + AVX FromReal kernels tested directly (`TestFromRealKernels`); `TestSSE2KernelsAreBaselineSSE2` confirms the SSE2 kernel stays in-baseline
- [x] `go vet` clean, `golangci-lint run` 0 issues, no goroutine-register clobbers
- [x] Whole module builds for riscv64, js/wasm, ppc64, mips64, s390x

Note: AVX-512 has no local hardware here; those paths share the verified AVX kernel's logic and are exercised in CI.