### PR TITLE
cpu: add SIMD_DISABLE env var to disable feature tiers at startup

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,6 +84,45 @@ fmt.Println(cpu.HasPCLMULQDQ()) // true/false (x86 carry-less multiply)
 fmt.Println(cpu.HasPMULL())    // true/false (ARM64 polynomial multiply)
 ```
 
+#### Disabling feature tiers with `SIMD_DISABLE`
+
+Set the `SIMD_DISABLE` environment variable before the process starts to mask
+detected CPU features. This is useful for forcing a lower tier on parts where
+heavy AVX-512 use causes frequency downclocking, exercising the SSE2/NEON/pure-Go
+paths locally, and benchmarking tiers against each other on one machine.
+
+The value is a comma-separated, case-insensitive list of tokens, read once at
+program start. Each token clears its own flag plus everything that depends on it:
+
+| Token       | Clears                                    |
+| ----------- | ----------------------------------------- |
+| `avx512`    | AVX512F, AVX512VL                         |
+| `avx2`      | AVX2 (and the `avx512` set)               |
+| `avx`       | AVX, FMA (and the `avx2` set)             |
+| `fma`       | FMA only                                  |
+| `sse42`     | SSE42 (and the `avx` set)                 |
+| `sse41`     | SSE41 (and the `sse42` set)               |
+| `ssse3`     | SSSE3 (and the `sse41` set)               |
+| `sse3`      | SSE3 (and the `ssse3` set)                |
+| `pclmulqdq` | PCLMULQDQ only                            |
+| `neon`      | NEON, FP16, SVE, SVE2, PMULL              |
+| `fp16`      | FP16 only                                 |
+| `sve`       | SVE, SVE2                                 |
+| `pmull`     | PMULL only                                |
+| `all`       | every flag (forces the pure-Go path)      |
+
+Unknown tokens are ignored (the library never panics or writes to stderr on env
+input). `cpu.Info()` reflects the cleared flags.
+
+```sh
+SIMD_DISABLE=avx512 go test ./...   # run as if the CPU had no AVX-512
+SIMD_DISABLE=all go test ./...      # force the pure-Go path everywhere
+```
+
+The variable must be set before the process starts; it cannot be toggled at
+runtime, because the amd64 packages freeze their kernel function pointers during
+package init based on the features visible at that moment.
+
 ### `crc` - Cyclic Redundancy Checks
 
 ```go

