### PR TITLE
ci: add native Linux arm64 test job (ubuntu-24.04-arm)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,7 +22,11 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-latest, macos-latest, windows-latest]
+        # ubuntu-24.04-arm is a native Linux arm64 runner (free for public repos).
+        # It exercises the linux/arm64 detection path (cpu_arm64.go), not the
+        # darwin override that macos-latest hits, and runs the objdump FP16 (.8H)
+        # cross-check natively. macos-latest still covers Apple Silicon.
+        os: [ubuntu-latest, macos-latest, windows-latest, ubuntu-24.04-arm]
         include:
           - os: ubuntu-latest
             coverage: true
@@ -41,7 +45,18 @@ jobs:
 
       - name: Install aarch64 binutils (FP16 .8H encoding cross-check)
         if: runner.os == 'Linux'
-        run: sudo apt-get update && sudo apt-get install -y binutils-aarch64-linux-gnu
+        run: |
+          sudo apt-get update
+          if [ "${{ runner.arch }}" = "ARM64" ]; then
+            # Native arm64 runner: plain binutils ships an aarch64-capable objdump.
+            # The asmcheck probe (objdumpCandidates) accepts the host `objdump` on
+            # linux/arm64, so the cross-binutils package is unnecessary here.
+            sudo apt-get install -y binutils
+          else
+            # amd64 runner: the cross package supplies aarch64-linux-gnu-objdump,
+            # the only aarch64-capable objdump on an x86 host.
+            sudo apt-get install -y binutils-aarch64-linux-gnu
+          fi
 
       - name: Run tests
         env:

--- a/cpu/cpu_test.go
+++ b/cpu/cpu_test.go
@@ -61,6 +61,10 @@ func TestInfo(t *testing.T) {
 	if info == "" {
 		t.Error("Info() returned empty string")
 	}
+	// Surface the selected tier in `go test -v` output so CI logs show which
+	// dispatch path each runner exercised (e.g. the native linux/arm64 leg
+	// reporting an ARM64 NEON configuration rather than the darwin override).
+	t.Logf("cpu.Info() = %q", info)
 }
 
 // TestCpuInfo tests the cpuInfo function directly


### PR DESCRIPTION
## Summary

Fixes #100. The test matrix covered arm64 only via `macos-latest` (Apple Silicon), which:

- exercises the darwin detection override (`cpu_arm64_darwin.go` hardcodes FP16/PMULL) instead of the linux/arm64 detection path in `cpu_arm64.go` that the Raspberry Pi regression hosts and most deployment targets actually run;
- skips the objdump cross-check of the WORD-encoded NEON instructions (binutils install and `SIMD_REQUIRE_OBJDUMP=1` were Linux-only).

GitHub's free `ubuntu-24.04-arm` runners let Linux arm64 run natively on every PR.

## Changes

- Add `ubuntu-24.04-arm` to the `test` matrix `os` list. It runs `-race` (supported on linux/arm64) and keeps `SIMD_REQUIRE_OBJDUMP=1`, so the FP16 `.8H` cross-check is **enforced, not skipped**.
- Branch the binutils install on `runner.arch`: install plain `binutils` on the arm64 leg (its native `objdump` is aarch64-capable, and `objdumpCandidates()` already accepts the host `objdump` on linux/arm64), and the cross package on amd64. Coverage upload stays on the amd64 leg only.
- `TestInfo` now logs `cpu.Info()` so `go test -v` surfaces which tier each runner exercised.

Note: item 3 of the issue (extend the objdump probe to accept plain `objdump` on arm64) was already implemented in `internal/asmencoding/objdump.go` (`objdumpCandidates` appends `objdump` when `GOOS==linux && GOARCH==arm64`), so no probe change was needed.

## Verification

Replicated the new CI leg on a native linux/arm64 host (Raspberry Pi 5, Cortex-A76) by syncing the working tree and running `go test`:

```
SIMD_REQUIRE_OBJDUMP=1 go test ./...   # all 11 packages ok
# TestArm64WordEncodings passes via the host objdump (.8H cross-check enforced)
# cpu.Info() = "ARM64 NEON+FP16"  (linux detection path, not the darwin override)
```

`-race` works on GitHub's `ubuntu-24.04-arm` runners (48-bit VMA kernel). It cannot run on this particular Pi 5 (47-bit VMA, a host kernel quirk: "ThreadSanitizer: unsupported VMA range"), which is unrelated to the CI runner, so it is kept as the issue specifies.