### PR TITLE
crc: add Checksum16 with PCLMULQDQ/PMULL carry-less-multiply fold

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,7 +80,23 @@ fmt.Println(cpu.HasFMA())      // true/false
 fmt.Println(cpu.HasAVX512VL()) // true/false (AVX-512 F+VL)
 fmt.Println(cpu.HasNEON())     // true/false
 fmt.Println(cpu.HasFP16())     // true/false (ARM64 half-precision SIMD)
+fmt.Println(cpu.HasPCLMULQDQ()) // true/false (x86 carry-less multiply)
+fmt.Println(cpu.HasPMULL())    // true/false (ARM64 polynomial multiply)
 ```
+
+### `crc` - Cyclic Redundancy Checks
+
+```go
+import "github.com/tphakala/simd/crc"
+
+// FLAC CRC-16 (poly 0x8005, init 0, MSB-first, no reflection), folded 16 bytes
+// at a time with PCLMULQDQ (amd64) / PMULL (arm64), scalar slice-by-16 fallback.
+sum := crc.Checksum16(p) // bit-identical to the scalar reference, zero-alloc
+```
+
+| Function          | Description                              | Acceleration                       |
+| ----------------- | ---------------------------------------- | ---------------------------------- |
+| `Checksum16(p)`   | FLAC CRC-16 (poly 0x8005, MSB-first)     | PCLMULQDQ / PMULL carry-less fold  |
 
 ### `f64` - float64 Operations
 

--- a/cpu/cpu.go
+++ b/cpu/cpu.go
@@ -4,26 +4,28 @@ package cpu
 // Features contains detected CPU SIMD capabilities.
 type Features struct {
 	// x86/AMD64 features
-	SSE      bool
-	SSE2     bool
-	SSE3     bool
-	SSSE3    bool
-	SSE41    bool
-	SSE42    bool
-	AVX      bool
-	AVX2     bool
-	AVX512F  bool
-	AVX512VL bool
-	FMA      bool
-	BMI1     bool
-	BMI2     bool
-	POPCNT   bool
+	SSE       bool
+	SSE2      bool
+	SSE3      bool
+	SSSE3     bool
+	SSE41     bool
+	SSE42     bool
+	AVX       bool
+	AVX2      bool
+	AVX512F   bool
+	AVX512VL  bool
+	FMA       bool
+	BMI1      bool
+	BMI2      bool
+	POPCNT    bool
+	PCLMULQDQ bool // carry-less multiply (CLMUL) - used for CRC folding
 
 	// ARM64 features
-	NEON bool
-	FP16 bool // ARM64 half-precision floating point (FEAT_FP16)
-	SVE  bool
-	SVE2 bool
+	NEON  bool
+	FP16  bool // ARM64 half-precision floating point (FEAT_FP16)
+	SVE   bool
+	SVE2  bool
+	PMULL bool // polynomial multiply (FEAT_PMULL) - used for CRC folding
 }
 
 // X86 contains x86/AMD64 CPU features (populated on amd64).
@@ -43,6 +45,14 @@ func HasFMA() bool { return X86.FMA }
 
 // HasNEON returns true if ARM NEON is available.
 func HasNEON() bool { return ARM64.NEON }
+
+// HasPCLMULQDQ returns true if the x86 carry-less multiply instruction
+// (PCLMULQDQ) is available. It is used to accelerate CRC folding.
+func HasPCLMULQDQ() bool { return X86.PCLMULQDQ }
+
+// HasPMULL returns true if the ARM64 polynomial multiply instruction (PMULL)
+// is available. It is used to accelerate CRC folding.
+func HasPMULL() bool { return ARM64.PMULL }
 
 // HasFP16 returns true if ARM FP16 (half-precision) is available.
 func HasFP16() bool { return ARM64.FP16 }

--- a/cpu/cpu_amd64.go
+++ b/cpu/cpu_amd64.go
@@ -19,6 +19,7 @@ func init() {
 	X86.BMI1 = cpu.X86.HasBMI1
 	X86.BMI2 = cpu.X86.HasBMI2
 	X86.POPCNT = cpu.X86.HasPOPCNT
+	X86.PCLMULQDQ = cpu.X86.HasPCLMULQDQ
 }
 
 func cpuInfo() string {

--- a/cpu/cpu_arm64.go
+++ b/cpu/cpu_arm64.go
@@ -9,6 +9,7 @@ func init() {
 	ARM64.FP16 = cpu.ARM64.HasASIMDHP // FEAT_FP16 - half-precision SIMD
 	ARM64.SVE = cpu.ARM64.HasSVE
 	ARM64.SVE2 = cpu.ARM64.HasSVE2
+	ARM64.PMULL = cpu.ARM64.HasPMULL // FEAT_PMULL - polynomial multiply
 }
 
 func cpuInfo() string {

--- a/cpu/cpu_arm64_darwin.go
+++ b/cpu/cpu_arm64_darwin.go
@@ -4,15 +4,16 @@ package cpu
 
 import "golang.org/x/sys/cpu"
 
-// Apple Silicon (M1/M2/M3/M4) all support FEAT_FP16 (half-precision floating point).
-// The golang.org/x/sys/cpu package doesn't properly detect this on macOS,
-// so we enable it unconditionally on darwin/arm64.
+// Apple Silicon (M1/M2/M3/M4) all support FEAT_FP16 (half-precision floating point)
+// and FEAT_PMULL (polynomial multiply). The golang.org/x/sys/cpu package doesn't
+// properly detect these on macOS, so we enable them unconditionally on darwin/arm64.
 
 func init() {
 	ARM64.NEON = cpu.ARM64.HasASIMD
 	ARM64.FP16 = true // All Apple Silicon chips support FP16
 	ARM64.SVE = cpu.ARM64.HasSVE
 	ARM64.SVE2 = cpu.ARM64.HasSVE2
+	ARM64.PMULL = true // All Apple Silicon chips support PMULL
 }
 
 func cpuInfo() string {

--- a/cpu/cpu_test.go
+++ b/cpu/cpu_test.go
@@ -37,6 +37,18 @@ func TestHasFP16(_ *testing.T) {
 	_ = got
 }
 
+// TestHasPCLMULQDQ tests the HasPCLMULQDQ function
+func TestHasPCLMULQDQ(_ *testing.T) {
+	got := HasPCLMULQDQ()
+	_ = got
+}
+
+// TestHasPMULL tests the HasPMULL function
+func TestHasPMULL(_ *testing.T) {
+	got := HasPMULL()
+	_ = got
+}
+
 // TestHasAVX512VL tests the HasAVX512VL function
 func TestHasAVX512VL(_ *testing.T) {
 	got := HasAVX512VL()
@@ -76,10 +88,12 @@ func TestFeatures(_ *testing.T) {
 	_ = X86.BMI1
 	_ = X86.BMI2
 	_ = X86.POPCNT
+	_ = X86.PCLMULQDQ
 
 	// Test ARM64 features struct
 	_ = ARM64.NEON
 	_ = ARM64.FP16
 	_ = ARM64.SVE
 	_ = ARM64.SVE2
+	_ = ARM64.PMULL
 }

--- a/crc/crc.go
+++ b/crc/crc.go
@@ -1,0 +1,132 @@
+// Package crc provides SIMD-accelerated cyclic redundancy checks.
+//
+// The initial focus is the FLAC CRC-16 (polynomial x^16+x^15+x^2+1 = 0x8005,
+// init 0, MSB-first with no input/output reflection), which a pure-Go FLAC
+// encoder computes over every coded frame. Checksum16 folds the bulk of the
+// buffer 16 bytes at a time using a carry-less-multiply kernel (PCLMULQDQ on
+// amd64, PMULL on arm64) and falls back to a slice-by-16 table loop on
+// architectures without a polynomial-multiply instruction.
+//
+// All functions are bit-identical to the scalar reference and allocation-free.
+//
+// Thread Safety: All functions are safe for concurrent use.
+package crc
+
+import "encoding/binary"
+
+// poly16 is the FLAC CRC-16 generator polynomial x^16+x^15+x^2+1 without its
+// implicit x^16 term (the full 17-bit form is 0x18005).
+const poly16 = 0x8005
+
+const (
+	// bitsPerByte is the MSB-first byte stride: folding one byte into the CRC
+	// shifts the 16-bit register left by one byte and indexes on the byte that
+	// falls out of the top.
+	bitsPerByte = 8
+	// blockBytes is the carry-less-multiply fold stride and the width of the
+	// 128-bit accumulator in bytes.
+	blockBytes = 16
+)
+
+// Fold constants for the carry-less-multiply kernels. Folding a 128-bit
+// accumulator forward by one 16-byte block computes acc*x^128 mod P, which
+// splits into the two 64-bit halves of acc multiplied (carry-less) by:
+//
+//	crc16K1 = x^192 mod P  (applied to the high half, bits 127..64)
+//	crc16K2 = x^128 mod P  (applied to the low half,  bits  63..0)
+//
+// Both reduce to degree < 16, so each carry-less product stays below 80 bits.
+// The assembly kernels embed these same literals; crc_model_test.go asserts
+// they equal x^192 mod P and x^128 mod P so the two never drift apart.
+const (
+	crc16K1 = 0x1666 // x^192 mod 0x18005
+	crc16K2 = 0x0106 // x^128 mod 0x18005
+)
+
+var (
+	table16  [256]uint16
+	table16x [16][256]uint16
+)
+
+func init() {
+	for i := range 256 {
+		c := uint16(i) << bitsPerByte
+		for range bitsPerByte {
+			if c&0x8000 != 0 {
+				c = (c << 1) ^ poly16
+			} else {
+				c <<= 1
+			}
+		}
+		table16[i] = c
+	}
+
+	// Slice-by-16 derived tables: table16x[0] == table16; table16x[n][b] is the
+	// CRC-16 of byte b followed by n zero bytes, so sixteen input bytes fold in
+	// one step. MSB-first, no reflection, matching update16.
+	for b := range 256 {
+		table16x[0][b] = table16[b]
+	}
+	for n := 1; n < 16; n++ {
+		for b := range 256 {
+			prev := table16x[n-1][b]
+			table16x[n][b] = (prev << bitsPerByte) ^ table16[byte(prev>>bitsPerByte)]
+		}
+	}
+}
+
+// update16 folds one byte into a running CRC-16.
+func update16(c uint16, b byte) uint16 {
+	return (c << bitsPerByte) ^ table16[byte(c>>bitsPerByte)^b]
+}
+
+// Checksum16 returns the FLAC CRC-16 of p (polynomial 0x8005, init 0, MSB-first,
+// no reflection). It is bit-identical to a byte-at-a-time reference loop and
+// allocation-free.
+func Checksum16(p []byte) uint16 {
+	return checksum16(p)
+}
+
+// checksum16Go is the pure-Go slice-by-16 reference. It is the fallback on
+// architectures without a carry-less-multiply instruction and the final
+// reduction step shared by the SIMD kernels.
+func checksum16Go(p []byte) uint16 {
+	var c uint16
+	for len(p) >= blockBytes {
+		c = table16x[15][byte(c>>bitsPerByte)^p[0]] ^
+			table16x[14][byte(c)^p[1]] ^
+			table16x[13][p[2]] ^
+			table16x[12][p[3]] ^
+			table16x[11][p[4]] ^
+			table16x[10][p[5]] ^
+			table16x[9][p[6]] ^
+			table16x[8][p[7]] ^
+			table16x[7][p[8]] ^
+			table16x[6][p[9]] ^
+			table16x[5][p[10]] ^
+			table16x[4][p[11]] ^
+			table16x[3][p[12]] ^
+			table16x[2][p[13]] ^
+			table16x[1][p[14]] ^
+			table16x[0][p[15]]
+		p = p[16:]
+	}
+	for _, b := range p {
+		c = update16(c, b)
+	}
+	return c
+}
+
+// checksum16FromAcc finishes a folded accumulator. After the fold loop, the
+// 128-bit accumulator (accHi:accLo, most-significant byte first) is congruent
+// to the already-processed prefix modulo the CRC polynomial, so the final CRC
+// is the scalar CRC-16 of the accumulator's 16 bytes followed by the unfolded
+// tail (fewer than 16 bytes). The fixed 31-byte stack buffer keeps it
+// allocation-free.
+func checksum16FromAcc(accHi, accLo uint64, tail []byte) uint16 {
+	var b [2*blockBytes - 1]byte // 16 accumulator bytes + at most 15 tail bytes
+	binary.BigEndian.PutUint64(b[0:8], accHi)
+	binary.BigEndian.PutUint64(b[8:blockBytes], accLo)
+	n := blockBytes + copy(b[blockBytes:], tail)
+	return checksum16Go(b[:n])
+}

--- a/crc/crc_amd64.go
+++ b/crc/crc_amd64.go
@@ -1,0 +1,31 @@
+//go:build amd64
+
+package crc
+
+import "github.com/tphakala/simd/cpu"
+
+// minFoldBytes is the smallest input routed through the PCLMULQDQ fold. Below it
+// the scalar slice-by-16 loop wins, because the fold pays a fixed scalar
+// reduction over the 16 accumulator bytes regardless of input length. Tuned from
+// the benchmarks; FLAC frames are kilobytes, so the hot path always folds.
+const minFoldBytes = 64
+
+var hasPCLMULQDQ = cpu.X86.PCLMULQDQ
+
+// foldSupported reports whether the carry-less-multiply kernel is active.
+func foldSupported() bool { return hasPCLMULQDQ }
+
+// checksum16 folds the bulk of p with PCLMULQDQ when available, then reduces the
+// folded accumulator plus the trailing tail with the scalar path.
+func checksum16(p []byte) uint16 {
+	if hasPCLMULQDQ && len(p) >= minFoldBytes {
+		full := len(p) &^ (blockBytes - 1)
+		var acc [2]uint64
+		crc16FoldBlocks(&acc, p[:full])
+		return checksum16FromAcc(acc[0], acc[1], p[full:])
+	}
+	return checksum16Go(p)
+}
+
+//go:noescape
+func crc16FoldBlocks(acc *[2]uint64, p []byte)

--- a/crc/crc_amd64.s
+++ b/crc/crc_amd64.s
@@ -1,0 +1,73 @@
+//go:build amd64
+
+#include "textflag.h"
+
+// FLAC CRC-16 (polynomial 0x8005, MSB-first, no reflection) carry-less-multiply
+// fold for AMD64 (PCLMULQDQ).
+//
+// crc16FoldBlocks folds every full 16-byte block of p into the 128-bit
+// accumulator *acc (acc[0] = high bits 127..64, acc[1] = low bits 63..0). Each
+// block computes acc = (acc * x^128 mod P) ^ block via two carry-less products:
+//
+//	fold = clmul(acc_hi, x^192 mod P) ^ clmul(acc_lo, x^128 mod P)
+//	acc  = fold ^ block
+//
+// which keeps acc congruent to the processed prefix modulo P; the Go caller
+// finishes with the scalar reduction. This is a 1:1 translation of crc16FoldGo
+// in crc_model_test.go and is pinned against it by the parity tests.
+//
+// A single accumulator means the loop is bound by PCLMULQDQ latency rather than
+// throughput, but that still clears the slice-by-16 table loop several times
+// over. The internal xmm layout keeps logical bit i in xmm bit i: lane0 holds
+// the low 64 bits, lane1 the high 64 bits. Input blocks are byte-reversed with
+// PSHUFB so the first (most significant) byte lands in the high lane, matching
+// the MSB-first CRC.
+
+// bswapMask reverses all 16 bytes of a block: out[i] = in[15-i].
+DATA bswapMask<>+0(SB)/8, $0x08090a0b0c0d0e0f
+DATA bswapMask<>+8(SB)/8, $0x0001020304050607
+GLOBL bswapMask<>(SB), RODATA|NOPTR, $16
+
+// func crc16FoldBlocks(acc *[2]uint64, p []byte)
+TEXT ·crc16FoldBlocks(SB), NOSPLIT, $0-32
+	MOVQ acc+0(FP), AX     // AX = &acc
+	MOVQ p_base+8(FP), SI  // SI = &p[0]
+	MOVQ p_len+16(FP), CX  // CX = len(p)
+	SHRQ $4, CX            // CX = number of full 16-byte blocks
+
+	// Load accumulator into X0: lane0 = accLo = acc[1], lane1 = accHi = acc[0].
+	MOVQ   8(AX), X0
+	MOVQ   0(AX), BX
+	PINSRQ $1, BX, X0
+
+	// Fold constants in low lanes: X1 = K1 (x^192 mod P), X2 = K2 (x^128 mod P).
+	MOVQ $0x1666, BX
+	MOVQ BX, X1
+	MOVQ $0x0106, BX
+	MOVQ BX, X2
+
+	MOVOU bswapMask<>(SB), X5 // byte-reverse shuffle control
+
+	TESTQ CX, CX
+	JZ    done
+
+loop:
+	MOVOU  (SI), X3          // X3 = next 16 bytes (little-endian)
+	PSHUFB X5, X3            // byte-reverse: first byte -> high lane (MSB-first)
+
+	MOVOU     X0, X4         // X4 = acc copy for the high-half product
+	PCLMULQDQ $0x01, X1, X4  // X4 = clmul(acc_hi, K1)  [dst hi qword, src lo qword]
+	PCLMULQDQ $0x00, X2, X0  // X0 = clmul(acc_lo, K2)  [dst lo qword, src lo qword]
+	PXOR      X4, X0         // X0 = clmul(acc_hi,K1) ^ clmul(acc_lo,K2)
+	PXOR      X3, X0         // X0 = fold ^ block  ->  new accumulator
+
+	ADDQ $16, SI
+	DECQ CX
+	JNZ  loop
+
+done:
+	// Store accumulator back: acc[0] = accHi = lane1, acc[1] = accLo = lane0.
+	MOVQ   X0, 8(AX)
+	PEXTRQ $1, X0, BX
+	MOVQ   BX, 0(AX)
+	RET

--- a/crc/crc_arm64.go
+++ b/crc/crc_arm64.go
@@ -1,0 +1,31 @@
+//go:build arm64
+
+package crc
+
+import "github.com/tphakala/simd/cpu"
+
+// minFoldBytes is the smallest input routed through the PMULL fold. Below it the
+// scalar slice-by-16 loop wins, because the fold pays a fixed scalar reduction
+// over the 16 accumulator bytes regardless of input length. FLAC frames are
+// kilobytes, so the hot path always folds.
+const minFoldBytes = 64
+
+var hasPMULL = cpu.ARM64.PMULL
+
+// foldSupported reports whether the carry-less-multiply kernel is active.
+func foldSupported() bool { return hasPMULL }
+
+// checksum16 folds the bulk of p with PMULL when available, then reduces the
+// folded accumulator plus the trailing tail with the scalar path.
+func checksum16(p []byte) uint16 {
+	if hasPMULL && len(p) >= minFoldBytes {
+		full := len(p) &^ (blockBytes - 1)
+		var acc [2]uint64
+		crc16FoldBlocks(&acc, p[:full])
+		return checksum16FromAcc(acc[0], acc[1], p[full:])
+	}
+	return checksum16Go(p)
+}
+
+//go:noescape
+func crc16FoldBlocks(acc *[2]uint64, p []byte)

--- a/crc/crc_arm64.s
+++ b/crc/crc_arm64.s
@@ -1,0 +1,69 @@
+//go:build arm64
+
+#include "textflag.h"
+
+// FLAC CRC-16 (polynomial 0x8005, MSB-first, no reflection) carry-less-multiply
+// fold for ARM64 (PMULL / FEAT_PMULL).
+//
+// crc16FoldBlocks folds every full 16-byte block of p into the 128-bit
+// accumulator *acc (acc[0] = high bits 127..64, acc[1] = low bits 63..0). Each
+// block computes acc = (acc * x^128 mod P) ^ block via two carry-less products:
+//
+//	fold = clmul(acc_lo, x^128 mod P) ^ clmul(acc_hi, x^192 mod P)
+//	acc  = fold ^ block
+//
+// which keeps acc congruent to the processed prefix modulo P; the Go caller
+// finishes with the scalar reduction. This is a 1:1 translation of crc16FoldGo
+// in crc_model_test.go and is pinned against it by the parity tests.
+//
+// The internal vector layout keeps logical bit i in vector bit i, so the high 64
+// bits live in lane d[1] (where PMULL2 reads) and the low 64 bits in lane d[0]
+// (where PMULL reads). Input blocks are byte-reversed (VREV64 + VEXT) so the
+// first, most significant byte lands in the high lane, matching the MSB-first
+// CRC. Carry-less multiply and EOR are commutative, so operand order is free.
+//
+// Every instruction here is a native Go arm64 mnemonic, so there are no
+// hand-encoded WORD directives for asmcheck to validate.
+
+// foldConst holds the fold constants: lane d[0] = K2 (x^128 mod P) for the low
+// half, lane d[1] = K1 (x^192 mod P) for the high half.
+DATA foldConst<>+0(SB)/8, $0x0106
+DATA foldConst<>+8(SB)/8, $0x1666
+GLOBL foldConst<>(SB), RODATA|NOPTR, $16
+
+// func crc16FoldBlocks(acc *[2]uint64, p []byte)
+TEXT ·crc16FoldBlocks(SB), NOSPLIT, $0-32
+	MOVD acc+0(FP), R0     // R0 = &acc
+	MOVD p_base+8(FP), R1  // R1 = &p[0]
+	MOVD p_len+16(FP), R2  // R2 = len(p)
+	LSR  $4, R2, R2        // R2 = number of full 16-byte blocks
+
+	// Load accumulator. VLD1 fills d[0] from acc[0] (=accHi) and d[1] from
+	// acc[1] (=accLo); swap the lanes so the high bits sit in d[1].
+	VLD1 (R0), [V0.D2]
+	VEXT $8, V0.B16, V0.B16, V0.B16 // d[0]=accLo, d[1]=accHi
+
+	// Load fold constants: V1.d[0]=K2, V1.d[1]=K1.
+	MOVD $foldConst<>(SB), R3
+	VLD1 (R3), [V1.D2]
+
+	CBZ R2, done
+
+loop:
+	VLD1.P 16(R1), [V2.B16]         // V2 = next 16 bytes (little-endian)
+	VREV64 V2.B16, V2.B16           // reverse bytes within each doubleword
+	VEXT   $8, V2.B16, V2.B16, V2.B16 // swap doublewords -> full 16-byte reverse
+
+	VPMULL  V1.D1, V0.D1, V3.Q1     // V3 = clmul(acc_lo, K2)
+	VPMULL2 V1.D2, V0.D2, V4.Q1     // V4 = clmul(acc_hi, K1)
+	VEOR    V4.B16, V3.B16, V0.B16  // V0 = clmul(acc_lo,K2) ^ clmul(acc_hi,K1)
+	VEOR    V2.B16, V0.B16, V0.B16  // V0 = fold ^ block  ->  new accumulator
+
+	SUB  $1, R2
+	CBNZ R2, loop
+
+done:
+	// Swap lanes back to memory order (d[0]=accHi, d[1]=accLo) and store.
+	VEXT $8, V0.B16, V0.B16, V0.B16
+	VST1 [V0.D2], (R0)
+	RET

--- a/crc/crc_model_test.go
+++ b/crc/crc_model_test.go
@@ -1,0 +1,100 @@
+package crc
+
+import (
+	"encoding/binary"
+	"math/rand"
+	"testing"
+)
+
+// This file holds the pure-Go reference model for the carry-less-multiply fold.
+// It is the executable specification the PCLMULQDQ and PMULL kernels must match:
+// the assembly is a 1:1 translation of crc16FoldGo, and the per-arch tests pin
+// the assembly output against this model. Keeping the model in test code means
+// production builds never carry the slow bit-serial clmul emulation.
+
+// xnModPRef computes x^n mod P for the FLAC CRC-16 polynomial (P = 0x18005,
+// degree 16); the result has degree < 16.
+func xnModPRef(n int) uint16 {
+	r := uint32(1)
+	for range n {
+		r <<= 1
+		if r&0x10000 != 0 {
+			r ^= 0x18005
+		}
+	}
+	return uint16(r)
+}
+
+// clmul64 is a carry-less (GF(2)) multiply of two 64-bit polynomials, returning
+// the 128-bit product as (hi, lo). It mirrors one PCLMULQDQ / PMULL lane.
+func clmul64(a, b uint64) (hi, lo uint64) {
+	for i := range 64 {
+		if (b>>uint(i))&1 != 0 {
+			lo ^= a << uint(i)
+			hi ^= a >> uint(64-i) // i==0 -> a>>64 == 0 per Go shift semantics
+		}
+	}
+	return hi, lo
+}
+
+// crc16FoldGo folds every full 16-byte block of p into the 128-bit accumulator
+// acc (acc[0]=high bits 127..64, acc[1]=low bits 63..0), updating it in place.
+// Each block computes acc = (acc*x^128 mod P) ^ block, which keeps acc congruent
+// to the processed prefix modulo P. This is the reference for crc16FoldBlocks.
+func crc16FoldGo(acc *[2]uint64, p []byte) {
+	accHi, accLo := acc[0], acc[1]
+	for len(p) >= 16 {
+		dHi := binary.BigEndian.Uint64(p[0:8])
+		dLo := binary.BigEndian.Uint64(p[8:16])
+		f1h, f1l := clmul64(accHi, crc16K1) // high half * x^192 mod P
+		f2h, f2l := clmul64(accLo, crc16K2) // low half  * x^128 mod P
+		accHi = f1h ^ f2h ^ dHi
+		accLo = f1l ^ f2l ^ dLo
+		p = p[16:]
+	}
+	acc[0], acc[1] = accHi, accLo
+}
+
+// foldModelChecksum is the full CRC-16 via the fold model plus scalar reduction,
+// mirroring exactly what the SIMD dispatch does with the assembly kernel.
+func foldModelChecksum(p []byte) uint16 {
+	full := len(p) &^ 15
+	var acc [2]uint64
+	crc16FoldGo(&acc, p[:full])
+	return checksum16FromAcc(acc[0], acc[1], p[full:])
+}
+
+// TestFoldConstantsAreXnModP pins the embedded fold constants to their algebraic
+// definitions so the Go model and the assembly literals cannot drift.
+func TestFoldConstantsAreXnModP(t *testing.T) {
+	if got := xnModPRef(192); got != crc16K1 {
+		t.Errorf("crc16K1 = %#04x, want x^192 mod P = %#04x", uint16(crc16K1), got)
+	}
+	if got := xnModPRef(128); got != crc16K2 {
+		t.Errorf("crc16K2 = %#04x, want x^128 mod P = %#04x", uint16(crc16K2), got)
+	}
+}
+
+// TestFoldModelMatchesScalar validates the fold algorithm end-to-end against the
+// independent scalar reference, independent of any assembly.
+func TestFoldModelMatchesScalar(t *testing.T) {
+	r := rand.New(rand.NewSource(7))
+	for n := 0; n <= 600; n++ {
+		buf := make([]byte, n)
+		for i := range buf {
+			buf[i] = byte(r.Intn(256))
+		}
+		if got, want := foldModelChecksum(buf), refChecksum16(buf); got != want {
+			t.Fatalf("n=%d: foldModel=%#04x want %#04x", n, got, want)
+		}
+	}
+	for _, n := range []int{1024, 4096, 4097, 8192, 16384, 16385} {
+		buf := make([]byte, n)
+		for i := range buf {
+			buf[i] = byte(r.Intn(256))
+		}
+		if got, want := foldModelChecksum(buf), refChecksum16(buf); got != want {
+			t.Fatalf("n=%d: foldModel=%#04x want %#04x", n, got, want)
+		}
+	}
+}

--- a/crc/crc_other.go
+++ b/crc/crc_other.go
@@ -1,0 +1,7 @@
+//go:build !amd64 && !arm64
+
+package crc
+
+// checksum16 uses the scalar slice-by-16 loop on architectures without a
+// carry-less-multiply instruction.
+func checksum16(p []byte) uint16 { return checksum16Go(p) }

--- a/crc/crc_simd_test.go
+++ b/crc/crc_simd_test.go
@@ -1,0 +1,35 @@
+//go:build amd64 || arm64
+
+package crc
+
+import (
+	"math/rand"
+	"testing"
+)
+
+// TestCRC16FoldBlocksMatchesModel pins the carry-less-multiply kernel (PCLMULQDQ
+// on amd64, PMULL on arm64) against the pure-Go fold model. A random nonzero
+// starting accumulator exercises the loop-carried fold dependency, not just the
+// acc==0 first block. It runs only when the kernel is actually wired in, i.e.
+// when the CPU has the polynomial-multiply instruction.
+func TestCRC16FoldBlocksMatchesModel(t *testing.T) {
+	if !foldSupported() {
+		t.Skip("CPU has no carry-less-multiply instruction")
+	}
+	r := rand.New(rand.NewSource(99))
+	for _, blocks := range []int{0, 1, 2, 3, 4, 5, 8, 16, 64, 256, 1024} {
+		buf := make([]byte, blocks*16)
+		for i := range buf {
+			buf[i] = byte(r.Intn(256))
+		}
+		var model, asm [2]uint64
+		model[0], model[1] = r.Uint64(), r.Uint64()
+		asm = model // identical nonzero start
+		crc16FoldGo(&model, buf)
+		crc16FoldBlocks(&asm, buf)
+		if asm != model {
+			t.Fatalf("blocks=%d: asm={%#016x,%#016x} model={%#016x,%#016x}",
+				blocks, asm[0], asm[1], model[0], model[1])
+		}
+	}
+}

--- a/crc/crc_test.go
+++ b/crc/crc_test.go
@@ -1,0 +1,128 @@
+package crc
+
+import (
+	"math/rand"
+	"strconv"
+	"testing"
+)
+
+// refChecksum16 is an independent byte-at-a-time CRC-16 reference (FLAC poly
+// 0x8005, init 0, MSB-first, no reflection) used as the oracle for parity. It
+// is deliberately the simplest possible implementation.
+func refChecksum16(p []byte) uint16 {
+	const poly = 0x8005
+	var c uint16
+	for _, b := range p {
+		c ^= uint16(b) << 8
+		for range 8 {
+			if c&0x8000 != 0 {
+				c = (c << 1) ^ poly
+			} else {
+				c <<= 1
+			}
+		}
+	}
+	return c
+}
+
+// TestChecksum16CheckVector pins the standard CRC-16/UMTS check value.
+func TestChecksum16CheckVector(t *testing.T) {
+	if got := Checksum16([]byte("123456789")); got != 0xFEE8 {
+		t.Fatalf("Checksum16(\"123456789\") = %#04x, want 0xFEE8", got)
+	}
+}
+
+// TestChecksum16ParityScalarReference checks Checksum16 against the independent
+// byte-at-a-time reference across lengths that straddle the 16-byte fold stride,
+// the fold threshold, and odd tails.
+func TestChecksum16ParityScalarReference(t *testing.T) {
+	r := rand.New(rand.NewSource(1))
+	for n := 0; n <= 600; n++ {
+		buf := make([]byte, n)
+		for i := range buf {
+			buf[i] = byte(r.Intn(256))
+		}
+		if got, want := Checksum16(buf), refChecksum16(buf); got != want {
+			t.Fatalf("n=%d: Checksum16=%#04x want %#04x", n, got, want)
+		}
+	}
+}
+
+// TestChecksum16ParityLargeBuffers exercises the fold path on multi-KB buffers
+// with assorted tail lengths.
+func TestChecksum16ParityLargeBuffers(t *testing.T) {
+	r := rand.New(rand.NewSource(42))
+	for _, n := range []int{1024, 4096, 4097, 4111, 8192, 16384, 16385, 65535} {
+		buf := make([]byte, n)
+		for i := range buf {
+			buf[i] = byte(r.Intn(256))
+		}
+		if got, want := Checksum16(buf), refChecksum16(buf); got != want {
+			t.Fatalf("n=%d: Checksum16=%#04x want %#04x", n, got, want)
+		}
+	}
+}
+
+// TestChecksum16AllByteValues guards against a folded byte being mistreated by
+// a buffer that walks every byte value at the fold boundary.
+func TestChecksum16AllByteValues(t *testing.T) {
+	buf := make([]byte, 256)
+	for i := range buf {
+		buf[i] = byte(i)
+	}
+	for n := 0; n <= 256; n++ {
+		if got, want := Checksum16(buf[:n]), refChecksum16(buf[:n]); got != want {
+			t.Fatalf("n=%d: Checksum16=%#04x want %#04x", n, got, want)
+		}
+	}
+}
+
+// TestChecksum16ZeroAlloc asserts the hot path allocates nothing.
+func TestChecksum16ZeroAlloc(t *testing.T) {
+	buf := make([]byte, 16384)
+	for i := range buf {
+		buf[i] = byte(i)
+	}
+	if n := testing.AllocsPerRun(100, func() { _ = Checksum16(buf) }); n != 0 {
+		t.Fatalf("Checksum16 allocated %v times per run, want 0", n)
+	}
+}
+
+func BenchmarkChecksum16(b *testing.B) {
+	buf := make([]byte, 16384)
+	for i := range buf {
+		buf[i] = byte(i)
+	}
+	b.SetBytes(int64(len(buf)))
+	for b.Loop() {
+		_ = Checksum16(buf)
+	}
+}
+
+// BenchmarkChecksum16Scalar measures the slice-by-16 fallback directly, so the
+// carry-less-multiply speedup can be read against the scalar baseline.
+func BenchmarkChecksum16Scalar(b *testing.B) {
+	buf := make([]byte, 16384)
+	for i := range buf {
+		buf[i] = byte(i)
+	}
+	b.SetBytes(int64(len(buf)))
+	for b.Loop() {
+		_ = checksum16Go(buf)
+	}
+}
+
+func BenchmarkChecksum16Sizes(b *testing.B) {
+	for _, n := range []int{32, 48, 64, 96, 128, 256, 1024, 4096, 8192} {
+		buf := make([]byte, n)
+		for i := range buf {
+			buf[i] = byte(i)
+		}
+		b.Run(strconv.Itoa(n), func(b *testing.B) {
+			b.SetBytes(int64(n))
+			for b.Loop() {
+				_ = Checksum16(buf)
+			}
+		})
+	}
+}

--- a/doc.go
+++ b/doc.go
@@ -8,6 +8,7 @@
 //   - [github.com/tphakala/simd/f32] - float32 SIMD operations
 //   - [github.com/tphakala/simd/i32] - int32 SIMD operations (integer DSP)
 //   - [github.com/tphakala/simd/c128] - complex128 SIMD operations
+//   - [github.com/tphakala/simd/crc] - CRC checksums (carry-less-multiply folding)
 //
 // # Architecture Support
 //
@@ -56,6 +57,8 @@
 // Integer DSP (i32): Interleave2, Deinterleave2, Add, Sub, MidSideEncode, MidSideDecode, Diff1..Diff4, Restore1..Restore4, LPCResidualEncode, LPCRestore, RiceSums, RiceBestParam
 //
 // Complex (c128): Add, Sub, Mul, MulConj, Conj, Abs, AbsSq, Scale
+//
+// CRC (crc): Checksum16 (FLAC CRC-16, PCLMULQDQ/PMULL carry-less-multiply fold)
 //
 // # Design Principles
 //


### PR DESCRIPTION
## Summary

New `crc` package providing the FLAC CRC-16 (polynomial 0x8005, init 0,
MSB-first, no reflection). `Checksum16` folds the bulk of the buffer 16
bytes at a time with a carry-less-multiply kernel and finishes with the
existing scalar slice-by-16 reduction.

The fold keeps a 128-bit accumulator congruent to the processed prefix
modulo P: each block computes `acc = (acc*x^128 mod P) ^ block` via two
products, `clmul(acc_hi, x^192 mod P)` and `clmul(acc_lo, x^128 mod P)`.
The final CRC is just the scalar CRC-16 of the accumulator's 16 bytes
plus the unfolded tail, so no Barrett reduction is needed in assembly.

- Kernels: PCLMULQDQ on amd64, PMULL on arm64 (native Go mnemonics, no
  hand-encoded WORD directives). Pure-Go slice-by-16 fallback on other
  architectures and for buffers below the fold threshold.
- The assembly is a 1:1 translation of the `crc16FoldGo` model in
  `crc_model_test.go`, which is pinned against an independent scalar
  reference and the fold constants against x^192 / x^128 mod P.
- `cpu`: adds PCLMULQDQ (amd64) and PMULL (arm64) feature detection to
  gate the kernels (`HasPCLMULQDQ`, `HasPMULL`).

## Verification

- Parity against an independent byte-at-a-time reference across lengths
  0..600 plus multi-KB buffers, the all-byte-values walk, and the
  random nonzero-accumulator fold-vs-model check.
- Known-answer 0xFEE8 (CRC-16/UMTS) on both architectures.
- Zero allocations; gofmt, `go vet`, asmcheck, and golangci-lint clean.
- arm64 verified on Cortex-A76 hardware (build, run, and `cpu.pmull=off`
  fallback all bit-identical).

Throughput on a 16 KB buffer: amd64 (i7-1260P) 3.0 -> 11.6 GB/s (3.8x),
arm64 (Cortex-A76) 1.2 -> 4.2 GB/s (3.5x). Bit-identical to the scalar
reference.

## Test Plan

- [x] `go test ./crc/ ./cpu/` on amd64
- [x] full crc + cpu suite cross-compiled and run on arm64 hardware
- [x] `go vet`, asmcheck, golangci-lint, gofmt

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added PCLMULQDQ and PMULL CPU feature detection with helper functions.
  * Introduced CRC-16 checksum computation with hardware acceleration on x86 (PCLMULQDQ) and ARM64 (PMULL) platforms, with fallback for other architectures.

* **Documentation**
  * Updated README with CPU feature query examples and CRC package documentation.
  * Expanded package documentation to describe CRC functionality.

* **Tests**
  * Added comprehensive test coverage for CPU feature detection and CRC checksum validation across multiple input sizes and architectures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->