--- a/README.md
+++ b/README.md
@@ -120,8 +120,9 @@ SIMD_DISABLE=all go test ./...      # force the pure-Go path everywhere
 ```
 
 The variable must be set before the process starts; it cannot be toggled at
-runtime, because the amd64 packages freeze their kernel function pointers during
-package init based on the features visible at that moment.
+runtime, because the SIMD packages cache their selected kernels during package
+init based on the features visible at that moment (function pointers on amd64,
+capability flags on arm64).
 
 ### `crc` - Cyclic Redundancy Checks
 

--- a/cpu/cpu.go
+++ b/cpu/cpu.go
@@ -1,6 +1,8 @@
 // Package cpu provides CPU feature detection for SIMD operations.
 package cpu
 
+import "strings"
+
 // Features contains detected CPU SIMD capabilities.
 type Features struct {
 	// x86/AMD64 features
@@ -63,4 +65,121 @@ func HasAVX512VL() bool { return X86.AVX512VL }
 // Info returns a string describing the available SIMD features.
 func Info() string {
 	return cpuInfo()
+}
+
+// applyDisable clears CPU feature flags in f according to the comma-separated,
+// case-insensitive token list in spec (the value of the SIMD_DISABLE env var).
+// Each token clears its own flag plus every flag that depends on it, so the
+// resulting Features value never describes an impossible CPU (for example, AVX2
+// set while AVX is cleared). Unknown and empty tokens are ignored: a library must
+// not panic or write to stderr in response to environment input.
+//
+// Recognized tokens:
+//
+//	avx512     AVX512F, AVX512VL
+//	avx2       AVX2 and the avx512 set
+//	avx        AVX, FMA and the avx2 set
+//	fma        FMA only
+//	sse42      SSE42 and the avx set
+//	sse41      SSE41 and the sse42 set
+//	ssse3      SSSE3 and the sse41 set
+//	sse3       SSE3 and the ssse3 set
+//	pclmulqdq  PCLMULQDQ only
+//	neon       NEON, FP16, SVE, SVE2, PMULL
+//	fp16       FP16 only
+//	sve        SVE, SVE2
+//	pmull      PMULL only
+//	all        every flag (forces the pure-Go path everywhere)
+func applyDisable(f *Features, spec string) {
+	for tok := range strings.SplitSeq(spec, ",") {
+		switch strings.ToLower(strings.TrimSpace(tok)) {
+		case "":
+			// Empty token (e.g. trailing comma): ignore.
+		case "avx512":
+			clearAVX512(f)
+		case "avx2":
+			clearAVX2(f)
+		case "avx":
+			clearAVX(f)
+		case "fma":
+			f.FMA = false
+		case "sse42":
+			clearSSE42(f)
+		case "sse41":
+			clearSSE41(f)
+		case "ssse3":
+			clearSSSE3(f)
+		case "sse3":
+			clearSSE3(f)
+		case "pclmulqdq":
+			f.PCLMULQDQ = false
+		case "neon":
+			clearNEON(f)
+		case "fp16":
+			f.FP16 = false
+		case "sve":
+			clearSVE(f)
+		case "pmull":
+			f.PMULL = false
+		case "all":
+			*f = Features{}
+		default:
+			// Unknown token: ignore.
+		}
+	}
+}
+
+// The clearXxx helpers encode the x86 tier dependency chain: disabling a lower
+// tier also disables every higher tier that requires it, because the runtime
+// dispatch checks the highest tier first.
+
+func clearAVX512(f *Features) {
+	f.AVX512F = false
+	f.AVX512VL = false
+}
+
+func clearAVX2(f *Features) {
+	f.AVX2 = false
+	clearAVX512(f)
+}
+
+func clearAVX(f *Features) {
+	f.AVX = false
+	f.FMA = false
+	clearAVX2(f)
+}
+
+func clearSSE42(f *Features) {
+	f.SSE42 = false
+	clearAVX(f)
+}
+
+func clearSSE41(f *Features) {
+	f.SSE41 = false
+	clearSSE42(f)
+}
+
+func clearSSSE3(f *Features) {
+	f.SSSE3 = false
+	clearSSE41(f)
+}
+
+func clearSSE3(f *Features) {
+	f.SSE3 = false
+	clearSSSE3(f)
+}
+
+// clearNEON disables the entire ARM64 SIMD feature set.
+func clearNEON(f *Features) {
+	f.NEON = false
+	f.FP16 = false
+	f.SVE = false
+	f.SVE2 = false
+	f.PMULL = false
+}
+
+// clearSVE disables the scalable-vector tiers without touching NEON.
+func clearSVE(f *Features) {
+	f.SVE = false
+	f.SVE2 = false
 }

--- a/cpu/cpu.go
+++ b/cpu/cpu.go
@@ -91,6 +91,9 @@ func Info() string {
 //	pmull      PMULL only
 //	all        every flag (forces the pure-Go path everywhere)
 func applyDisable(f *Features, spec string) {
+	if spec == "" {
+		return // common case: SIMD_DISABLE unset, nothing to clear
+	}
 	for tok := range strings.SplitSeq(spec, ",") {
 		switch strings.ToLower(strings.TrimSpace(tok)) {
 		case "":

--- a/cpu/cpu_amd64.go
+++ b/cpu/cpu_amd64.go
@@ -2,7 +2,11 @@
 
 package cpu
 
-import "golang.org/x/sys/cpu"
+import (
+	"os"
+
+	"golang.org/x/sys/cpu"
+)
 
 func init() {
 	X86.SSE = true // SSE is baseline for amd64
@@ -20,6 +24,9 @@ func init() {
 	X86.BMI2 = cpu.X86.HasBMI2
 	X86.POPCNT = cpu.X86.HasPOPCNT
 	X86.PCLMULQDQ = cpu.X86.HasPCLMULQDQ
+
+	// Honor SIMD_DISABLE last, so the env var can mask any detected feature.
+	applyDisable(&X86, os.Getenv("SIMD_DISABLE"))
 }
 
 func cpuInfo() string {

--- a/cpu/cpu_arm64.go
+++ b/cpu/cpu_arm64.go
@@ -2,7 +2,11 @@
 
 package cpu
 
-import "golang.org/x/sys/cpu"
+import (
+	"os"
+
+	"golang.org/x/sys/cpu"
+)
 
 func init() {
 	ARM64.NEON = cpu.ARM64.HasASIMD
@@ -10,6 +14,9 @@ func init() {
 	ARM64.SVE = cpu.ARM64.HasSVE
 	ARM64.SVE2 = cpu.ARM64.HasSVE2
 	ARM64.PMULL = cpu.ARM64.HasPMULL // FEAT_PMULL - polynomial multiply
+
+	// Honor SIMD_DISABLE last, so the env var can mask any detected feature.
+	applyDisable(&ARM64, os.Getenv("SIMD_DISABLE"))
 }
 
 func cpuInfo() string {

--- a/cpu/cpu_arm64_darwin.go
+++ b/cpu/cpu_arm64_darwin.go
@@ -2,7 +2,11 @@
 
 package cpu
 
-import "golang.org/x/sys/cpu"
+import (
+	"os"
+
+	"golang.org/x/sys/cpu"
+)
 
 // Apple Silicon (M1/M2/M3/M4) all support FEAT_FP16 (half-precision floating point)
 // and FEAT_PMULL (polynomial multiply). The golang.org/x/sys/cpu package doesn't
@@ -14,6 +18,9 @@ func init() {
 	ARM64.SVE = cpu.ARM64.HasSVE
 	ARM64.SVE2 = cpu.ARM64.HasSVE2
 	ARM64.PMULL = true // All Apple Silicon chips support PMULL
+
+	// Honor SIMD_DISABLE last, so the env var can mask any detected feature.
+	applyDisable(&ARM64, os.Getenv("SIMD_DISABLE"))
 }
 
 func cpuInfo() string {

--- a/cpu/disable_test.go
+++ b/cpu/disable_test.go
@@ -1,0 +1,135 @@
+package cpu
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"os/exec"
+	"reflect"
+	"runtime"
+	"sort"
+	"strings"
+	"testing"
+	"time"
+)
+
+// fullFeatures returns a Features value with every boolean field set to true,
+// so a disable spec can be checked by which fields it turns back off.
+func fullFeatures() Features {
+	var f Features
+	v := reflect.ValueOf(&f).Elem()
+	for i := 0; i < v.NumField(); i++ {
+		v.Field(i).SetBool(true)
+	}
+	return f
+}
+
+// disabledFields returns the sorted names of the boolean fields that are false in f.
+func disabledFields(f Features) []string {
+	var names []string
+	v := reflect.ValueOf(f)
+	t := v.Type()
+	for i := 0; i < v.NumField(); i++ {
+		if !v.Field(i).Bool() {
+			names = append(names, t.Field(i).Name)
+		}
+	}
+	sort.Strings(names)
+	return names
+}
+
+func TestApplyDisable(t *testing.T) {
+	tests := []struct {
+		spec     string
+		disabled []string
+	}{
+		{"", nil},
+		{"avx512", []string{"AVX512F", "AVX512VL"}},
+		{"avx2", []string{"AVX2", "AVX512F", "AVX512VL"}},
+		{"avx", []string{"AVX", "AVX2", "AVX512F", "AVX512VL", "FMA"}},
+		{"fma", []string{"FMA"}},
+		{"sse42", []string{"AVX", "AVX2", "AVX512F", "AVX512VL", "FMA", "SSE42"}},
+		{"sse41", []string{"AVX", "AVX2", "AVX512F", "AVX512VL", "FMA", "SSE41", "SSE42"}},
+		{"ssse3", []string{"AVX", "AVX2", "AVX512F", "AVX512VL", "FMA", "SSE41", "SSE42", "SSSE3"}},
+		{"sse3", []string{"AVX", "AVX2", "AVX512F", "AVX512VL", "FMA", "SSE3", "SSE41", "SSE42", "SSSE3"}},
+		{"pclmulqdq", []string{"PCLMULQDQ"}},
+		{"neon", []string{"FP16", "NEON", "PMULL", "SVE", "SVE2"}},
+		{"fp16", []string{"FP16"}},
+		{"sve", []string{"SVE", "SVE2"}},
+		{"pmull", []string{"PMULL"}},
+		// Case-insensitivity and surrounding whitespace.
+		{"AVX512", []string{"AVX512F", "AVX512VL"}},
+		{"  avx512  ", []string{"AVX512F", "AVX512VL"}},
+		{"Avx2", []string{"AVX2", "AVX512F", "AVX512VL"}},
+		// Unknown tokens are ignored.
+		{"foobar", nil},
+		{"avx512,foobar", []string{"AVX512F", "AVX512VL"}},
+		// Empty tokens between commas are ignored.
+		{"avx512,,neon", []string{"AVX512F", "AVX512VL", "FP16", "NEON", "PMULL", "SVE", "SVE2"}},
+		// Multiple tokens combine.
+		{"avx512,neon", []string{"AVX512F", "AVX512VL", "FP16", "NEON", "PMULL", "SVE", "SVE2"}},
+	}
+	for _, tt := range tests {
+		f := fullFeatures()
+		applyDisable(&f, tt.spec)
+		got := disabledFields(f)
+		want := append([]string(nil), tt.disabled...)
+		sort.Strings(want)
+		if !reflect.DeepEqual(got, want) {
+			t.Errorf("applyDisable(%q): disabled = %v, want %v", tt.spec, got, want)
+		}
+	}
+}
+
+// TestApplyDisableAll verifies the "all" token forces every feature off.
+func TestApplyDisableAll(t *testing.T) {
+	f := fullFeatures()
+	applyDisable(&f, "all")
+	if f != (Features{}) {
+		t.Errorf("applyDisable(\"all\") left fields set: %+v", f)
+	}
+}
+
+// TestHelperInfo is the helper process for TestSIMDDisableAllIntegration. It only
+// runs when re-executed with SIMD_DISABLE_HELPER=1 and prints cpu.Info().
+func TestHelperInfo(t *testing.T) {
+	if os.Getenv("SIMD_DISABLE_HELPER") != "1" {
+		t.Skip("not the helper process")
+	}
+	fmt.Printf("CPUINFO=%s\n", Info())
+}
+
+// TestSIMDDisableAllIntegration re-execs the test binary with SIMD_DISABLE=all
+// and asserts cpu.Info() reports the no-SIMD string for this architecture, which
+// proves the env var is read and applied during package init.
+func TestSIMDDisableAllIntegration(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+	cmd := exec.CommandContext(ctx, os.Args[0], "-test.run=^TestHelperInfo$", "-test.v")
+	cmd.Env = append(os.Environ(), "SIMD_DISABLE_HELPER=1", "SIMD_DISABLE=all")
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		t.Fatalf("helper process failed: %v\n%s", err, out)
+	}
+
+	var want string
+	switch runtime.GOARCH {
+	case "amd64":
+		want = "AMD64 (scalar)"
+	case "arm64":
+		want = "ARM64 (no SIMD)"
+	default:
+		want = "Generic (no SIMD)"
+	}
+
+	got := ""
+	for line := range strings.SplitSeq(string(out), "\n") {
+		if v, ok := strings.CutPrefix(strings.TrimSpace(line), "CPUINFO="); ok {
+			got = v
+			break
+		}
+	}
+	if got != want {
+		t.Errorf("Info() under SIMD_DISABLE=all = %q, want %q\nfull output:\n%s", got, want, out)
+	}
+}

--- a/doc.go
+++ b/doc.go
@@ -25,8 +25,9 @@
 // "avx512", "avx", "neon", or "all"). It is useful for avoiding AVX-512
 // downclocking, exercising the lower tiers locally, and benchmarking tiers
 // against each other. Unknown tokens are ignored. The variable cannot be toggled
-// at runtime, because the amd64 packages freeze their kernel function pointers
-// during package init. See the cpu package for the full token table.
+// at runtime, because the SIMD packages cache their selected kernels during
+// package init (function pointers on amd64, capability flags on arm64). See the
+// cpu package for the full token table.
 //
 // # Quick Start
 //

--- a/doc.go
+++ b/doc.go
@@ -18,6 +18,16 @@
 //   - ARM64: NEON/ASIMD instructions (2x float64, 4x float32)
 //   - Other: Pure Go fallback
 //
+// # Disabling SIMD tiers
+//
+// Set the SIMD_DISABLE environment variable before the process starts to mask
+// detected CPU features (a comma-separated, case-insensitive token list such as
+// "avx512", "avx", "neon", or "all"). It is useful for avoiding AVX-512
+// downclocking, exercising the lower tiers locally, and benchmarking tiers
+// against each other. Unknown tokens are ignored. The variable cannot be toggled
+// at runtime, because the amd64 packages freeze their kernel function pointers
+// during package init. See the cpu package for the full token table.
+//
 // # Quick Start
 //
 //	import (


### PR DESCRIPTION
Closes #99.

## What

Adds a `SIMD_DISABLE` environment variable, read once during `cpu` package init, that masks detected CPU features. The value is a comma-separated, case-insensitive list of tokens; each token clears its own flag plus everything that depends on it (so the result never describes an impossible CPU like AVX2-set-but-AVX-cleared). Unknown and empty tokens are ignored: a library must not panic or write to stderr on env input.

| Token | Clears |
| --- | --- |
| `avx512` | AVX512F, AVX512VL |
| `avx2` | AVX2 (+ avx512 set) |
| `avx` | AVX, FMA (+ avx2 set) |
| `fma` | FMA only |
| `sse42` | SSE42 (+ avx set) |
| `sse41` | SSE41 (+ sse42 set) |
| `ssse3` | SSSE3 (+ sse41 set) |
| `sse3` | SSE3 (+ ssse3 set) |
| `pclmulqdq` | PCLMULQDQ only |
| `neon` | NEON, FP16, SVE, SVE2, PMULL |
| `fp16` | FP16 only |
| `sve` | SVE, SVE2 |
| `pmull` | PMULL only |
| `all` | every flag (forces pure Go everywhere) |

## Why

- Avoid AVX-512 downclocking on early Skylake-SP/X parts.
- Exercise the SSE2/NEON/pure-Go paths locally without the QEMU CI job.
- Same-machine tier-versus-tier benchmarks.

Consumer packages select kernel function pointers during their own init, which Go runs after the imported `cpu` package, so clearing flags in `cpu` init is sufficient and race-free with zero changes in `f32`/`f64`/`c64`/`c128`/`i32`/`i16`/`crc`. `cpu.Info()` reflects the cleared flags.

## Implementation

- `applyDisable(f *Features, spec string)` is a pure function in `cpu/cpu.go` with cascade helpers encoding the tier dependency chain.
- Called at the end of init in `cpu_amd64.go`, `cpu_arm64.go`, and `cpu_arm64_darwin.go`.
- `doc.go` and the README `cpu` section document the table and the set-before-start constraint (it cannot be toggled at runtime because the amd64 packages freeze function pointers during init).

## Tests

- Unit tests for `applyDisable`: every token, the dependency chains, case-insensitivity, surrounding whitespace, unknown tokens, empty/trailing-comma tokens, and the empty string no-op.
- Integration test re-execs the test binary with `SIMD_DISABLE=all` and asserts `cpu.Info()` reports the no-SIMD string for the running arch.

## Verification

- `go test ./cpu/` and `golangci-lint run ./cpu/` clean on amd64 (AVX+FMA host).
- Cross-compiled and ran the cpu test binary natively on a Raspberry Pi 5 (linux/arm64): all green, and `SIMD_DISABLE=neon` correctly drops `cpu.Info()` to `ARM64 (no SIMD)`.
- `darwin/arm64` and `linux/riscv64` build checks pass.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for the `SIMD_DISABLE` environment variable, allowing users to selectively disable CPU SIMD feature tiers via comma-separated, case-insensitive tokens (e.g., `avx`, `neon`, `all`). Unknown tokens are silently ignored. Must be set before process start.

* **Documentation**
  * Updated guides to explain the new `SIMD_DISABLE` environment variable and its usage patterns.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->