### PR TITLE
docs: per-package amd64 tiers, SVE-detected-but-unused, scope notes

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,10 +9,10 @@ A high-performance SIMD (Single Instruction, Multiple Data) library for Go provi
 ## Features
 
 - **Pure Go assembly** - Native Go assembler, simple cross-compilation
-- **Runtime CPU detection** - Automatically selects optimal implementation (AVX-512, AVX+FMA, AVX without FMA, SSE4.1, NEON, NEON+FP16, or pure Go)
+- **Runtime CPU detection** - Automatically selects optimal implementation (AVX-512, AVX+FMA, AVX without FMA, SSE2, NEON, NEON+FP16, or pure Go); the minimum amd64 SIMD tier is per-package (see [Architecture Support](#architecture-support))
 - **Zero allocations** - All operations work on pre-allocated slices
 - **80+ operations** - Arithmetic, reduction, statistical, vector, signal processing, activation functions, and complex number operations
-- **Multi-architecture** - AMD64 (AVX-512/AVX+FMA/SSE4.1) and ARM64 (NEON/NEON+FP16) with pure Go fallback
+- **Multi-architecture** - AMD64 (AVX-512/AVX+FMA/SSE2, c64 needs SSE4.1) and ARM64 (NEON/NEON+FP16) with pure Go fallback
 - **Half-precision support** - Native FP16 SIMD on ARM64 with FP16 extension (Apple Silicon, Cortex-A55+); F16C-accelerated conversions on AMD64
 - **Tunable dispatch** - `SIMD_DISABLE` env var masks feature tiers at startup (avoid AVX-512 downclocking, exercise lower tiers, benchmark tier-vs-tier)
 - **Thread-safe** - All functions are safe for concurrent use
@@ -75,6 +75,7 @@ func main() {
 import "github.com/tphakala/simd/cpu"
 
 fmt.Println(cpu.Info())        // "AMD64 AVX-512", "AMD64 AVX+FMA", "AMD64 AVX", "AMD64 SSE2", "AMD64 (scalar)", "ARM64 NEON+FP16", or "ARM64 NEON"
+                               // SVE-capable ARM64 hosts append " (SVE detected, unused)" - the library runs the NEON path
 fmt.Println(cpu.HasAVX())      // true/false
 fmt.Println(cpu.HasAVX2())     // true/false
 fmt.Println(cpu.HasFMA())      // true/false
@@ -142,6 +143,11 @@ sum := crc.Checksum16(p) // bit-identical to the scalar reference, zero-alloc
 
 ### `f64` - float64 Operations
 
+**Scope:** `f64` carries the FLAC/LPC and scientific double-precision surface,
+including `Autocorrelate` (lag-vectorized LPC autocorrelation). Audio/ML-specific
+helpers (PCM conversions, split-format complex ops, indexed/strided dot products)
+live in `f32` instead, so the two float surfaces are intentionally asymmetric.
+
 | Category        | Function                            | Description                   | SIMD Width                          |
 | --------------- | ----------------------------------- | ----------------------------- | ----------------------------------- |
 | **Arithmetic**  | `Add(dst, a, b)`                    | Element-wise addition         | 8x (AVX-512) / 4x (AVX) / 2x (NEON) |
@@ -205,7 +211,12 @@ non-AVX2/NEON CPUs and short blocks use the scalar reference.
 
 ### `f32` - float32 Operations
 
-Same API as `f64` but for `float32` with wider SIMD:
+Same API as `f64` but for `float32` with wider SIMD.
+
+**Scope:** `f32` carries the audio/FFT/ML surface on top of the shared arithmetic
+API: PCM sample-format conversions, split-format complex operations, and the
+indexed/strided dot products (`DotProductIndexed`, `DotProductStrided`) used by
+streaming DSP. These are f32-specific and have no f64 equivalent by design.
 
 | Architecture    | SIMD Width  |
 | --------------- | ----------- |
@@ -367,7 +378,12 @@ f16.ReLU(dst, a)             // Activation functions
 
 ### `c128` - complex128 Operations
 
-SIMD-accelerated complex number operations for FFT-based signal processing:
+SIMD-accelerated complex number operations for FFT-based signal processing.
+
+**Scope:** `c64`/`c128` are deliberately small, FFT-pipeline helper sets (multiply,
+conjugate-multiply, dot/Hermitian products, scale, add/sub, abs/absSq, conj). They
+are not a general complex-arithmetic surface; operations outside the FFT pipeline
+are intentionally absent.
 
 | Category       | Function             | Description                        | SIMD Width              |
 | -------------- | -------------------- | ---------------------------------- | ----------------------- |
@@ -422,7 +438,10 @@ c128.Abs(magnitude, signalFFT)                  // Extract magnitude for display
 
 ### `c64` - complex64 Operations
 
-SIMD-accelerated single-precision complex number operations:
+SIMD-accelerated single-precision complex number operations. Like `c128`, this is
+a deliberately small FFT-pipeline helper set (see the `c128` scope note). On amd64
+the SIMD floor is SSE4.1 (the "SSE2" routines use `BLENDPS`), one tier above the
+other float packages.
 
 | Category       | Function             | Description                        | SIMD Width                        |
 | -------------- | -------------------- | ---------------------------------- | --------------------------------- |
@@ -506,6 +525,10 @@ Interleaving is pure 32-bit-lane movement, so those kernels reuse the proven `f3
 ### `i16` - int16 Operations
 
 The 16-bit integer counterpart to `i32`, for raw-PCM hot loops (such as a pure-Go FLAC codec) where the source samples are 16-bit and the cheapest place to vectorize is the channel (de)interleaving that happens before samples are widened to int32. FLAC decorrelation widens samples (the side and mid channels can exceed the source bit depth by one bit), so the arithmetic primitives live in `i32`; this package carries only the operations that provably help at 16-bit width:
+
+**Scope:** `i16` is deliberately movement-only (interleave/deinterleave). There are
+no int16 arithmetic primitives on purpose: widen to `i32` and use its arithmetic
+surface, because 16-bit arithmetic overflows as soon as channels are decorrelated.
 
 | Category       | Function                   | Description                                | SIMD Width                         |
 | -------------- | -------------------------- | ------------------------------------------ | ---------------------------------- |
@@ -767,18 +790,48 @@ The Go fallback for small slices is intentional and likely optimal - SIMD setup 
 
 ## Architecture Support
 
+The library selects the best available kernel at runtime and falls back to pure
+Go when no SIMD path applies. The amd64 baseline is not uniform across packages:
+each package only ships the kernels its workload needs, so the **minimum amd64
+instruction-set tier that activates SIMD differs per package** (verified against
+each package's `*_amd64.go` dispatch):
+
+| Package | amd64 minimum SIMD tier | Higher amd64 tiers used | Below the minimum |
+| ------- | ----------------------- | ----------------------- | ----------------- |
+| `f32`   | SSE2                    | AVX+FMA, AVX-512        | pure Go (baseline guarantees SSE2 on amd64) |
+| `f64`   | SSE2                    | AVX (no FMA), AVX+FMA, AVX-512 | pure Go (baseline guarantees SSE2) |
+| `c128`  | SSE2                    | AVX (no FMA), AVX+FMA, AVX-512 | pure Go (baseline guarantees SSE2) |
+| `c64`   | SSE4.1 (BLENDPS)        | AVX+FMA, AVX-512        | pure Go |
+| `i16`   | SSE2                    | AVX2                    | pure Go (baseline guarantees SSE2) |
+| `i32`   | AVX (interleave), AVX2 (arithmetic) | -           | pure Go |
+| `f16`   | F16C (slice conversions only) | -                 | pure Go (all f16 compute is pure Go on amd64) |
+| `crc`   | PCLMULQDQ               | -                       | scalar slice-by-16 |
+
+SSE2 is part of the amd64 baseline, so `f32`/`f64`/`c128`/`i16` always run SIMD on
+amd64 (their pure-Go path is effectively a non-amd64 safety net). AVX-512 uses the
+`AVX512F && AVX512VL` gate. `cpu.Info()` reports the host-wide tier (AVX-512 /
+AVX+FMA / AVX / SSE2 / scalar); a package whose minimum is above that tier (e.g.
+`i32` on an SSE-only host) runs pure Go even though `Info()` shows SSE2.
+
+ARM64 runs NEON kernels throughout, with an FP16 (FEAT_FP16) fast path in `f16`
+and FP16-widened variants elsewhere. **SVE/SVE2 is detected but unused:** there are
+no SVE kernels yet, so an SVE-capable host (Graviton 3, Neoverse V1) still runs the
+NEON path, and `cpu.Info()` annotates this as `ARM64 NEON+FP16 (SVE detected, unused)`.
+
+The f16 per-architecture summary:
+
 | Architecture | Instruction Set | f64/f32/c128/c64  | f16                    |
 | ------------ | --------------- | ----------------- | ---------------------- |
 | AMD64        | AVX-512         | Full SIMD support | F16C conversions       |
 | AMD64        | AVX + FMA       | Full SIMD support | F16C conversions       |
-| AMD64        | SSE4.1          | Full SIMD support | Pure Go fallback       |
+| AMD64        | SSE2/SSE4.1     | Full SIMD support | Pure Go fallback       |
 | ARM64        | NEON + FP16     | Full SIMD support | Full SIMD support      |
 | ARM64        | NEON only       | Full SIMD support | Pure Go fallback       |
 | Other        | -               | Pure Go fallback  | Pure Go fallback       |
 
 (AMD64 f16 "F16C conversions" = hardware `ToFloat32Slice`/`FromFloat32Slice`; all
-other f16 ops run the pure-Go reference. F16C needs AVX, so SSE4.1-only parts use
-pure Go.)
+other f16 ops run the pure-Go reference. F16C is VEX-encoded and needs AVX, so
+amd64 parts without AVX use pure Go for conversions too.)
 
 **ARM64 FP16 support by device:**
 

--- a/cpu/cpu_arm64.go
+++ b/cpu/cpu_arm64.go
@@ -19,25 +19,4 @@ func init() {
 	applyDisable(&ARM64, os.Getenv("SIMD_DISABLE"))
 }
 
-func cpuInfo() string {
-	// Report the tier the library actually runs (NEON), not SVE: there are no SVE
-	// kernels yet, so an SVE-capable host still executes the NEON path. SVE/SVE2 is
-	// annotated as detected-but-unused so the capability is still visible.
-	var base string
-	switch {
-	case ARM64.NEON && ARM64.FP16:
-		base = "ARM64 NEON+FP16"
-	case ARM64.NEON:
-		base = "ARM64 NEON"
-	default:
-		return "ARM64 (no SIMD)"
-	}
-	switch {
-	case ARM64.SVE2:
-		return base + " (SVE2 detected, unused)"
-	case ARM64.SVE:
-		return base + " (SVE detected, unused)"
-	default:
-		return base
-	}
-}
+// cpuInfo is shared with the darwin build; see cpu_arm64_info.go.

--- a/cpu/cpu_arm64.go
+++ b/cpu/cpu_arm64.go
@@ -20,16 +20,24 @@ func init() {
 }
 
 func cpuInfo() string {
+	// Report the tier the library actually runs (NEON), not SVE: there are no SVE
+	// kernels yet, so an SVE-capable host still executes the NEON path. SVE/SVE2 is
+	// annotated as detected-but-unused so the capability is still visible.
+	var base string
 	switch {
-	case ARM64.SVE2:
-		return "ARM64 SVE2"
-	case ARM64.SVE:
-		return "ARM64 SVE"
 	case ARM64.NEON && ARM64.FP16:
-		return "ARM64 NEON+FP16"
+		base = "ARM64 NEON+FP16"
 	case ARM64.NEON:
-		return "ARM64 NEON"
+		base = "ARM64 NEON"
 	default:
 		return "ARM64 (no SIMD)"
+	}
+	switch {
+	case ARM64.SVE2:
+		return base + " (SVE2 detected, unused)"
+	case ARM64.SVE:
+		return base + " (SVE detected, unused)"
+	default:
+		return base
 	}
 }

--- a/cpu/cpu_arm64_darwin.go
+++ b/cpu/cpu_arm64_darwin.go
@@ -23,25 +23,4 @@ func init() {
 	applyDisable(&ARM64, os.Getenv("SIMD_DISABLE"))
 }
 
-func cpuInfo() string {
-	// Report the tier the library actually runs (NEON), not SVE: there are no SVE
-	// kernels yet, so an SVE-capable host still executes the NEON path. SVE/SVE2 is
-	// annotated as detected-but-unused so the capability is still visible.
-	var base string
-	switch {
-	case ARM64.NEON && ARM64.FP16:
-		base = "ARM64 NEON+FP16"
-	case ARM64.NEON:
-		base = "ARM64 NEON"
-	default:
-		return "ARM64 (no SIMD)"
-	}
-	switch {
-	case ARM64.SVE2:
-		return base + " (SVE2 detected, unused)"
-	case ARM64.SVE:
-		return base + " (SVE detected, unused)"
-	default:
-		return base
-	}
-}
+// cpuInfo is shared with the Linux build; see cpu_arm64_info.go.

--- a/cpu/cpu_arm64_darwin.go
+++ b/cpu/cpu_arm64_darwin.go
@@ -24,16 +24,24 @@ func init() {
 }
 
 func cpuInfo() string {
+	// Report the tier the library actually runs (NEON), not SVE: there are no SVE
+	// kernels yet, so an SVE-capable host still executes the NEON path. SVE/SVE2 is
+	// annotated as detected-but-unused so the capability is still visible.
+	var base string
 	switch {
-	case ARM64.SVE2:
-		return "ARM64 SVE2"
-	case ARM64.SVE:
-		return "ARM64 SVE"
 	case ARM64.NEON && ARM64.FP16:
-		return "ARM64 NEON+FP16"
+		base = "ARM64 NEON+FP16"
 	case ARM64.NEON:
-		return "ARM64 NEON"
+		base = "ARM64 NEON"
 	default:
 		return "ARM64 (no SIMD)"
+	}
+	switch {
+	case ARM64.SVE2:
+		return base + " (SVE2 detected, unused)"
+	case ARM64.SVE:
+		return base + " (SVE detected, unused)"
+	default:
+		return base
 	}
 }

--- a/cpu/cpu_arm64_info.go
+++ b/cpu/cpu_arm64_info.go
@@ -1,0 +1,28 @@
+//go:build arm64
+
+package cpu
+
+// cpuInfo is shared by the Linux and darwin arm64 builds: the two files differ
+// only in their init() feature detection, but report the tier identically.
+func cpuInfo() string {
+	// Report the tier the library actually runs (NEON), not SVE: there are no SVE
+	// kernels yet, so an SVE-capable host still executes the NEON path. SVE/SVE2 is
+	// annotated as detected-but-unused so the capability is still visible.
+	var base string
+	switch {
+	case ARM64.NEON && ARM64.FP16:
+		base = "ARM64 NEON+FP16"
+	case ARM64.NEON:
+		base = "ARM64 NEON"
+	default:
+		return "ARM64 (no SIMD)"
+	}
+	switch {
+	case ARM64.SVE2:
+		return base + " (SVE2 detected, unused)"
+	case ARM64.SVE:
+		return base + " (SVE detected, unused)"
+	default:
+		return base
+	}
+}

--- a/cpu/cpu_arm64_test.go
+++ b/cpu/cpu_arm64_test.go
@@ -22,12 +22,15 @@ func TestCpuInfoAllBranches(t *testing.T) {
 	}()
 
 	tests := []struct {
-		name                 string
+		name                  string
 		neon, fp16, sve, sve2 bool
-		want                 string
+		want                  string
 	}{
-		{"SVE2", true, true, true, true, "ARM64 SVE2"},
-		{"SVE", true, true, true, false, "ARM64 SVE"},
+		// SVE/SVE2 is detected but unused: the library runs the NEON tier, so Info()
+		// reports the NEON base with a detected-but-unused annotation.
+		{"SVE2", true, true, true, true, "ARM64 NEON+FP16 (SVE2 detected, unused)"},
+		{"SVE", true, true, true, false, "ARM64 NEON+FP16 (SVE detected, unused)"},
+		{"SVE_no_FP16", true, false, true, false, "ARM64 NEON (SVE detected, unused)"},
 		{"NEON+FP16", true, true, false, false, "ARM64 NEON+FP16"},
 		{"NEON", true, false, false, false, "ARM64 NEON"},
 		{"no_SIMD", false, false, false, false, "ARM64 (no SIMD)"},

--- a/doc.go
+++ b/doc.go
@@ -4,19 +4,33 @@
 // numeric operations:
 //
 //   - [github.com/tphakala/simd/cpu] - CPU feature detection
-//   - [github.com/tphakala/simd/f64] - float64 SIMD operations
-//   - [github.com/tphakala/simd/f32] - float32 SIMD operations
+//   - [github.com/tphakala/simd/f64] - float64 SIMD operations (FLAC/LPC and scientific surface)
+//   - [github.com/tphakala/simd/f32] - float32 SIMD operations (audio/FFT/ML surface)
+//   - [github.com/tphakala/simd/f16] - float16 storage type (ARM64 NEON+FP16 compute; amd64 F16C slice conversions)
 //   - [github.com/tphakala/simd/i32] - int32 SIMD operations (integer DSP)
-//   - [github.com/tphakala/simd/c128] - complex128 SIMD operations
+//   - [github.com/tphakala/simd/i16] - int16 SIMD operations (movement only; widen to i32 for arithmetic)
+//   - [github.com/tphakala/simd/c64] - complex64 SIMD operations (FFT-pipeline helpers)
+//   - [github.com/tphakala/simd/c128] - complex128 SIMD operations (FFT-pipeline helpers)
 //   - [github.com/tphakala/simd/crc] - CRC checksums (carry-less-multiply folding)
 //
 // # Architecture Support
 //
-// The library automatically selects the optimal implementation at runtime:
+// The library automatically selects the optimal implementation at runtime. The
+// minimum amd64 instruction-set tier that activates SIMD differs per package
+// (each package only ships the kernels its workload needs):
 //
-//   - AMD64: AVX-512 (8x float64, 16x float32), AVX+FMA (4x float64, 8x float32), or SSE2 fallback
-//   - ARM64: NEON/ASIMD instructions (2x float64, 4x float32)
+//   - AMD64: AVX-512 (8x float64, 16x float32) > AVX+FMA (4x float64, 8x float32) >
+//     AVX (no FMA, f64/c128) > SSE2 (f32/f64/c128/i16) or SSE4.1 (c64) > pure Go.
+//     i32 needs AVX/AVX2, crc needs PCLMULQDQ, and f16 uses F16C for its slice
+//     conversions only (every other f16 op is pure Go on amd64). SSE2 is part of
+//     the amd64 baseline, so f32/f64/c128/i16 always get SIMD on amd64.
+//   - ARM64: NEON/ASIMD throughout (2x float64, 4x float32), with an FP16
+//     (FEAT_FP16) fast path in the f16 package. SVE/SVE2 is detected by cpu.Info()
+//     but no SVE kernels exist yet, so SVE hosts run the NEON path.
 //   - Other: Pure Go fallback
+//
+// f16 is a storage type: SIMD acceleration is ARM64-only for compute (NEON+FP16),
+// plus F16C-accelerated ToFloat32Slice/FromFloat32Slice conversions on amd64.
 //
 // # Disabling SIMD tiers
 //


### PR DESCRIPTION
## Summary

Fixes #105. Several documentation claims disagreed with each other or with the dispatch code. None of these change behavior, but they misled users evaluating the library. Every claim was verified against the relevant `*_amd64.go` / `*_arm64.go` dispatch before writing.

## Changes

**1. Per-package amd64 minimum-tier table (was a blanket SSE4.1/SSE2 claim).**
README:12/15 said the amd64 baseline is SSE4.1; `doc.go` said SSE2; `cpu.Info()` returns "AMD64 SSE2". The real minimum SIMD tier is per package:

| Package | amd64 minimum SIMD tier |
| ------- | ----------------------- |
| f32 / f64 / c128 / i16 | SSE2 (baseline) |
| c64 | SSE4.1 (BLENDPS) |
| i32 | AVX (interleave) / AVX2 (arithmetic) |
| f16 | F16C (slice conversions only) |
| crc | PCLMULQDQ |

Replaced the blanket claim with a per-package table in the README "Architecture Support" section and aligned the `doc.go` bullets.

**2. SVE detected but unused.** Both `cpuInfo()` switches (`cpu_arm64.go`, `cpu_arm64_darwin.go`) put SVE2/SVE first, so a Graviton 3 / Neoverse V1 host reported "ARM64 SVE2" while every kernel that runs is NEON. They now report the NEON tier the library actually uses, annotated `(SVE/SVE2 detected, unused)`, with a matching README note. Updated `TestCpuInfoAllBranches` and added an SVE-without-FP16 case.

**3. `doc.go` subpackage list** omitted f16, i16, c64; added all three (with one-line scope hints).

**4. Per-package scope notes** added to each README package section so the intentional API asymmetries (f32 audio/FFT/ML surface, f64 FLAC/LPC + scientific, i16 movement-only, c64/c128 FFT-pipeline helpers) no longer read as gaps.

## Verification

- `go build ./...`, `go vet ./...`, `gofmt` clean, `golangci-lint run ./cpu/...` → 0 issues.
- Cross-compiled and ran the cpu suite on a **Raspberry Pi 5** (Cortex-A76, NEON+FP16): `cpu.Info()` still reports `ARM64 NEON+FP16` and `TestCpuInfoAllBranches` passes (including the new SVE annotation cases). The Pi has no SVE, so no annotation appears there, as expected.

Note: the f16 row reflects the current state after #110 (F16C amd64 conversions), not the issue's pre-#110 "no amd64 kernels" wording.