### PR TITLE
f64: NEON batch-of-4 kernel for DotProductBatch on ARM64 (parity with f32 #71)

### DIFF
--- a/README.md
+++ b/README.md
@@ -150,8 +150,9 @@ sum := crc.Checksum16(p) // bit-identical to the scalar reference, zero-alloc
 
 `DotProductBatch` scores its `[][]float64` rows in groups of four, keeping the
 query vector resident in registers across each group via a fused 4-row kernel on
-AMD64 (AVX-512 and AVX+FMA) instead of re-loading it per row. Short, ragged, or
-sub-SIMD-width rows fall back to the per-row dot product, with identical results.
+AMD64 (AVX-512 and AVX+FMA) and ARM64 NEON instead of re-loading it per row.
+Short, ragged, or sub-SIMD-width rows fall back to the per-row dot product, with
+identical results.
 
 `Autocorrelate` computes the LPC autocorrelation `autoc[lag] = Σ x[i]·x[i-lag]`
 used by FLAC-style encoders. It vectorizes across lags (one accumulator lane per

--- a/f64/dot_product_batch4_arm64_test.go
+++ b/f64/dot_product_batch4_arm64_test.go
@@ -1,0 +1,36 @@
+//go:build arm64
+
+package f64
+
+import "testing"
+
+// TestDotProduct4NEONKernel scores four deterministic rows against one query with
+// the NEON batch-of-4 kernel and compares each result to the pure-scalar
+// dotProductGo oracle, so a buggy hand-encoded kernel (wrong lane count, bad
+// horizontal reduction, mishandled 2-element or scalar tail) is caught rather
+// than passing by SIMD-vs-SIMD agreement.
+func TestDotProduct4NEONKernel(t *testing.T) {
+	if !hasNEON {
+		t.Skip("NEON required")
+	}
+	// Cover sub-vector, exact-multiple, and tail-bearing dims for the 4/iter main
+	// loop, the 2-element remainder, and the scalar (odd) tail.
+	dims := []int{1, 2, 3, 4, 5, 7, 8, 15, 16, 31, 32, 63, 64, 65, 127, 128, 256, 768}
+	for _, dim := range dims {
+		vec := deterministicF64Vector(11, dim)
+		rows := [4][]float64{
+			deterministicF64Vector(100, dim),
+			deterministicF64Vector(101, dim),
+			deterministicF64Vector(102, dim),
+			deterministicF64Vector(103, dim),
+		}
+		results := make([]float64, 4)
+		dotProduct4NEON(&results[0], &rows[0][0], &rows[1][0], &rows[2][0], &rows[3][0], &vec[0], dim)
+		for i, row := range rows {
+			want := dotProductGo(row, vec)
+			if !closeFloat64(results[i], want) {
+				t.Fatalf("dim=%d row=%d got=%g want=%g", dim, i, results[i], want)
+			}
+		}
+	}
+}

--- a/f64/dot_product_batch4_arm64_test.go
+++ b/f64/dot_product_batch4_arm64_test.go
@@ -33,4 +33,20 @@ func TestDotProduct4NEONKernel(t *testing.T) {
 			}
 		}
 	}
+
+	// The kernel must not allocate.
+	const dim = 256
+	vec := deterministicF64Vector(11, dim)
+	rows := [4][]float64{
+		deterministicF64Vector(100, dim),
+		deterministicF64Vector(101, dim),
+		deterministicF64Vector(102, dim),
+		deterministicF64Vector(103, dim),
+	}
+	results := make([]float64, 4)
+	if a := testing.AllocsPerRun(100, func() {
+		dotProduct4NEON(&results[0], &rows[0][0], &rows[1][0], &rows[2][0], &rows[3][0], &vec[0], dim)
+	}); a != 0 {
+		t.Errorf("dotProduct4NEON allocated %v times per run, want 0", a)
+	}
 }

--- a/f64/f64_arm64.go
+++ b/f64/f64_arm64.go
@@ -2,7 +2,11 @@
 
 package f64
 
