### PR TITLE
cpu: SIMD_DISABLE=avx now also masks F16C

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,7 +100,7 @@ program start. Each token clears its own flag plus everything that depends on it
 | ----------- | ----------------------------------------- |
 | `avx512`    | AVX512F, AVX512VL                         |
 | `avx2`      | AVX2 (and the `avx512` set)               |
-| `avx`       | AVX, FMA (and the `avx2` set)             |
+| `avx`       | AVX, FMA, F16C (and the `avx2` set)       |
 | `fma`       | FMA only                                  |
 | `sse42`     | SSE42 (and the `avx` set)                 |
 | `sse41`     | SSE41 (and the `sse42` set)               |
@@ -112,6 +112,10 @@ program start. Each token clears its own flag plus everything that depends on it
 | `sve`       | SVE, SVE2                                 |
 | `pmull`     | PMULL only                                |
 | `all`       | every flag (forces the pure-Go path)      |
+
+F16C is VEX-encoded and only detected alongside AVX, so it clears with the `avx`
+cascade (and therefore with every `sse*` token and `all`); `avx2`, `fma`, and
+`avx512` sit above AVX and leave F16C set.
 
 Unknown tokens are ignored (the library never panics or writes to stderr on env
 input). `cpu.Info()` reflects the cleared flags.

--- a/cpu/cpu.go
+++ b/cpu/cpu.go
@@ -155,6 +155,10 @@ func clearAVX2(f *Features) {
 func clearAVX(f *Features) {
 	f.AVX = false
 	f.FMA = false
+	// F16C is VEX-encoded and only detected when AVX is present, so disabling the
+	// AVX family must also drop the F16C conversion path back to pure Go. avx2/fma/
+	// avx512 sit above AVX and do not cascade here, so they correctly leave it set.
+	f.F16C = false
 	clearAVX2(f)
 }
 

--- a/cpu/cpu.go
+++ b/cpu/cpu.go
@@ -156,8 +156,9 @@ func clearAVX(f *Features) {
 	f.AVX = false
 	f.FMA = false
 	// F16C is VEX-encoded and only detected when AVX is present, so disabling the
-	// AVX family must also drop the F16C conversion path back to pure Go. avx2/fma/
-	// avx512 sit above AVX and do not cascade here, so they correctly leave it set.
+	// AVX family must also drop the F16C conversion path back to pure Go.
+	// avx2, fma, and avx512 sit above AVX and do not cascade here, so they
+	// correctly leave it set.
 	f.F16C = false
 	clearAVX2(f)
 }

--- a/cpu/disable_test.go
+++ b/cpu/disable_test.go
@@ -46,12 +46,15 @@ func TestApplyDisable(t *testing.T) {
 		{"", nil},
 		{"avx512", []string{"AVX512F", "AVX512VL"}},
 		{"avx2", []string{"AVX2", "AVX512F", "AVX512VL"}},
-		{"avx", []string{"AVX", "AVX2", "AVX512F", "AVX512VL", "FMA"}},
+		// F16C is VEX-encoded and gated on AVX, so the avx cascade (and every SSE
+		// token that cascades through clearAVX) must also clear F16C. avx2/fma/avx512
+		// sit above AVX and correctly leave it set.
+		{"avx", []string{"AVX", "AVX2", "AVX512F", "AVX512VL", "F16C", "FMA"}},
 		{"fma", []string{"FMA"}},
-		{"sse42", []string{"AVX", "AVX2", "AVX512F", "AVX512VL", "FMA", "SSE42"}},
-		{"sse41", []string{"AVX", "AVX2", "AVX512F", "AVX512VL", "FMA", "SSE41", "SSE42"}},
-		{"ssse3", []string{"AVX", "AVX2", "AVX512F", "AVX512VL", "FMA", "SSE41", "SSE42", "SSSE3"}},
-		{"sse3", []string{"AVX", "AVX2", "AVX512F", "AVX512VL", "FMA", "SSE3", "SSE41", "SSE42", "SSSE3"}},
+		{"sse42", []string{"AVX", "AVX2", "AVX512F", "AVX512VL", "F16C", "FMA", "SSE42"}},
+		{"sse41", []string{"AVX", "AVX2", "AVX512F", "AVX512VL", "F16C", "FMA", "SSE41", "SSE42"}},
+		{"ssse3", []string{"AVX", "AVX2", "AVX512F", "AVX512VL", "F16C", "FMA", "SSE41", "SSE42", "SSSE3"}},
+		{"sse3", []string{"AVX", "AVX2", "AVX512F", "AVX512VL", "F16C", "FMA", "SSE3", "SSE41", "SSE42", "SSSE3"}},
 		{"pclmulqdq", []string{"PCLMULQDQ"}},
 		{"neon", []string{"FP16", "NEON", "PMULL", "SVE", "SVE2"}},
 		{"fp16", []string{"FP16"}},


### PR DESCRIPTION
## Summary

Follow-up from #110 (F16C) interacting with #99 (`SIMD_DISABLE`). Fixes #114.

`X86.F16C` is detected as `X86.AVX && (CPUID leaf 1 ECX bit 29)` and gated on AVX because F16C is VEX-encoded and needs AVX/YMM OS support. Before this change, `SIMD_DISABLE=avx` cleared `AVX`/`AVX2`/`FMA`/`AVX512*` but left `F16C` set, so `cpu.HasF16C()` stayed true and the `f16` package kept using the VEX-encoded `VCVTPH2PS`/`VCVTPS2PH` conversions. Not a crash (the hardware still supports the instructions), but inconsistent: disabling the AVX family should drop the F16C path back to pure Go too.

## Change

- `cpu/cpu.go`: add `f.F16C = false` to `clearAVX`. Because the cascade is `clearSSE3 → clearSSSE3 → clearSSE41 → clearSSE42 → clearAVX → clearAVX2 → clearAVX512`, the `avx`, `sse42`, `sse41`, `ssse3`, `sse3`, and `all` tokens now clear F16C, while `avx2`, `fma`, and `avx512` (which do not route through `clearAVX`) correctly leave it set.
- `cpu/disable_test.go`: updated `TestApplyDisable` expectations for the avx/sse* cases. `TestApplyDisableAll` already covered the `all` case.
- `README.md`: updated the `SIMD_DISABLE` token table (`avx` row) and added a note explaining the F16C cascade.

## Verification

```
go test ./cpu/ -count=1   # ok
go vet ./cpu/             # clean
golangci-lint run ./cpu/...  # 0 issues
```