### PR TITLE
f16: add amd64 F16C conversion kernels; fix a denormal bug in the reference

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -114,14 +114,13 @@ jobs:
       matrix:
         goos: [linux, darwin, windows]
         goarch: [amd64, arm64]
-        # Guard the pure-Go *_other.go fallbacks. Six packages
-        # (c64/c128/f32/f64/i16/i32) gate their fallback on `!amd64 && !arm64`,
+        # Guard the pure-Go *_other.go fallbacks. Seven packages
+        # (c64/c128/f32/f64/f16/i16/i32) gate their fallback on `!amd64 && !arm64`,
         # so the amd64/arm64 legs above never compile those files: a primitive
         # added to the SIMD dispatch but forgotten in the fallback builds green
         # here and breaks only on other architectures (see #93/#94). riscv64 is
         # a normal 64-bit non-SIMD target; js/wasm additionally exercises the
         # assembler-less wasm backend. Build-only is enough to catch the gap.
-        # (f16's fallback is `!arm64`, so the amd64 legs already cover it.)
         include:
           - goos: linux
             goarch: riscv64

--- a/cpu/cpu.go
+++ b/cpu/cpu.go
@@ -21,6 +21,7 @@ type Features struct {
 	BMI2      bool
 	POPCNT    bool
 	PCLMULQDQ bool // carry-less multiply (CLMUL) - used for CRC folding
+	F16C      bool // half<->single float conversion (VCVTPH2PS/VCVTPS2PH)
 
 	// ARM64 features
 	NEON  bool
@@ -51,6 +52,11 @@ func HasNEON() bool { return ARM64.NEON }
 // HasPCLMULQDQ returns true if the x86 carry-less multiply instruction
 // (PCLMULQDQ) is available. It is used to accelerate CRC folding.
 func HasPCLMULQDQ() bool { return X86.PCLMULQDQ }
+
+// HasF16C returns true if the x86 F16C half-precision conversion instructions
+// (VCVTPH2PS / VCVTPS2PH) are available. They accelerate Float16 <-> float32
+// slice conversion. F16C provides conversion only, not half-precision arithmetic.
+func HasF16C() bool { return X86.F16C }
 
 // HasPMULL returns true if the ARM64 polynomial multiply instruction (PMULL)
 // is available. It is used to accelerate CRC folding.

--- a/cpu/cpu_amd64.go
+++ b/cpu/cpu_amd64.go
@@ -25,9 +25,25 @@ func init() {
 	X86.POPCNT = cpu.X86.HasPOPCNT
 	X86.PCLMULQDQ = cpu.X86.HasPCLMULQDQ
 
-	// Honor SIMD_DISABLE last, so the env var can mask any detected feature.
+	// F16C (half<->single conversion) is not exposed by golang.org/x/sys/cpu, so
+	// read it directly from CPUID leaf 1, ECX bit 29. Gate on the x/sys AVX flag,
+	// which already includes the OSXSAVE/XGETBV OS-support check that F16C needs
+	// because it operates on VEX/YMM state.
+	_, _, ecx, _ := cpuid(1, 0)
+	X86.F16C = X86.AVX && ecx&cpuidF16CBit != 0
+
+	// Honor SIMD_DISABLE last, so the env var can mask any detected feature
+	// (including F16C via the "all" token).
 	applyDisable(&X86, os.Getenv("SIMD_DISABLE"))
 }
+
+// cpuidF16CBit is CPUID leaf 1 ECX bit 29, set when F16C is supported.
+const cpuidF16CBit = 1 << 29
+
+// cpuid is the raw CPUID wrapper implemented in cpuid_amd64.s.
+//
+//go:noescape
+func cpuid(leaf, subleaf uint32) (eax, ebx, ecx, edx uint32)
 
 func cpuInfo() string {
 	switch {

--- a/cpu/cpuid_amd64.s
+++ b/cpu/cpuid_amd64.s
@@ -1,0 +1,17 @@
+//go:build amd64
+
+#include "textflag.h"
+
+// func cpuid(leaf, subleaf uint32) (eax, ebx, ecx, edx uint32)
+// Raw CPUID wrapper, needed because golang.org/x/sys/cpu does not expose F16C.
+// Modeled on x/sys/cpu's own cpu_x86.s. CPUID clobbers AX/BX/CX/DX, all of which
+// are caller-saved general registers in the Go ABI (no reserved register touched).
+TEXT ·cpuid(SB), NOSPLIT, $0-24
+	MOVL leaf+0(FP), AX
+	MOVL subleaf+4(FP), CX
+	CPUID
+	MOVL AX, eax+8(FP)
+	MOVL BX, ebx+12(FP)
+	MOVL CX, ecx+16(FP)
+	MOVL DX, edx+20(FP)
+	RET

--- a/f16/conv_correctness_test.go
+++ b/f16/conv_correctness_test.go
@@ -1,0 +1,164 @@
+package f16
+
+import (
+	"math"
+	"testing"
+)
+
+// f16IsNaN reports whether a Float16 bit pattern is NaN (exponent all ones,
+// mantissa non-zero). Hardware conversions quiet signaling NaNs and may not
+// preserve the exact payload the scalar reference produces, so NaN inputs are
+// compared by class, not by bits.
+func f16IsNaN(h Float16) bool {
+	return h&0x7C00 == 0x7C00 && h&0x03FF != 0
+}
+
+// fromFloat32Corpus returns float32 inputs that stress every FromFloat32 branch:
+// rounding ties, the overflow boundary, the full denormal range including the
+// underflow rounding boundary at 2^-25, signed zero, and the special values.
+func fromFloat32Corpus() []float32 {
+	return []float32{
+		0, float32(math.Copysign(0, -1)), // +0, -0
+		float32(math.Inf(1)), float32(math.Inf(-1)),
+		float32(math.NaN()), -float32(math.NaN()),
+		1, -1, 2, -2, 0.5, -0.5, 3.14159, -100, 100,
+		65504, -65504, // max finite f16
+		65505, 65519, 65520, 65536, // overflow boundary (>= 65520 -> Inf under RNE)
+		6.1035156e-05,                    // smallest normal f16 (2^-14)
+		6.097555e-05,                     // largest f16 denormal region (just below 2^-14)
+		5.9604645e-08,                    // smallest positive f16 denormal (2^-24)
+		math.Float32frombits(0x33592e01), // between 2^-25 and 2^-24: rounds up to 0x0001
+		2.9802322e-08,                    // 2^-25 exactly: RNE -> 0 (even)
+		1.4901161e-08,                    // below 2^-25: flushes to 0
+		1 + 1.0/2048,                     // 1 + 2^-11: tie at 1.0, RNE -> 1.0
+		1 + 1.0/1024,                     // 1 + 2^-10: exactly representable
+		1 + 3.0/2048,                     // tie up, RNE -> 1 + 2^-10
+		1024.5, 2048.25,                  // large values that round
+	}
+}
+
+// TestToFloat32SliceParity converts every Float16 value through the public
+// dispatch (F16C on amd64, NEON on arm64, Go elsewhere) and checks bit-exact
+// parity with the scalar reference, NaN by class.
+func TestToFloat32SliceParity(t *testing.T) {
+	const total = 1 << 16
+	src := make([]Float16, total)
+	for i := range src {
+		src[i] = Float16(i)
+	}
+	got := make([]float32, total)
+	ToFloat32Slice(got, src)
+
+	for i := range src {
+		want := toFloat32Go(src[i])
+		if math.IsNaN(float64(want)) {
+			if !math.IsNaN(float64(got[i])) {
+				t.Fatalf("h=%#04x: got %v, want NaN", src[i], got[i])
+			}
+			continue
+		}
+		if math.Float32bits(got[i]) != math.Float32bits(want) {
+			t.Fatalf("h=%#04x: got bits %#08x, want %#08x", src[i], math.Float32bits(got[i]), math.Float32bits(want))
+		}
+	}
+}
+
+// TestFromFloat32SliceParity feeds the boundary corpus plus a large random sweep
+// through the public dispatch and asserts bit-exact parity with the scalar
+// reference for non-NaN inputs, class parity for NaN. On arm64 this validates the
+// NEON kernel; on amd64 the F16C kernel.
+func TestFromFloat32SliceParity(t *testing.T) {
+	src := fromFloat32Corpus()
+	seed := uint32(0x9e3779b9)
+	for range 8192 {
+		seed = seed*1664525 + 1013904223
+		src = append(src, math.Float32frombits(seed))
+	}
+	got := make([]Float16, len(src))
+	FromFloat32Slice(got, src)
+
+	for i, f := range src {
+		want := fromFloat32Go(f)
+		if math.IsNaN(float64(f)) {
+			if !f16IsNaN(got[i]) {
+				t.Fatalf("src=%v (%#08x): got %#04x, want a NaN", f, math.Float32bits(f), got[i])
+			}
+			continue
+		}
+		if got[i] != want {
+			t.Fatalf("src=%v (%#08x): got %#04x, want %#04x", f, math.Float32bits(f), got[i], want)
+		}
+	}
+}
+
+// TestConvRoundTripExhaustive round-trips every non-Inf/NaN Float16 value through
+// ToFloat32Slice and back through FromFloat32Slice and asserts exact recovery.
+// This covers all representable FromFloat32 outputs, including the full denormal
+// range, against whichever kernel the platform dispatches to.
+func TestConvRoundTripExhaustive(t *testing.T) {
+	const total = 1 << 16
+	src := make([]Float16, 0, total)
+	for i := range total {
+		h := Float16(i)
+		if h&0x7C00 == 0x7C00 { // skip Inf/NaN exponent
+			continue
+		}
+		src = append(src, h)
+	}
+	f32 := make([]float32, len(src))
+	ToFloat32Slice(f32, src)
+	back := make([]Float16, len(src))
+	FromFloat32Slice(back, f32)
+
+	for i, h := range src {
+		if h&0x7FFF == 0 && back[i]&0x7FFF == 0 { // +0/-0 both fine
+			continue
+		}
+		if back[i] != h {
+			t.Fatalf("round-trip h=%#04x: got %#04x", h, back[i])
+		}
+	}
+}
+
+// TestConvSliceDispatchLengths exercises the kernel-prefix plus Go-remainder split
+// across lengths 0..24 in both directions.
+func TestConvSliceDispatchLengths(t *testing.T) {
+	for n := 0; n <= 24; n++ {
+		src16 := make([]Float16, n)
+		for i := range src16 {
+			src16[i] = Float16((i*37 + 1) & 0x7BFF) // avoid Inf/NaN exponent
+		}
+		f32 := make([]float32, n)
+		ToFloat32Slice(f32, src16)
+		for i := range f32 {
+			want := toFloat32Go(src16[i])
+			if math.Float32bits(f32[i]) != math.Float32bits(want) {
+				t.Fatalf("ToFloat32Slice n=%d i=%d: got %#08x want %#08x", n, i, math.Float32bits(f32[i]), math.Float32bits(want))
+			}
+		}
+		back := make([]Float16, n)
+		FromFloat32Slice(back, f32)
+		for i := range back {
+			want := fromFloat32Go(f32[i])
+			if back[i] != want {
+				t.Fatalf("FromFloat32Slice n=%d i=%d: got %#04x want %#04x", n, i, back[i], want)
+			}
+		}
+	}
+}
+
+// TestConvSliceAllocs confirms the public conversion APIs stay allocation-free.
+func TestConvSliceAllocs(t *testing.T) {
+	src16 := make([]Float16, 1024)
+	for i := range src16 {
+		src16[i] = Float16((i * 7) & 0x7BFF)
+	}
+	f32 := make([]float32, 1024)
+	if allocs := testing.AllocsPerRun(100, func() { ToFloat32Slice(f32, src16) }); allocs != 0 {
+		t.Errorf("ToFloat32Slice allocs = %v, want 0", allocs)
+	}
+	out16 := make([]Float16, 1024)
+	if allocs := testing.AllocsPerRun(100, func() { FromFloat32Slice(out16, f32) }); allocs != 0 {
+		t.Errorf("FromFloat32Slice allocs = %v, want 0", allocs)
+	}
+}

--- a/f16/f16_amd64.go
+++ b/f16/f16_amd64.go
@@ -1,6 +1,18 @@
-//go:build !arm64 && !amd64
+//go:build amd64
 
 package f16
+
+import "github.com/tphakala/simd/cpu"
+
+// f16cWidth is the number of FP16 elements the F16C kernels convert per
+// iteration (VCVTPH2PS widens, VCVTPS2PH narrows 8 packed halves at a time).
+const f16cWidth = 8
+
+// hasF16C caches the F16C conversion capability at package init. amd64 has no
+// half-precision arithmetic outside AVX512-FP16 (Sapphire Rapids and newer), so
+// only the slice conversions are accelerated; every other op stays pure Go,
+// mirroring the storage-type design (Float16 is an alias for uint16).
+var hasF16C = cpu.X86.F16C
 
 func toFloat32(h Float16) float32 {
 	return toFloat32Go(h)
@@ -11,12 +23,31 @@ func fromFloat32(f float32) Float16 {
 }
 
 func toFloat32Slice(dst []float32, src []Float16) {
+	n := len(dst)
+	if hasF16C && n >= f16cWidth {
+		// Convert the multiple-of-8 prefix with F16C, the tail with Go.
+		nVec := (n / f16cWidth) * f16cWidth
+		toFloat32SliceF16C(dst[:nVec], src[:nVec])
+		toFloat32SliceGo(dst[nVec:], src[nVec:])
+		return
+	}
 	toFloat32SliceGo(dst, src)
 }
 
 func fromFloat32Slice(dst []Float16, src []float32) {
+	n := len(dst)
+	if hasF16C && n >= f16cWidth {
+		nVec := (n / f16cWidth) * f16cWidth
+		fromFloat32SliceF16C(dst[:nVec], src[:nVec])
+		fromFloat32SliceGo(dst[nVec:], src[nVec:])
+		return
+	}
 	fromFloat32SliceGo(dst, src)
 }
+
+// Every operation other than the two slice conversions stays pure Go on amd64:
+// there is no F16C arithmetic, and the compute ops are not yet implemented as
+// convert-to-f32 + f32 SIMD + convert-back. These delegate to the references.
 
 func dotProduct(a, b []Float16) float32 {
 	return dotProductGo(a, b)
@@ -149,3 +180,12 @@ func deinterleave2_16(a, b, src []Float16) {
 func clampScale16(dst, src []Float16, minVal, maxVal, scale Float16) {
 	clampScaleGo(dst, src, minVal, maxVal, scale)
 }
+
+// F16C conversion kernels (implemented in f16_amd64.s). Each is called only with
+// a non-zero multiple of f16cWidth elements; the dispatch handles the tail.
+//
+//go:noescape
+func toFloat32SliceF16C(dst []float32, src []Float16)
+
+//go:noescape
+func fromFloat32SliceF16C(dst []Float16, src []float32)

--- a/f16/f16_amd64.s
+++ b/f16/f16_amd64.s
@@ -1,0 +1,54 @@
+//go:build amd64
+
+#include "textflag.h"
+
+// func toFloat32SliceF16C(dst []float32, src []Float16)
+// Widens packed Float16 to float32 with VCVTPH2PS, 8 elements per iteration.
+// The dispatch in f16_amd64.go calls this only with len(dst) == len(src) a
+// non-zero multiple of 8; any sub-8 tail is handled in Go.
+// Registers: DI/SI/CX and X0/Y1 only (no reserved register touched).
+TEXT ·toFloat32SliceF16C(SB), NOSPLIT, $0-48
+	MOVQ dst_base+0(FP), DI
+	MOVQ dst_len+8(FP), CX
+	MOVQ src_base+24(FP), SI
+
+	SHRQ $3, CX            // CX = number of 8-element blocks
+	JZ   to_f16c_done
+
+to_f16c_loop:
+	VMOVDQU (SI), X0       // load 8 packed Float16 (128 bits)
+	VCVTPH2PS X0, Y1       // widen to 8 float32 (256 bits)
+	VMOVUPS Y1, (DI)
+	ADDQ $16, SI           // 8 * 2 bytes consumed
+	ADDQ $32, DI           // 8 * 4 bytes written
+	DECQ CX
+	JNZ  to_f16c_loop
+
+to_f16c_done:
+	VZEROUPPER
+	RET
+
+// func fromFloat32SliceF16C(dst []Float16, src []float32)
+// Narrows float32 to Float16 with VCVTPS2PH, immediate 0 selecting
+// round-to-nearest-even, matching fromFloat32Go. 8 elements per iteration.
+// The dispatch calls this only with a non-zero multiple of 8.
+TEXT ·fromFloat32SliceF16C(SB), NOSPLIT, $0-48
+	MOVQ dst_base+0(FP), DI
+	MOVQ dst_len+8(FP), CX
+	MOVQ src_base+24(FP), SI
+
+	SHRQ $3, CX            // CX = number of 8-element blocks
+	JZ   from_f16c_done
+
+from_f16c_loop:
+	VMOVUPS (SI), Y0       // load 8 float32 (256 bits)
+	VCVTPS2PH $0, Y0, X1   // narrow to 8 Float16, round-to-nearest-even
+	VMOVDQU X1, (DI)
+	ADDQ $32, SI           // 8 * 4 bytes consumed
+	ADDQ $16, DI           // 8 * 2 bytes written
+	DECQ CX
+	JNZ  from_f16c_loop
+
+from_f16c_done:
+	VZEROUPPER
+	RET

--- a/f16/f16_go.go
+++ b/f16/f16_go.go
@@ -28,14 +28,17 @@ const (
 	fp32MantHighBit = 0x800000
 
 	// Conversion constants
-	fp32MantShift   = 13                            // FP32 mantissa bits to shift for FP16
-	fp32SignExtract = 16                            // Shift to extract sign from FP32 to FP16 position
-	fp32RoundBit    = 0x1000                        // Bit 12 for rounding
-	fp32RoundMask   = 0xFFF                         // Bits below round bit
-	fp32RoundCheck  = 0x2000                        // Bit 13 for round-to-even check
-	expBiasDiff     = fp32ExpBias - fp16ExpBias     // 112
-	expOverflow     = fp32ExpBias + fp16ExpBias     // 142 - overflow threshold
-	expUnderflow    = fp32ExpBias - 24              // 103 - underflow threshold
+	fp32MantShift   = 13                        // FP32 mantissa bits to shift for FP16
+	fp32SignExtract = 16                        // Shift to extract sign from FP32 to FP16 position
+	fp32RoundBit    = 0x1000                    // Bit 12 for rounding
+	fp32RoundMask   = 0xFFF                     // Bits below round bit
+	fp32RoundCheck  = 0x2000                    // Bit 13 for round-to-even check
+	expBiasDiff     = fp32ExpBias - fp16ExpBias // 112
+	expOverflow     = fp32ExpBias + fp16ExpBias // 142 - overflow threshold
+	// Flush to zero only below 2^-25 (half the smallest f16 denormal, 2^-24).
+	// Inputs in [2^-25, 2^-24) round to the smallest denormal under
+	// round-to-nearest-even, so the cutoff is fp32ExpBias-25, not -24.
+	expUnderflow    = fp32ExpBias - 25              // 102 - underflow threshold
 	expDenormThresh = fp32ExpBias - fp16ExpBias + 1 // 113 - denormalized threshold
 )
 
@@ -107,11 +110,15 @@ func fromFloat32Go(f float32) Float16 {
 		return sign
 
 	case exp < expDenormThresh:
-		// Denormalized result
-		// Add implicit 1 to mantissa
+		// Denormalized result.
+		// Add the implicit leading 1 to the f32 mantissa.
 		mant |= fp32MantHighBit
-		// Shift right to create denormalized value
-		shift := uint(expDenormThresh - exp)
+		// Shift right by the f32-to-f16 mantissa-width difference (fp32MantShift)
+		// plus the extra exponent gap, so the value lands in the f16 denormal
+		// mantissa range [1, 0x3FF]. Omitting fp32MantShift here was a bug: it
+		// left the result ~13 bits too large, so positive subnormal inputs
+		// truncated to wrong (even sign-flipped) Float16 bits.
+		shift := uint(fp32MantShift + (expDenormThresh - exp))
 		// Round to nearest even
 		round := uint32(1) << (shift - 1)
 		if mant&round != 0 && (mant&(round-1) != 0 || mant&(round<<1) != 0) {

--- a/f16/f16c_amd64_test.go
+++ b/f16/f16c_amd64_test.go
@@ -1,0 +1,79 @@
+//go:build amd64
+
+package f16
+
+import (
+	"math"
+	"testing"
+
+	"github.com/tphakala/simd/cpu"
+)
+
+// These tests call the F16C kernels directly (bypassing the dispatch thresholds)
+// so the kernel itself is exercised regardless of length. f16IsNaN and
+// fromFloat32Corpus are shared with the cross-platform parity tests in
+// conv_correctness_test.go.
+
+// TestToFloat32SliceF16C_Exhaustive converts every one of the 65536 possible
+// Float16 values through the F16C kernel and checks bit-exact parity with the
+// scalar reference, comparing NaN by class.
+func TestToFloat32SliceF16C_Exhaustive(t *testing.T) {
+	if !cpu.X86.F16C {
+		t.Skip("F16C not available on this CPU")
+	}
+	const total = 1 << 16 // multiple of 8, so the kernel converts every element
+	src := make([]Float16, total)
+	for i := range src {
+		src[i] = Float16(i)
+	}
+	got := make([]float32, total)
+	toFloat32SliceF16C(got, src)
+
+	for i := range src {
+		want := toFloat32Go(src[i])
+		if math.IsNaN(float64(want)) {
+			if !math.IsNaN(float64(got[i])) {
+				t.Fatalf("h=%#04x: got %v, want NaN", src[i], got[i])
+			}
+			continue
+		}
+		if math.Float32bits(got[i]) != math.Float32bits(want) {
+			t.Fatalf("h=%#04x: got bits %#08x, want %#08x", src[i], math.Float32bits(got[i]), math.Float32bits(want))
+		}
+	}
+}
+
+// TestFromFloat32SliceF16C_Direct feeds the boundary corpus plus a large random
+// sweep through the F16C kernel directly and asserts bit-exact parity with the
+// scalar reference for non-NaN inputs, class parity for NaN.
+func TestFromFloat32SliceF16C_Direct(t *testing.T) {
+	if !cpu.X86.F16C {
+		t.Skip("F16C not available on this CPU")
+	}
+
+	src := fromFloat32Corpus()
+	seed := uint32(0x9e3779b9)
+	for range 4096 {
+		seed = seed*1664525 + 1013904223
+		src = append(src, math.Float32frombits(seed))
+	}
+	for len(src)%8 != 0 { // kernel requires a multiple of 8
+		src = append(src, 0)
+	}
+
+	got := make([]Float16, len(src))
+	fromFloat32SliceF16C(got, src)
+
+	for i, f := range src {
+		want := fromFloat32Go(f)
+		if math.IsNaN(float64(f)) {
+			if !f16IsNaN(got[i]) {
+				t.Fatalf("src=%v (%#08x): got %#04x, want a NaN", f, math.Float32bits(f), got[i])
+			}
+			continue
+		}
+		if got[i] != want {
+			t.Fatalf("src=%v (%#08x): got %#04x, want %#04x", f, math.Float32bits(f), got[i], want)
+		}
+	}
+}


### PR DESCRIPTION
Closes #98.

## What

amd64 had no f16 assembly: every op ran the pure-Go reference. This adds F16C-accelerated slice conversions (the only practical amd64 path: native FP16 arithmetic needs AVX512-FP16, but F16C `VCVTPH2PS`/`VCVTPS2PH` half<->single conversion has shipped on every AVX2-capable x86 since 2012). Compute ops stay pure Go for now, matching the storage-type design (`Float16` is an alias for `uint16`).

### cpu package
- `cpu/cpuid_amd64.s`: raw CPUID wrapper, because `golang.org/x/sys/cpu` does not expose F16C.
- `cpu_amd64.go`: `X86.F16C` from CPUID leaf 1 ECX bit 29, gated on the x/sys AVX flag (which carries the OSXSAVE/XGETBV OS-support check F16C needs for VEX/YMM state). New `F16C` field and `HasF16C()` accessor.

### f16 package
- `f16_amd64.go`: dispatches the two conversions to F16C on the multiple-of-8 prefix and the Go reference on the tail; every other op delegates to the references.
- `f16_amd64.s`: `toFloat32SliceF16C` (8 halves/iter via `VCVTPH2PS`), `fromFloat32SliceF16C` (8 floats/iter via `VCVTPS2PH $0` = round-to-nearest-even). Only `DI`/`SI`/`CX` and X/Y regs used; no reserved register touched.
- `f16_other.go` build tag becomes `!arm64 && !amd64`, so the riscv64/wasm CI legs now guard its fallback like the other packages. CI comment updated.

## Bug fix: f16 denormal conversion in the shared reference

Cross-validating F16C against `fromFloat32Go` exposed a latent bug in the reference's denormal handling, **with no test coverage on any platform**:

1. The denormal shift omitted the 13-bit f32->f16 mantissa-width difference (`shift` was `expDenormThresh - exp` instead of `fp32MantShift + (expDenormThresh - exp)`). Positive subnormal inputs produced wildly wrong, sometimes **sign-flipped**, Float16 bits, e.g. `~6.1e-5` returned `0xe000` (a negative ~512).
2. `expUnderflow` was off by one (flushed `exp=102` to zero), so values in `[2^-25, 2^-24)` wrongly rounded to zero instead of the smallest denormal.

Both are fixed to match IEEE round-to-nearest-even. Ground truth is unambiguous: the **F16C hardware** and the **arm64 NEON FCVTN** output both agree with the corrected reference across the whole denormal range. (The NEON path was already correct in hardware; it just had no denormal test, so the buggy reference had never been challenged.)

## Tests

- Exhaustive `ToFloat32` parity over all 65536 Float16 values (NaN by class).
- `FromFloat32` over a boundary corpus (rounding ties, the 65520 overflow edge, the full denormal range incl. the 2^-25 underflow boundary, signed zero, Inf, NaN) plus a random sweep.
- Exhaustive round-trip over every representable value (covers all `FromFloat32` outputs, including all denormals).
- Dispatch length/remainder coverage (0..24) and `AllocsPerRun == 0`.
- Cross-platform parity tests validate the NEON kernel on arm64 and the F16C kernel on amd64 against the corrected reference. A 4.2M-value F16C-vs-reference sweep (run locally) found no further differences.

## Verification

- amd64 (i7-1260P, F16C): `go test ./...`, `go vet`, `golangci-lint` clean.
- arm64 (Raspberry Pi 5, NEON): cross-compiled and ran the f16 + cpu suites natively, all green, including the new denormal parity coverage.
- Cross-arch builds for linux/arm64, darwin/arm64, linux/riscv64, js/wasm, windows/amd64 all OK.