### PR TITLE
f64: add fused real-input STFT primitive (STFTPlan)

### DIFF
--- a/README.md
+++ b/README.md
@@ -203,6 +203,36 @@ order of the scalar loop and every build emits byte-identical results to the pur
 reference. The AVX2 path accumulates four lags per YMM, NEON two lags per V register;
 non-AVX2/NEON CPUs and short blocks use the scalar reference.
 
+#### STFT (fused real-input short-time Fourier transform)
+
+`STFTPlan` is the spectral front-end's missing middle: the library already covers
+the post-FFT power spectrum (`c128.AbsSq`), mel projection (`DotProductBatch`),
+and PCEN / log-mel normalization (`Exp`, `Mul`, `Log`), but not the transform.
+
+```go
+plan, _ := f64.NewSTFTPlan(1024)         // power-of-two nfft; reuse across calls
+bins := plan.NumBins()                   // nfft/2 + 1 (Hermitian half-spectrum)
+
+spec := make([][]complex128, nFrames)    // caller-owned output, one row per frame
+for i := range spec { spec[i] = make([]complex128, bins) }
+n := plan.STFT(spec, signal, hann, hop)  // returns frames written
+
+// Or skip the complex bins and get |X|^2 directly:
+power := make([][]float64, nFrames)
+for i := range power { power[i] = make([]float64, bins) }
+plan.STFTPower(power, signal, hann, hop)
+```
+
+The transform uses a half-length complex FFT (rfft, ~2x cheaper than a full
+complex FFT), keeps the twiddle/bit-reversal plan resident, and fuses the window
+multiply into the frame pack (and the `|.|^2` power step in `STFTPower`). Frames
+follow the no-padding convention (frame `f` is `signal[f*hop : f*hop+nfft]`,
+matching librosa `stft(..., center=False)`; pre-pad for centered frames). The
+plan is allocation-free across calls; a plan holds transform scratch, so use one
+plan per goroutine. This first cut is a correct scalar radix-2 transform
+(power-of-two `nfft`); vectorizing the inner butterfly is a profile-gated
+follow-up.
+
 ### `f32` - float32 Operations
 
 Same API as `f64` but for `float32` with wider SIMD:

--- a/doc.go
+++ b/doc.go
@@ -65,6 +65,8 @@
 //
 // Audio DSP: Interleave2, Deinterleave2, ConvolveValid, ConvolveValidMulti, ConvolveDecimate, AccumulateAdd, CumulativeSum, CubicInterpDot, Int32ToFloat32Scale, Int16ToFloat32Scale, Float32ToInt16Scale
 //
+// Spectral (f64): STFTPlan (NewSTFTPlan, STFT, STFTPower) - fused real-input short-time Fourier transform
+//
 // Integer DSP (i32): Interleave2, Deinterleave2, Add, Sub, MidSideEncode, MidSideDecode, Diff1..Diff4, Restore1..Restore4, LPCResidualEncode, LPCRestore, RiceSums, RiceBestParam
 //
 // Complex (c64/c128): Add, Sub, Mul, MulConj, DotProduct, DotProductConj, Conj, Abs, AbsSq, Scale