-import "github.com/tphakala/simd/cpu"
+import (
+	"unsafe"
+
+	"github.com/tphakala/simd/cpu"
+)
 
 var (
 	hasNEON = cpu.ARM64.NEON
@@ -167,10 +171,44 @@ func cumulativeSum64(dst, a []float64) {
 	cumulativeSum64Go(dst, a)
 }
 
+// dotProductBatch64 scores rows against vec in groups of four, keeping the query
+// vector resident across each group via dotProduct4NEON instead of reloading it
+// per row. Rows shorter than vecLen (and any tail past the last full group of
+// four) fall back to the per-row dotProduct, so results stay anchored to the
+// scalar contract regardless of row shape. f64 packs half the lanes of f32, so
+// the query-reuse win is smaller; benchmarks on the Raspberry Pi 5 justify
+// keeping the kernel.
 func dotProductBatch64(results []float64, rows [][]float64, vec []float64) {
-	// Batch dot product benefits from cache locality of vec
 	vecLen := len(vec)
-	for i, row := range rows {
+	i := 0
+	if hasNEON && vecLen > 0 {
+		for i+3 < len(rows) {
+			row0, row1, row2, row3 := rows[i], rows[i+1], rows[i+2], rows[i+3]
+			if len(row0) >= vecLen && len(row1) >= vecLen && len(row2) >= vecLen && len(row3) >= vecLen {
+				res := (*float64)(unsafe.Pointer(&results[i]))
+				r0 := (*float64)(unsafe.Pointer(&row0[0]))
+				r1 := (*float64)(unsafe.Pointer(&row1[0]))
+				r2 := (*float64)(unsafe.Pointer(&row2[0]))
+				r3 := (*float64)(unsafe.Pointer(&row3[0]))
+				q := (*float64)(unsafe.Pointer(&vec[0]))
+				dotProduct4NEON(res, r0, r1, r2, r3, q, vecLen)
+				i += 4
+				continue
+			}
+			for j := range 4 {
+				row := rows[i+j]
+				n := min(len(row), vecLen)
+				if n == 0 {
+					results[i+j] = 0
+				} else {
+					results[i+j] = dotProduct(row[:n], vec[:n])
+				}
+			}
+			i += 4
+		}
+	}
+	for ; i < len(rows); i++ {
+		row := rows[i]
 		n := min(len(row), vecLen)
 		if n == 0 {
 			results[i] = 0
@@ -253,6 +291,9 @@ func accumulateAdd64(dst, src []float64) {
 
 //go:noescape
 func dotProductNEON(a, b []float64) float64
+
+//go:noescape
+func dotProduct4NEON(results, row0, row1, row2, row3, vec *float64, n int)
 
 //go:noescape
 func addNEON(dst, a, b []float64)

--- a/f64/f64_arm64.s
+++ b/f64/f64_arm64.s
@@ -1756,25 +1756,27 @@ TEXT ·dotProduct4NEON(SB), NOSPLIT, $0-56
     CBZ R7, dot4d_rem2_check
 
 dot4d_loop4:
-    // chunk a: vec[0:2] -> V16, accumulate into bank a (V0-V3)
+    // chunk a: group the vec + 4 row loads, then the FMLAs into bank a (V0-V3),
+    // so the load/store unit pipelines the loads instead of stalling each FMLA on
+    // its just-loaded operand.
     VLD1.P 16(R5), [V16.D2]
     VLD1.P 16(R1), [V18.D2]
-    WORD $0x4E70CE40           // FMLA V0.2D, V18.2D, V16.2D
     VLD1.P 16(R2), [V19.D2]
-    WORD $0x4E70CE61           // FMLA V1.2D, V19.2D, V16.2D
     VLD1.P 16(R3), [V20.D2]
-    WORD $0x4E70CE82           // FMLA V2.2D, V20.2D, V16.2D
     VLD1.P 16(R4), [V21.D2]
+    WORD $0x4E70CE40           // FMLA V0.2D, V18.2D, V16.2D
+    WORD $0x4E70CE61           // FMLA V1.2D, V19.2D, V16.2D
+    WORD $0x4E70CE82           // FMLA V2.2D, V20.2D, V16.2D
     WORD $0x4E70CEA3           // FMLA V3.2D, V21.2D, V16.2D
-    // chunk b: vec[2:4] -> V17, accumulate into bank b (V4-V7)
+    // chunk b: same for bank b (V4-V7) with vec[2:4] -> V17
     VLD1.P 16(R5), [V17.D2]
     VLD1.P 16(R1), [V18.D2]
-    WORD $0x4E71CE44           // FMLA V4.2D, V18.2D, V17.2D
     VLD1.P 16(R2), [V19.D2]
-    WORD $0x4E71CE65           // FMLA V5.2D, V19.2D, V17.2D
     VLD1.P 16(R3), [V20.D2]
-    WORD $0x4E71CE86           // FMLA V6.2D, V20.2D, V17.2D
     VLD1.P 16(R4), [V21.D2]
+    WORD $0x4E71CE44           // FMLA V4.2D, V18.2D, V17.2D
+    WORD $0x4E71CE65           // FMLA V5.2D, V19.2D, V17.2D
+    WORD $0x4E71CE86           // FMLA V6.2D, V20.2D, V17.2D
     WORD $0x4E71CEA7           // FMLA V7.2D, V21.2D, V17.2D
     SUB $1, R7
     CBNZ R7, dot4d_loop4
@@ -1790,15 +1792,15 @@ dot4d_rem2_check:
     LSR $1, R8, R9             // R9 = (n & 3) / 2
     CBZ R9, dot4d_reduce
 
-    // One 2-element chunk into bank a.
+    // One 2-element chunk into bank a: group the loads, then the FMLAs.
     VLD1.P 16(R5), [V16.D2]
     VLD1.P 16(R1), [V18.D2]
-    WORD $0x4E70CE40           // FMLA V0.2D, V18.2D, V16.2D
     VLD1.P 16(R2), [V19.D2]
-    WORD $0x4E70CE61           // FMLA V1.2D, V19.2D, V16.2D
     VLD1.P 16(R3), [V20.D2]
-    WORD $0x4E70CE82           // FMLA V2.2D, V20.2D, V16.2D
     VLD1.P 16(R4), [V21.D2]
+    WORD $0x4E70CE40           // FMLA V0.2D, V18.2D, V16.2D
+    WORD $0x4E70CE61           // FMLA V1.2D, V19.2D, V16.2D
+    WORD $0x4E70CE82           // FMLA V2.2D, V20.2D, V16.2D
     WORD $0x4E70CEA3           // FMLA V3.2D, V21.2D, V16.2D
 
 dot4d_reduce:

--- a/f64/f64_arm64.s
+++ b/f64/f64_arm64.s
@@ -1723,3 +1723,108 @@ autocorr2_loop:
 
 autocorr2_done:
     RET
+
+// func dotProduct4NEON(results, row0, row1, row2, row3, vec *float64, n int)
+// Scores four rows against the same vec, reusing each vec load across the group
+// instead of reloading the query per row (parity with the f32 kernel, ported
+// from .4S to .2D: 2 float64 per vector). Two accumulator banks per row
+// (V0-V3 bank a, V4-V7 bank b) hide FMLA latency over a 4-element main loop;
+// V16/V17 hold the two query chunks, V18-V21 the four row chunks.
+// FMLA  Vd.2D, Vn.2D, Vm.2D: 0x4E60CC00 | (Vm << 16) | (Vn << 5) | Vd
+// FADD  Vd.2D, Vn.2D, Vm.2D: 0x4E60D400 | (Vm << 16) | (Vn << 5) | Vd
+// FADDP Dd, Vn.2D:           0x7E70D800 | (Vn << 5) | Vd
+TEXT ·dotProduct4NEON(SB), NOSPLIT, $0-56
+    MOVD results+0(FP), R0
+    MOVD row0+8(FP), R1
+    MOVD row1+16(FP), R2
+    MOVD row2+24(FP), R3
+    MOVD row3+32(FP), R4
+    MOVD vec+40(FP), R5
+    MOVD n+48(FP), R6
+
+    VEOR V0.B16, V0.B16, V0.B16
+    VEOR V1.B16, V1.B16, V1.B16
+    VEOR V2.B16, V2.B16, V2.B16
+    VEOR V3.B16, V3.B16, V3.B16
+    VEOR V4.B16, V4.B16, V4.B16
+    VEOR V5.B16, V5.B16, V5.B16
+    VEOR V6.B16, V6.B16, V6.B16
+    VEOR V7.B16, V7.B16, V7.B16
+
+    // Process 4 elements per row (2 chunks of 2 doubles) per iteration.
+    LSR $2, R6, R7             // R7 = n / 4
+    CBZ R7, dot4d_rem2_check
+
+dot4d_loop4:
+    // chunk a: vec[0:2] -> V16, accumulate into bank a (V0-V3)
+    VLD1.P 16(R5), [V16.D2]
+    VLD1.P 16(R1), [V18.D2]
+    WORD $0x4E70CE40           // FMLA V0.2D, V18.2D, V16.2D
+    VLD1.P 16(R2), [V19.D2]
+    WORD $0x4E70CE61           // FMLA V1.2D, V19.2D, V16.2D
+    VLD1.P 16(R3), [V20.D2]
+    WORD $0x4E70CE82           // FMLA V2.2D, V20.2D, V16.2D
+    VLD1.P 16(R4), [V21.D2]
+    WORD $0x4E70CEA3           // FMLA V3.2D, V21.2D, V16.2D
+    // chunk b: vec[2:4] -> V17, accumulate into bank b (V4-V7)
+    VLD1.P 16(R5), [V17.D2]
+    VLD1.P 16(R1), [V18.D2]
+    WORD $0x4E71CE44           // FMLA V4.2D, V18.2D, V17.2D
+    VLD1.P 16(R2), [V19.D2]
+    WORD $0x4E71CE65           // FMLA V5.2D, V19.2D, V17.2D
+    VLD1.P 16(R3), [V20.D2]
+    WORD $0x4E71CE86           // FMLA V6.2D, V20.2D, V17.2D
+    VLD1.P 16(R4), [V21.D2]
+    WORD $0x4E71CEA7           // FMLA V7.2D, V21.2D, V17.2D
+    SUB $1, R7
+    CBNZ R7, dot4d_loop4
+
+    // Fold bank b into bank a (only reached when the main loop ran).
+    WORD $0x4E64D400           // FADD V0.2D, V0.2D, V4.2D
+    WORD $0x4E65D421           // FADD V1.2D, V1.2D, V5.2D
+    WORD $0x4E66D442           // FADD V2.2D, V2.2D, V6.2D
+    WORD $0x4E67D463           // FADD V3.2D, V3.2D, V7.2D
+
+dot4d_rem2_check:
+    AND $3, R6, R8
+    LSR $1, R8, R9             // R9 = (n & 3) / 2
+    CBZ R9, dot4d_reduce
+
+    // One 2-element chunk into bank a.
+    VLD1.P 16(R5), [V16.D2]
+    VLD1.P 16(R1), [V18.D2]
+    WORD $0x4E70CE40           // FMLA V0.2D, V18.2D, V16.2D
+    VLD1.P 16(R2), [V19.D2]
+    WORD $0x4E70CE61           // FMLA V1.2D, V19.2D, V16.2D
+    VLD1.P 16(R3), [V20.D2]
+    WORD $0x4E70CE82           // FMLA V2.2D, V20.2D, V16.2D
+    VLD1.P 16(R4), [V21.D2]
+    WORD $0x4E70CEA3           // FMLA V3.2D, V21.2D, V16.2D
+
+dot4d_reduce:
+    // Reduce each bank-a accumulator to a scalar (D0..D3) BEFORE any scalar FMA,
+    // since scalar ops zero the upper lane of the V register.
+    WORD $0x7E70D800           // FADDP D0, V0.2D
+    WORD $0x7E70D821           // FADDP D1, V1.2D
+    WORD $0x7E70D842           // FADDP D2, V2.2D
+    WORD $0x7E70D863           // FADDP D3, V3.2D
+
+    AND $1, R6, R8             // R8 = n & 1 (scalar tail count, 0 or 1)
+    CBZ R8, dot4d_store
+
+    FMOVD (R5), F18
+    FMOVD (R1), F19
+    FMADDD F18, F0, F19, F0    // F0 = F19 * F18 + F0
+    FMOVD (R2), F19
+    FMADDD F18, F1, F19, F1
+    FMOVD (R3), F19
+    FMADDD F18, F2, F19, F2
+    FMOVD (R4), F19
+    FMADDD F18, F3, F19, F3
+
+dot4d_store:
+    FMOVD F0, (R0)
+    FMOVD F1, 8(R0)
+    FMOVD F2, 16(R0)
+    FMOVD F3, 24(R0)
+    RET


### PR DESCRIPTION
Closes #102.

## What

f64 `DotProductBatch` on ARM64 scored rows one at a time, reloading the query vector for every row (`dotProductBatch64` in `f64/f64_arm64.go`). This adds the f64 NEON batch-of-4 kernel, parity with the f32 #71 path.

`dotProduct4NEON` is ported from the f32 `.4S` kernel to `.2D` (2 float64 per vector): four row accumulators, the query resident across the group of four, horizontal `FADDP` reduction per row at the end. Two accumulator banks (V0-V3, V4-V7) hide FMLA latency over a 4-element main loop, with a 2-element remainder chunk and an odd-element scalar tail.

`dotProductBatch64` now takes rows in groups of four through the kernel when each row and the query meet the eligibility checks (NEON present, `vecLen > 0`, each row at least `vecLen` long), and falls back to the per-row loop otherwise, so results stay identical to the scalar contract for any row shape.

## Register safety

Every `WORD` encoding was generated with `aarch64-as` and passes the `arm64asm` cross-check (`TestArm64WordEncodings`). No reserved register is touched (`TestNoGoroutineRegisterClobber` green). The kernel uses R0-R9 and V0-V21.

## Profiling gate (Raspberry Pi 5, batch vs per-row loop, both NEON)

| rows | dim | batch | per-row | speedup |
| --- | --- | --- | --- | --- |
| 16  | 16  | 95 ns   | 236 ns  | **2.5x** |
| 64  | 16  | 371 ns  | 917 ns  | **2.5x** |
| 64  | 64  | 975 ns  | 1817 ns | **1.9x** |
| 256 | 64  | 4.9 us  | 7.9 us  | **1.6x** |
| 256 | 256 | 17.1 us | 23.5 us | **1.4x** |

f64 packs half the lanes of f32, so the query-reuse win is smaller than f32's, but the kernel still wins decisively across every representative shape (best at small dims, where per-row call overhead and query reuse matter most), so it is kept.

## Tests

A kernel-direct parity test (`dot_product_batch4_arm64_test.go`, mirroring the f32 one) compares all four row results against `dotProductGo` across dims 1..768, covering the 4/iter main loop, the 2-element remainder, and the scalar (odd) tail.

## Verification

- arm64 (Raspberry Pi 5): kernel-direct parity test and the full f64 suite green; allocation-free.
- amd64: `go test ./...`, `go vet`, `golangci-lint`, asmcheck all clean (the kernel is arm64-only; the amd64 batch path is unchanged).
- Cross-arch builds for linux/arm64, linux/riscv64, js/wasm OK.

README f64 `DotProductBatch` note updated to include ARM64 NEON.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added ARM64 NEON batch processing for dot product operations on supported systems.

* **Tests**
  * Added test coverage for ARM64 NEON batch kernels across multiple vector dimensions.

* **Documentation**
  * Updated documentation to reference ARM64 NEON support alongside existing AMD64 SIMD optimizations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->