### PR TITLE
f32: ARM64 NEON InterleaveN/DeinterleaveN for N=6 and N=8 (profiling-gated)

### DIFF
--- a/README.md
+++ b/README.md
@@ -184,9 +184,13 @@ Each has an `Unsafe` variant that skips bounds reconciliation.
 `InterleaveN`/`DeinterleaveN` add an 8-stream AVX path (8x8 register transpose) and
 a 3-stream AVX2 path (per-stream `VPERMPS` gathers merged with `VPBLENDD`, since 3
 streams do not map onto a clean register transpose) on top of the shared N=2/4 (AVX)
-and N=2/3/4 (NEON) kernels; all other stream counts use the allocation-free generic
-path. The N=3 case is the 16k -> 48k upsample hot path: the AVX2 gather/blend kernel
-runs roughly 2.8x (interleave) and 3.2x (deinterleave) over the generic loop on AVX2.
+and N=2/3/4/6/8 (NEON) kernels; all other stream counts use the allocation-free
+generic path. The N=3 case is the 16k -> 48k upsample hot path: the AVX2
+gather/blend kernel runs roughly 2.8x (interleave) and 3.2x (deinterleave) over the
+generic loop on AVX2. The ARM64 N=6 (5.1 audio) and N=8 (7.1 audio) NEON kernels zip
+adjacent channel pairs at `.4S` so each 64-bit lane holds a frame pair, then store
+with `ST3`/`ST4` at `.2D` (the inverse via `LD3`/`LD4` plus `UZP1`/`UZP2`); they run
+roughly 4.4x (N=6) and 3.4x-4.6x (N=8) over the generic loop on the Raspberry Pi 5.
 The 6-stream AVX2 path (the 8k -> 48k upsample) zips stream pairs into three
 double-wide pair streams, then reuses the f64 N=3 interleave on those pairs, so it
 needs no index tables; it runs roughly 2x (interleave and deinterleave) on AVX2.

