### PR TITLE
f32: add fused real-input STFT primitive (STFTPlan) (#108)

### DIFF
--- a/f32/stft.go
+++ b/f32/stft.go
@@ -109,15 +109,17 @@ func NewSTFTPlan(nfft int) (*STFTPlan, error) {
 	// Size-half FFT twiddles (computed in float64, stored as float32).
 	for t := range p.twRe {
 		ang := 2 * math.Pi * float64(t) / float64(half)
-		p.twRe[t] = float32(math.Cos(ang))
-		p.twIm[t] = float32(-math.Sin(ang))
+		s, c := math.Sincos(ang)
+		p.twRe[t] = float32(c)
+		p.twIm[t] = float32(-s)
 	}
 
 	// Real-input unravel twiddles W_N^k.
 	for k := 0; k <= half; k++ {
 		ang := 2 * math.Pi * float64(k) / float64(nfft)
-		p.unRe[k] = float32(math.Cos(ang))
-		p.unIm[k] = float32(-math.Sin(ang))
+		s, c := math.Sincos(ang)
+		p.unRe[k] = float32(c)
+		p.unIm[k] = float32(-s)
 	}
 
 	return p, nil
@@ -185,9 +187,15 @@ func (p *STFTPlan) numFrames(signalLen, hop int) int {
 // unravelBin computes the real-input spectrum bin X[k] (k in [0, half]) from the
 // half-length complex FFT result currently in p.re/p.im, returning (re, im).
 func (p *STFTPlan) unravelBin(k int) (re, im float32) {
-	km := (p.half - k) % p.half
-	ckr, cki := p.re[k%p.half], p.im[k%p.half]
-	cmr, cmi := p.re[km], p.im[km]
+	// k runs 0..half inclusive; the half-size spectrum C wraps at p.half,
+	// so both k == 0 and k == p.half read C[0]. Branch instead of modulo
+	// to keep integer division off this per-bin path.
+	ck, cm := 0, 0
+	if k > 0 && k < p.half {
+		ck, cm = k, p.half-k
+	}
+	ckr, cki := p.re[ck], p.im[ck]
+	cmr, cmi := p.re[cm], p.im[cm]
 
 	// Even/odd half-spectra: E = 0.5*(C[k] + conj(C[half-k])),
 	// O = -0.5i*(C[k] - conj(C[half-k])).

--- a/f32/stft.go
+++ b/f32/stft.go
@@ -1,0 +1,263 @@
+package f32
+
+import (
+	"errors"
+	"math"
+)
+
+// This file implements a fused, real-input Short-Time Fourier Transform for
+// float32, mirroring the f64 STFTPlan (see f64/stft.go). The transform is the
+// missing middle of a spectral feature pipeline: the library already covers
+// windowing inputs, the post-FFT power spectrum (c64.AbsSq), mel projection
+// (DotProductBatch), and PCEN/log-mel normalization (Exp/Mul/Log), but not the
+// FFT itself.
+//
+// Design (matches the rest of the library's batched primitives such as
+// DotProductBatch / ConvolveValidMulti):
+//
+//   - Real input via a half-length complex FFT (rfft): an N-point real transform
+//     is computed as an N/2-point complex FFT plus an O(N) unravel, ~2x cheaper
+//     than a full complex FFT and producing the Hermitian half-spectrum
+//     (N/2+1 bins) that librosa/scipy return.
+//   - Batched framing: one call emits every hop-spaced frame, with the twiddle
+//     tables and bit-reversal plan resident in the STFTPlan, so there is no
+//     per-frame setup or dispatch.
+//   - Fused window + (optional) power: the analysis window is applied while the
+//     frame is packed into the FFT input, and STFTPower emits |X|^2 directly
+//     without materializing the complex bins.
+//
+// The transform runs in float32 to match the rest of the f32 package; the
+// twiddle and unravel tables are computed in float64 and rounded once to float32
+// so the resident constants carry full precision. This first cut is a correct
+// scalar radix-2 transform (power-of-two nfft only); vectorizing the inner
+// butterfly is a separate, profile-gated change. See #108.
+
+// ErrSTFT* describe invalid STFTPlan configurations.
+var (
+	// ErrNotPowerOfTwo is returned when nfft is not a power of two >= 2.
+	ErrNotPowerOfTwo = errors.New("f32: STFT nfft must be a power of two >= 2")
+)
+
+// rfftHalf is the 1/2 factor in the real-FFT even/odd half-spectrum split.
+const rfftHalf = 0.5
+
+// STFTPlan holds the resident twiddle tables, bit-reversal permutation, and
+// transform scratch for a fixed nfft. Build one with NewSTFTPlan and reuse it
+// across many STFT/STFTPower calls to stay allocation-free.
+//
+// A plan holds per-transform scratch, so its methods are NOT safe for concurrent
+// use on the same plan; use one plan per goroutine (plans are cheap to create
+// and the underlying tables are small). Distinct plans share no state.
+type STFTPlan struct {
+	nfft int // transform size (power of two)
+	half int // nfft / 2: size of the packed complex FFT
+
+	bitrev []int // bit-reversal permutation for the size-half FFT
+
+	// Twiddles for the size-half radix-2 FFT: twRe[t] = cos(2*pi*t/half),
+	// twIm[t] = -sin(2*pi*t/half) for t in [0, half/2).
+	twRe, twIm []float32
+
+	// Unravel twiddles W_N^k = exp(-i*2*pi*k/nfft) for k in [0, half], used to
+	// recombine the even/odd half-spectra into the real-input spectrum.
+	unRe, unIm []float32
+
+	// Per-transform scratch (the packed complex frame, FFT'd in place).
+	re, im []float32
+}
+
+// NumBins returns the number of output bins per frame, nfft/2 + 1 (the Hermitian
+// half-spectrum, DC through Nyquist).
+func (p *STFTPlan) NumBins() int { return p.half + 1 }
+
+// NFFT returns the transform size the plan was built for.
+func (p *STFTPlan) NFFT() int { return p.nfft }
+
+// NewSTFTPlan builds a reusable plan for nfft-point real-input STFTs. nfft must
+// be a power of two and at least 2; otherwise ErrNotPowerOfTwo is returned.
+func NewSTFTPlan(nfft int) (*STFTPlan, error) {
+	if nfft < 2 || nfft&(nfft-1) != 0 {
+		return nil, ErrNotPowerOfTwo
+	}
+	half := nfft >> 1
+
+	p := &STFTPlan{
+		nfft:   nfft,
+		half:   half,
+		bitrev: make([]int, half),
+		twRe:   make([]float32, max(half>>1, 1)),
+		twIm:   make([]float32, max(half>>1, 1)),
+		unRe:   make([]float32, half+1),
+		unIm:   make([]float32, half+1),
+		re:     make([]float32, half),
+		im:     make([]float32, half),
+	}
+
+	// Bit-reversal permutation for a size-half FFT.
+	logHalf := 0
+	for (1 << logHalf) < half {
+		logHalf++
+	}
+	for i := range p.bitrev {
+		r := 0
+		for b := range logHalf {
+			r |= ((i >> b) & 1) << (logHalf - 1 - b)
+		}
+		p.bitrev[i] = r
+	}
+
+	// Size-half FFT twiddles (computed in float64, stored as float32).
+	for t := range p.twRe {
+		ang := 2 * math.Pi * float64(t) / float64(half)
+		p.twRe[t] = float32(math.Cos(ang))
+		p.twIm[t] = float32(-math.Sin(ang))
+	}
+
+	// Real-input unravel twiddles W_N^k.
+	for k := 0; k <= half; k++ {
+		ang := 2 * math.Pi * float64(k) / float64(nfft)
+		p.unRe[k] = float32(math.Cos(ang))
+		p.unIm[k] = float32(-math.Sin(ang))
+	}
+
+	return p, nil
+}
+
+// fftHalf runs an in-place size-half radix-2 decimation-in-time complex FFT on
+// the plan's scratch (p.re, p.im), using the resident bit-reversal and twiddles.
+func (p *STFTPlan) fftHalf() {
+	re, im := p.re, p.im
+	// Bit-reversal reorder.
+	for i, j := range p.bitrev {
+		if j > i {
+			re[i], re[j] = re[j], re[i]
+			im[i], im[j] = im[j], im[i]
+		}
+	}
+	// Butterfly stages.
+	for m := 2; m <= p.half; m <<= 1 {
+		halfM := m >> 1
+		step := p.half / m // twiddle stride into twRe/twIm
+		for k := 0; k < p.half; k += m {
+			for j := range halfM {
+				idx := j * step
+				wr, wi := p.twRe[idx], p.twIm[idx]
+				a := k + j
+				b := a + halfM
+				vr := wr*re[b] - wi*im[b]
+				vi := wr*im[b] + wi*re[b]
+				re[b] = re[a] - vr
+				im[b] = im[a] - vi
+				re[a] += vr
+				im[a] += vi
+			}
+		}
+	}
+}
+
+// packFrame loads frame f (signal[base : base+nfft]) into the scratch as half
+// complex samples c[j] = x[2j] + i*x[2j+1], applying the window during the pack.
+// window may be nil (rectangular). The caller guarantees the frame fits.
+func (p *STFTPlan) packFrame(signal, window []float32, base int) {
+	re, im := p.re, p.im
+	if window == nil {
+		for j := range p.half {
+			re[j] = signal[base+2*j]
+			im[j] = signal[base+2*j+1]
+		}
+		return
+	}
+	for j := range p.half {
+		re[j] = signal[base+2*j] * window[2*j]
+		im[j] = signal[base+2*j+1] * window[2*j+1]
+	}
+}
+
+// numFrames returns how many full, non-centered frames of nfft samples fit in
+// signal at the given hop.
+func (p *STFTPlan) numFrames(signalLen, hop int) int {
+	if signalLen < p.nfft || hop <= 0 {
+		return 0
+	}
+	return 1 + (signalLen-p.nfft)/hop
+}
+
+// unravelBin computes the real-input spectrum bin X[k] (k in [0, half]) from the
+// half-length complex FFT result currently in p.re/p.im, returning (re, im).
+func (p *STFTPlan) unravelBin(k int) (re, im float32) {
+	km := (p.half - k) % p.half
+	ckr, cki := p.re[k%p.half], p.im[k%p.half]
+	cmr, cmi := p.re[km], p.im[km]
+
+	// Even/odd half-spectra: E = 0.5*(C[k] + conj(C[half-k])),
+	// O = -0.5i*(C[k] - conj(C[half-k])).
+	er := rfftHalf * (ckr + cmr)
+	ei := rfftHalf * (cki - cmi)
+	or := rfftHalf * (cki + cmi)
+	oi := -rfftHalf * (ckr - cmr)
+
+	// X[k] = E + W_N^k * O.
+	wr, wi := p.unRe[k], p.unIm[k]
+	re = er + (wr*or - wi*oi)
+	im = ei + (wr*oi + wi*or)
+	return re, im
+}
+
+// STFT computes the real-input STFT of signal and writes one Hermitian
+// half-spectrum (NumBins complex64 values) per frame into dst. Frame f is
+// signal[f*hop : f*hop+nfft], windowed by window when non-nil (which must have
+// length nfft). This is the center=false / no-padding convention (matching
+// librosa stft(..., center=False)); pre-pad the signal yourself for centered
+// frames.
+//
+// It writes min(len(dst), numFrames) frames and, per frame, min(len(dst[f]),
+// NumBins) bins, and returns the number of frames written. It is allocation-free
+// and reuses the plan scratch.
+func (p *STFTPlan) STFT(dst [][]complex64, signal, window []float32, hop int) int {
+	frames := min(p.numFrames(len(signal), hop), len(dst))
+	if frames == 0 {
+		return 0
+	}
+	if window != nil && len(window) < p.nfft {
+		// Treat a short window as rectangular rather than panicking, matching the
+		// library's lenient public-API style.
+		window = nil
+	}
+	bins := p.NumBins()
+	for f := range frames {
+		p.packFrame(signal, window, f*hop)
+		p.fftHalf()
+		row := dst[f]
+		nb := min(len(row), bins)
+		for k := range nb {
+			xr, xi := p.unravelBin(k)
+			row[k] = complex(xr, xi)
+		}
+	}
+	return frames
+}
+
+// STFTPower computes the real-input STFT power spectrum |X|^2 directly, skipping
+// materialization of the complex bins. dst, signal, window, and hop follow the
+// same conventions as STFT. Returns the number of frames written. Allocation-free.
+func (p *STFTPlan) STFTPower(dst [][]float32, signal, window []float32, hop int) int {
+	frames := min(p.numFrames(len(signal), hop), len(dst))
+	if frames == 0 {
+		return 0
+	}
+	if window != nil && len(window) < p.nfft {
+		window = nil
+	}
+	bins := p.NumBins()
+	for f := range frames {
+		p.packFrame(signal, window, f*hop)
+		p.fftHalf()
+		row := dst[f]
+		nb := min(len(row), bins)
+		for k := range nb {
+			xr, xi := p.unravelBin(k)
+			row[k] = xr*xr + xi*xi
+		}
+	}
+	return frames
+}

--- a/f32/stft_test.go
+++ b/f32/stft_test.go
@@ -1,0 +1,357 @@
+package f32
+
+import (
+	"fmt"
+	"math"
+	"testing"
+)
+
+// dftBinF32 computes a single DFT bin X[k] = sum_n frame[n] * exp(-i 2pi k n / N)
+// directly in float64, as an independent reference for the float32 FFT-based
+// STFT. The frame samples are float32 but the reference math is float64 so the
+// comparison measures the f32 transform's error against the true value.
+func dftBinF32(frame []float32, k int) complex128 {
+	n := len(frame)
+	var re, im float64
+	for t := range n {
+		ang := -2 * math.Pi * float64(k) * float64(t) / float64(n)
+		s, c := math.Sincos(ang)
+		re += float64(frame[t]) * c
+		im += float64(frame[t]) * s
+	}
+	return complex(re, im)
+}
+
+func hannF32(nfft int) []float32 {
+	w := make([]float32, nfft)
+	for i := range w {
+		w[i] = float32(0.5 - 0.5*math.Cos(2*math.Pi*float64(i)/float64(nfft)))
+	}
+	return w
+}
+
+// testSignalF32 builds a deterministic pseudo-random-ish real signal.
+func testSignalF32(n int) []float32 {
+	s := make([]float32, n)
+	for i := range s {
+		s[i] = float32(math.Sin(0.3*float64(i)) + 0.5*math.Cos(0.11*float64(i)+1) - 0.25*math.Sin(0.027*float64(i)))
+	}
+	return s
+}
+
+// stftTolF32 bounds the error of an nfft-point float32 radix-2 transform against
+// the true (float64) DFT: the relative error grows roughly with log2(nfft)*eps32,
+// scaled by the sum of frame magnitudes that bounds the bin, plus a floor.
+func stftTolF32(nfft int, scale float64) float64 {
+	const eps32 = 1.1920928955078125e-07
+	logN := math.Log2(float64(nfft))
+	return 8*logN*eps32*scale + 1e-5
+}
+
+func cmplxCloseF32(t *testing.T, ctx string, got complex64, want complex128, tol float64) {
+	t.Helper()
+	if d := math.Hypot(float64(real(got))-real(want), float64(imag(got))-imag(want)); d > tol {
+		t.Fatalf("%s: got %v want %v (|diff|=%g tol=%g)", ctx, got, want, d, tol)
+	}
+}
+
+func TestNewSTFTPlanErrorsF32(t *testing.T) {
+	for _, bad := range []int{0, 1, 3, 5, 6, 7, 9, 100, 1000} {
+		if _, err := NewSTFTPlan(bad); err == nil {
+			t.Errorf("NewSTFTPlan(%d) = nil error, want ErrNotPowerOfTwo", bad)
+		}
+	}
+	for _, good := range []int{2, 4, 8, 16, 1024} {
+		p, err := NewSTFTPlan(good)
+		if err != nil {
+			t.Errorf("NewSTFTPlan(%d) unexpected error: %v", good, err)
+			continue
+		}
+		if p.NFFT() != good || p.NumBins() != good/2+1 {
+			t.Errorf("NewSTFTPlan(%d): NFFT=%d NumBins=%d", good, p.NFFT(), p.NumBins())
+		}
+	}
+}
+
+// TestSTFTAgainstDFTF32 is the core correctness gate: every bin of every frame
+// must match a direct DFT of the windowed frame within the float32 tolerance,
+// across nfft sizes, hops, and with or without a window.
+func TestSTFTAgainstDFTF32(t *testing.T) {
+	signal := testSignalF32(5000)
+	for _, nfft := range []int{2, 4, 8, 16, 64, 256, 1024} {
+		for _, useWin := range []bool{false, true} {
+			plan, err := NewSTFTPlan(nfft)
+			if err != nil {
+				t.Fatal(err)
+			}
+			var window []float32
+			if useWin {
+				window = hannF32(nfft)
+			}
+			hop := max(nfft/2, 1)
+			nf := plan.numFrames(len(signal), hop)
+			dst := make([][]complex64, nf)
+			for f := range dst {
+				dst[f] = make([]complex64, plan.NumBins())
+			}
+			got := plan.STFT(dst, signal, window, hop)
+			if got != nf {
+				t.Fatalf("nfft=%d: STFT wrote %d frames, want %d", nfft, got, nf)
+			}
+
+			frame := make([]float32, nfft)
+			for f := range nf {
+				base := f * hop
+				var scale float64
+				for i := range nfft {
+					v := signal[base+i]
+					if window != nil {
+						v *= window[i]
+					}
+					frame[i] = v
+					scale += math.Abs(float64(v))
+				}
+				tol := stftTolF32(nfft, scale)
+				for k := range plan.NumBins() {
+					want := dftBinF32(frame, k)
+					ctx := fmt.Sprintf("nfft=%d win=%v frame=%d bin=%d", nfft, useWin, f, k)
+					cmplxCloseF32(t, ctx, dst[f][k], want, tol)
+				}
+			}
+		}
+	}
+}
+
+// TestSTFTPowerMatchesSTFTF32 verifies STFTPower equals |STFT|^2 bin-for-bin
+// (both derive from the same unravel, so the agreement is essentially exact).
+func TestSTFTPowerMatchesSTFTF32(t *testing.T) {
+	signal := testSignalF32(4096)
+	plan, _ := NewSTFTPlan(512)
+	window := hannF32(512)
+	hop := 128
+	nf := plan.numFrames(len(signal), hop)
+
+	spec := make([][]complex64, nf)
+	pow := make([][]float32, nf)
+	for f := range spec {
+		spec[f] = make([]complex64, plan.NumBins())
+		pow[f] = make([]float32, plan.NumBins())
+	}
+	plan.STFT(spec, signal, window, hop)
+	plan.STFTPower(pow, signal, window, hop)
+
+	for f := range nf {
+		for k := range plan.NumBins() {
+			want := real(spec[f][k])*real(spec[f][k]) + imag(spec[f][k])*imag(spec[f][k])
+			if d := math.Abs(float64(pow[f][k] - want)); d > 1e-6*(1+float64(want)) {
+				t.Fatalf("STFTPower[%d][%d] = %v, want |X|^2 = %v", f, k, pow[f][k], want)
+			}
+		}
+	}
+}
+
+// TestSTFTPureToneF32 checks a single-bin cosine concentrates its energy in that
+// bin and that DC/Nyquist come out (numerically) real.
+func TestSTFTPureToneF32(t *testing.T) {
+	const nfft = 64
+	plan, _ := NewSTFTPlan(nfft)
+	k0 := 5
+	signal := make([]float32, nfft)
+	for n := range signal {
+		signal[n] = float32(math.Cos(2 * math.Pi * float64(k0) * float64(n) / float64(nfft)))
+	}
+	dst := [][]complex64{make([]complex64, plan.NumBins())}
+	plan.STFT(dst, signal, nil, nfft)
+
+	mag := func(c complex64) float64 { return math.Hypot(float64(real(c)), float64(imag(c))) }
+	// Bin k0 should hold ~nfft/2; every other bin should be ~0.
+	if got := mag(dst[0][k0]); math.Abs(got-float64(nfft)/2) > 1e-3 {
+		t.Errorf("tone bin %d magnitude = %v, want ~%v", k0, got, float64(nfft)/2)
+	}
+	for k := range plan.NumBins() {
+		if k == k0 {
+			continue
+		}
+		if got := mag(dst[0][k]); got > 1e-3 {
+			t.Errorf("non-tone bin %d magnitude = %v, want ~0", k, got)
+		}
+	}
+	// DC and Nyquist bins of a real signal are real.
+	if math.Abs(float64(imag(dst[0][0]))) > 1e-4 {
+		t.Errorf("DC bin not real: %v", dst[0][0])
+	}
+	if math.Abs(float64(imag(dst[0][plan.NumBins()-1]))) > 1e-4 {
+		t.Errorf("Nyquist bin not real: %v", dst[0][plan.NumBins()-1])
+	}
+}
+
+// TestSTFTFramingF32 checks frame counting and the no-padding (center=false)
+// convention: frame f starts at f*hop.
+func TestSTFTFramingF32(t *testing.T) {
+	plan, _ := NewSTFTPlan(8)
+	signal := make([]float32, 20)
+	for i := range signal {
+		signal[i] = float32(i)
+	}
+	hop := 4
+	// frames at offsets 0,4,8,12 fit (need 8 samples): 12+8=20 ok, 16+8=24 no.
+	wantFrames := 4
+	if got := plan.numFrames(len(signal), hop); got != wantFrames {
+		t.Fatalf("numFrames = %d, want %d", got, wantFrames)
+	}
+	dst := make([][]complex64, wantFrames)
+	for f := range dst {
+		dst[f] = make([]complex64, plan.NumBins())
+	}
+	if n := plan.STFT(dst, signal, nil, hop); n != wantFrames {
+		t.Fatalf("STFT frames = %d, want %d", n, wantFrames)
+	}
+	// DC bin of frame f is the sum of signal[f*hop : f*hop+8].
+	for f := range wantFrames {
+		var sum float64
+		for i := range 8 {
+			sum += float64(signal[f*hop+i])
+		}
+		if math.Abs(float64(real(dst[f][0]))-sum) > 1e-4*(1+sum) {
+			t.Errorf("frame %d DC = %v, want %v", f, real(dst[f][0]), sum)
+		}
+	}
+}
+
+// TestSTFTClampsF32 verifies dst shorter than the frame count, and rows shorter
+// than NumBins, are handled without panic.
+func TestSTFTClampsF32(t *testing.T) {
+	plan, _ := NewSTFTPlan(16)
+	signal := testSignalF32(200)
+	hop := 8
+	full := plan.numFrames(len(signal), hop)
+
+	// Fewer rows than frames: only len(dst) frames written.
+	short := make([][]complex64, full-2)
+	for f := range short {
+		short[f] = make([]complex64, plan.NumBins())
+	}
+	if n := plan.STFT(short, signal, nil, hop); n != full-2 {
+		t.Errorf("clamped frames = %d, want %d", n, full-2)
+	}
+
+	// Rows shorter than NumBins: only the available bins written, no panic.
+	rows := make([][]complex64, 1)
+	rows[0] = make([]complex64, 3)
+	if n := plan.STFT(rows, signal, nil, hop); n != 1 {
+		t.Errorf("partial-row frames = %d, want 1", n)
+	}
+}
+
+func TestSTFTAllocFreeF32(t *testing.T) {
+	plan, _ := NewSTFTPlan(512)
+	signal := testSignalF32(8192)
+	window := hannF32(512)
+	hop := 128
+	nf := plan.numFrames(len(signal), hop)
+	spec := make([][]complex64, nf)
+	pow := make([][]float32, nf)
+	for f := range spec {
+		spec[f] = make([]complex64, plan.NumBins())
+		pow[f] = make([]float32, plan.NumBins())
+	}
+	if a := testing.AllocsPerRun(5, func() { plan.STFT(spec, signal, window, hop) }); a != 0 {
+		t.Errorf("STFT allocated %v times per run, want 0", a)
+	}
+	if a := testing.AllocsPerRun(5, func() { plan.STFTPower(pow, signal, window, hop) }); a != 0 {
+		t.Errorf("STFTPower allocated %v times per run, want 0", a)
+	}
+}
+
+// FuzzSTFT is a differential fuzz target: every STFT bin must match a direct DFT
+// of the windowed frame within the float32 tolerance, across fuzzed signal
+// contents, nfft, hop, and window choice. Inputs are bounded to [-1, 1] (via
+// f32sUnit) so the DFT bin magnitudes stay well-conditioned. Seeds run under
+// plain `go test`; `go test -fuzz=FuzzSTFT` widens the space.
+func FuzzSTFT(f *testing.F) {
+	f.Add(make([]byte, 256), uint8(3), uint8(7), false)
+	f.Add(make([]byte, 600), uint8(5), uint8(3), true)
+
+	f.Fuzz(func(t *testing.T, raw []byte, nfftSel, hopSel uint8, useWin bool) {
+		// nfft in {4, 8, 16, 32, 64}; keep it small so the O(n^2) DFT is cheap.
+		nfft := 1 << (2 + int(nfftSel)%5)
+		signal := f32sUnit(raw)
+		if len(signal) < nfft {
+			return
+		}
+		plan, err := NewSTFTPlan(nfft)
+		if err != nil {
+			t.Fatal(err)
+		}
+		var window []float32
+		if useWin {
+			window = hannF32(nfft)
+		}
+		hop := 1 + int(hopSel)%nfft
+		nf := plan.numFrames(len(signal), hop)
+		if nf == 0 {
+			return
+		}
+		dst := make([][]complex64, nf)
+		for i := range dst {
+			dst[i] = make([]complex64, plan.NumBins())
+		}
+		plan.STFT(dst, signal, window, hop)
+
+		frame := make([]float32, nfft)
+		for fr := range nf {
+			base := fr * hop
+			var scale float64
+			for i := range nfft {
+				v := signal[base+i]
+				if window != nil {
+					v *= window[i]
+				}
+				frame[i] = v
+				scale += math.Abs(float64(v))
+			}
+			tol := stftTolF32(nfft, scale)
+			for k := range plan.NumBins() {
+				want := dftBinF32(frame, k)
+				got := dst[fr][k]
+				if d := math.Hypot(float64(real(got))-real(want), float64(imag(got))-imag(want)); d > tol {
+					t.Fatalf("nfft=%d hop=%d frame=%d bin=%d: got %v want %v |diff|=%g tol=%g", nfft, hop, fr, k, got, want, d, tol)
+				}
+			}
+		}
+	})
+}
+
+func BenchmarkSTFT(b *testing.B) {
+	const nfft = 1024
+	plan, _ := NewSTFTPlan(nfft)
+	window := hannF32(nfft)
+	signal := testSignalF32(48000) // ~1s of 48 kHz audio
+	hop := 256
+	nf := plan.numFrames(len(signal), hop)
+	dst := make([][]complex64, nf)
+	for f := range dst {
+		dst[f] = make([]complex64, plan.NumBins())
+	}
+	b.ReportAllocs()
+	for b.Loop() {
+		plan.STFT(dst, signal, window, hop)
+	}
+}
+
+func BenchmarkSTFTPower(b *testing.B) {
+	const nfft = 1024
+	plan, _ := NewSTFTPlan(nfft)
+	window := hannF32(nfft)
+	signal := testSignalF32(48000)
+	hop := 256
+	nf := plan.numFrames(len(signal), hop)
+	dst := make([][]float32, nf)
+	for f := range dst {
+		dst[f] = make([]float32, plan.NumBins())
+	}
+	b.ReportAllocs()
+	for b.Loop() {
+		plan.STFTPower(dst, signal, window, hop)
+	}
+}

--- a/f64/stft.go
+++ b/f64/stft.go
@@ -105,15 +105,17 @@ func NewSTFTPlan(nfft int) (*STFTPlan, error) {
 	// Size-half FFT twiddles.
 	for t := range p.twRe {
 		ang := 2 * math.Pi * float64(t) / float64(half)
-		p.twRe[t] = math.Cos(ang)
-		p.twIm[t] = -math.Sin(ang)
+		s, c := math.Sincos(ang)
+		p.twRe[t] = c
+		p.twIm[t] = -s
 	}
 
 	// Real-input unravel twiddles W_N^k.
 	for k := 0; k <= half; k++ {
 		ang := 2 * math.Pi * float64(k) / float64(nfft)
-		p.unRe[k] = math.Cos(ang)
-		p.unIm[k] = -math.Sin(ang)
+		s, c := math.Sincos(ang)
+		p.unRe[k] = c
+		p.unIm[k] = -s
 	}
 
 	return p, nil
@@ -181,9 +183,15 @@ func (p *STFTPlan) numFrames(signalLen, hop int) int {
 // unravelBin computes the real-input spectrum bin X[k] (k in [0, half]) from the
 // half-length complex FFT result currently in p.re/p.im, returning (re, im).
 func (p *STFTPlan) unravelBin(k int) (re, im float64) {
-	km := (p.half - k) % p.half
-	ckr, cki := p.re[k%p.half], p.im[k%p.half]
-	cmr, cmi := p.re[km], p.im[km]
+	// k runs 0..half inclusive; the half-size spectrum C wraps at p.half,
+	// so both k == 0 and k == p.half read C[0]. Branch instead of modulo
+	// to keep integer division off this per-bin path.
+	ck, cm := 0, 0
+	if k > 0 && k < p.half {
+		ck, cm = k, p.half-k
+	}
+	ckr, cki := p.re[ck], p.im[ck]
+	cmr, cmi := p.re[cm], p.im[cm]
 
 	// Even/odd half-spectra: E = 0.5*(C[k] + conj(C[half-k])),
 	// O = -0.5i*(C[k] - conj(C[half-k])).


### PR DESCRIPTION
Ports the f64 `STFTPlan` landed in #120 to **float32**, giving the f32 package the same fused, real-input Short-Time Fourier Transform. This is the f32/complex64 variant #108 asks for and completes the spectral front-end (`c64.AbsSq` for power, `DotProductBatch` for mel projection, `Exp`/`Mul`/`Log` for PCEN/log-mel) with the FFT itself.

Addresses the f32 part of #108.

## API (mirrors f64)

```go
func NewSTFTPlan(nfft int) (*STFTPlan, error)
func (p *STFTPlan) NumBins() int   // nfft/2 + 1
func (p *STFTPlan) NFFT() int
func (p *STFTPlan) STFT(dst [][]complex64, signal, window []float32, hop int) int
func (p *STFTPlan) STFTPower(dst [][]float32, signal, window []float32, hop int) int
```

`STFTPower` emits `|X|^2` directly without materializing the complex bins. The analysis window is fused into the FFT-input pack. One call emits every hop-spaced frame with the twiddle/bit-reversal tables resident in the plan, so there is no per-frame setup.

## Design notes

- Half-length complex FFT (rfft): an nfft-point real transform via an nfft/2-point complex FFT plus an O(n) unravel, producing the Hermitian half-spectrum (nfft/2+1 bins) that librosa/scipy return.
- Runs in float32 to match the rest of the package; twiddle and unravel tables are computed in float64 and rounded once to float32, so the resident constants keep full precision.
- Power-of-two nfft only (covers 512/1024/2048); `center=false` / no-padding convention, matching `librosa.stft(..., center=False)`. Allocation-free into caller buffers.
- A plan holds per-transform scratch, so its methods are not safe for concurrent use on the same plan; use one plan per goroutine (plans are cheap). Same contract as f64.

## Tests

Mirror the f64 suite with float32 tolerances:
- **Core gate**: every bin of every frame matches an independent direct DFT computed in float64 (the true value), across nfft 2..1024, with and without a Hann window. The error bound scales with `log2(nfft)*eps32` times the frame magnitude.
- Pure-tone energy localization; DC/Nyquist real; `STFTPower == |STFT|^2`; framing and clamping; allocation-free; and a differential fuzz target `FuzzSTFT` against the DFT.

## Verification

Tested on **amd64 (AVX+FMA)** and **arm64 (NEON+FP16, Raspberry Pi 5)**: full `go test ./...` green on both, `golangci-lint run ./...` clean, and `FuzzSTFT` survives active fuzzing on both architectures with no differentials (~1.9M execs on amd64).

The vectorized inner butterfly remains a separate, profile-gated change, as noted for the f64 version.