### PR TITLE
f32: add amd64 SSE/AVX kernels for Variance and EuclideanDistance

### DIFF
--- a/README.md
+++ b/README.md
@@ -522,7 +522,14 @@ Like the `i32` interleave kernels, these are pure 16-bit-lane movement (AVX2/SSE
 |                | Sum        | 41        | 123     | **3.0x**  |
 |                | Min        | 65        | 340     | **5.2x**  |
 |                | Max        | 66        | 352     | **5.3x**  |
+| **Statistical**| Variance\*  | 174       | 522     | **3.0x**  |
+|                | StdDev\*    | 208       | 529     | **2.5x**  |
+| **Vector**     | EuclideanDistance\* | 38 | 579     | **15.1x** |
 | **Range**      | Clamp      | 47        | 701     | **14.8x** |
+
+\*Variance/StdDev/EuclideanDistance gained their amd64 SSE/AVX kernels later than
+the rows above and were benchmarked in a separate run, so compare their SIMD/Go
+speedup rather than absolute ns against the other rows.
 
 #### Activation Functions - SIMD vs Pure Go
 

--- a/f32/f32_amd64.go
+++ b/f32/f32_amd64.go
@@ -22,45 +22,49 @@ var minSIMDElements = minAVXElements
 
 // Function pointer types for SIMD operations
 type (
-	dotProductFunc       func(a, b []float32) float32
-	binaryOpFunc         func(dst, a, b []float32)
-	scaleFunc            func(dst, a []float32, s float32)
-	unaryOpFunc          func(dst, a []float32)
-	reduceFunc           func(a []float32) float32
-	reduceIdxFunc        func(a []float32) int
-	fmaFunc              func(dst, a, b, c []float32)
-	clampFunc            func(dst, a []float32, minVal, maxVal float32)
-	addScaledFunc        func(dst []float32, alpha float32, s []float32)
-	convolveDecimateFunc func(dst, signal, kernel []float32, factor, phase int)
-	interleave2Func      func(dst, a, b []float32)
-	deinterleave2Func    func(a, b, src []float32)
+	dotProductFunc        func(a, b []float32) float32
+	binaryOpFunc          func(dst, a, b []float32)
+	scaleFunc             func(dst, a []float32, s float32)
+	unaryOpFunc           func(dst, a []float32)
+	reduceFunc            func(a []float32) float32
+	reduceIdxFunc         func(a []float32) int
+	fmaFunc               func(dst, a, b, c []float32)
+	clampFunc             func(dst, a []float32, minVal, maxVal float32)
+	varianceFunc          func(a []float32, mean float32) float32
+	euclideanDistanceFunc func(a, b []float32) float32
+	addScaledFunc         func(dst []float32, alpha float32, s []float32)
+	convolveDecimateFunc  func(dst, signal, kernel []float32, factor, phase int)
+	interleave2Func       func(dst, a, b []float32)
+	deinterleave2Func     func(a, b, src []float32)
 )
 
 // Function pointers - assigned at init time based on CPU features
 var (
-	dotProductImpl       dotProductFunc
-	addImpl              binaryOpFunc
-	subImpl              binaryOpFunc
-	mulImpl              binaryOpFunc
-	divImpl              binaryOpFunc
-	scaleImpl            scaleFunc
-	addScalarImpl        scaleFunc
-	sumImpl              reduceFunc
-	minImpl              reduceFunc
-	maxImpl              reduceFunc
-	absImpl              unaryOpFunc
-	negImpl              unaryOpFunc
-	sqrtImpl             unaryOpFunc
-	reciprocalImpl       unaryOpFunc
-	roundImpl            unaryOpFunc
-	fmaImpl              fmaFunc
-	clampImpl            clampFunc
-	minIdxImpl           reduceIdxFunc
-	maxIdxImpl           reduceIdxFunc
-	addScaledImpl        addScaledFunc
-	convolveDecimateImpl convolveDecimateFunc
-	interleave2Impl      interleave2Func
-	deinterleave2Impl    deinterleave2Func
+	dotProductImpl        dotProductFunc
+	addImpl               binaryOpFunc
+	subImpl               binaryOpFunc
+	mulImpl               binaryOpFunc
+	divImpl               binaryOpFunc
+	scaleImpl             scaleFunc
+	addScalarImpl         scaleFunc
+	sumImpl               reduceFunc
+	minImpl               reduceFunc
+	maxImpl               reduceFunc
+	absImpl               unaryOpFunc
+	negImpl               unaryOpFunc
+	sqrtImpl              unaryOpFunc
+	reciprocalImpl        unaryOpFunc
+	roundImpl             unaryOpFunc
+	fmaImpl               fmaFunc
+	clampImpl             clampFunc
+	varianceImpl          varianceFunc
+	euclideanDistanceImpl euclideanDistanceFunc
+	minIdxImpl            reduceIdxFunc
+	maxIdxImpl            reduceIdxFunc
+	addScaledImpl         addScaledFunc
+	convolveDecimateImpl  convolveDecimateFunc
+	interleave2Impl       interleave2Func
+	deinterleave2Impl     deinterleave2Func
 )
 
 func init() {
@@ -97,6 +101,10 @@ func initAVX512() {
 	roundImpl = roundAVX
 	fmaImpl = fmaAVX512
 	clampImpl = clampAVX512
+	// AVX-512 variance/euclidean kernels are out of scope (no AVX-512 hardware to
+	// verify them; see #75/#96); reuse the AVX kernels so the tier still benefits.
+	varianceImpl = varianceAVX
+	euclideanDistanceImpl = euclideanDistanceAVX
 	minIdxImpl = minIdxGo
 	maxIdxImpl = maxIdxGo
 	addScaledImpl = addScaledAVX512
@@ -123,6 +131,8 @@ func initAVX() {
 	roundImpl = roundAVX
 	fmaImpl = fmaAVX
 	clampImpl = clampAVX
+	varianceImpl = varianceAVX
+	euclideanDistanceImpl = euclideanDistanceAVX
 	minIdxImpl = minIdxGo
 	maxIdxImpl = maxIdxGo
 	addScaledImpl = addScaledAVX
@@ -148,6 +158,8 @@ func initSSE() {
 	roundImpl = round32Go
 	fmaImpl = fmaSSE
 	clampImpl = clampSSE
+	varianceImpl = varianceSSE
+	euclideanDistanceImpl = euclideanDistanceSSE
 	minIdxImpl = minIdxGo
 	maxIdxImpl = maxIdxGo
 	addScaledImpl = addScaledSSE
@@ -175,6 +187,8 @@ func initGo() {
 	roundImpl = round32Go
 	fmaImpl = fmaGo
 	clampImpl = clampGo
+	varianceImpl = variance32Go
+	euclideanDistanceImpl = euclideanDistance32Go
 	minIdxImpl = minIdxGo
 	maxIdxImpl = maxIdxGo
 	addScaledImpl = addScaledGo
@@ -265,7 +279,6 @@ func sqrt32(dst, a []float32) {
 func reciprocal32(dst, a []float32) {
 	reciprocalImpl(dst, a)
 }
-
 
 func round32(dst, src []float32) {
 	roundImpl(dst, src)
@@ -724,6 +737,21 @@ func reciprocalAVX(dst, a []float32)
 //go:noescape
 func addScaledAVX(dst []float32, alpha float32, s []float32)
 
+// Variance and Euclidean-distance reductions. sum((a[i]-mean)^2)/n and
+// sqrt(sum((a[i]-b[i])^2)), accumulated in float32 to match the Go references.
+//
+//go:noescape
+func varianceSSE(a []float32, mean float32) float32
+
+//go:noescape
+func varianceAVX(a []float32, mean float32) float32
+
+//go:noescape
+func euclideanDistanceSSE(a, b []float32) float32
+
+//go:noescape
+func euclideanDistanceAVX(a, b []float32) float32
+
 // AVX-512 assembly function declarations (16x float32 per iteration)
 //
 //go:noescape
@@ -866,11 +894,11 @@ func interleave8AVX(dst []float32, srcs [][]float32, n int)
 func deinterleave8AVX(dsts [][]float32, src []float32, n int)
 
 func variance32(a []float32, mean float32) float32 {
-	return variance32Go(a, mean)
+	return varianceImpl(a, mean)
 }
 
 func euclideanDistance32(a, b []float32) float32 {
-	return euclideanDistance32Go(a, b)
+	return euclideanDistanceImpl(a, b)
 }
 
 func cubicInterpDot32(hist, a, b, c, d []float32, x float32) float32 {

--- a/f32/f32_amd64.s
+++ b/f32/f32_amd64.s
@@ -5847,3 +5847,366 @@ dot4_512_done:
     VMOVSS X5, 12(DX)
     VZEROUPPER
     RET
+
+// ============================================================================
+// VARIANCE / EUCLIDEAN DISTANCE REDUCTIONS
+// Ported from the f64 kernels (f64/f64_amd64.s). float32 doubles the lane count
+// versus float64: 4 per XMM (SSE), 8 per YMM (AVX). Accumulation is in float32
+// to match variance32Go / euclideanDistance32Go (f32/f32_go.go).
+// ============================================================================
+
+// func varianceSSE(a []float32, mean float32) float32
+// Population variance: sum((a[i]-mean)^2) / len(a). 4 accumulators of 4 floats.
+TEXT ·varianceSSE(SB), NOSPLIT, $0-36
+    MOVQ a_base+0(FP), SI
+    MOVQ a_len+8(FP), CX
+    MOVSS mean+24(FP), X2
+    SHUFPS $0, X2, X2          // broadcast mean to all 4 lanes
+
+    XORPS X0, X0
+    XORPS X3, X3
+    XORPS X4, X4
+    XORPS X5, X5
+
+    // Process 16 elements (4 vectors of 4) per iteration
+    MOVQ CX, AX
+    SHRQ $4, AX                // len / 16
+    JZ   var32_sse_loop4_check
+
+var32_sse_loop16:
+    MOVUPS 0(SI), X1
+    SUBPS X2, X1
+    MULPS X1, X1
+    ADDPS X1, X0
+
+    MOVUPS 16(SI), X1
+    SUBPS X2, X1
+    MULPS X1, X1
+    ADDPS X1, X3
+
+    MOVUPS 32(SI), X1
+    SUBPS X2, X1
+    MULPS X1, X1
+    ADDPS X1, X4
+
+    MOVUPS 48(SI), X1
+    SUBPS X2, X1
+    MULPS X1, X1
+    ADDPS X1, X5
+
+    ADDQ $64, SI
+    DECQ AX
+    JNZ  var32_sse_loop16
+
+    ADDPS X3, X0
+    ADDPS X5, X4
+    ADDPS X4, X0
+
+var32_sse_loop4_check:
+    ANDQ $15, CX
+    MOVQ CX, AX
+    SHRQ $2, AX
+    JZ   var32_sse_remainder
+
+var32_sse_loop4:
+    MOVUPS (SI), X1
+    SUBPS X2, X1
+    MULPS X1, X1
+    ADDPS X1, X0
+    ADDQ $16, SI
+    DECQ AX
+    JNZ  var32_sse_loop4
+
+var32_sse_remainder:
+    // Horizontal sum of the 4 float lanes in X0 into X0[0].
+    MOVAPS X0, X1
+    SHUFPS $0x0E, X1, X1
+    ADDPS X1, X0
+    MOVAPS X0, X1
+    SHUFPS $0x01, X1, X1
+    ADDSS X1, X0
+
+    ANDQ $3, CX
+    JZ   var32_sse_divide
+    MOVSS mean+24(FP), X2      // scalar mean for the tail
+
+var32_sse_scalar:
+    MOVSS (SI), X1
+    SUBSS X2, X1
+    MULSS X1, X1
+    ADDSS X1, X0
+    ADDQ $4, SI
+    DECQ CX
+    JNZ  var32_sse_scalar
+
+var32_sse_divide:
+    MOVQ a_len+8(FP), CX
+    CVTSQ2SS CX, X1
+    DIVSS X1, X0
+    MOVSS X0, ret+32(FP)
+    RET
+
+// func varianceAVX(a []float32, mean float32) float32
+// 4 independent FMA accumulators of 8 floats to hide FMA latency.
+TEXT ·varianceAVX(SB), NOSPLIT, $0-36
+    MOVQ a_base+0(FP), SI
+    MOVQ a_len+8(FP), CX
+    VBROADCASTSS mean+24(FP), Y2
+
+    VXORPS Y0, Y0, Y0
+    VXORPS Y3, Y3, Y3
+    VXORPS Y4, Y4, Y4
+    VXORPS Y5, Y5, Y5
+
+    // Process 32 elements (4 vectors of 8) per iteration
+    MOVQ CX, AX
+    SHRQ $5, AX                // len / 32
+    JZ   var32_avx_loop8_check
+
+var32_avx_loop32:
+    VMOVUPS 0(SI), Y1
+    VSUBPS Y2, Y1, Y1
+    VFMADD231PS Y1, Y1, Y0
+
+    VMOVUPS 32(SI), Y1
+    VSUBPS Y2, Y1, Y1
+    VFMADD231PS Y1, Y1, Y3
+
+    VMOVUPS 64(SI), Y1
+    VSUBPS Y2, Y1, Y1
+    VFMADD231PS Y1, Y1, Y4
+
+    VMOVUPS 96(SI), Y1
+    VSUBPS Y2, Y1, Y1
+    VFMADD231PS Y1, Y1, Y5
+
+    ADDQ $128, SI
+    DECQ AX
+    JNZ  var32_avx_loop32
+
+    VADDPS Y3, Y0, Y0
+    VADDPS Y5, Y4, Y4
+    VADDPS Y4, Y0, Y0
+
+var32_avx_loop8_check:
+    ANDQ $31, CX
+    MOVQ CX, AX
+    SHRQ $3, AX
+    JZ   var32_avx_remainder
+
+var32_avx_loop8:
+    VMOVUPS (SI), Y1
+    VSUBPS Y2, Y1, Y1
+    VFMADD231PS Y1, Y1, Y0
+    ADDQ $32, SI
+    DECQ AX
+    JNZ  var32_avx_loop8
+
+var32_avx_remainder:
+    // Reduce Y0 (8 floats) to X0[0] before any VEX scalar op zeroes the upper YMM.
+    VEXTRACTF128 $1, Y0, X1
+    VADDPS X1, X0, X0
+    VHADDPS X0, X0, X0
+    VHADDPS X0, X0, X0
+
+    ANDQ $7, CX
+    JZ   var32_avx_divide
+    VMOVSS mean+24(FP), X2
+
+var32_avx_scalar:
+    VMOVSS (SI), X1
+    VSUBSS X2, X1, X1
+    VFMADD231SS X1, X1, X0
+    ADDQ $4, SI
+    DECQ CX
+    JNZ  var32_avx_scalar
+
+var32_avx_divide:
+    MOVQ a_len+8(FP), CX
+    CVTSQ2SS CX, X1
+    VDIVSS X1, X0, X0
+    VMOVSS X0, ret+32(FP)
+    VZEROUPPER
+    RET
+
+// func euclideanDistanceSSE(a, b []float32) float32
+// sqrt(sum((a[i]-b[i])^2)). 4 accumulators of 4 floats. Callers pass equal-length
+// slices (EuclideanDistance slices both to min length).
+TEXT ·euclideanDistanceSSE(SB), NOSPLIT, $0-52
+    MOVQ a_base+0(FP), SI
+    MOVQ a_len+8(FP), CX
+    MOVQ b_base+24(FP), DI
+
+    XORPS X0, X0
+    XORPS X3, X3
+    XORPS X4, X4
+    XORPS X5, X5
+
+    MOVQ CX, AX
+    SHRQ $4, AX                // len / 16
+    JZ   euclid32_sse_loop4_check
+
+euclid32_sse_loop16:
+    MOVUPS 0(SI), X1
+    MOVUPS 0(DI), X2
+    SUBPS X2, X1
+    MULPS X1, X1
+    ADDPS X1, X0
+
+    MOVUPS 16(SI), X1
+    MOVUPS 16(DI), X2
+    SUBPS X2, X1
+    MULPS X1, X1
+    ADDPS X1, X3
+
+    MOVUPS 32(SI), X1
+    MOVUPS 32(DI), X2
+    SUBPS X2, X1
+    MULPS X1, X1
+    ADDPS X1, X4
+
+    MOVUPS 48(SI), X1
+    MOVUPS 48(DI), X2
+    SUBPS X2, X1
+    MULPS X1, X1
+    ADDPS X1, X5
+
+    ADDQ $64, SI
+    ADDQ $64, DI
+    DECQ AX
+    JNZ  euclid32_sse_loop16
+
+    ADDPS X3, X0
+    ADDPS X5, X4
+    ADDPS X4, X0
+
+euclid32_sse_loop4_check:
+    ANDQ $15, CX
+    MOVQ CX, AX
+    SHRQ $2, AX
+    JZ   euclid32_sse_remainder
+
+euclid32_sse_loop4:
+    MOVUPS (SI), X1
+    MOVUPS (DI), X2
+    SUBPS X2, X1
+    MULPS X1, X1
+    ADDPS X1, X0
+    ADDQ $16, SI
+    ADDQ $16, DI
+    DECQ AX
+    JNZ  euclid32_sse_loop4
+
+euclid32_sse_remainder:
+    MOVAPS X0, X1
+    SHUFPS $0x0E, X1, X1
+    ADDPS X1, X0
+    MOVAPS X0, X1
+    SHUFPS $0x01, X1, X1
+    ADDSS X1, X0
+
+    ANDQ $3, CX
+    JZ   euclid32_sse_sqrt
+
+euclid32_sse_scalar:
+    MOVSS (SI), X1
+    MOVSS (DI), X2
+    SUBSS X2, X1
+    MULSS X1, X1
+    ADDSS X1, X0
+    ADDQ $4, SI
+    ADDQ $4, DI
+    DECQ CX
+    JNZ  euclid32_sse_scalar
+
+euclid32_sse_sqrt:
+    SQRTSS X0, X0
+    MOVSS X0, ret+48(FP)
+    RET
+
+// func euclideanDistanceAVX(a, b []float32) float32
+// 4 independent FMA accumulators of 8 floats, then horizontal reduce and sqrt.
+TEXT ·euclideanDistanceAVX(SB), NOSPLIT, $0-52
+    MOVQ a_base+0(FP), SI
+    MOVQ a_len+8(FP), CX
+    MOVQ b_base+24(FP), DI
+
+    VXORPS Y0, Y0, Y0
+    VXORPS Y3, Y3, Y3
+    VXORPS Y4, Y4, Y4
+    VXORPS Y5, Y5, Y5
+
+    MOVQ CX, AX
+    SHRQ $5, AX                // len / 32
+    JZ   euclid32_avx_loop8_check
+
+euclid32_avx_loop32:
+    VMOVUPS (SI), Y1
+    VMOVUPS (DI), Y2
+    VSUBPS Y2, Y1, Y1
+    VFMADD231PS Y1, Y1, Y0
+
+    VMOVUPS 32(SI), Y1
+    VMOVUPS 32(DI), Y2
+    VSUBPS Y2, Y1, Y1
+    VFMADD231PS Y1, Y1, Y3
+
+    VMOVUPS 64(SI), Y1
+    VMOVUPS 64(DI), Y2
+    VSUBPS Y2, Y1, Y1
+    VFMADD231PS Y1, Y1, Y4
+
+    VMOVUPS 96(SI), Y1
+    VMOVUPS 96(DI), Y2
+    VSUBPS Y2, Y1, Y1
+    VFMADD231PS Y1, Y1, Y5
+
+    ADDQ $128, SI
+    ADDQ $128, DI
+    DECQ AX
+    JNZ  euclid32_avx_loop32
+
+    VADDPS Y3, Y0, Y0
+    VADDPS Y4, Y0, Y0
+    VADDPS Y5, Y0, Y0
+
+euclid32_avx_loop8_check:
+    ANDQ $31, CX
+    MOVQ CX, AX
+    SHRQ $3, AX
+    JZ   euclid32_avx_remainder
+
+euclid32_avx_loop8:
+    VMOVUPS (SI), Y1
+    VMOVUPS (DI), Y2
+    VSUBPS Y2, Y1, Y1
+    VFMADD231PS Y1, Y1, Y0
+    ADDQ $32, SI
+    ADDQ $32, DI
+    DECQ AX
+    JNZ  euclid32_avx_loop8
+
+euclid32_avx_remainder:
+    VEXTRACTF128 $1, Y0, X1
+    VADDPS X1, X0, X0
+    VHADDPS X0, X0, X0
+    VHADDPS X0, X0, X0
+
+    ANDQ $7, CX
+    JZ   euclid32_avx_sqrt
+
+euclid32_avx_scalar:
+    VMOVSS (SI), X1
+    VMOVSS (DI), X2
+    VSUBSS X2, X1, X1
+    VFMADD231SS X1, X1, X0
+    ADDQ $4, SI
+    ADDQ $4, DI
+    DECQ CX
+    JNZ  euclid32_avx_scalar
+
+euclid32_avx_sqrt:
+    VSQRTSS X0, X0, X0
+    VMOVSS X0, ret+48(FP)
+    VZEROUPPER
+    RET

--- a/f32/f32_amd64.s
+++ b/f32/f32_amd64.s
@@ -6167,8 +6167,8 @@ euclid32_avx_loop32:
     JNZ  euclid32_avx_loop32
 
     VADDPS Y3, Y0, Y0
+    VADDPS Y5, Y4, Y4
     VADDPS Y4, Y0, Y0
-    VADDPS Y5, Y0, Y0
 
 euclid32_avx_loop8_check:
     ANDQ $31, CX

--- a/f32/variance_euclidean_amd64_test.go
+++ b/f32/variance_euclidean_amd64_test.go
@@ -1,0 +1,136 @@
+//go:build amd64
+
+package f32
+
+import (
+	"math"
+	"testing"
+
+	"github.com/tphakala/simd/cpu"
+)
+
+// varEuclidSeq builds a deterministic float32 slice that mixes signs and
+// magnitudes so the kernel's lane reduction is exercised across every unroll
+// remainder.
+func varEuclidSeq(n, seed int) []float32 {
+	s := make([]float32, n)
+	for i := range s {
+		s[i] = (float32((i*7+seed)%17) - 8) * 0.5 // range [-4, 4]
+	}
+	return s
+}
+
+// reduceMatch32 reports whether got and want agree within the tolerance used for
+// f32 reductions, comparing NaN and Inf by class rather than by value because the
+// SIMD path accumulates in a different order than the scalar reference.
+func reduceMatch32(got, want float32) bool {
+	g, w := float64(got), float64(want)
+	if math.IsNaN(w) || math.IsNaN(g) {
+		return math.IsNaN(w) == math.IsNaN(g)
+	}
+	if math.IsInf(w, 0) || math.IsInf(g, 0) {
+		return math.IsInf(w, 1) == math.IsInf(g, 1) && math.IsInf(w, -1) == math.IsInf(g, -1)
+	}
+	return math.Abs(g-w) <= 1e-4*math.Abs(w)+1e-5
+}
+
+func TestVarianceKernelsAMD64(t *testing.T) {
+	for n := 0; n <= 40; n++ {
+		a := varEuclidSeq(n, 1)
+		var mean float32
+		if n > 0 {
+			mean = Mean(a)
+		}
+		want := variance32Go(a, mean)
+
+		if cpu.X86.SSE2 {
+			if got := varianceSSE(a, mean); !reduceMatch32(got, want) {
+				t.Errorf("varianceSSE(n=%d) = %v, want %v", n, got, want)
+			}
+		}
+		if cpu.X86.AVX && cpu.X86.FMA {
+			if got := varianceAVX(a, mean); !reduceMatch32(got, want) {
+				t.Errorf("varianceAVX(n=%d) = %v, want %v", n, got, want)
+			}
+		}
+	}
+}
+
+func TestEuclideanDistanceKernelsAMD64(t *testing.T) {
+	for n := 0; n <= 40; n++ {
+		a := varEuclidSeq(n, 1)
+		b := varEuclidSeq(n, 9)
+		want := euclideanDistance32Go(a, b)
+
+		if cpu.X86.SSE2 {
+			if got := euclideanDistanceSSE(a, b); !reduceMatch32(got, want) {
+				t.Errorf("euclideanDistanceSSE(n=%d) = %v, want %v", n, got, want)
+			}
+		}
+		if cpu.X86.AVX && cpu.X86.FMA {
+			if got := euclideanDistanceAVX(a, b); !reduceMatch32(got, want) {
+				t.Errorf("euclideanDistanceAVX(n=%d) = %v, want %v", n, got, want)
+			}
+		}
+	}
+}
+
+// TestVarianceEuclideanSpecialValuesAMD64 feeds NaN, +/-Inf, and denormal inputs
+// through the kernels and asserts they propagate the same special class as the
+// scalar reference.
+func TestVarianceEuclideanSpecialValuesAMD64(t *testing.T) {
+	inf := float32(math.Inf(1))
+	nan := float32(math.NaN())
+	denorm := math.Float32frombits(1) // smallest positive subnormal
+
+	cases := [][]float32{
+		{nan, 1, 2, 3, 4, 5, 6, 7, 8},
+		{1, 2, 3, inf, 5, 6, 7, 8, 9},
+		{denorm, denorm, denorm, denorm, denorm},
+		{1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, nan},
+		{-inf, 1, 2, 3},
+	}
+	for ci, a := range cases {
+		mean := Mean(a)
+		vwant := variance32Go(a, mean)
+
+		b := make([]float32, len(a))
+		for i := range a {
+			b[i] = a[i] * 0.5
+		}
+		ewant := euclideanDistance32Go(a, b)
+
+		if cpu.X86.SSE2 {
+			if got := varianceSSE(a, mean); !reduceMatch32(got, vwant) {
+				t.Errorf("case %d varianceSSE = %v, want %v", ci, got, vwant)
+			}
+			if got := euclideanDistanceSSE(a, b); !reduceMatch32(got, ewant) {
+				t.Errorf("case %d euclideanDistanceSSE = %v, want %v", ci, got, ewant)
+			}
+		}
+		if cpu.X86.AVX && cpu.X86.FMA {
+			if got := varianceAVX(a, mean); !reduceMatch32(got, vwant) {
+				t.Errorf("case %d varianceAVX = %v, want %v", ci, got, vwant)
+			}
+			if got := euclideanDistanceAVX(a, b); !reduceMatch32(got, ewant) {
+				t.Errorf("case %d euclideanDistanceAVX = %v, want %v", ci, got, ewant)
+			}
+		}
+	}
+}
+
+// TestVarianceEuclideanAllocsAMD64 confirms the public APIs stay allocation-free
+// through the SIMD dispatch path.
+func TestVarianceEuclideanAllocsAMD64(t *testing.T) {
+	a := varEuclidSeq(100, 1)
+	b := varEuclidSeq(100, 2)
+	if allocs := testing.AllocsPerRun(100, func() { _ = Variance(a) }); allocs != 0 {
+		t.Errorf("Variance allocs = %v, want 0", allocs)
+	}
+	if allocs := testing.AllocsPerRun(100, func() { _ = StdDev(a) }); allocs != 0 {
+		t.Errorf("StdDev allocs = %v, want 0", allocs)
+	}
+	if allocs := testing.AllocsPerRun(100, func() { _ = EuclideanDistance(a, b) }); allocs != 0 {
+		t.Errorf("EuclideanDistance allocs = %v, want 0", allocs)
+	}
+}


### PR DESCRIPTION
Closes #97.

## What

`variance32` and `euclideanDistance32` fell back unconditionally to the pure-Go references on amd64 (`f32/f32_amd64.go`), even though `f64` ships the full kernel set and `f32` on ARM64 already has `varianceNEON32`/`euclideanDistanceNEON32`. This ports the f64 kernels to f32 and wires them through the existing dispatch.

- New kernels in `f32/f32_amd64.s`: `varianceSSE`, `varianceAVX`, `euclideanDistanceSSE`, `euclideanDistanceAVX`. Lane counts double versus f64 (4 floats/XMM for SSE, 8 floats/YMM for AVX); the reduction structure mirrors the f64 templates.
- Accumulation stays in float32 to match the Go references: `variance32Go` divides the squared-diff sum by `n`; `euclideanDistance32Go` takes the sqrt of the float32 sum.
- Dispatch wired like f64: `varianceImpl`/`euclideanDistanceImpl` pointers, SSE in `initSSE`, AVX+FMA in `initAVX`, Go in `initGo`.

## AVX-512 scope

No AVX-512 hardware is available to runtime-verify new AVX-512 asm (see #75/#96), so `initAVX512` reuses the AVX kernels. The AVX-512 tier still gets the AVX speedup; dedicated AVX-512 kernels can follow once #96 lands the SDE CI job.

## Register safety

Kernels use only `SI`, `DI`, `CX`, `AX`, and `X0`-`X5`; `R14`/`R15`/`BP`/`SP` are untouched per the `CLAUDE.md` reserved-register table.

## Tests

- The four kernels are tested directly against the Go references across lengths 0-40 (every unroll remainder).
- NaN/+/-Inf/denormal special-value cases, compared by class (the reference and the kernel both collapse Inf/NaN inputs to NaN here).
- Reductions accumulate in a different order than the scalar loop, so parity uses a relative tolerance, not bit-exact equality.
- `AllocsPerRun == 0` for `Variance`, `StdDev`, and `EuclideanDistance`.

## Verification

- `go test ./...`, `go vet ./f32/`, and `golangci-lint run ./f32/` all clean on amd64 (i7-1260P, AVX+FMA). Both the SSE and AVX kernels are exercised directly by the parity tests regardless of the active tier.
- arm64 path is untouched; cross-compiled the f32 test binary and re-ran it on a Raspberry Pi 5 (linux/arm64): green.
- Benchmarks (i7-1260P, 1024 elements, same-run SIMD vs forced-Go): Variance 3.0x, StdDev 2.5x, EuclideanDistance 15.1x. The f32 README perf table's existing absolute numbers predate a faster environment, so the three new rows carry a footnote to compare speedup, not absolute ns.

## Docs

Added Statistical (Variance, StdDev) and Vector (EuclideanDistance) rows to the f32 amd64 performance table.