--- a/f64/stft.go
+++ b/f64/stft.go
@@ -1,0 +1,259 @@
+package f64
+
+import (
+	"errors"
+	"math"
+)
+
+// This file implements a fused, real-input Short-Time Fourier Transform. The
+// transform is the missing middle of a spectral feature pipeline: the library
+// already covers windowing inputs, the post-FFT power spectrum (c128.AbsSq), mel
+// projection (DotProductBatch), and PCEN/log-mel normalization (Exp/Mul/Log),
+// but not the FFT itself.
+//
+// Design (matches the rest of the library's batched primitives such as
+// DotProductBatch / ConvolveValidMulti):
+//
+//   - Real input via a half-length complex FFT (rfft): an N-point real transform
+//     is computed as an N/2-point complex FFT plus an O(N) unravel, ~2x cheaper
+//     than a full complex FFT and producing the Hermitian half-spectrum
+//     (N/2+1 bins) that librosa/scipy return.
+//   - Batched framing: one call emits every hop-spaced frame, with the twiddle
+//     tables and bit-reversal plan resident in the STFTPlan, so there is no
+//     per-frame setup or dispatch.
+//   - Fused window + (optional) power: the analysis window is applied while the
+//     frame is packed into the FFT input, and STFTPower emits |X|^2 directly
+//     without materializing the complex bins.
+//
+// This first cut is a correct scalar radix-2 transform (power-of-two nfft only);
+// vectorizing the inner butterfly is a separate, profile-gated change. See #108.
+
+// ErrSTFT* describe invalid STFTPlan configurations.
+var (
+	// ErrNotPowerOfTwo is returned when nfft is not a power of two >= 2.
+	ErrNotPowerOfTwo = errors.New("f64: STFT nfft must be a power of two >= 2")
+)
+
+// rfftHalf is the 1/2 factor in the real-FFT even/odd half-spectrum split.
+const rfftHalf = 0.5
+
+// STFTPlan holds the resident twiddle tables, bit-reversal permutation, and
+// transform scratch for a fixed nfft. Build one with NewSTFTPlan and reuse it
+// across many STFT/STFTPower calls to stay allocation-free.
+//
+// A plan holds per-transform scratch, so its methods are NOT safe for concurrent
+// use on the same plan; use one plan per goroutine (plans are cheap to create
+// and the underlying tables are small). Distinct plans share no state.
+type STFTPlan struct {
+	nfft int // transform size (power of two)
+	half int // nfft / 2: size of the packed complex FFT
+
+	bitrev []int // bit-reversal permutation for the size-half FFT
+
+	// Twiddles for the size-half radix-2 FFT: twRe[t] = cos(2*pi*t/half),
+	// twIm[t] = -sin(2*pi*t/half) for t in [0, half/2).
+	twRe, twIm []float64
+
+	// Unravel twiddles W_N^k = exp(-i*2*pi*k/nfft) for k in [0, half], used to
+	// recombine the even/odd half-spectra into the real-input spectrum.
+	unRe, unIm []float64
+
+	// Per-transform scratch (the packed complex frame, FFT'd in place).
+	re, im []float64
+}
+
+// NumBins returns the number of output bins per frame, nfft/2 + 1 (the Hermitian
+// half-spectrum, DC through Nyquist).
+func (p *STFTPlan) NumBins() int { return p.half + 1 }
+
+// NFFT returns the transform size the plan was built for.
+func (p *STFTPlan) NFFT() int { return p.nfft }
+
+// NewSTFTPlan builds a reusable plan for nfft-point real-input STFTs. nfft must
+// be a power of two and at least 2; otherwise ErrNotPowerOfTwo is returned.
+func NewSTFTPlan(nfft int) (*STFTPlan, error) {
+	if nfft < 2 || nfft&(nfft-1) != 0 {
+		return nil, ErrNotPowerOfTwo
+	}
+	half := nfft >> 1
+
+	p := &STFTPlan{
+		nfft:   nfft,
+		half:   half,
+		bitrev: make([]int, half),
+		twRe:   make([]float64, max(half>>1, 1)),
+		twIm:   make([]float64, max(half>>1, 1)),
+		unRe:   make([]float64, half+1),
+		unIm:   make([]float64, half+1),
+		re:     make([]float64, half),
+		im:     make([]float64, half),
+	}
+
+	// Bit-reversal permutation for a size-half FFT.
+	logHalf := 0
+	for (1 << logHalf) < half {
+		logHalf++
+	}
+	for i := range p.bitrev {
+		r := 0
+		for b := range logHalf {
+			r |= ((i >> b) & 1) << (logHalf - 1 - b)
+		}
+		p.bitrev[i] = r
+	}
+
+	// Size-half FFT twiddles.
+	for t := range p.twRe {
+		ang := 2 * math.Pi * float64(t) / float64(half)
+		p.twRe[t] = math.Cos(ang)
+		p.twIm[t] = -math.Sin(ang)
+	}
+
+	// Real-input unravel twiddles W_N^k.
+	for k := 0; k <= half; k++ {
+		ang := 2 * math.Pi * float64(k) / float64(nfft)
+		p.unRe[k] = math.Cos(ang)
+		p.unIm[k] = -math.Sin(ang)
+	}
+
+	return p, nil
+}
+
+// fftHalf runs an in-place size-half radix-2 decimation-in-time complex FFT on
+// the plan's scratch (p.re, p.im), using the resident bit-reversal and twiddles.
+func (p *STFTPlan) fftHalf() {
+	re, im := p.re, p.im
+	// Bit-reversal reorder.
+	for i, j := range p.bitrev {
+		if j > i {
+			re[i], re[j] = re[j], re[i]
+			im[i], im[j] = im[j], im[i]
+		}
+	}
+	// Butterfly stages.
+	for m := 2; m <= p.half; m <<= 1 {
+		halfM := m >> 1
+		step := p.half / m // twiddle stride into twRe/twIm
+		for k := 0; k < p.half; k += m {
+			for j := range halfM {
+				idx := j * step
+				wr, wi := p.twRe[idx], p.twIm[idx]
+				a := k + j
+				b := a + halfM
+				vr := wr*re[b] - wi*im[b]
+				vi := wr*im[b] + wi*re[b]
+				re[b] = re[a] - vr
+				im[b] = im[a] - vi
+				re[a] += vr
+				im[a] += vi
+			}
+		}
+	}
+}
+
+// packFrame loads frame f (signal[f*hop : f*hop+nfft]) into the scratch as half
+// complex samples c[j] = x[2j] + i*x[2j+1], applying the window during the pack.
+// window may be nil (rectangular). The caller guarantees the frame fits.
+func (p *STFTPlan) packFrame(signal, window []float64, base int) {
+	re, im := p.re, p.im
+	if window == nil {
+		for j := range p.half {
+			re[j] = signal[base+2*j]
+			im[j] = signal[base+2*j+1]
+		}
+		return
+	}
+	for j := range p.half {
+		re[j] = signal[base+2*j] * window[2*j]
+		im[j] = signal[base+2*j+1] * window[2*j+1]
+	}
+}
+
+// numFrames returns how many full, non-centered frames of nfft samples fit in
+// signal at the given hop.
+func (p *STFTPlan) numFrames(signalLen, hop int) int {
+	if signalLen < p.nfft || hop <= 0 {
+		return 0
+	}
+	return 1 + (signalLen-p.nfft)/hop
+}
+
+// unravelBin computes the real-input spectrum bin X[k] (k in [0, half]) from the
+// half-length complex FFT result currently in p.re/p.im, returning (re, im).
+func (p *STFTPlan) unravelBin(k int) (re, im float64) {
+	km := (p.half - k) % p.half
+	ckr, cki := p.re[k%p.half], p.im[k%p.half]
+	cmr, cmi := p.re[km], p.im[km]
+
+	// Even/odd half-spectra: E = 0.5*(C[k] + conj(C[half-k])),
+	// O = -0.5i*(C[k] - conj(C[half-k])).
+	er := rfftHalf * (ckr + cmr)
+	ei := rfftHalf * (cki - cmi)
+	or := rfftHalf * (cki + cmi)
+	oi := -rfftHalf * (ckr - cmr)
+
+	// X[k] = E + W_N^k * O.
+	wr, wi := p.unRe[k], p.unIm[k]
+	re = er + (wr*or - wi*oi)
+	im = ei + (wr*oi + wi*or)
+	return re, im
+}
+
+// STFT computes the real-input STFT of signal and writes one Hermitian
+// half-spectrum (NumBins complex128 values) per frame into dst. Frame f is
+// signal[f*hop : f*hop+nfft], windowed by window when non-nil (which must have
+// length nfft). This is the center=false / no-padding convention (matching
+// librosa stft(..., center=False)); pre-pad the signal yourself for centered
+// frames.
+//
+// It writes min(len(dst), numFrames) frames and, per frame, min(len(dst[f]),
+// NumBins) bins, and returns the number of frames written. It is allocation-free
+// and reuses the plan scratch.
+func (p *STFTPlan) STFT(dst [][]complex128, signal, window []float64, hop int) int {
+	frames := min(p.numFrames(len(signal), hop), len(dst))
+	if frames == 0 {
+		return 0
+	}
+	if window != nil && len(window) < p.nfft {
+		// Treat a short window as rectangular rather than panicking, matching the
+		// library's lenient public-API style.
+		window = nil
+	}
+	bins := p.NumBins()
+	for f := range frames {
+		p.packFrame(signal, window, f*hop)
+		p.fftHalf()
+		row := dst[f]
+		nb := min(len(row), bins)
+		for k := range nb {
+			xr, xi := p.unravelBin(k)
+			row[k] = complex(xr, xi)
+		}
+	}
+	return frames
+}
+
+// STFTPower computes the real-input STFT power spectrum |X|^2 directly, skipping
+// materialization of the complex bins. dst, signal, window, and hop follow the
+// same conventions as STFT. Returns the number of frames written. Allocation-free.
+func (p *STFTPlan) STFTPower(dst [][]float64, signal, window []float64, hop int) int {
+	frames := min(p.numFrames(len(signal), hop), len(dst))
+	if frames == 0 {
+		return 0
+	}
+	if window != nil && len(window) < p.nfft {
+		window = nil
+	}
+	bins := p.NumBins()
+	for f := range frames {
+		p.packFrame(signal, window, f*hop)
+		p.fftHalf()
+		row := dst[f]
+		nb := min(len(row), bins)
+		for k := range nb {
+			xr, xi := p.unravelBin(k)
+			row[k] = xr*xr + xi*xi
+		}
+	}
+	return frames
+}

