### PR TITLE
c64/c128: add DotProduct and DotProductConj reductions

### DIFF
--- a/README.md
+++ b/README.md
@@ -327,6 +327,8 @@ SIMD-accelerated complex number operations for FFT-based signal processing:
 |                | `Scale(dst, a, s)`   | Scale by complex scalar            | 4x / 2x                 |
 |                | `Add(dst, a, b)`     | Complex addition                   | 4x / 2x                 |
 |                | `Sub(dst, a, b)`     | Complex subtraction                | 4x / 2x                 |
+| **Reduction**  | `DotProduct(a, b)`     | Complex dot product sum(a·b)       | 2x (AVX) / 1x (SSE2, NEON) |
+|                | `DotProductConj(a, b)` | Hermitian inner product sum(a·conj(b)) | 2x (AVX) / 1x (SSE2, NEON) |
 | **Unary**      | `Abs(dst, a)`        | Complex magnitude \|a + bi\|       | 4x (AVX-512) / 2x (AVX) |
 |                | `AbsSq(dst, a)`      | Magnitude squared \|a + bi\|²      | 4x / 2x                 |
 |                | `Conj(dst, a)`       | Complex conjugate: a - bi          | 4x / 2x                 |
@@ -380,6 +382,8 @@ SIMD-accelerated single-precision complex number operations:
 |                | `Scale(dst, a, s)`   | Scale by complex scalar            | 8x / 4x / 2x                      |
 |                | `Add(dst, a, b)`     | Complex addition                   | 8x / 4x / 2x                      |
 |                | `Sub(dst, a, b)`     | Complex subtraction                | 8x / 4x / 2x                      |
+| **Reduction**  | `DotProduct(a, b)`     | Complex dot product sum(a·b)       | 4x (AVX) / 2x (SSE, NEON) |
+|                | `DotProductConj(a, b)` | Hermitian inner product sum(a·conj(b)) | 4x (AVX) / 2x (SSE, NEON) |
 | **Unary**      | `Abs(dst, a)`        | Complex magnitude \|a + bi\|       | 8x / 4x / 2x                      |
 |                | `AbsSq(dst, a)`      | Magnitude squared \|a + bi\|²      | 8x / 4x / 2x                      |
 |                | `Conj(dst, a)`       | Complex conjugate: a - bi          | 8x / 4x / 2x                      |

--- a/c128/c128.go
+++ b/c128/c128.go
@@ -3,6 +3,8 @@
 // These operations are designed to accelerate FFT-based convolution pipelines:
 // - Mul: Complex multiplication for frequency-domain convolution
 // - MulConj: Multiply by conjugate for correlation
+// - DotProduct: Complex dot product sum(a[i]*b[i]) for frequency-domain folding
+// - DotProductConj: Hermitian inner product sum(a[i]*conj(b[i])) for correlation
 // - Scale: Scale by complex scalar
 // - FromReal: Convert real float64 to complex128 (FFT input preparation)
 //
@@ -112,7 +114,6 @@ func Conj(dst, a []complex128) {
 	conj128(dst[:n], a[:n])
 }
 
-
 // FromReal converts real float64 values to complex128: dst[i] = complex(src[i], 0).
 // Processes min(len(dst), len(src)) elements.
 //
@@ -123,6 +124,36 @@ func FromReal(dst []complex128, src []float64) {
 		return
 	}
 	fromReal128(dst[:n], src[:n])