--- a/f32/f32_arm64.go
+++ b/f32/f32_arm64.go
@@ -384,6 +384,8 @@ func deinterleave2_32(a, b, src []float32) {
 const (
 	interleave3Streams  = 3
 	interleave4Streams  = 4
+	interleave6Streams  = 6
+	interleave8Streams  = 8
 	neonInterleaveBlock = 4
 )
 
@@ -400,6 +402,18 @@ func interleaveN32(dst []float32, srcs [][]float32, n int) {
 	case interleave4Streams:
 		if hasNEON && n >= neonInterleaveBlock {
 			interleave4NEON(dst, srcs[0], srcs[1], srcs[2], srcs[3], n)
+			return
+		}
+		interleaveNGo(dst, srcs, n)
+	case interleave6Streams:
+		if hasNEON && n >= neonInterleaveBlock {
+			interleave6NEON(dst, srcs[0], srcs[1], srcs[2], srcs[3], srcs[4], srcs[5], n)
+			return
+		}
+		interleaveNGo(dst, srcs, n)
+	case interleave8Streams:
+		if hasNEON && n >= neonInterleaveBlock {
+			interleave8NEON(dst, srcs[0], srcs[1], srcs[2], srcs[3], srcs[4], srcs[5], srcs[6], srcs[7], n)
 			return
 		}
 		interleaveNGo(dst, srcs, n)
@@ -424,6 +438,18 @@ func deinterleaveN32(dsts [][]float32, src []float32, n int) {
 	case interleave4Streams:
 		if hasNEON && n >= neonInterleaveBlock {
 			deinterleave4NEON(dsts[0], dsts[1], dsts[2], dsts[3], src, n)
+			return
+		}
+		deinterleaveNGo(dsts, src, n)
+	case interleave6Streams:
+		if hasNEON && n >= neonInterleaveBlock {
+			deinterleave6NEON(dsts[0], dsts[1], dsts[2], dsts[3], dsts[4], dsts[5], src, n)
+			return
+		}
+		deinterleaveNGo(dsts, src, n)
+	case interleave8Streams:
+		if hasNEON && n >= neonInterleaveBlock {
+			deinterleave8NEON(dsts[0], dsts[1], dsts[2], dsts[3], dsts[4], dsts[5], dsts[6], dsts[7], src, n)
 			return
 		}
 		deinterleaveNGo(dsts, src, n)
@@ -457,6 +483,18 @@ func interleave4NEON(dst, s0, s1, s2, s3 []float32, n int)
 //go:noescape
 func deinterleave4NEON(d0, d1, d2, d3, src []float32, n int)
 
+//go:noescape
+func interleave6NEON(dst, s0, s1, s2, s3, s4, s5 []float32, n int)
+
+//go:noescape
+func deinterleave6NEON(d0, d1, d2, d3, d4, d5, src []float32, n int)
+
+//go:noescape
+func interleave8NEON(dst, s0, s1, s2, s3, s4, s5, s6, s7 []float32, n int)
+
+//go:noescape
+func deinterleave8NEON(d0, d1, d2, d3, d4, d5, d6, d7, src []float32, n int)
+
 func sqrt32(dst, a []float32) {
 	if hasNEON && len(dst) >= 4 {
 		sqrtNEON(dst, a)
@@ -464,7 +502,6 @@ func sqrt32(dst, a []float32) {
 	}
 	sqrt32Go(dst, a)
 }
-
 
 func round32(dst, src []float32) {
 	if hasNEON && len(dst) >= 4 {

--- a/f32/f32_arm64.s
+++ b/f32/f32_arm64.s
@@ -2872,3 +2872,288 @@ cd_neon_store:
 
 cd_neon_done:
     RET
+
+// ============================================================================
+// INTERLEAVE / DEINTERLEAVE N=6 and N=8 (profiling-gated, 5.1/7.1 audio)
+// The pair trick: ZIP adjacent channel pairs at .4S so each 64-bit lane holds a
+// [cA_i, cB_i] frame pair, then ST3/ST4 with .2D arrangement lays the pairs down
+// in frame order (and the inverse for deinterleave via LD3/LD4 .2D + UZP). Four
+// frames per iteration, then a scalar tail. WORD-encoded with arm64asm-checked
+// comments.
+// ZIP1 Vd.4S, Vn.4S, Vm.4S: 0x4E803800 | (Vm << 16) | (Vn << 5) | Vd
+// ZIP2 Vd.4S, Vn.4S, Vm.4S: 0x4E807800 | (Vm << 16) | (Vn << 5) | Vd
+// UZP1 Vd.4S, Vn.4S, Vm.4S: 0x4E801800 | (Vm << 16) | (Vn << 5) | Vd
+// UZP2 Vd.4S, Vn.4S, Vm.4S: 0x4E805800 | (Vm << 16) | (Vn << 5) | Vd
+// ============================================================================
+
+// func interleave6NEON(dst, s0, s1, s2, s3, s4, s5 []float32, n int)
+TEXT ·interleave6NEON(SB), NOSPLIT, $0-176
+    MOVD dst_base+0(FP), R0
+    MOVD s0_base+24(FP), R1
+    MOVD s1_base+48(FP), R2
+    MOVD s2_base+72(FP), R3
+    MOVD s3_base+96(FP), R4
+    MOVD s4_base+120(FP), R5
+    MOVD s5_base+144(FP), R6
+    MOVD n+168(FP), R7
+
+    LSR $2, R7, R8             // R8 = n / 4 (4 frames per iteration)
+    CBZ R8, interleave6_neon_tail
+
+interleave6_neon_loop4:
+    VLD1.P 16(R1), [V0.S4]
+    VLD1.P 16(R2), [V1.S4]
+    VLD1.P 16(R3), [V2.S4]
+    VLD1.P 16(R4), [V3.S4]
+    VLD1.P 16(R5), [V4.S4]
+    VLD1.P 16(R6), [V5.S4]
+    WORD $0x4E813806           // ZIP1 V6.4S, V0.4S, V1.4S   (frames 0,1 ch 0,1)
+    WORD $0x4E833847           // ZIP1 V7.4S, V2.4S, V3.4S   (frames 0,1 ch 2,3)
+    WORD $0x4E853888           // ZIP1 V8.4S, V4.4S, V5.4S   (frames 0,1 ch 4,5)
+    WORD $0x4E817809           // ZIP2 V9.4S, V0.4S, V1.4S   (frames 2,3 ch 0,1)
+    WORD $0x4E83784A           // ZIP2 V10.4S, V2.4S, V3.4S  (frames 2,3 ch 2,3)
+    WORD $0x4E85788B           // ZIP2 V11.4S, V4.4S, V5.4S  (frames 2,3 ch 4,5)
+    VST3.P [V6.D2, V7.D2, V8.D2], 48(R0)     // frames 0,1
+    VST3.P [V9.D2, V10.D2, V11.D2], 48(R0)   // frames 2,3
+    SUB $1, R8
+    CBNZ R8, interleave6_neon_loop4
+
+interleave6_neon_tail:
+    AND $3, R7
+    CBZ R7, interleave6_neon_done
+
+interleave6_neon_tail1:
+    FMOVS (R1), F0
+    FMOVS (R2), F1
+    FMOVS (R3), F2
+    FMOVS (R4), F3
+    FMOVS (R5), F4
+    FMOVS (R6), F5
+    FMOVS F0, (R0)
+    FMOVS F1, 4(R0)
+    FMOVS F2, 8(R0)
+    FMOVS F3, 12(R0)
+    FMOVS F4, 16(R0)
+    FMOVS F5, 20(R0)
+    ADD $4, R1
+    ADD $4, R2
+    ADD $4, R3
+    ADD $4, R4
+    ADD $4, R5
+    ADD $4, R6
+    ADD $24, R0
+    SUB $1, R7
+    CBNZ R7, interleave6_neon_tail1
+
+interleave6_neon_done:
+    RET
+
+// func deinterleave6NEON(d0, d1, d2, d3, d4, d5, src []float32, n int)
+TEXT ·deinterleave6NEON(SB), NOSPLIT, $0-176
+    MOVD d0_base+0(FP), R0
+    MOVD d1_base+24(FP), R1
+    MOVD d2_base+48(FP), R2
+    MOVD d3_base+72(FP), R3
+    MOVD d4_base+96(FP), R4
+    MOVD d5_base+120(FP), R5
+    MOVD src_base+144(FP), R6
+    MOVD n+168(FP), R7
+
+    LSR $2, R7, R8             // 4 frames per iteration
+    CBZ R8, deinterleave6_neon_tail
+
+deinterleave6_neon_loop4:
+    VLD3.P 48(R6), [V0.D2, V1.D2, V2.D2]     // frames 0,1: V0=ch(0,1), V1=ch(2,3), V2=ch(4,5)
+    VLD3.P 48(R6), [V3.D2, V4.D2, V5.D2]     // frames 2,3
+    WORD $0x4E831810           // UZP1 V16.4S, V0.4S, V3.4S  (s0)
+    WORD $0x4E835811           // UZP2 V17.4S, V0.4S, V3.4S  (s1)
+    WORD $0x4E841832           // UZP1 V18.4S, V1.4S, V4.4S  (s2)
+    WORD $0x4E845833           // UZP2 V19.4S, V1.4S, V4.4S  (s3)
+    WORD $0x4E851854           // UZP1 V20.4S, V2.4S, V5.4S  (s4)
+    WORD $0x4E855855           // UZP2 V21.4S, V2.4S, V5.4S  (s5)
+    VST1.P [V16.S4], 16(R0)
+    VST1.P [V17.S4], 16(R1)
+    VST1.P [V18.S4], 16(R2)
+    VST1.P [V19.S4], 16(R3)
+    VST1.P [V20.S4], 16(R4)
+    VST1.P [V21.S4], 16(R5)
+    SUB $1, R8
+    CBNZ R8, deinterleave6_neon_loop4
+
+deinterleave6_neon_tail:
+    AND $3, R7
+    CBZ R7, deinterleave6_neon_done
+
+deinterleave6_neon_tail1:
+    FMOVS (R6), F0
+    FMOVS 4(R6), F1
+    FMOVS 8(R6), F2
+    FMOVS 12(R6), F3
+    FMOVS 16(R6), F4
+    FMOVS 20(R6), F5
+    FMOVS F0, (R0)
+    FMOVS F1, (R1)
+    FMOVS F2, (R2)
+    FMOVS F3, (R3)
+    FMOVS F4, (R4)
+    FMOVS F5, (R5)
+    ADD $24, R6
+    ADD $4, R0
+    ADD $4, R1
+    ADD $4, R2
+    ADD $4, R3
+    ADD $4, R4
+    ADD $4, R5
+    SUB $1, R7
+    CBNZ R7, deinterleave6_neon_tail1
+
+deinterleave6_neon_done:
+    RET
+
+// func interleave8NEON(dst, s0, s1, s2, s3, s4, s5, s6, s7 []float32, n int)
+TEXT ·interleave8NEON(SB), NOSPLIT, $0-224
+    MOVD dst_base+0(FP), R0
+    MOVD s0_base+24(FP), R1
+    MOVD s1_base+48(FP), R2
+    MOVD s2_base+72(FP), R3
+    MOVD s3_base+96(FP), R4
+    MOVD s4_base+120(FP), R5
+    MOVD s5_base+144(FP), R6
+    MOVD s6_base+168(FP), R7
+    MOVD s7_base+192(FP), R8
+    MOVD n+216(FP), R9
+
+    LSR $2, R9, R10            // 4 frames per iteration
+    CBZ R10, interleave8_neon_tail
+
+interleave8_neon_loop4:
+    VLD1.P 16(R1), [V0.S4]
+    VLD1.P 16(R2), [V1.S4]
+    VLD1.P 16(R3), [V2.S4]
+    VLD1.P 16(R4), [V3.S4]
+    VLD1.P 16(R5), [V4.S4]
+    VLD1.P 16(R6), [V5.S4]
+    VLD1.P 16(R7), [V6.S4]
+    VLD1.P 16(R8), [V7.S4]
+    WORD $0x4E813808           // ZIP1 V8.4S, V0.4S, V1.4S   (frames 0,1 ch 0,1)
+    WORD $0x4E833849           // ZIP1 V9.4S, V2.4S, V3.4S   (frames 0,1 ch 2,3)
+    WORD $0x4E85388A           // ZIP1 V10.4S, V4.4S, V5.4S  (frames 0,1 ch 4,5)
+    WORD $0x4E8738CB           // ZIP1 V11.4S, V6.4S, V7.4S  (frames 0,1 ch 6,7)
+    WORD $0x4E81780C           // ZIP2 V12.4S, V0.4S, V1.4S  (frames 2,3 ch 0,1)
+    WORD $0x4E83784D           // ZIP2 V13.4S, V2.4S, V3.4S  (frames 2,3 ch 2,3)
+    WORD $0x4E85788E           // ZIP2 V14.4S, V4.4S, V5.4S  (frames 2,3 ch 4,5)
+    WORD $0x4E8778CF           // ZIP2 V15.4S, V6.4S, V7.4S  (frames 2,3 ch 6,7)
+    VST4.P [V8.D2, V9.D2, V10.D2, V11.D2], 64(R0)     // frames 0,1
+    VST4.P [V12.D2, V13.D2, V14.D2, V15.D2], 64(R0)   // frames 2,3
+    SUB $1, R10
+    CBNZ R10, interleave8_neon_loop4
+
+interleave8_neon_tail:
+    AND $3, R9
+    CBZ R9, interleave8_neon_done
+
+interleave8_neon_tail1:
+    FMOVS (R1), F0
+    FMOVS (R2), F1
+    FMOVS (R3), F2
+    FMOVS (R4), F3
+    FMOVS (R5), F4
+    FMOVS (R6), F5
+    FMOVS (R7), F6
+    FMOVS (R8), F7
+    FMOVS F0, (R0)
+    FMOVS F1, 4(R0)
+    FMOVS F2, 8(R0)
+    FMOVS F3, 12(R0)
+    FMOVS F4, 16(R0)
+    FMOVS F5, 20(R0)
+    FMOVS F6, 24(R0)
+    FMOVS F7, 28(R0)
+    ADD $4, R1
+    ADD $4, R2
+    ADD $4, R3
+    ADD $4, R4
+    ADD $4, R5
+    ADD $4, R6
+    ADD $4, R7
+    ADD $4, R8
+    ADD $32, R0
+    SUB $1, R9
+    CBNZ R9, interleave8_neon_tail1
+
+interleave8_neon_done:
+    RET
+
+// func deinterleave8NEON(d0, d1, d2, d3, d4, d5, d6, d7, src []float32, n int)
+TEXT ·deinterleave8NEON(SB), NOSPLIT, $0-224
+    MOVD d0_base+0(FP), R0
+    MOVD d1_base+24(FP), R1
+    MOVD d2_base+48(FP), R2
+    MOVD d3_base+72(FP), R3
+    MOVD d4_base+96(FP), R4
+    MOVD d5_base+120(FP), R5
+    MOVD d6_base+144(FP), R6
+    MOVD d7_base+168(FP), R7
+    MOVD src_base+192(FP), R8
+    MOVD n+216(FP), R9
+
+    LSR $2, R9, R10            // 4 frames per iteration
+    CBZ R10, deinterleave8_neon_tail
+
+deinterleave8_neon_loop4:
+    VLD4.P 64(R8), [V0.D2, V1.D2, V2.D2, V3.D2]   // frames 0,1: ch(0,1),(2,3),(4,5),(6,7)
+    VLD4.P 64(R8), [V4.D2, V5.D2, V6.D2, V7.D2]   // frames 2,3
+    WORD $0x4E841810           // UZP1 V16.4S, V0.4S, V4.4S  (s0)
+    WORD $0x4E845811           // UZP2 V17.4S, V0.4S, V4.4S  (s1)
+    WORD $0x4E851832           // UZP1 V18.4S, V1.4S, V5.4S  (s2)
+    WORD $0x4E855833           // UZP2 V19.4S, V1.4S, V5.4S  (s3)
+    WORD $0x4E861854           // UZP1 V20.4S, V2.4S, V6.4S  (s4)
+    WORD $0x4E865855           // UZP2 V21.4S, V2.4S, V6.4S  (s5)
+    WORD $0x4E871876           // UZP1 V22.4S, V3.4S, V7.4S  (s6)
+    WORD $0x4E875877           // UZP2 V23.4S, V3.4S, V7.4S  (s7)
+    VST1.P [V16.S4], 16(R0)
+    VST1.P [V17.S4], 16(R1)
+    VST1.P [V18.S4], 16(R2)
+    VST1.P [V19.S4], 16(R3)
+    VST1.P [V20.S4], 16(R4)
+    VST1.P [V21.S4], 16(R5)
+    VST1.P [V22.S4], 16(R6)
+    VST1.P [V23.S4], 16(R7)
+    SUB $1, R10
+    CBNZ R10, deinterleave8_neon_loop4
+
+deinterleave8_neon_tail:
+    AND $3, R9
+    CBZ R9, deinterleave8_neon_done
+
+deinterleave8_neon_tail1:
+    FMOVS (R8), F0
+    FMOVS 4(R8), F1
+    FMOVS 8(R8), F2
+    FMOVS 12(R8), F3
+    FMOVS 16(R8), F4
+    FMOVS 20(R8), F5
+    FMOVS 24(R8), F6
+    FMOVS 28(R8), F7
+    FMOVS F0, (R0)
+    FMOVS F1, (R1)
+    FMOVS F2, (R2)
+    FMOVS F3, (R3)
+    FMOVS F4, (R4)
+    FMOVS F5, (R5)
+    FMOVS F6, (R6)
+    FMOVS F7, (R7)
+    ADD $32, R8
+    ADD $4, R0
+    ADD $4, R1
+    ADD $4, R2
+    ADD $4, R3
+    ADD $4, R4
+    ADD $4, R5
+    ADD $4, R6
+    ADD $4, R7
+    SUB $1, R9
+    CBNZ R9, deinterleave8_neon_tail1
+
+deinterleave8_neon_done:
+    RET

--- a/f32/interleave68_arm64_test.go
+++ b/f32/interleave68_arm64_test.go
@@ -1,0 +1,103 @@
+//go:build arm64
+
+package f32
+
+import "testing"
+
+// buildStreams returns nc planar streams of length n, each value unique to its
+// (channel, frame) via chanVal so a misplaced lane is always caught.
+func buildStreams(nc, n int) [][]float32 {
+	srcs := make([][]float32, nc)
+	for c := range srcs {
+		srcs[c] = make([]float32, n)
+		for i := range srcs[c] {
+			srcs[c][i] = chanVal(c, i)
+		}
+	}
+	return srcs
+}
+
+// TestInterleave68NEONKernels calls the N=6 and N=8 NEON kernels directly
+// (bypassing the dispatch threshold) and checks interleave against the scalar
+// oracle and the deinterleave round-trip, across the 4-frame main loop and every
+// frame remainder (n mod 4 = 0..3).
+func TestInterleave68NEONKernels(t *testing.T) {
+	if !hasNEON {
+		t.Skip("NEON required")
+	}
+	lengths := []int{4, 5, 6, 7, 8, 9, 11, 16, 17, 19, 64, 100, 255}
+	for _, n := range lengths {
+		// N=6 interleave vs oracle.
+		s6 := buildStreams(6, n)
+		got6 := make([]float32, n*6)
+		interleave6NEON(got6, s6[0], s6[1], s6[2], s6[3], s6[4], s6[5], n)
+		want6 := make([]float32, n*6)
+		interleaveNRef(want6, s6, n)
+		for i := range want6 {
+			if got6[i] != want6[i] {
+				t.Fatalf("interleave6NEON n=%d i=%d got %v want %v", n, i, got6[i], want6[i])
+			}
+		}
+		// N=6 deinterleave round-trip.
+		back6 := make([][]float32, 6)
+		for c := range back6 {
+			back6[c] = make([]float32, n)
+		}
+		deinterleave6NEON(back6[0], back6[1], back6[2], back6[3], back6[4], back6[5], got6, n)
+		for c := range back6 {
+			for i := range n {
+				if back6[c][i] != s6[c][i] {
+					t.Fatalf("deinterleave6NEON n=%d c=%d i=%d got %v want %v", n, c, i, back6[c][i], s6[c][i])
+				}
+			}
+		}
+
+		// N=8 interleave vs oracle.
+		s8 := buildStreams(8, n)
+		got8 := make([]float32, n*8)
+		interleave8NEON(got8, s8[0], s8[1], s8[2], s8[3], s8[4], s8[5], s8[6], s8[7], n)
+		want8 := make([]float32, n*8)
+		interleaveNRef(want8, s8, n)
+		for i := range want8 {
+			if got8[i] != want8[i] {
+				t.Fatalf("interleave8NEON n=%d i=%d got %v want %v", n, i, got8[i], want8[i])
+			}
+		}
+		// N=8 deinterleave round-trip.
+		back8 := make([][]float32, 8)
+		for c := range back8 {
+			back8[c] = make([]float32, n)
+		}
+		deinterleave8NEON(back8[0], back8[1], back8[2], back8[3], back8[4], back8[5], back8[6], back8[7], got8, n)
+		for c := range back8 {
+			for i := range n {
+				if back8[c][i] != s8[c][i] {
+					t.Fatalf("deinterleave8NEON n=%d c=%d i=%d got %v want %v", n, c, i, back8[c][i], s8[c][i])
+				}
+			}
+		}
+	}
+}
+
+// TestInterleave68AllocFreeARM64 confirms the N=6/N=8 public dispatch stays
+// allocation-free through the NEON kernels.
+func TestInterleave68AllocFreeARM64(t *testing.T) {
+	if !hasNEON {
+		t.Skip("NEON required")
+	}
+	const n = 256
+	for _, nc := range []int{6, 8} {
+		srcs := buildStreams(nc, n)
+		dst := make([]float32, n*nc)
+		if a := testing.AllocsPerRun(50, func() { InterleaveN(dst, srcs) }); a != 0 {
+			t.Errorf("InterleaveN N=%d allocated %v times per run, want 0", nc, a)
+		}
+		outs := make([][]float32, nc)
+		for c := range outs {
+			outs[c] = make([]float32, n)
+		}
+		if a := testing.AllocsPerRun(50, func() { DeinterleaveN(outs, dst) }); a != 0 {
+			t.Errorf("DeinterleaveN N=%d allocated %v times per run, want 0", nc, a)
+		}
+	}
+}


### PR DESCRIPTION
Closes #103.

## What

AMD64 covered N=2,3,4,6,8 for f32 `InterleaveN`/`DeinterleaveN`, but ARM64 NEON only covered N=2,3,4; N>=5 fell back to the generic Go path. This adds N=6 (5.1 audio) and N=8 (7.1 audio) NEON kernels.

**The pair trick**: ZIP adjacent channel pairs at `.4S` so each 64-bit lane holds a `[cA_i, cB_i]` frame pair, then `ST3`/`ST4` with `.2D` arrangement lays the pairs down in frame order. Deinterleave is the inverse: `LD3`/`LD4` `.2D` then `UZP1`/`UZP2` to separate the paired channels. Four frames per iteration, then a scalar tail.

Dispatch in `interleaveN32`/`deinterleaveN32` gains N=6/N=8 cases that run the multiple-of-4-frames prefix in the kernel and delegate the tail, exactly as N=3/N=4 do; sub-block-size inputs still use the generic Go path.

## Register safety

Every `WORD` encoding (ZIP/UZP) was generated with `aarch64-as` and passes the `arm64asm` cross-check (`TestArm64WordEncodings`). No reserved register is touched (`TestNoGoroutineRegisterClobber` green). The `.2D` structured `ST3`/`ST4`/`LD3`/`LD4` use native Go assembler mnemonics.

## Profiling gate (Raspberry Pi 5, 1024 frames, NEON vs generic Go)

| op | N | NEON | Go | speedup |
| --- | --- | --- | --- | --- |
| InterleaveN   | 6 | 1192 ns | 5196 ns | **4.4x** |
| InterleaveN   | 8 | 1516 ns | 6923 ns | **4.6x** |
| DeinterleaveN | 6 | 1192 ns | 5191 ns | **4.4x** |
| DeinterleaveN | 8 | 2012 ns | 6919 ns | **3.4x** |

The kernels win decisively in both directions, so they are kept.

## Tests

- The existing `interleave_n_test.go` matrix already exercises N=6/N=8 against an independent scalar oracle (stream counts include 6 and 8 across many frame counts including remainders).
- A new kernel-direct arm64 test calls the four kernels directly across the 4-frame main loop and every frame remainder (n mod 4 = 0..3), checks interleave against the oracle and the deinterleave round-trip, and asserts the public dispatch stays allocation-free.

## Verification

- arm64 (Raspberry Pi 5, NEON): kernel-direct test, the full dispatch matrix, round-trip, and alloc-free assertions all green; full f32 suite green.
- amd64: `go test ./...`, `go vet`, `golangci-lint`, asmcheck all clean (the kernels are arm64-only; amd64 paths unchanged).
- Cross-arch builds for linux/arm64, darwin/arm64, linux/riscv64, js/wasm, windows/amd64 all OK.

README audio interleave note updated from N=2,3,4 to N=2,3,4,6,8 NEON.