--- a/f64/stft_test.go
+++ b/f64/stft_test.go
@@ -331,8 +331,7 @@ func BenchmarkSTFT(b *testing.B) {
 		dst[f] = make([]complex128, plan.NumBins())
 	}
 	b.ReportAllocs()
-	b.ResetTimer()
-	for range b.N {
+	for b.Loop() {
 		plan.STFT(dst, signal, window, hop)
 	}
 }
@@ -349,8 +348,7 @@ func BenchmarkSTFTPower(b *testing.B) {
 		dst[f] = make([]float64, plan.NumBins())
 	}
 	b.ReportAllocs()
-	b.ResetTimer()
-	for range b.N {
+	for b.Loop() {
 		plan.STFTPower(dst, signal, window, hop)
 	}
 }

--- a/f64/stft_test.go
+++ b/f64/stft_test.go
@@ -1,0 +1,356 @@
+package f64
+
+import (
+	"fmt"
+	"math"
+	"testing"
+)
+
+// dftBin computes a single DFT bin X[k] = sum_n frame[n] * exp(-i 2pi k n / N)
+// directly, as an independent reference for the FFT-based STFT.
+func dftBin(frame []float64, k int) complex128 {
+	n := len(frame)
+	var re, im float64
+	for t := range n {
+		ang := -2 * math.Pi * float64(k) * float64(t) / float64(n)
+		s, c := math.Sincos(ang)
+		re += frame[t] * c
+		im += frame[t] * s
+	}
+	return complex(re, im)
+}
+
+func hann(nfft int) []float64 {
+	w := make([]float64, nfft)
+	for i := range w {
+		w[i] = 0.5 - 0.5*math.Cos(2*math.Pi*float64(i)/float64(nfft))
+	}
+	return w
+}
+
+// testSignal builds a deterministic pseudo-random-ish real signal.
+func testSignal(n int) []float64 {
+	s := make([]float64, n)
+	for i := range s {
+		s[i] = math.Sin(0.3*float64(i)) + 0.5*math.Cos(0.11*float64(i)+1) - 0.25*math.Sin(0.027*float64(i))
+	}
+	return s
+}
+
+func cmplxClose(t *testing.T, ctx string, got, want complex128, scale float64) {
+	t.Helper()
+	tol := 1e-9*scale + 1e-9
+	if d := math.Hypot(real(got)-real(want), imag(got)-imag(want)); d > tol {
+		t.Fatalf("%s: got %v want %v (|diff|=%g tol=%g)", ctx, got, want, d, tol)
+	}
+}
+
+func TestNewSTFTPlanErrors(t *testing.T) {
+	for _, bad := range []int{0, 1, 3, 5, 6, 7, 9, 100, 1000} {
+		if _, err := NewSTFTPlan(bad); err == nil {
+			t.Errorf("NewSTFTPlan(%d) = nil error, want ErrNotPowerOfTwo", bad)
+		}
+	}
+	for _, good := range []int{2, 4, 8, 16, 1024} {
+		p, err := NewSTFTPlan(good)
+		if err != nil {
+			t.Errorf("NewSTFTPlan(%d) unexpected error: %v", good, err)
+			continue
+		}
+		if p.NFFT() != good || p.NumBins() != good/2+1 {
+			t.Errorf("NewSTFTPlan(%d): NFFT=%d NumBins=%d", good, p.NFFT(), p.NumBins())
+		}
+	}
+}
+
+// TestSTFTAgainstDFT is the core correctness gate: every bin of every frame must
+// match a direct DFT of the windowed frame, across nfft sizes, hops, and with or
+// without a window.
+func TestSTFTAgainstDFT(t *testing.T) {
+	signal := testSignal(5000)
+	for _, nfft := range []int{2, 4, 8, 16, 64, 256, 1024} {
+		for _, useWin := range []bool{false, true} {
+			plan, err := NewSTFTPlan(nfft)
+			if err != nil {
+				t.Fatal(err)
+			}
+			var window []float64
+			if useWin {
+				window = hann(nfft)
+			}
+			hop := max(nfft/2, 1)
+			nf := plan.numFrames(len(signal), hop)
+			dst := make([][]complex128, nf)
+			for f := range dst {
+				dst[f] = make([]complex128, plan.NumBins())
+			}
+			got := plan.STFT(dst, signal, window, hop)
+			if got != nf {
+				t.Fatalf("nfft=%d: STFT wrote %d frames, want %d", nfft, got, nf)
+			}
+
+			frame := make([]float64, nfft)
+			for f := range nf {
+				base := f * hop
+				var scale float64
+				for i := range nfft {
+					v := signal[base+i]
+					if window != nil {
+						v *= window[i]
+					}
+					frame[i] = v
+					scale += math.Abs(v)
+				}
+				for k := range plan.NumBins() {
+					want := dftBin(frame, k)
+					ctx := fmt.Sprintf("nfft=%d win=%v frame=%d bin=%d", nfft, useWin, f, k)
+					cmplxClose(t, ctx, dst[f][k], want, scale)
+				}
+			}
+		}
+	}
+}
+
+// TestSTFTPowerMatchesSTFT verifies STFTPower equals |STFT|^2 bin-for-bin.
+func TestSTFTPowerMatchesSTFT(t *testing.T) {
+	signal := testSignal(4096)
+	plan, _ := NewSTFTPlan(512)
+	window := hann(512)
+	hop := 128
+	nf := plan.numFrames(len(signal), hop)
+
+	spec := make([][]complex128, nf)
+	pow := make([][]float64, nf)
+	for f := range spec {
+		spec[f] = make([]complex128, plan.NumBins())
+		pow[f] = make([]float64, plan.NumBins())
+	}
+	plan.STFT(spec, signal, window, hop)
+	plan.STFTPower(pow, signal, window, hop)
+
+	for f := range nf {
+		for k := range plan.NumBins() {
+			want := real(spec[f][k])*real(spec[f][k]) + imag(spec[f][k])*imag(spec[f][k])
+			if d := math.Abs(pow[f][k] - want); d > 1e-9*(1+want) {
+				t.Fatalf("STFTPower[%d][%d] = %v, want |X|^2 = %v", f, k, pow[f][k], want)
+			}
+		}
+	}
+}
+
+// TestSTFTPureTone checks a single-bin cosine concentrates its energy in that
+// bin and that DC/Nyquist come out (numerically) real.
+func TestSTFTPureTone(t *testing.T) {
+	const nfft = 64
+	plan, _ := NewSTFTPlan(nfft)
+	k0 := 5
+	signal := make([]float64, nfft)
+	for n := range signal {
+		signal[n] = math.Cos(2 * math.Pi * float64(k0) * float64(n) / float64(nfft))
+	}
+	dst := [][]complex128{make([]complex128, plan.NumBins())}
+	plan.STFT(dst, signal, nil, nfft)
+
+	mag := func(c complex128) float64 { return math.Hypot(real(c), imag(c)) }
+	// Bin k0 should hold ~nfft/2; every other bin should be ~0.
+	if got := mag(dst[0][k0]); math.Abs(got-float64(nfft)/2) > 1e-7 {
+		t.Errorf("tone bin %d magnitude = %v, want ~%v", k0, got, float64(nfft)/2)
+	}
+	for k := range plan.NumBins() {
+		if k == k0 {
+			continue
+		}
+		if got := mag(dst[0][k]); got > 1e-7 {
+			t.Errorf("non-tone bin %d magnitude = %v, want ~0", k, got)
+		}
+	}
+	// DC and Nyquist bins of a real signal are real.
+	if math.Abs(imag(dst[0][0])) > 1e-9 {
+		t.Errorf("DC bin not real: %v", dst[0][0])
+	}
+	if math.Abs(imag(dst[0][plan.NumBins()-1])) > 1e-9 {
+		t.Errorf("Nyquist bin not real: %v", dst[0][plan.NumBins()-1])
+	}
+}
+
+// TestSTFTFraming checks frame counting and the no-padding (center=false)
+// convention: frame f starts at f*hop.
+func TestSTFTFraming(t *testing.T) {
+	plan, _ := NewSTFTPlan(8)
+	signal := make([]float64, 20)
+	for i := range signal {
+		signal[i] = float64(i)
+	}
+	hop := 4
+	// frames at offsets 0,4,8,12 fit (need 8 samples): 12+8=20 ok, 16+8=24 no.
+	wantFrames := 4
+	if got := plan.numFrames(len(signal), hop); got != wantFrames {
+		t.Fatalf("numFrames = %d, want %d", got, wantFrames)
+	}
+	dst := make([][]complex128, wantFrames)
+	for f := range dst {
+		dst[f] = make([]complex128, plan.NumBins())
+	}
+	if n := plan.STFT(dst, signal, nil, hop); n != wantFrames {
+		t.Fatalf("STFT frames = %d, want %d", n, wantFrames)
+	}
+	// DC bin of frame f is the sum of signal[f*hop : f*hop+8].
+	for f := range wantFrames {
+		var sum float64
+		for i := range 8 {
+			sum += signal[f*hop+i]
+		}
+		if math.Abs(real(dst[f][0])-sum) > 1e-9 {
+			t.Errorf("frame %d DC = %v, want %v", f, real(dst[f][0]), sum)
+		}
+	}
+}
+
+// TestSTFTClamps verifies dst shorter than the frame count, and rows shorter than
+// NumBins, are handled without panic.
+func TestSTFTClamps(t *testing.T) {
+	plan, _ := NewSTFTPlan(16)
+	signal := testSignal(200)
+	hop := 8
+	full := plan.numFrames(len(signal), hop)
+
+	// Fewer rows than frames: only len(dst) frames written.
+	short := make([][]complex128, full-2)
+	for f := range short {
+		short[f] = make([]complex128, plan.NumBins())
+	}
+	if n := plan.STFT(short, signal, nil, hop); n != full-2 {
+		t.Errorf("clamped frames = %d, want %d", n, full-2)
+	}
+
+	// Rows shorter than NumBins: only the available bins written, no panic.
+	rows := make([][]complex128, 1)
+	rows[0] = make([]complex128, 3)
+	if n := plan.STFT(rows, signal, nil, hop); n != 1 {
+		t.Errorf("partial-row frames = %d, want 1", n)
+	}
+}
+
+func TestSTFTAllocFree(t *testing.T) {
+	plan, _ := NewSTFTPlan(512)
+	signal := testSignal(8192)
+	window := hann(512)
+	hop := 128
+	nf := plan.numFrames(len(signal), hop)
+	spec := make([][]complex128, nf)
+	pow := make([][]float64, nf)
+	for f := range spec {
+		spec[f] = make([]complex128, plan.NumBins())
+		pow[f] = make([]float64, plan.NumBins())
+	}
+	if a := testing.AllocsPerRun(5, func() { plan.STFT(spec, signal, window, hop) }); a != 0 {
+		t.Errorf("STFT allocated %v times per run, want 0", a)
+	}
+	if a := testing.AllocsPerRun(5, func() { plan.STFTPower(pow, signal, window, hop) }); a != 0 {
+		t.Errorf("STFTPower allocated %v times per run, want 0", a)
+	}
+}
+
+// FuzzSTFT is a differential fuzz target: every STFT bin must match a direct DFT
+// of the windowed frame, across fuzzed signal contents, nfft, hop, and window
+// choice. Inputs are bounded to [-1, 1] so the DFT bin magnitudes stay
+// well-conditioned for the epsilon-scaled tolerance. Seeds run under plain
+// `go test`; `go test -fuzz=FuzzSTFT` widens the space.
+func FuzzSTFT(f *testing.F) {
+	f.Add(make([]byte, 256), uint8(3), uint8(7), false)
+	f.Add(make([]byte, 600), uint8(5), uint8(3), true)
+
+	f.Fuzz(func(t *testing.T, raw []byte, nfftSel, hopSel uint8, useWin bool) {
+		// nfft in {4, 8, 16, 32, 64}; keep it small so the O(n^2) DFT is cheap.
+		nfft := 1 << (2 + int(nfftSel)%5)
+		samples := len(raw) / 8
+		if samples < nfft {
+			return
+		}
+		signal := make([]float64, samples)
+		for i := range signal {
+			signal[i] = float64(int64(binU64(raw[i*8:]))) / 9223372036854775808.0
+		}
+		plan, err := NewSTFTPlan(nfft)
+		if err != nil {
+			t.Fatal(err)
+		}
+		var window []float64
+		if useWin {
+			window = hann(nfft)
+		}
+		hop := 1 + int(hopSel)%nfft
+		nf := plan.numFrames(samples, hop)
+		if nf == 0 {
+			return
+		}
+		dst := make([][]complex128, nf)
+		for i := range dst {
+			dst[i] = make([]complex128, plan.NumBins())
+		}
+		plan.STFT(dst, signal, window, hop)
+
+		frame := make([]float64, nfft)
+		for fr := range nf {
+			base := fr * hop
+			var scale float64
+			for i := range nfft {
+				v := signal[base+i]
+				if window != nil {
+					v *= window[i]
+				}
+				frame[i] = v
+				scale += math.Abs(v)
+			}
+			for k := range plan.NumBins() {
+				want := dftBin(frame, k)
+				got := dst[fr][k]
+				tol := 1e-9*scale + 1e-9
+				if d := math.Hypot(real(got)-real(want), imag(got)-imag(want)); d > tol {
+					t.Fatalf("nfft=%d hop=%d frame=%d bin=%d: got %v want %v |diff|=%g", nfft, hop, fr, k, got, want, d)
+				}
+			}
+		}
+	})
+}
+
+func binU64(b []byte) uint64 {
+	return uint64(b[0]) | uint64(b[1])<<8 | uint64(b[2])<<16 | uint64(b[3])<<24 |
+		uint64(b[4])<<32 | uint64(b[5])<<40 | uint64(b[6])<<48 | uint64(b[7])<<56
+}
+
+func BenchmarkSTFT(b *testing.B) {
+	const nfft = 1024
+	plan, _ := NewSTFTPlan(nfft)
+	window := hann(nfft)
+	signal := testSignal(48000) // ~1s of 48 kHz audio
+	hop := 256
+	nf := plan.numFrames(len(signal), hop)
+	dst := make([][]complex128, nf)
+	for f := range dst {
+		dst[f] = make([]complex128, plan.NumBins())
+	}
+	b.ReportAllocs()
+	b.ResetTimer()
+	for range b.N {
+		plan.STFT(dst, signal, window, hop)
+	}
+}
+
+func BenchmarkSTFTPower(b *testing.B) {
+	const nfft = 1024
+	plan, _ := NewSTFTPlan(nfft)
+	window := hann(nfft)
+	signal := testSignal(48000)
+	hop := 256
+	nf := plan.numFrames(len(signal), hop)
+	dst := make([][]float64, nf)
+	for f := range dst {
+		dst[f] = make([]float64, plan.NumBins())
+	}
+	b.ReportAllocs()
+	b.ResetTimer()
+	for range b.N {
+		plan.STFTPower(dst, signal, window, hop)
+	}
+}