+}
+
+// DotProduct computes the complex dot product: sum(a[i] * b[i]).
+// Processes min(len(a), len(b)) elements; returns 0 for empty input.
+//
+// Dot product: sum((ar + ai*i)(br + bi*i)) = sum((ar*br - ai*bi) + (ar*bi + ai*br)i)
+//
+// The real and imaginary parts accumulate in float64. This is the inner product
+// used by frequency-domain folding.
+func DotProduct(a, b []complex128) complex128 {
+	n := min(len(a), len(b))
+	if n == 0 {
+		return 0
+	}
+	return dotProduct128(a[:n], b[:n])
+}
+
+// DotProductConj computes the conjugated complex dot product: sum(a[i] * conj(b[i])).
+// Processes min(len(a), len(b)) elements; returns 0 for empty input.
+//
+// Conjugated dot product: sum((ar + ai*i)(br - bi*i)) = sum((ar*br + ai*bi) + (ai*br - ar*bi)i)
+//
+// This is the standard Hermitian inner product used for cross-correlation and
+// matched filtering.
+func DotProductConj(a, b []complex128) complex128 {
+	n := min(len(a), len(b))
+	if n == 0 {
+		return 0
+	}
+	return dotProductConj128(a[:n], b[:n])
 }
 
 func minLen(a, b, c int) int {

--- a/c128/c128_amd64.go
+++ b/c128/c128_amd64.go
@@ -15,6 +15,7 @@ const (
 // Function pointer types for SIMD operations
 type (
 	binaryOpFunc  func(dst, a, b []complex128)
+	reduceFunc    func(a, b []complex128) complex128
 	scaleFunc     func(dst, a []complex128, s complex128)
 	unaryAbsFunc  func(dst []float64, a []complex128)
 	unaryConjFunc func(dst, a []complex128)
@@ -23,15 +24,17 @@ type (
 
 // Function pointers - assigned at init time based on CPU features
 var (
-	mulImpl      binaryOpFunc
-	mulConjImpl  binaryOpFunc
-	scaleImpl    scaleFunc
-	addImpl      binaryOpFunc
-	subImpl      binaryOpFunc
-	absImpl      unaryAbsFunc
-	absSqImpl    unaryAbsFunc
-	conjImpl     unaryConjFunc
-	fromRealImpl fromRealFunc
+	mulImpl            binaryOpFunc
+	mulConjImpl        binaryOpFunc
+	dotProductImpl     reduceFunc
+	dotProductConjImpl reduceFunc
+	scaleImpl          scaleFunc
+	addImpl            binaryOpFunc
+	subImpl            binaryOpFunc
+	absImpl            unaryAbsFunc
+	absSqImpl          unaryAbsFunc
+	conjImpl           unaryConjFunc
+	fromRealImpl       fromRealFunc
 )
 
 func init() {
@@ -65,6 +68,10 @@ func selectImpl(avx512, avxFMA, avx, sse2 bool) {
 func initAVX512() {
 	mulImpl = mulAVX512
 	mulConjImpl = mulConjAVX512
+	// No AVX-512 dot kernels yet (no AVX-512 hardware to verify; see #75/#96):
+	// reuse the AVX kernels so the tier still gets the speedup.
+	dotProductImpl = dotProductAVX
+	dotProductConjImpl = dotProductConjAVX
 	scaleImpl = scaleAVX512
 	addImpl = addAVX512
 	subImpl = subAVX512
@@ -77,6 +84,8 @@ func initAVX512() {
 func initAVX() {
 	mulImpl = mulAVX
 	mulConjImpl = mulConjAVX
+	dotProductImpl = dotProductAVX
+	dotProductConjImpl = dotProductConjAVX
 	scaleImpl = scaleAVX
 	addImpl = addAVX
 	subImpl = subAVX
@@ -94,6 +103,10 @@ func initAVXNoFMA() {
 	mulImpl = mulSSE2
 	mulConjImpl = mulConjSSE2
 	scaleImpl = scaleSSE2
+	// The dot kernels use VFMADDSUB213PD as well, so they follow mul/mulConj
+	// down to SSE2 on AVX-without-FMA parts.
+	dotProductImpl = dotProductSSE2
+	dotProductConjImpl = dotProductConjSSE2
 	addImpl = addAVX
 	subImpl = subAVX
 	absImpl = absAVX
@@ -107,6 +120,8 @@ func initSSE2() {
 	mulImpl = mulSSE2
 	mulConjImpl = mulConjSSE2
 	scaleImpl = scaleSSE2
+	dotProductImpl = dotProductSSE2
+	dotProductConjImpl = dotProductConjSSE2
 	addImpl = addSSE2
 	subImpl = subSSE2
 	absImpl = absSSE2
@@ -118,6 +133,8 @@ func initSSE2() {
 func initGo() {
 	mulImpl = mulGo
 	mulConjImpl = mulConjGo
+	dotProductImpl = dotProductGo
+	dotProductConjImpl = dotProductConjGo
 	scaleImpl = scaleGo
 	addImpl = addGo
 	subImpl = subGo
@@ -135,6 +152,14 @@ func mul128(dst, a, b []complex128) {
 
 func mulConj128(dst, a, b []complex128) {
 	mulConjImpl(dst, a, b)
+}
+
+func dotProduct128(a, b []complex128) complex128 {
+	return dotProductImpl(a, b)
+}
+
+func dotProductConj128(a, b []complex128) complex128 {
+	return dotProductConjImpl(a, b)
 }
 
 func scale128(dst, a []complex128, s complex128) {
@@ -174,6 +199,12 @@ func mulAVX(dst, a, b []complex128)
 func mulConjAVX(dst, a, b []complex128)
 
 //go:noescape
+func dotProductAVX(a, b []complex128) complex128
+
+//go:noescape
+func dotProductConjAVX(a, b []complex128) complex128
+
+//go:noescape
 func scaleAVX(dst, a []complex128, s complex128)
 
 //go:noescape
@@ -206,6 +237,12 @@ func mulSSE2(dst, a, b []complex128)
 
 //go:noescape
 func mulConjSSE2(dst, a, b []complex128)
+
+//go:noescape
+func dotProductSSE2(a, b []complex128) complex128
+
+//go:noescape
+func dotProductConjSSE2(a, b []complex128) complex128
 
 //go:noescape
 func scaleSSE2(dst, a []complex128, s complex128)

--- a/c128/c128_amd64.s
+++ b/c128/c128_amd64.s
@@ -1222,3 +1222,189 @@ fromreal_sse2_loop:
 
 fromreal_sse2_done:
     RET
+
+// ============================================================================
+// DOT PRODUCT REDUCTIONS
+// sum(a[i]*b[i]) and sum(a[i]*conj(b[i])). Each reuses the mul/mulConj product,
+// accumulating into a register instead of storing, then horizontally reduces.
+// Accumulation is in float64 to match dotProductGo / dotProductConjGo.
+// AVX processes 2 complex128 per iteration; SSE2 processes 1 (its two float64
+// lanes are already the real/imag accumulators, so no lane reduction is needed).
+// ============================================================================
+
+// func dotProductAVX(a, b []complex128) complex128
+TEXT ·dotProductAVX(SB), NOSPLIT, $0-64
+    MOVQ a_base+0(FP), SI
+    MOVQ a_len+8(FP), CX
+    MOVQ b_base+24(FP), DI
+
+    VXORPD Y6, Y6, Y6          // accumulator [r,i,r,i]
+
+    MOVQ CX, AX
+    SHRQ $1, AX                // 2 complex128 per iteration
+    JZ   dp128_avx_reduce
+
+dp128_avx_loop2:
+    VMOVUPD (SI), Y0
+    VMOVUPD (DI), Y1
+    VMOVDDUP Y0, Y2            // [ar,ar,...]
+    VSHUFPD $0x0F, Y0, Y0, Y3  // [ai,ai,...]
+    VSHUFPD $0x05, Y1, Y1, Y4  // [bi,br,...]
+    VMULPD Y4, Y3, Y5          // [ai*bi, ai*br, ...]
+    VFMADDSUB213PD Y5, Y1, Y2  // Y2 = [ar*br-ai*bi, ar*bi+ai*br, ...]
+    VADDPD Y2, Y6, Y6
+    ADDQ $32, SI
+    ADDQ $32, DI
+    DECQ AX
+    JNZ  dp128_avx_loop2
+
+dp128_avx_reduce:
+    VEXTRACTF128 $1, Y6, X0    // [r1,i1]
+    VADDPD X0, X6, X6          // [sumRe,sumIm]
+
+    ANDQ $1, CX
+    JZ   dp128_avx_done
+
+    VMOVUPD (SI), X0
+    VMOVUPD (DI), X1
+    VMOVDDUP X0, X2
+    VSHUFPD $0x03, X0, X0, X3
+    VSHUFPD $0x01, X1, X1, X4
+    VMULPD X4, X3, X5
+    VFMADDSUB213PD X5, X1, X2  // X2 = [re,im]
+    VADDPD X2, X6, X6
+
+dp128_avx_done:
+    VMOVSD X6, ret_real+48(FP)
+    VSHUFPD $0x01, X6, X6, X6   // move imag (high lane) to low
+    VMOVSD X6, ret_imag+56(FP)
+    VZEROUPPER
+    RET
+
+// func dotProductConjAVX(a, b []complex128) complex128
+TEXT ·dotProductConjAVX(SB), NOSPLIT, $0-64
+    MOVQ a_base+0(FP), SI
+    MOVQ a_len+8(FP), CX
+    MOVQ b_base+24(FP), DI
+
+    VXORPD Y6, Y6, Y6
+
+    MOVQ CX, AX
+    SHRQ $1, AX
+    JZ   dpc128_avx_reduce
+
+dpc128_avx_loop2:
+    VMOVUPD (SI), Y0
+    VMOVUPD (DI), Y1
+    VMOVDDUP Y0, Y2            // [ar,ar,...]
+    VSHUFPD $0x0F, Y0, Y0, Y3  // [ai,ai,...]
+    VSHUFPD $0x05, Y1, Y1, Y4  // [bi,br,...]
+    VMULPD Y4, Y2, Y5          // [ar*bi, ar*br, ...]
+    VFMADDSUB213PD Y5, Y1, Y3  // Y3 = [ai*br-ar*bi, ai*bi+ar*br, ...]
+    VSHUFPD $0x05, Y3, Y3, Y2  // [ar*br+ai*bi, ai*br-ar*bi, ...]
+    VADDPD Y2, Y6, Y6
+    ADDQ $32, SI
+    ADDQ $32, DI
+    DECQ AX
+    JNZ  dpc128_avx_loop2
+
+dpc128_avx_reduce:
+    VEXTRACTF128 $1, Y6, X0
+    VADDPD X0, X6, X6
+
+    ANDQ $1, CX
+    JZ   dpc128_avx_done
+
+    VMOVUPD (SI), X0
+    VMOVUPD (DI), X1
+    VMOVDDUP X0, X2
+    VSHUFPD $0x03, X0, X0, X3
+    VSHUFPD $0x01, X1, X1, X4
+    VMULPD X4, X2, X5
+    VFMADDSUB213PD X5, X1, X3
+    VSHUFPD $0x01, X3, X3, X2
+    VADDPD X2, X6, X6
+
+dpc128_avx_done:
+    VMOVSD X6, ret_real+48(FP)
+    VSHUFPD $0x01, X6, X6, X6   // move imag (high lane) to low
+    VMOVSD X6, ret_imag+56(FP)
+    VZEROUPPER
+    RET
+
+// func dotProductSSE2(a, b []complex128) complex128
+TEXT ·dotProductSSE2(SB), NOSPLIT, $0-64
+    MOVQ a_base+0(FP), SI
+    MOVQ a_len+8(FP), CX
+    MOVQ b_base+24(FP), DI
+
+    XORPD X7, X7               // [sumRe, sumIm]
+
+    TESTQ CX, CX
+    JZ   dp128_sse_done
+
+dp128_sse_loop:
+    MOVUPD (SI), X0
+    MOVUPD (DI), X1
+    MOVAPD X0, X2
+    SHUFPD $0x00, X2, X2       // [ar,ar]
+    MOVAPD X0, X3
+    SHUFPD $0x03, X3, X3       // [ai,ai]
+    MOVAPD X1, X4
+    SHUFPD $0x01, X4, X4       // [bi,br]
+    MULPD X1, X2              // [ar*br, ar*bi]
+    MULPD X4, X3              // [ai*bi, ai*br]
+    MOVAPD X2, X5
+    SUBPD X3, X5             // [ar*br-ai*bi, ar*bi-ai*br]
+    ADDPD X3, X2             // [ar*br+ai*bi, ar*bi+ai*br]
+    SHUFPD $0x2, X2, X5      // X5 = [re, im]
+    ADDPD X5, X7
+    ADDQ $16, SI
+    ADDQ $16, DI
+    DECQ CX
+    JNZ  dp128_sse_loop
+
+dp128_sse_done:
+    MOVSD X7, ret_real+48(FP)
+    SHUFPD $0x01, X7, X7        // move imag (high lane) to low
+    MOVSD X7, ret_imag+56(FP)
+    RET
+
+// func dotProductConjSSE2(a, b []complex128) complex128
+TEXT ·dotProductConjSSE2(SB), NOSPLIT, $0-64
+    MOVQ a_base+0(FP), SI
+    MOVQ a_len+8(FP), CX
+    MOVQ b_base+24(FP), DI
+
+    XORPD X7, X7
+
+    TESTQ CX, CX
+    JZ   dpc128_sse_done
+
+dpc128_sse_loop:
+    MOVUPD (SI), X0
+    MOVUPD (DI), X1
+    MOVAPD X0, X2
+    SHUFPD $0x00, X2, X2
+    MOVAPD X0, X3
+    SHUFPD $0x03, X3, X3
+    MOVAPD X1, X4
+    SHUFPD $0x01, X4, X4
+    MULPD X1, X2              // [ar*br, ar*bi]
+    MULPD X4, X3              // [ai*bi, ai*br]
+    MOVAPD X2, X5
+    ADDPD X3, X5             // [ar*br+ai*bi, ar*bi+ai*br]
+    MOVAPD X3, X6
+    SUBPD X2, X6             // [ai*bi-ar*br, ai*br-ar*bi]
+    SHUFPD $0x2, X6, X5      // X5 = [re, im]
+    ADDPD X5, X7
+    ADDQ $16, SI
+    ADDQ $16, DI
+    DECQ CX
+    JNZ  dpc128_sse_loop
+
+dpc128_sse_done:
+    MOVSD X7, ret_real+48(FP)
+    SHUFPD $0x01, X7, X7        // move imag (high lane) to low
+    MOVSD X7, ret_imag+56(FP)
+    RET

--- a/c128/c128_arm64.go
+++ b/c128/c128_arm64.go
@@ -24,6 +24,20 @@ func mulConj128(dst, a, b []complex128) {
 	mulConjGo(dst, a, b)
 }
 
+func dotProduct128(a, b []complex128) complex128 {
+	if hasNEON {
+		return dotProductNEON(a, b)
+	}
+	return dotProductGo(a, b)
+}
+
+func dotProductConj128(a, b []complex128) complex128 {
+	if hasNEON {
+		return dotProductConjNEON(a, b)
+	}
+	return dotProductConjGo(a, b)
+}
+
 func scale128(dst, a []complex128, s complex128) {
 	if hasNEON && len(dst) >= 1 {
 		scaleNEON(dst, a, s)
@@ -85,6 +99,12 @@ func mulNEON(dst, a, b []complex128)
 
 //go:noescape
 func mulConjNEON(dst, a, b []complex128)
+
+//go:noescape
+func dotProductNEON(a, b []complex128) complex128
+
+//go:noescape
+func dotProductConjNEON(a, b []complex128) complex128
 
 //go:noescape
 func scaleNEON(dst, a []complex128, s complex128)

--- a/c128/c128_arm64.s
+++ b/c128/c128_arm64.s
@@ -603,3 +603,128 @@ fromreal_neon_tail:
 
 fromreal_neon_done:
     RET
+
+// ============================================================================
+// DOT PRODUCT REDUCTIONS
+// sum(a[i]*b[i]) and sum(a[i]*conj(b[i])). Each reuses the mul/mulConj product
+// above but accumulates the real and imaginary result lanes into V14/V15 and
+// horizontally reduces each .2D vector with a scalar FADDP. Accumulation is in
+// float64 to match dotProductGo / dotProductConjGo.
+// FADD  Vd.2D, Vn.2D, Vm.2D: 0x4E60D400 | (Vm << 16) | (Vn << 5) | Vd
+// FADDP Dd, Vn.2D:           0x7E70D800 | (Vn << 5) | Vd
+// ============================================================================
+
+// func dotProductNEON(a, b []complex128) complex128
+TEXT ·dotProductNEON(SB), NOSPLIT, $0-64
+    MOVD a_base+0(FP), R0
+    MOVD a_len+8(FP), R1
+    MOVD b_base+24(FP), R2
+
+    VEOR V14.B16, V14.B16, V14.B16   // accRe
+    VEOR V15.B16, V15.B16, V15.B16   // accIm
+
+    CMP  $2, R1
+    BLT  dp128_neon_reduce
+
+dp128_neon_loop2:
+    VLD1.P 16(R0), [V0.D2]
+    VLD1.P 16(R0), [V1.D2]
+    VLD1.P 16(R2), [V2.D2]
+    VLD1.P 16(R2), [V3.D2]
+    WORD $0x4EC11804             // UZP1 V4.2D, V0.2D, V1.2D
+    WORD $0x4EC15805             // UZP2 V5.2D, V0.2D, V1.2D
+    WORD $0x4EC31846             // UZP1 V6.2D, V2.2D, V3.2D
+    WORD $0x4EC35847             // UZP2 V7.2D, V2.2D, V3.2D
+    WORD $0x6E66DC88             // FMUL V8.2D, V4.2D, V6.2D
+    WORD $0x6E67DCA9             // FMUL V9.2D, V5.2D, V7.2D
+    WORD $0x6E67DC8A             // FMUL V10.2D, V4.2D, V7.2D
+    WORD $0x6E66DCAB             // FMUL V11.2D, V5.2D, V6.2D
+    WORD $0x4EE9D50C             // FSUB V12.2D, V8.2D, V9.2D
+    WORD $0x4E6BD54D             // FADD V13.2D, V10.2D, V11.2D
+    WORD $0x4E6CD5CE             // FADD V14.2D, V14.2D, V12.2D
+    WORD $0x4E6DD5EF             // FADD V15.2D, V15.2D, V13.2D
+    SUB  $2, R1
+    CMP  $2, R1
+    BGE  dp128_neon_loop2
+
+dp128_neon_reduce:
+    WORD $0x7E70D9CE             // FADDP D14, V14.2D
+    WORD $0x7E70D9EF             // FADDP D15, V15.2D
+
+    CBZ  R1, dp128_neon_done
+
+    VLD1 (R0), [V0.D2]           // [ar, ai]
+    VLD1 (R2), [V1.D2]           // [br, bi]
+    VDUP V0.D[1], V2.D2          // F2 = ai
+    VDUP V1.D[1], V3.D2          // F3 = bi
+    FMULD F0, F1, F4             // ar*br
+    FMULD F2, F3, F5             // ai*bi
+    FMULD F0, F3, F6             // ar*bi
+    FMULD F2, F1, F7             // ai*br
+    FSUBD F5, F4, F4             // ar*br - ai*bi
+    FADDD F6, F7, F5             // ar*bi + ai*br
+    FADDD F4, F14, F14           // sumRe += real
+    FADDD F5, F15, F15           // sumIm += imag
+
+dp128_neon_done:
+    FMOVD F14, ret_real+48(FP)
+    FMOVD F15, ret_imag+56(FP)
+    RET
+
+// func dotProductConjNEON(a, b []complex128) complex128
+// a*conj(b) = (ar*br + ai*bi) + (ai*br - ar*bi)i
+TEXT ·dotProductConjNEON(SB), NOSPLIT, $0-64
+    MOVD a_base+0(FP), R0
+    MOVD a_len+8(FP), R1
+    MOVD b_base+24(FP), R2
+
+    VEOR V14.B16, V14.B16, V14.B16
+    VEOR V15.B16, V15.B16, V15.B16
+
+    CMP  $2, R1
+    BLT  dpc128_neon_reduce
+
+dpc128_neon_loop2:
+    VLD1.P 16(R0), [V0.D2]
+    VLD1.P 16(R0), [V1.D2]
+    VLD1.P 16(R2), [V2.D2]
+    VLD1.P 16(R2), [V3.D2]
+    WORD $0x4EC11804             // UZP1 V4.2D, V0.2D, V1.2D
+    WORD $0x4EC15805             // UZP2 V5.2D, V0.2D, V1.2D
+    WORD $0x4EC31846             // UZP1 V6.2D, V2.2D, V3.2D
+    WORD $0x4EC35847             // UZP2 V7.2D, V2.2D, V3.2D
+    WORD $0x6E66DC88             // FMUL V8.2D, V4.2D, V6.2D
+    WORD $0x6E67DCA9             // FMUL V9.2D, V5.2D, V7.2D
+    WORD $0x6E66DCAA             // FMUL V10.2D, V5.2D, V6.2D
+    WORD $0x6E67DC8B             // FMUL V11.2D, V4.2D, V7.2D
+    WORD $0x4E69D50C             // FADD V12.2D, V8.2D, V9.2D
+    WORD $0x4EEBD54D             // FSUB V13.2D, V10.2D, V11.2D
+    WORD $0x4E6CD5CE             // FADD V14.2D, V14.2D, V12.2D
+    WORD $0x4E6DD5EF             // FADD V15.2D, V15.2D, V13.2D
+    SUB  $2, R1
+    CMP  $2, R1
+    BGE  dpc128_neon_loop2
+
+dpc128_neon_reduce:
+    WORD $0x7E70D9CE             // FADDP D14, V14.2D
+    WORD $0x7E70D9EF             // FADDP D15, V15.2D
+
+    CBZ  R1, dpc128_neon_done
+
+    VLD1 (R0), [V0.D2]
+    VLD1 (R2), [V1.D2]
+    VDUP V0.D[1], V2.D2
+    VDUP V1.D[1], V3.D2
+    FMULD F0, F1, F4             // ar*br
+    FMULD F2, F3, F5             // ai*bi
+    FMULD F2, F1, F6             // ai*br
+    FMULD F0, F3, F7             // ar*bi
+    FADDD F4, F5, F4             // ar*br + ai*bi
+    FSUBD F7, F6, F5             // ai*br - ar*bi
+    FADDD F4, F14, F14           // sumRe += real
+    FADDD F5, F15, F15           // sumIm += imag
+
+dpc128_neon_done:
+    FMOVD F14, ret_real+48(FP)
+    FMOVD F15, ret_imag+56(FP)
+    RET

--- a/c128/c128_go.go
+++ b/c128/c128_go.go
@@ -109,7 +109,6 @@ func conjGo(dst, a []complex128) {
 	}
 }
 
-
 // fromRealGo converts real float64 values to complex128: dst[i] = complex(src[i], 0).
 // This is the trusted reference and the path that runs on architectures without
 // SIMD.
@@ -121,4 +120,36 @@ func fromRealGo(dst []complex128, src []float64) {
 	for i := range dst {
 		dst[i] = complex(src[i], 0)
 	}
+}
+
+// dotProductGo computes the complex dot product sum(a[i]*b[i]) over
+// min(len(a), len(b)) elements, accumulating the real and imaginary parts in
+// float64 (the native element precision).
+func dotProductGo(a, b []complex128) complex128 {
+	n := min(len(a), len(b))
+	var sumRe, sumIm float64
+	for i := range n {
+		ar, ai := real(a[i]), imag(a[i])
+		br, bi := real(b[i]), imag(b[i])
+		// a*b = (ar*br - ai*bi) + (ar*bi + ai*br)i
+		sumRe += ar*br - ai*bi
+		sumIm += ar*bi + ai*br
+	}
+	return complex(sumRe, sumIm)
+}
+
+// dotProductConjGo computes the conjugated dot product sum(a[i]*conj(b[i])) over
+// min(len(a), len(b)) elements, accumulating in float64. This is the standard
+// Hermitian inner product used for correlation and matched filtering.
+func dotProductConjGo(a, b []complex128) complex128 {
+	n := min(len(a), len(b))
+	var sumRe, sumIm float64
+	for i := range n {
+		ar, ai := real(a[i]), imag(a[i])
+		br, bi := real(b[i]), imag(b[i])
+		// a*conj(b) = (ar*br + ai*bi) + (ai*br - ar*bi)i
+		sumRe += ar*br + ai*bi
+		sumIm += ai*br - ar*bi
+	}
+	return complex(sumRe, sumIm)
 }

--- a/c128/c128_other.go
+++ b/c128/c128_other.go
@@ -4,12 +4,14 @@ package c128
 
 // Fallback implementations for unsupported architectures
 
-func mul128(dst, a, b []complex128)               { mulGo(dst, a, b) }
-func mulConj128(dst, a, b []complex128)           { mulConjGo(dst, a, b) }
-func scale128(dst, a []complex128, s complex128)  { scaleGo(dst, a, s) }
-func add128(dst, a, b []complex128)               { addGo(dst, a, b) }
-func sub128(dst, a, b []complex128)               { subGo(dst, a, b) }
-func abs128(dst []float64, a []complex128)        { absGo(dst, a) }
-func absSq128(dst []float64, a []complex128)      { absSqGo(dst, a) }
-func conj128(dst, a []complex128)                 { conjGo(dst, a) }
-func fromReal128(dst []complex128, src []float64) { fromRealGo(dst, src) }
+func mul128(dst, a, b []complex128)                  { mulGo(dst, a, b) }
+func mulConj128(dst, a, b []complex128)              { mulConjGo(dst, a, b) }
+func dotProduct128(a, b []complex128) complex128     { return dotProductGo(a, b) }
+func dotProductConj128(a, b []complex128) complex128 { return dotProductConjGo(a, b) }
+func scale128(dst, a []complex128, s complex128)     { scaleGo(dst, a, s) }
+func add128(dst, a, b []complex128)                  { addGo(dst, a, b) }
+func sub128(dst, a, b []complex128)                  { subGo(dst, a, b) }
+func abs128(dst []float64, a []complex128)           { absGo(dst, a) }
+func absSq128(dst []float64, a []complex128)         { absSqGo(dst, a) }
+func conj128(dst, a []complex128)                    { conjGo(dst, a) }
+func fromReal128(dst []complex128, src []float64)    { fromRealGo(dst, src) }

--- a/c128/dot_product_amd64_test.go
+++ b/c128/dot_product_amd64_test.go
@@ -1,0 +1,38 @@
+//go:build amd64
+
+package c128
+
+import (
+	"testing"
+
+	"github.com/tphakala/simd/cpu"
+)
+
+// TestDotProductKernelsAMD64 exercises the SSE and AVX kernels directly against
+// the scalar references, so both tiers are covered regardless of which one the
+// active CPU selects.
+func TestDotProductKernelsAMD64(t *testing.T) {
+	for n := 0; n <= 20; n++ {
+		a := dpSeq(n, 1)
+		b := dpSeq(n, 4)
+		want := dotProductGo(a, b)
+		wantConj := dotProductConjGo(a, b)
+
+		if cpu.X86.SSE2 {
+			if got := dotProductSSE2(a, b); !dpClose(got, want) {
+				t.Errorf("dotProductSSE2 n=%d = %v, want %v", n, got, want)
+			}
+			if got := dotProductConjSSE2(a, b); !dpClose(got, wantConj) {
+				t.Errorf("dotProductConjSSE2 n=%d = %v, want %v", n, got, wantConj)
+			}
+		}
+		if cpu.X86.AVX && cpu.X86.FMA {
+			if got := dotProductAVX(a, b); !dpClose(got, want) {
+				t.Errorf("dotProductAVX n=%d = %v, want %v", n, got, want)
+			}
+			if got := dotProductConjAVX(a, b); !dpClose(got, wantConj) {
+				t.Errorf("dotProductConjAVX n=%d = %v, want %v", n, got, wantConj)
+			}
+		}
+	}
+}

--- a/c128/dot_product_test.go
+++ b/c128/dot_product_test.go
@@ -1,0 +1,105 @@
+package c128
+
+import (
+	"math"
+	"testing"
+)
+
+// dpSeq builds a deterministic complex128 slice mixing signs and magnitudes so
+// the kernel's lane reduction is exercised across every unroll remainder.
+func dpSeq(n, seed int) []complex128 {
+	s := make([]complex128, n)
+	for i := range s {
+		re := float64((i*7+seed)%13) - 6
+		im := float64((i*5+seed*3)%11) - 5
+		s[i] = complex(re*0.25, im*0.25)
+	}
+	return s
+}
+
+// dpCloseF reports whether two float64 components agree within the tolerance used
+// for f64 reductions, comparing NaN and Inf by class (the SIMD path accumulates
+// in a different order than the scalar reference).
+func dpCloseF(got, want float64) bool {
+	if math.IsNaN(want) || math.IsNaN(got) {
+		return math.IsNaN(want) == math.IsNaN(got)
+	}
+	if math.IsInf(want, 0) || math.IsInf(got, 0) {
+		return math.IsInf(want, 1) == math.IsInf(got, 1) && math.IsInf(want, -1) == math.IsInf(got, -1)
+	}
+	return math.Abs(got-want) <= 1e-9*math.Abs(want)+1e-12
+}
+
+func dpClose(got, want complex128) bool {
+	return dpCloseF(real(got), real(want)) && dpCloseF(imag(got), imag(want))
+}
+
+// TestDotProductParity validates the public dispatch (AVX on amd64, NEON on
+// arm64, Go elsewhere) against the scalar references across every remainder.
+func TestDotProductParity(t *testing.T) {
+	for n := 0; n <= 20; n++ {
+		a := dpSeq(n, 1)
+		b := dpSeq(n, 4)
+		if got, want := DotProduct(a, b), dotProductGo(a, b); !dpClose(got, want) {
+			t.Errorf("DotProduct n=%d = %v, want %v", n, got, want)
+		}
+		if got, want := DotProductConj(a, b), dotProductConjGo(a, b); !dpClose(got, want) {
+			t.Errorf("DotProductConj n=%d = %v, want %v", n, got, want)
+		}
+	}
+}
+
+// TestDotProductMismatchedLengths checks the min(len(a), len(b)) contract.
+func TestDotProductMismatchedLengths(t *testing.T) {
+	a := dpSeq(15, 1)
+	b := dpSeq(9, 4)
+	if got, want := DotProduct(a, b), dotProductGo(a, b); !dpClose(got, want) {
+		t.Errorf("DotProduct mismatched = %v, want %v", got, want)
+	}
+	if got, want := DotProductConj(b, a), dotProductConjGo(b, a); !dpClose(got, want) {
+		t.Errorf("DotProductConj mismatched = %v, want %v", got, want)
+	}
+}
+
+// TestDotProductEmpty confirms empty input returns 0.
+func TestDotProductEmpty(t *testing.T) {
+	if got := DotProduct(nil, nil); got != 0 {
+		t.Errorf("DotProduct(nil) = %v, want 0", got)
+	}
+	if got := DotProductConj([]complex128{}, []complex128{}); got != 0 {
+		t.Errorf("DotProductConj(empty) = %v, want 0", got)
+	}
+}
+
+// TestDotProductSpecialValues feeds NaN/Inf inputs and asserts the result
+// propagates the same special class as the reference.
+func TestDotProductSpecialValues(t *testing.T) {
+	inf := math.Inf(1)
+	nan := math.NaN()
+	cases := [][2][]complex128{
+		{{complex(1, 2), complex(nan, 1), complex(3, 4)}, {complex(5, 6), complex(7, 8), complex(9, 1)}},
+		{{complex(inf, 0), complex(1, 1)}, {complex(2, 2), complex(3, 3)}},
+		{{complex(1, inf), complex(1, 1), complex(2, 2)}, {complex(2, 2), complex(3, 3), complex(4, 4)}},
+	}
+	for ci, c := range cases {
+		a, b := c[0], c[1]
+		if got, want := DotProduct(a, b), dotProductGo(a, b); !dpClose(got, want) {
+			t.Errorf("case %d DotProduct = %v, want %v", ci, got, want)
+		}
+		if got, want := DotProductConj(a, b), dotProductConjGo(a, b); !dpClose(got, want) {
+			t.Errorf("case %d DotProductConj = %v, want %v", ci, got, want)
+		}
+	}
+}
+
+// TestDotProductAllocs confirms the public APIs stay allocation-free.
+func TestDotProductAllocs(t *testing.T) {
+	a := dpSeq(256, 1)
+	b := dpSeq(256, 2)
+	if allocs := testing.AllocsPerRun(100, func() { _ = DotProduct(a, b) }); allocs != 0 {
+		t.Errorf("DotProduct allocs = %v, want 0", allocs)
+	}
+	if allocs := testing.AllocsPerRun(100, func() { _ = DotProductConj(a, b) }); allocs != 0 {
+		t.Errorf("DotProductConj allocs = %v, want 0", allocs)
+	}
+}

--- a/c64/c64.go
+++ b/c64/c64.go
@@ -4,6 +4,8 @@
 // using float32 precision for higher throughput:
 // - Mul: Complex multiplication for frequency-domain convolution
 // - MulConj: Multiply by conjugate for correlation
+// - DotProduct: Complex dot product sum(a[i]*b[i]) for frequency-domain folding
+// - DotProductConj: Hermitian inner product sum(a[i]*conj(b[i])) for correlation
 // - Scale: Scale by complex scalar
 // - Add/Sub: Complex addition/subtraction for FFT butterflies
 // - AbsSq: Magnitude squared for power spectrum computation
@@ -131,6 +133,36 @@ func FromReal(dst []complex64, src []float32) {
 		return
 	}
 	fromReal64(dst[:n], src[:n])
+}
+
+// DotProduct computes the complex dot product: sum(a[i] * b[i]).
+// Processes min(len(a), len(b)) elements; returns 0 for empty input.
+//
+// Dot product: sum((ar + ai*i)(br + bi*i)) = sum((ar*br - ai*bi) + (ar*bi + ai*br)i)
+//
+// The real and imaginary parts accumulate in float32, matching the element
+// precision. This is the inner product used by frequency-domain folding.
+func DotProduct(a, b []complex64) complex64 {
+	n := min(len(a), len(b))
+	if n == 0 {
+		return 0
+	}
+	return dotProduct64(a[:n], b[:n])
+}
+
+// DotProductConj computes the conjugated complex dot product: sum(a[i] * conj(b[i])).
+// Processes min(len(a), len(b)) elements; returns 0 for empty input.
+//
+// Conjugated dot product: sum((ar + ai*i)(br - bi*i)) = sum((ar*br + ai*bi) + (ai*br - ar*bi)i)
+//
+// This is the standard Hermitian inner product used for cross-correlation and
+// matched filtering. The real and imaginary parts accumulate in float32.
+func DotProductConj(a, b []complex64) complex64 {
+	n := min(len(a), len(b))
+	if n == 0 {
+		return 0
+	}
+	return dotProductConj64(a[:n], b[:n])
 }
 
 func minLen(a, b, c int) int {

--- a/c64/c64_amd64.go
+++ b/c64/c64_amd64.go
@@ -7,6 +7,7 @@ import "github.com/tphakala/simd/cpu"
 // Function pointer types for SIMD operations
 type (
 	binaryOpFunc  func(dst, a, b []complex64)
+	reduceFunc    func(a, b []complex64) complex64
 	scaleFunc     func(dst, a []complex64, s complex64)
 	unaryAbsFunc  func(dst []float32, a []complex64)
 	unaryConjFunc func(dst, a []complex64)
@@ -15,15 +16,17 @@ type (
 
 // Function pointers - assigned at init time based on CPU features
 var (
-	mulImpl      binaryOpFunc
-	mulConjImpl  binaryOpFunc
-	scaleImpl    scaleFunc
-	addImpl      binaryOpFunc
-	subImpl      binaryOpFunc
-	absImpl      unaryAbsFunc
-	absSqImpl    unaryAbsFunc
-	conjImpl     unaryConjFunc
-	fromRealImpl fromRealFunc
+	mulImpl            binaryOpFunc
+	mulConjImpl        binaryOpFunc
+	dotProductImpl     reduceFunc
+	dotProductConjImpl reduceFunc
+	scaleImpl          scaleFunc
+	addImpl            binaryOpFunc
+	subImpl            binaryOpFunc
+	absImpl            unaryAbsFunc
+	absSqImpl          unaryAbsFunc
+	conjImpl           unaryConjFunc
+	fromRealImpl       fromRealFunc
 )
 
 func init() {
@@ -45,6 +48,10 @@ func init() {
 func initAVX512() {
 	mulImpl = mulAVX512
 	mulConjImpl = mulConjAVX512
+	// No AVX-512 dot kernels yet (no AVX-512 hardware to verify; see #75/#96):
+	// reuse the AVX kernels so the tier still gets the speedup.
+	dotProductImpl = dotProductAVX
+	dotProductConjImpl = dotProductConjAVX
 	scaleImpl = scaleAVX512
 	addImpl = addAVX512
 	subImpl = subAVX512
@@ -57,6 +64,8 @@ func initAVX512() {
 func initAVX() {
 	mulImpl = mulAVX
 	mulConjImpl = mulConjAVX
+	dotProductImpl = dotProductAVX
+	dotProductConjImpl = dotProductConjAVX
 	scaleImpl = scaleAVX
 	addImpl = addAVX
 	subImpl = subAVX
@@ -69,6 +78,8 @@ func initAVX() {
 func initSSE2() {
 	mulImpl = mulSSE2
 	mulConjImpl = mulConjSSE2
+	dotProductImpl = dotProductSSE2
+	dotProductConjImpl = dotProductConjSSE2
 	scaleImpl = scaleSSE2
 	addImpl = addSSE2
 	subImpl = subSSE2
@@ -81,6 +92,8 @@ func initSSE2() {
 func initGo() {
 	mulImpl = mulGo
 	mulConjImpl = mulConjGo
+	dotProductImpl = dotProductGo
+	dotProductConjImpl = dotProductConjGo
 	scaleImpl = scaleGo
 	addImpl = addGo
 	subImpl = subGo
@@ -98,6 +111,14 @@ func mul64(dst, a, b []complex64) {
 
 func mulConj64(dst, a, b []complex64) {
 	mulConjImpl(dst, a, b)
+}
+
+func dotProduct64(a, b []complex64) complex64 {
+	return dotProductImpl(a, b)
+}
+
+func dotProductConj64(a, b []complex64) complex64 {
+	return dotProductConjImpl(a, b)
 }
 
 func scale64(dst, a []complex64, s complex64) {
@@ -137,6 +158,12 @@ func mulAVX(dst, a, b []complex64)
 func mulConjAVX(dst, a, b []complex64)
 
 //go:noescape
+func dotProductAVX(a, b []complex64) complex64
+
+//go:noescape
+func dotProductConjAVX(a, b []complex64) complex64
+
+//go:noescape
 func scaleAVX(dst, a []complex64, s complex64)
 
 //go:noescape
@@ -169,6 +196,12 @@ func mulSSE2(dst, a, b []complex64)
 
 //go:noescape
 func mulConjSSE2(dst, a, b []complex64)
+
+//go:noescape
+func dotProductSSE2(a, b []complex64) complex64
+
+//go:noescape
+func dotProductConjSSE2(a, b []complex64) complex64
 
 //go:noescape
 func scaleSSE2(dst, a []complex64, s complex64)

--- a/c64/c64_amd64.s
+++ b/c64/c64_amd64.s
@@ -1348,3 +1348,241 @@ fromreal_sse2_remainder:
 
 fromreal_sse2_done:
     RET
+
+// ============================================================================
+// DOT PRODUCT REDUCTIONS
+// sum(a[i]*b[i]) and sum(a[i]*conj(b[i])). Each reuses the element-wise complex
+// product from mul/mulConj above, accumulating into a vector register instead of
+// storing, then horizontally reduces the real and imaginary lanes. Accumulation
+// is in float32 to match dotProductGo / dotProductConjGo.
+// ============================================================================
+
+// func dotProductAVX(a, b []complex64) complex64
+TEXT ·dotProductAVX(SB), NOSPLIT, $0-56
+    MOVQ a_base+0(FP), SI
+    MOVQ a_len+8(FP), CX
+    MOVQ b_base+24(FP), DI
+
+    VXORPS Y6, Y6, Y6          // accumulator [r,i,r,i,r,i,r,i]
+
+    MOVQ CX, AX
+    SHRQ $2, AX                // 4 complex64 per iteration
+    JZ   dp_avx_reduce
+
+dp_avx_loop4:
+    VMOVUPS (SI), Y0
+    VMOVUPS (DI), Y1
+    VMOVSLDUP Y0, Y2           // [ar,ar,...]
+    VMOVSHDUP Y0, Y3           // [ai,ai,...]
+    VSHUFPS $0xB1, Y1, Y1, Y4  // [bi,br,...]
+    VMULPS Y4, Y3, Y5          // [ai*bi, ai*br, ...]
+    VFMADDSUB213PS Y5, Y1, Y2  // Y2 = [ar*br-ai*bi, ar*bi+ai*br, ...]
+    VADDPS Y2, Y6, Y6
+    ADDQ $32, SI
+    ADDQ $32, DI
+    DECQ AX
+    JNZ  dp_avx_loop4
+
+dp_avx_reduce:
+    // Reduce Y6 [r0,i0,r1,i1,r2,i2,r3,i3] -> X6 low 64 = [sumRe,sumIm]
+    VEXTRACTF128 $1, Y6, X0    // [r2,i2,r3,i3]
+    VADDPS X0, X6, X6          // [R0,I0,R1,I1]
+    VSHUFPS $0x0E, X6, X6, X0  // [R1,I1,R0,R0]
+    VADDPS X0, X6, X6          // low 64 = [sumRe,sumIm]
+
+    ANDQ $3, CX
+    JZ   dp_avx_done
+
+dp_avx_tail:
+    VMOVSD (SI), X0
+    VMOVSD (DI), X1
+    VMOVSLDUP X0, X2
+    VMOVSHDUP X0, X3
+    VSHUFPS $0xB1, X1, X1, X4
+    VMULPS X4, X3, X5
+    VFMADDSUB213PS X5, X1, X2  // X2 = [re,im,?,?]
+    VADDPS X2, X6, X6          // accumulate low 64
+    ADDQ $8, SI
+    ADDQ $8, DI
+    DECQ CX
+    JNZ  dp_avx_tail
+
+dp_avx_done:
+    VMOVSD X6, ret+48(FP)
+    VZEROUPPER
+    RET
+
+// func dotProductConjAVX(a, b []complex64) complex64
+// a*conj(b) = (ar*br + ai*bi) + (ai*br - ar*bi)i
+TEXT ·dotProductConjAVX(SB), NOSPLIT, $0-56
+    MOVQ a_base+0(FP), SI
+    MOVQ a_len+8(FP), CX
+    MOVQ b_base+24(FP), DI
+
+    VXORPS Y6, Y6, Y6
+
+    MOVQ CX, AX
+    SHRQ $2, AX
+    JZ   dpc_avx_reduce
+
+dpc_avx_loop4:
+    VMOVUPS (SI), Y0
+    VMOVUPS (DI), Y1
+    VMOVSLDUP Y0, Y2           // [ar,ar,...]
+    VMOVSHDUP Y0, Y3           // [ai,ai,...]
+    VSHUFPS $0xB1, Y1, Y1, Y4  // [bi,br,...]
+    VMULPS Y4, Y2, Y5          // [ar*bi, ar*br, ...]
+    VFMADDSUB213PS Y5, Y1, Y3  // Y3 = [ai*br-ar*bi, ai*bi+ar*br, ...]
+    VSHUFPS $0xB1, Y3, Y3, Y2  // [ar*br+ai*bi, ai*br-ar*bi, ...]
+    VADDPS Y2, Y6, Y6
+    ADDQ $32, SI
+    ADDQ $32, DI
+    DECQ AX
+    JNZ  dpc_avx_loop4
+
+dpc_avx_reduce:
+    VEXTRACTF128 $1, Y6, X0
+    VADDPS X0, X6, X6
+    VSHUFPS $0x0E, X6, X6, X0
+    VADDPS X0, X6, X6
+
+    ANDQ $3, CX
+    JZ   dpc_avx_done
+
+dpc_avx_tail:
+    VMOVSD (SI), X0
+    VMOVSD (DI), X1
+    VMOVSLDUP X0, X2
+    VMOVSHDUP X0, X3
+    VSHUFPS $0xB1, X1, X1, X4
+    VMULPS X4, X2, X5
+    VFMADDSUB213PS X5, X1, X3
+    VSHUFPS $0xB1, X3, X3, X2
+    VADDPS X2, X6, X6
+    ADDQ $8, SI
+    ADDQ $8, DI
+    DECQ CX
+    JNZ  dpc_avx_tail
+
+dpc_avx_done:
+    VMOVSD X6, ret+48(FP)
+    VZEROUPPER
+    RET
+
+// func dotProductSSE2(a, b []complex64) complex64
+// SSE4.1 (BLENDPS); accumulates 2 complex64 per iteration into X7.
+TEXT ·dotProductSSE2(SB), NOSPLIT, $0-56
+    MOVQ a_base+0(FP), SI
+    MOVQ a_len+8(FP), CX
+    MOVQ b_base+24(FP), DI
+
+    XORPS X7, X7               // accumulator [r0,i0,r1,i1]
+
+    MOVQ CX, AX
+    SHRQ $1, AX                // 2 complex64 per iteration
+    JZ   dp_sse_reduce
+
+dp_sse_loop2:
+    MOVUPS (SI), X0
+    MOVUPS (DI), X1
+    MOVSLDUP X0, X2            // [ar,ar,...]
+    MOVSHDUP X0, X3            // [ai,ai,...]
+    MOVAPS X1, X4
+    SHUFPS $0xB1, X4, X4       // [bi,br,...]
+    MULPS X1, X2               // [ar*br, ar*bi, ...]
+    MULPS X4, X3               // [ai*bi, ai*br, ...]
+    MOVAPS X2, X5
+    SUBPS X3, X5               // [ar*br-ai*bi, ar*bi-ai*br, ...]
+    ADDPS X3, X2               // [ar*br+ai*bi, ar*bi+ai*br, ...]
+    BLENDPS $0x0A, X2, X5      // X5 = [re0,im0,re1,im1]
+    ADDPS X5, X7
+    ADDQ $16, SI
+    ADDQ $16, DI
+    DECQ AX
+    JNZ  dp_sse_loop2
+
+dp_sse_reduce:
+    // Reduce X7 [R0,I0,R1,I1] -> low 64 = [sumRe,sumIm]
+    MOVAPS X7, X0
+    SHUFPS $0x0E, X0, X0       // [R1,I1,R0,R0]
+    ADDPS X0, X7              // low 64 = [sumRe,sumIm]
+
+    ANDQ $1, CX
+    JZ   dp_sse_done
+
+    MOVSD (SI), X0
+    MOVSD (DI), X1
+    MOVSLDUP X0, X2
+    MOVSHDUP X0, X3
+    MOVAPS X1, X4
+    SHUFPS $0xB1, X4, X4
+    MULPS X1, X2
+    MULPS X4, X3
+    MOVAPS X2, X5
+    SUBPS X3, X5
+    ADDPS X3, X2
+    BLENDPS $0x02, X2, X5      // X5 = [re,im,?,?]
+    ADDPS X5, X7
+
+dp_sse_done:
+    MOVSD X7, ret+48(FP)
+    RET
+
+// func dotProductConjSSE2(a, b []complex64) complex64
+TEXT ·dotProductConjSSE2(SB), NOSPLIT, $0-56
+    MOVQ a_base+0(FP), SI
+    MOVQ a_len+8(FP), CX
+    MOVQ b_base+24(FP), DI
+
+    XORPS X7, X7
+
+    MOVQ CX, AX
+    SHRQ $1, AX
+    JZ   dpc_sse_reduce
+
+dpc_sse_loop2:
+    MOVUPS (SI), X0
+    MOVUPS (DI), X1
+    MOVSLDUP X0, X2
+    MOVSHDUP X0, X3
+    MOVAPS X1, X4
+    SHUFPS $0xB1, X4, X4
+    MULPS X1, X2               // [ar*br, ar*bi, ...]
+    MULPS X4, X3               // [ai*bi, ai*br, ...]
+    MOVAPS X2, X5
+    ADDPS X3, X5               // [ar*br+ai*bi, ar*bi+ai*br, ...]
+    MOVAPS X3, X6
+    SUBPS X2, X6               // [ai*bi-ar*br, ai*br-ar*bi, ...]
+    BLENDPS $0x0A, X6, X5      // X5 = [re0,im0,re1,im1]
+    ADDPS X5, X7
+    ADDQ $16, SI
+    ADDQ $16, DI
+    DECQ AX
+    JNZ  dpc_sse_loop2
+
+dpc_sse_reduce:
+    MOVAPS X7, X0
+    SHUFPS $0x0E, X0, X0
+    ADDPS X0, X7
+
+    ANDQ $1, CX
+    JZ   dpc_sse_done
+
+    MOVSD (SI), X0
+    MOVSD (DI), X1
+    MOVSLDUP X0, X2
+    MOVSHDUP X0, X3
+    MOVAPS X1, X4
+    SHUFPS $0xB1, X4, X4
+    MULPS X1, X2
+    MULPS X4, X3
+    MOVAPS X2, X5
+    ADDPS X3, X5
+    MOVAPS X3, X6
+    SUBPS X2, X6
+    BLENDPS $0x02, X6, X5
+    ADDPS X5, X7
+
+dpc_sse_done:
+    MOVSD X7, ret+48(FP)
+    RET

--- a/c64/c64_arm64.go
+++ b/c64/c64_arm64.go
@@ -22,6 +22,20 @@ func mulConj64(dst, a, b []complex64) {
 	mulConjGo(dst, a, b)
 }
 
+func dotProduct64(a, b []complex64) complex64 {
+	if hasNEON {
+		return dotProductNEON(a, b)
+	}
+	return dotProductGo(a, b)
+}
+
+func dotProductConj64(a, b []complex64) complex64 {
+	if hasNEON {
+		return dotProductConjNEON(a, b)
+	}
+	return dotProductConjGo(a, b)
+}
+
 func scale64(dst, a []complex64, s complex64) {
 	if hasNEON {
 		scaleNEON(dst, a, s)
@@ -83,6 +97,12 @@ func mulNEON(dst, a, b []complex64)
 
 //go:noescape
 func mulConjNEON(dst, a, b []complex64)
+
+//go:noescape
+func dotProductNEON(a, b []complex64) complex64
+
+//go:noescape
+func dotProductConjNEON(a, b []complex64) complex64
 
 //go:noescape
 func scaleNEON(dst, a []complex64, s complex64)

--- a/c64/c64_arm64.s
+++ b/c64/c64_arm64.s
@@ -603,3 +603,143 @@ fromreal_neon_tail:
 
 fromreal_neon_done:
     RET
+
+// ============================================================================
+// DOT PRODUCT REDUCTIONS
+// sum(a[i]*b[i]) and sum(a[i]*conj(b[i])). Each reuses the mul/mulConj product
+// above but accumulates the real and imaginary result lanes into V14/V15 and
+// horizontally reduces with FADDP at the end. Accumulation is in float32 to
+// match dotProductGo / dotProductConjGo.
+// FADD  Vd.4S, Vn.4S, Vm.4S: 0x4E20D400 | (Vm << 16) | (Vn << 5) | Vd
+// FADDP Vd.4S, Vn.4S, Vm.4S: 0x6E20D400 | (Vm << 16) | (Vn << 5) | Vd
+// FADDP Sd, Vn.2S:           0x7E30D800 | (Vn << 5) | Vd
+// ============================================================================
+
+// func dotProductNEON(a, b []complex64) complex64
+TEXT ·dotProductNEON(SB), NOSPLIT, $0-56
+    MOVD a_base+0(FP), R0
+    MOVD a_len+8(FP), R1
+    MOVD b_base+24(FP), R2
+
+    VEOR V14.B16, V14.B16, V14.B16   // accRe
+    VEOR V15.B16, V15.B16, V15.B16   // accIm
+
+    CMP  $4, R1
+    BLT  dp_neon_reduce
+
+dp_neon_loop4:
+    VLD1.P 16(R0), [V0.S4]
+    VLD1.P 16(R0), [V1.S4]
+    VLD1.P 16(R2), [V2.S4]
+    VLD1.P 16(R2), [V3.S4]
+    WORD $0x4E811804             // UZP1 V4.4S, V0.4S, V1.4S
+    WORD $0x4E815805             // UZP2 V5.4S, V0.4S, V1.4S
+    WORD $0x4E831846             // UZP1 V6.4S, V2.4S, V3.4S
+    WORD $0x4E835847             // UZP2 V7.4S, V2.4S, V3.4S
+    WORD $0x6E26DC88             // FMUL V8.4S, V4.4S, V6.4S
+    WORD $0x6E27DCA9             // FMUL V9.4S, V5.4S, V7.4S
+    WORD $0x6E27DC8A             // FMUL V10.4S, V4.4S, V7.4S
+    WORD $0x6E26DCAB             // FMUL V11.4S, V5.4S, V6.4S
+    WORD $0x4EA9D50C             // FSUB V12.4S, V8.4S, V9.4S
+    WORD $0x4E2BD54D             // FADD V13.4S, V10.4S, V11.4S
+    WORD $0x4E2CD5CE             // FADD V14.4S, V14.4S, V12.4S
+    WORD $0x4E2DD5EF             // FADD V15.4S, V15.4S, V13.4S
+    SUB  $4, R1
+    CMP  $4, R1
+    BGE  dp_neon_loop4
+
+dp_neon_reduce:
+    WORD $0x6E2ED5CE             // FADDP V14.4S, V14.4S, V14.4S
+    WORD $0x7E30D9CE             // FADDP S14, V14.2S
+    WORD $0x6E2FD5EF             // FADDP V15.4S, V15.4S, V15.4S
+    WORD $0x7E30D9EF             // FADDP S15, V15.2S
+
+    CBZ  R1, dp_neon_done
+
+dp_neon_tail:
+    FMOVS (R0), F0
+    FMOVS 4(R0), F1
+    FMOVS (R2), F2
+    FMOVS 4(R2), F3
+    FMULS F0, F2, F4             // ar*br
+    FMULS F1, F3, F5             // ai*bi
+    FMULS F0, F3, F6             // ar*bi
+    FMULS F1, F2, F7             // ai*br
+    FSUBS F5, F4, F4             // ar*br - ai*bi
+    FADDS F6, F7, F5             // ar*bi + ai*br
+    FADDS F4, F14, F14           // sumRe += real
+    FADDS F5, F15, F15           // sumIm += imag
+    ADD  $8, R0
+    ADD  $8, R2
+    SUB  $1, R1
+    CBNZ R1, dp_neon_tail
+
+dp_neon_done:
+    FMOVS F14, ret_real+48(FP)
+    FMOVS F15, ret_imag+52(FP)
+    RET
+
+// func dotProductConjNEON(a, b []complex64) complex64
+// a*conj(b) = (ar*br + ai*bi) + (ai*br - ar*bi)i
+TEXT ·dotProductConjNEON(SB), NOSPLIT, $0-56
+    MOVD a_base+0(FP), R0
+    MOVD a_len+8(FP), R1
+    MOVD b_base+24(FP), R2
+
+    VEOR V14.B16, V14.B16, V14.B16   // accRe
+    VEOR V15.B16, V15.B16, V15.B16   // accIm
+
+    CMP  $4, R1
+    BLT  dpc_neon_reduce
+
+dpc_neon_loop4:
+    VLD1.P 16(R0), [V0.S4]
+    VLD1.P 16(R0), [V1.S4]
+    VLD1.P 16(R2), [V2.S4]
+    VLD1.P 16(R2), [V3.S4]
+    WORD $0x4E811804             // UZP1 V4.4S, V0.4S, V1.4S
+    WORD $0x4E815805             // UZP2 V5.4S, V0.4S, V1.4S
+    WORD $0x4E831846             // UZP1 V6.4S, V2.4S, V3.4S
+    WORD $0x4E835847             // UZP2 V7.4S, V2.4S, V3.4S
+    WORD $0x6E26DC88             // FMUL V8.4S, V4.4S, V6.4S
+    WORD $0x6E27DCA9             // FMUL V9.4S, V5.4S, V7.4S
+    WORD $0x6E26DCAA             // FMUL V10.4S, V5.4S, V6.4S
+    WORD $0x6E27DC8B             // FMUL V11.4S, V4.4S, V7.4S
+    WORD $0x4E29D50C             // FADD V12.4S, V8.4S, V9.4S
+    WORD $0x4EABD54D             // FSUB V13.4S, V10.4S, V11.4S
+    WORD $0x4E2CD5CE             // FADD V14.4S, V14.4S, V12.4S
+    WORD $0x4E2DD5EF             // FADD V15.4S, V15.4S, V13.4S
+    SUB  $4, R1
+    CMP  $4, R1
+    BGE  dpc_neon_loop4
+
+dpc_neon_reduce:
+    WORD $0x6E2ED5CE             // FADDP V14.4S, V14.4S, V14.4S
+    WORD $0x7E30D9CE             // FADDP S14, V14.2S
+    WORD $0x6E2FD5EF             // FADDP V15.4S, V15.4S, V15.4S
+    WORD $0x7E30D9EF             // FADDP S15, V15.2S
+
+    CBZ  R1, dpc_neon_done
+
+dpc_neon_tail:
+    FMOVS (R0), F0
+    FMOVS 4(R0), F1
+    FMOVS (R2), F2
+    FMOVS 4(R2), F3
+    FMULS F0, F2, F4             // ar*br
+    FMULS F1, F3, F5             // ai*bi
+    FMULS F1, F2, F6             // ai*br
+    FMULS F0, F3, F7             // ar*bi
+    FADDS F4, F5, F4             // ar*br + ai*bi
+    FSUBS F7, F6, F5             // ai*br - ar*bi
+    FADDS F4, F14, F14           // sumRe += real
+    FADDS F5, F15, F15           // sumIm += imag
+    ADD  $8, R0
+    ADD  $8, R2
+    SUB  $1, R1
+    CBNZ R1, dpc_neon_tail
+
+dpc_neon_done:
+    FMOVS F14, ret_real+48(FP)
+    FMOVS F15, ret_imag+52(FP)
+    RET

--- a/c64/c64_go.go
+++ b/c64/c64_go.go
@@ -119,3 +119,37 @@ func fromRealGo(dst []complex64, src []float32) {
 		dst[i] = complex(src[i], 0)
 	}
 }
+
+// dotProductGo computes the complex dot product sum(a[i]*b[i]) over
+// min(len(a), len(b)) elements, accumulating the real and imaginary parts in
+// float32. Like f32.DotProduct, the float32 accumulation trades a little
+// precision for throughput; widen to complex128 if the vectors are long and
+// accuracy-critical.
+func dotProductGo(a, b []complex64) complex64 {
+	n := min(len(a), len(b))
+	var sumRe, sumIm float32
+	for i := range n {
+		ar, ai := real(a[i]), imag(a[i])
+		br, bi := real(b[i]), imag(b[i])
+		// a*b = (ar*br - ai*bi) + (ar*bi + ai*br)i
+		sumRe += ar*br - ai*bi
+		sumIm += ar*bi + ai*br
+	}
+	return complex(sumRe, sumIm)
+}
+
+// dotProductConjGo computes the conjugated dot product sum(a[i]*conj(b[i])) over
+// min(len(a), len(b)) elements, accumulating in float32. This is the standard
+// Hermitian inner product used for correlation and matched filtering.
+func dotProductConjGo(a, b []complex64) complex64 {
+	n := min(len(a), len(b))
+	var sumRe, sumIm float32
+	for i := range n {
+		ar, ai := real(a[i]), imag(a[i])
+		br, bi := real(b[i]), imag(b[i])
+		// a*conj(b) = (ar*br + ai*bi) + (ai*br - ar*bi)i
+		sumRe += ar*br + ai*bi
+		sumIm += ai*br - ar*bi
+	}
+	return complex(sumRe, sumIm)
+}

--- a/c64/c64_other.go
+++ b/c64/c64_other.go
@@ -4,12 +4,14 @@ package c64
 
 // Fallback implementations for unsupported architectures
 
-func mul64(dst, a, b []complex64)               { mulGo(dst, a, b) }
-func mulConj64(dst, a, b []complex64)           { mulConjGo(dst, a, b) }
-func scale64(dst, a []complex64, s complex64)   { scaleGo(dst, a, s) }
-func add64(dst, a, b []complex64)               { addGo(dst, a, b) }
-func sub64(dst, a, b []complex64)               { subGo(dst, a, b) }
-func abs64(dst []float32, a []complex64)        { absGo(dst, a) }
-func absSq64(dst []float32, a []complex64)      { absSqGo(dst, a) }
-func conj64(dst, a []complex64)                 { conjGo(dst, a) }
-func fromReal64(dst []complex64, src []float32) { fromRealGo(dst, src) }
+func mul64(dst, a, b []complex64)                 { mulGo(dst, a, b) }
+func mulConj64(dst, a, b []complex64)             { mulConjGo(dst, a, b) }
+func dotProduct64(a, b []complex64) complex64     { return dotProductGo(a, b) }
+func dotProductConj64(a, b []complex64) complex64 { return dotProductConjGo(a, b) }
+func scale64(dst, a []complex64, s complex64)     { scaleGo(dst, a, s) }
+func add64(dst, a, b []complex64)                 { addGo(dst, a, b) }
+func sub64(dst, a, b []complex64)                 { subGo(dst, a, b) }
+func abs64(dst []float32, a []complex64)          { absGo(dst, a) }
+func absSq64(dst []float32, a []complex64)        { absSqGo(dst, a) }
+func conj64(dst, a []complex64)                   { conjGo(dst, a) }
+func fromReal64(dst []complex64, src []float32)   { fromRealGo(dst, src) }

--- a/c64/dot_product_amd64_test.go
+++ b/c64/dot_product_amd64_test.go
@@ -1,0 +1,38 @@
+//go:build amd64
+
+package c64
+
+import (
+	"testing"
+
+	"github.com/tphakala/simd/cpu"
+)
+
+// TestDotProductKernelsAMD64 exercises the SSE and AVX kernels directly against
+// the scalar references, so both tiers are covered regardless of which one the
+// active CPU selects.
+func TestDotProductKernelsAMD64(t *testing.T) {
+	for n := 0; n <= 20; n++ {
+		a := dpSeq(n, 1)
+		b := dpSeq(n, 4)
+		want := dotProductGo(a, b)
+		wantConj := dotProductConjGo(a, b)
+
+		if cpu.X86.SSE41 {
+			if got := dotProductSSE2(a, b); !dpClose(got, want) {
+				t.Errorf("dotProductSSE2 n=%d = %v, want %v", n, got, want)
+			}
+			if got := dotProductConjSSE2(a, b); !dpClose(got, wantConj) {
+				t.Errorf("dotProductConjSSE2 n=%d = %v, want %v", n, got, wantConj)
+			}
+		}
+		if cpu.X86.AVX && cpu.X86.FMA {
+			if got := dotProductAVX(a, b); !dpClose(got, want) {
+				t.Errorf("dotProductAVX n=%d = %v, want %v", n, got, want)
+			}
+			if got := dotProductConjAVX(a, b); !dpClose(got, wantConj) {
+				t.Errorf("dotProductConjAVX n=%d = %v, want %v", n, got, wantConj)
+			}
+		}
+	}
+}

--- a/c64/dot_product_test.go
+++ b/c64/dot_product_test.go
@@ -1,0 +1,106 @@
+package c64
+
+import (
+	"math"
+	"testing"
+)
+
+// dpSeq builds a deterministic complex64 slice mixing signs and magnitudes so
+// the kernel's lane reduction is exercised across every unroll remainder.
+func dpSeq(n, seed int) []complex64 {
+	s := make([]complex64, n)
+	for i := range s {
+		re := float32((i*7+seed)%13) - 6
+		im := float32((i*5+seed*3)%11) - 5
+		s[i] = complex(re*0.25, im*0.25)
+	}
+	return s
+}
+
+// dpCloseF reports whether two float32 components agree within the tolerance used
+// for f32 reductions, comparing NaN and Inf by class (the SIMD path accumulates
+// in a different order than the scalar reference).
+func dpCloseF(got, want float32) bool {
+	g, w := float64(got), float64(want)
+	if math.IsNaN(w) || math.IsNaN(g) {
+		return math.IsNaN(w) == math.IsNaN(g)
+	}
+	if math.IsInf(w, 0) || math.IsInf(g, 0) {
+		return math.IsInf(w, 1) == math.IsInf(g, 1) && math.IsInf(w, -1) == math.IsInf(g, -1)
+	}
+	return math.Abs(g-w) <= 1e-4*math.Abs(w)+1e-4
+}
+
+func dpClose(got, want complex64) bool {
+	return dpCloseF(real(got), real(want)) && dpCloseF(imag(got), imag(want))
+}
+
+// TestDotProductParity validates the public dispatch (AVX on amd64, NEON on
+// arm64, Go elsewhere) against the scalar references across every remainder.
+func TestDotProductParity(t *testing.T) {
+	for n := 0; n <= 20; n++ {
+		a := dpSeq(n, 1)
+		b := dpSeq(n, 4)
+		if got, want := DotProduct(a, b), dotProductGo(a, b); !dpClose(got, want) {
+			t.Errorf("DotProduct n=%d = %v, want %v", n, got, want)
+		}
+		if got, want := DotProductConj(a, b), dotProductConjGo(a, b); !dpClose(got, want) {
+			t.Errorf("DotProductConj n=%d = %v, want %v", n, got, want)
+		}
+	}
+}
+
+// TestDotProductMismatchedLengths checks the min(len(a), len(b)) contract.
+func TestDotProductMismatchedLengths(t *testing.T) {
+	a := dpSeq(15, 1)
+	b := dpSeq(9, 4)
+	if got, want := DotProduct(a, b), dotProductGo(a, b); !dpClose(got, want) {
+		t.Errorf("DotProduct mismatched = %v, want %v", got, want)
+	}
+	if got, want := DotProductConj(b, a), dotProductConjGo(b, a); !dpClose(got, want) {
+		t.Errorf("DotProductConj mismatched = %v, want %v", got, want)
+	}
+}
+
+// TestDotProductEmpty confirms empty input returns 0.
+func TestDotProductEmpty(t *testing.T) {
+	if got := DotProduct(nil, nil); got != 0 {
+		t.Errorf("DotProduct(nil) = %v, want 0", got)
+	}
+	if got := DotProductConj([]complex64{}, []complex64{}); got != 0 {
+		t.Errorf("DotProductConj(empty) = %v, want 0", got)
+	}
+}
+
+// TestDotProductSpecialValues feeds NaN/Inf inputs and asserts the result
+// propagates the same special class as the reference.
+func TestDotProductSpecialValues(t *testing.T) {
+	inf := float32(math.Inf(1))
+	nan := float32(math.NaN())
+	cases := [][2][]complex64{
+		{{complex(1, 2), complex(nan, 1), complex(3, 4)}, {complex(5, 6), complex(7, 8), complex(9, 1)}},
+		{{complex(inf, 0), complex(1, 1)}, {complex(2, 2), complex(3, 3)}},
+		{{complex(1, inf), complex(1, 1), complex(2, 2)}, {complex(2, 2), complex(3, 3), complex(4, 4)}},
+	}
+	for ci, c := range cases {
+		a, b := c[0], c[1]
+		if got, want := DotProduct(a, b), dotProductGo(a, b); !dpClose(got, want) {
+			t.Errorf("case %d DotProduct = %v, want %v", ci, got, want)
+		}
+		if got, want := DotProductConj(a, b), dotProductConjGo(a, b); !dpClose(got, want) {
+			t.Errorf("case %d DotProductConj = %v, want %v", ci, got, want)
+		}
+	}
+}
+
+// TestDotProductAllocs confirms the public APIs stay allocation-free.
+func TestDotProductAllocs(t *testing.T) {
+	a := dpSeq(256, 1)
+	b := dpSeq(256, 2)
+	if allocs := testing.AllocsPerRun(100, func() { _ = DotProduct(a, b) }); allocs != 0 {
+		t.Errorf("DotProduct allocs = %v, want 0", allocs)
+	}
+	if allocs := testing.AllocsPerRun(100, func() { _ = DotProductConj(a, b) }); allocs != 0 {
+		t.Errorf("DotProductConj allocs = %v, want 0", allocs)
+	}
+}

--- a/doc.go
+++ b/doc.go
@@ -56,7 +56,7 @@
 //
 // Integer DSP (i32): Interleave2, Deinterleave2, Add, Sub, MidSideEncode, MidSideDecode, Diff1..Diff4, Restore1..Restore4, LPCResidualEncode, LPCRestore, RiceSums, RiceBestParam
 //
-// Complex (c128): Add, Sub, Mul, MulConj, Conj, Abs, AbsSq, Scale
+// Complex (c64/c128): Add, Sub, Mul, MulConj, DotProduct, DotProductConj, Conj, Abs, AbsSq, Scale
 //
 // CRC (crc): Checksum16 (FLAC CRC-16, PCLMULQDQ/PMULL carry-less-multiply fold)
 //


### PR DESCRIPTION
Closes #104.

## What

c64 and c128 covered only element-wise ops, so a complex dot product required a `Mul` into scratch plus a manual sum (an extra memory pass and scratch storage in user code). This adds the reductions directly:

```go
func DotProduct(a, b []complex64) complex64      // sum of a[i] * b[i]
func DotProductConj(a, b []complex64) complex64  // sum of a[i] * conj(b[i])
// c128: same shapes with complex128
```

`DotProductConj` is the standard Hermitian inner product (correlation, matched filtering, beamforming); `DotProduct` is what frequency-domain folding uses. Both process `min(len(a), len(b))` elements, return 0 for empty input, and accumulate at the native element precision (float32 re/im for c64, float64 for c128), matching `f32`/`f64` `DotProduct`.

## Kernels

Each reuses the existing `mul`/`mulConj` product sequence, accumulating into a register instead of storing and horizontally reducing the real/imag lanes before returning.

- **amd64**: SSE and AVX+FMA via the function-pointer init. AVX-512 reuses the AVX kernels (no AVX-512 hardware to verify new asm; see #75/#96). c128's AVX-without-FMA path drops the dot kernels to SSE2 alongside `mul`/`mulConj`, since they share the `VFMADDSUB213PD` dependency.
- **arm64 NEON**: per-call `hasNEON` dispatch, accumulating the deinterleaved real/imag result vectors and reducing with `FADDP`. Every `WORD` encoding was verified with `aarch64-as` and passes the `arm64asm` cross-check (`TestArm64WordEncodings`). No reserved register is touched (`TestNoGoroutineRegisterClobber` green).

## Tests

- SSE and AVX kernels tested directly, plus the public dispatch (NEON on arm64), across lengths 0-20 (every tier's remainder).
- `min(len(a), len(b))` contract, empty input, NaN/+/-Inf special values compared by class, and `AllocsPerRun == 0`.
- Parity uses a relative tolerance because the SIMD path accumulates in a different order than the scalar reference.

## Verification

- amd64 (i7-1260P): `go test ./...`, `go vet`, `golangci-lint`, asmcheck all clean. Both SSE and AVX kernels exercised directly regardless of the active tier.
- arm64 (Raspberry Pi 5, NEON): cross-compiled and ran the full c64 + c128 suites natively, all green.
- Cross-arch builds for linux/arm64, darwin/arm64, linux/riscv64, js/wasm, windows/amd64 all OK.
- Benchmarks (i7-1260P, 1024 elements): c64 DotProduct **5.8x**, DotProductConj **4.6x**; c128 DotProduct **2.1x** over pure Go.

## Docs

Added Reduction rows to the README c64/c128 tables, updated the package doc-comment op lists, and the `doc.go` complex op list.