### PR DESCRIPTION
## Summary

Addresses #108. Adds a fused, real-input short-time Fourier transform so spectral feature pipelines (mel-spectrogram, PCEN, log-mel front-ends for audio ML) can stay on the fast path end to end. The library already covered everything *around* the transform (`c128.AbsSq` for the power spectrum, `DotProductBatch` for mel projection, `Exp`/`Mul`/`Log` for PCEN/log-mel) but not the FFT itself, forcing consumers to drop out to an external FFT for the single hottest step.

## API (f64)

A reusable plan that keeps the twiddle tables and bit-reversal permutation resident:

```go
plan, err := f64.NewSTFTPlan(nfft)            // power-of-two nfft
bins := plan.NumBins()                        // nfft/2 + 1 (Hermitian half-spectrum)
n := plan.STFT(dst, signal, window, hop)      // dst [][]complex128
n := plan.STFTPower(dst, signal, window, hop) // dst [][]float64, |X|^2 directly
```

(The sketch's free-function signature became a `Plan` to satisfy the "plan resident" + allocation-free requirements; the issue noted the API was open to bikeshedding.)

## Design

Matches the library's batched primitives (`DotProductBatch`, `ConvolveValidMulti`):

- **Real input via a half-length complex FFT (rfft):** an N-point real transform is an N/2-point complex FFT plus an O(N) unravel, ~2x cheaper than a full complex FFT, producing the Hermitian half-spectrum (N/2+1 bins) that librosa/scipy return. (Issue priority #1.)
- **Batched framing:** one call emits every hop-spaced frame; the plan is resident, so there is no per-frame setup or dispatch.
- **Fused window + power:** the analysis window is applied during the frame pack, and `STFTPower` emits `|X|^2` without materializing the complex bins.
- **No-padding (`center=false`) convention,** documented for librosa parity (`signal[f*hop : f*hop+nfft]`).

Per the issue's sequencing, this first cut is a **correct scalar radix-2 transform** (power-of-two `nfft` only); vectorizing the inner butterfly is a profile-gated follow-up, and f32/complex64 variants follow too.

## Correctness, allocation, concurrency

- **Allocation-free across calls** (plan scratch is resident; `BenchmarkSTFT`/`STFTPower` report `0 allocs/op`).
- A plan holds transform scratch, so it is **single-goroutine for execution**; distinct plans share no state (documented). Build one plan per goroutine.

## Tests

- `TestSTFTAgainstDFT`: the core gate, comparing **every bin of every frame to a direct DFT** of the windowed frame across `nfft` 2..1024, with and without a Hann window.
- `FuzzSTFT`: differential fuzz target (the #101 pattern) comparing STFT bins to the DFT over fuzzed signal/nfft/hop/window; 15s of `-fuzz` finds no differentials.
- `STFTPower == |STFT|^2`, pure-tone localization (energy in one bin, real DC/Nyquist), framing/`numFrames`, length-clamping, and zero-allocation.

Validated on the amd64 host and a **Raspberry Pi 5** (arm64): all STFT tests pass on both.