### PR TITLE
f64: add SIMD Log, Log2, Log10, Pow, PowElem kernels (AVX2+FMA, NEON)

### DIFF
--- a/README.md
+++ b/README.md
@@ -188,10 +188,10 @@ live in `f32` instead, so the two float surfaces are intentionally asymmetric.
 |                 | `Tanh(dst, src)`                    | Hyperbolic tangent            | 4x (AVX2) / 2x (NEON)               |
 |                 | `Exp(dst, src)`                     | Exponential e^x               | 4x (AVX2) / 2x (NEON)               |
 |                 | `ClampScale(dst, src, min, max, s)` | Fused clamp and scale         | 4x (AVX) / 2x (NEON)                |
-| **Transcendental** | `Log(dst, src)`                  | Natural log ln(x)             | Pure Go (SIMD kernel TODO)          |
-|                 | `Log2(dst, src)` / `Log10(dst, src)`| Base-2 / base-10 log          | Pure Go (SIMD kernel TODO)          |
-|                 | `Pow(dst, src, exp)`                | Scalar power x^exp (PCEN, dB) | Pure Go (SIMD kernel TODO)          |
-|                 | `PowElem(dst, base, exp)`           | Elementwise base^exp          | Pure Go (SIMD kernel TODO)          |
+| **Transcendental** | `Log(dst, src)`                  | Natural log ln(x)             | f64: 4x (AVX2+FMA) / 2x (NEON); f32 pure Go |
+|                 | `Log2(dst, src)` / `Log10(dst, src)`| Base-2 / base-10 log          | f64: 4x (AVX2+FMA) / 2x (NEON); f32 pure Go |
+|                 | `Pow(dst, src, exp)`                | Scalar power x^exp (PCEN, dB) | f64: 4x (AVX2+FMA) / 2x (NEON); f32 pure Go |
+|                 | `PowElem(dst, base, exp)`           | Elementwise base^exp          | f64: 4x (AVX2+FMA) / 2x (NEON); f32 pure Go |
 | **Batch**       | `DotProductBatch(r, rows, v)`       | Multiple dot products         | 8x / 4x / 2x                        |
 | **Signal**      | `ConvolveValid(dst, sig, k)`        | FIR filter / convolution      | 8x / 4x / 2x                        |
 |                 | `ConvolveValidMulti(dsts, sig, ks)` | Multi-kernel convolution      | 8x / 4x / 2x                        |

--- a/doc.go
+++ b/doc.go
@@ -77,7 +77,8 @@
 //
 // Activation functions: Sigmoid, ReLU, Tanh, Exp, ClampScale
 //
-// Transcendental (f32/f64): Log, Log2, Log10, Pow, PowElem (plus LogInPlace, PowInPlace)
+// Transcendental (f32/f64): Log, Log2, Log10, Pow, PowElem (plus LogInPlace, PowInPlace);
+// f64 is SIMD-accelerated on AVX2+FMA and NEON (f32 kernels tracked in #109)
 //
 // Audio DSP: Interleave2, Deinterleave2, ConvolveValid, ConvolveValidMulti, ConvolveDecimate, AccumulateAdd, CumulativeSum, CubicInterpDot, Int32ToFloat32Scale, Int16ToFloat32Scale, Float32ToInt16Scale
 //

--- a/f64/f64.go
+++ b/f64/f64.go
@@ -727,15 +727,16 @@ func ExpInPlace(a []float64) {
 // Processes min(len(dst), len(src)) elements. Edge cases match math.Log:
 // Log(0) = -Inf, Log(x < 0) = NaN, Log(+Inf) = +Inf, Log(NaN) = NaN.
 //
-// The implementation is currently the accurate pure-Go reference on every
-// architecture; a vectorized kernel is a profiled follow-up (see issue #109).
+// On AVX2+FMA and NEON hosts a vectorized kernel is used (atanh-form minimax
+// polynomial; worst-case relative error is a few float64 ulps, including
+// subnormal inputs). Elsewhere it falls back to the math.Log reference.
 // Allocation-free and safe for concurrent use on disjoint buffers.
 func Log(dst, src []float64) {
 	n := min(len(dst), len(src))
 	if n == 0 {
 		return
 	}
-	logGo(dst[:n], src[:n])
+	log64(dst[:n], src[:n])
 }
 
 // LogInPlace computes the natural logarithm in place: a[i] = ln(a[i]).
@@ -743,7 +744,7 @@ func LogInPlace(a []float64) {
 	if len(a) == 0 {
 		return
 	}
-	logGo(a, a)
+	log64(a, a)
 }
 
 // Log2 computes the base-2 logarithm elementwise: dst[i] = log2(src[i]).
@@ -754,7 +755,7 @@ func Log2(dst, src []float64) {
 	if n == 0 {
 		return
 	}
-	log2Go(dst[:n], src[:n])
+	log2_64(dst[:n], src[:n])
 }
 
 // Log10 computes the base-10 logarithm elementwise: dst[i] = log10(src[i]).
@@ -766,20 +767,27 @@ func Log10(dst, src []float64) {
 	if n == 0 {
 		return
 	}
-	log10Go(dst[:n], src[:n])
+	log10_64(dst[:n], src[:n])
 }
 
 // Pow raises each element to a scalar power: dst[i] = src[i]**exp. The scalar
 // exponent is the common DSP case (for example the ^0.35 power-law compression
 // in PCEN). Processes min(len(dst), len(src)) elements; edge cases match
 // math.Pow (Pow(x, 0) = 1, Pow(negative, non-integer) = NaN, Pow(0, negative)
-// = +Inf). Allocation-free; a vectorized kernel is a profiled follow-up (#109).
+// = +Inf).
+//
+// On AVX2+FMA and NEON hosts, slices whose elements are all positive and
+// finite are computed with a fused exp(exp*ln(x)) kernel whose relative error
+// is bounded by the Exp core (~3e-6); overflow yields +Inf and underflow 0,
+// matching math.Pow. Slices containing non-positive, infinite, or NaN bases,
+// and calls with a zero or non-finite exponent, take the exact math.Pow path.
+// Allocation-free and safe for concurrent use on disjoint buffers.
 func Pow(dst, src []float64, exp float64) {
 	n := min(len(dst), len(src))
 	if n == 0 {
 		return
 	}
-	powGo(dst[:n], src[:n], exp)
+	pow64(dst[:n], src[:n], exp)
 }
 
 // PowInPlace raises each element to a scalar power in place: a[i] = a[i]**exp.
@@ -787,16 +795,17 @@ func PowInPlace(a []float64, exp float64) {
 	if len(a) == 0 {
 		return
 	}
-	powGo(a, a, exp)
+	pow64(a, a, exp)
 }
 
 // PowElem raises each base to its own exponent: dst[i] = base[i]**exp[i].
 // Processes min(len(dst), len(base), len(exp)) elements; edge cases match
-// math.Pow.
+// math.Pow. The SIMD fast path and its fallback rules match Pow, with the
+// additional requirement that every exponent is finite.
 func PowElem(dst, base, exp []float64) {
 	n := min(len(dst), len(base), len(exp))
 	if n == 0 {
 		return
 	}
-	powElemGo(dst[:n], base[:n], exp[:n])
+	powElem64(dst[:n], base[:n], exp[:n])
 }

--- a/f64/f64_amd64.go
+++ b/f64/f64_amd64.go
@@ -3,6 +3,7 @@
 package f64
 
 import (
+	"math"
 	"unsafe"
 
 	"github.com/tphakala/simd/cpu"
@@ -683,6 +684,67 @@ func exp64(dst, src []float64) {
 	}
 	exp64Go(dst, src)
 }
+
+// logSIMDOK reports whether the AVX log/pow kernels can run: they need AVX2
+// (YMM integer ops for the exponent extraction) and FMA (polynomial
+// evaluation). AVX1-only or FMA-less CPUs use the accurate Go path.
+func logSIMDOK(n int) bool {
+	return cpu.X86.AVX2 && cpu.X86.FMA && n >= minAVXElements
+}
+
+func log64(dst, src []float64) {
+	if logSIMDOK(len(dst)) {
+		logAVX(dst, src, logLn2Hi64, logLn2Lo64, 1.0)
+		return
+	}
+	logGo(dst, src)
+}
+
+func log2_64(dst, src []float64) {
+	// log2(x) = e + ln(m)*log2(e): the e term is exact, so no hi/lo split is
+	// needed and exact powers of two come out exact.
+	if logSIMDOK(len(dst)) {
+		logAVX(dst, src, 1.0, 0.0, logLog2E64)
+		return
+	}
+	log2Go(dst, src)
+}
+
+func log10_64(dst, src []float64) {
+	if logSIMDOK(len(dst)) {
+		logAVX(dst, src, logL102Hi64, logL102Lo64, logLog10E64)
+		return
+	}
+	log10Go(dst, src)
+}
+
+func pow64(dst, src []float64, exp float64) {
+	// A zero or non-finite exponent has whole-slice math.Pow semantics
+	// (for example Pow(x, 0) = 1 even for NaN x); keep those exact.
+	if logSIMDOK(len(dst)) && exp != 0 && !math.IsNaN(exp) && !math.IsInf(exp, 0) &&
+		powSIMDOK64(src[:len(dst)]) {
+		powAVX(dst, src, exp)
+		return
+	}
+	powGo(dst, src, exp)
+}
+
+func powElem64(dst, base, exp []float64) {
+	if logSIMDOK(len(dst)) && powSIMDOK64(base[:len(dst)]) && allFinite64(exp[:len(dst)]) {
+		powElemAVX(dst, base, exp)
+		return
+	}
+	powElemGo(dst, base, exp)
+}
+
+//go:noescape
+func logAVX(dst, src []float64, k1hi, k1lo, k2 float64)
+
+//go:noescape
+func powAVX(dst, src []float64, exp float64)
+
+//go:noescape
+func powElemAVX(dst, base, exp []float64)
 
 //go:noescape
 func expAVX(dst, src []float64)

--- a/f64/f64_amd64.s
+++ b/f64/f64_amd64.s
@@ -5009,3 +5009,753 @@ cd_sse2_store:
 
 cd_sse2_ret:
     RET
+
+// ============================================================================
+// logAVX / powAVX / powElemAVX: vectorized natural log core (issue #109)
+// ============================================================================
+
+// Shared log-core constants. The mantissa reduction is the musl /
+// ARM-optimized-routines integer trick: tmp = bits(x) - OFF puts the biased
+// exponent of m = x / 2^e in tmp's exponent field such that
+// m in [sqrt(2)/2, sqrt(2)), with e = tmp >> 52 (arithmetic) and
+// bits(m) = bits(x) - (tmp & 0xfff0000000000000). No compares or branches.
+DATA log64_off<>+0x00(SB)/8, $0x3fe6a09e00000000
+DATA log64_off<>+0x08(SB)/8, $0x3fe6a09e00000000
+DATA log64_off<>+0x10(SB)/8, $0x3fe6a09e00000000
+DATA log64_off<>+0x18(SB)/8, $0x3fe6a09e00000000
+GLOBL log64_off<>(SB), RODATA|NOPTR, $32
+
+DATA log64_expmask<>+0x00(SB)/8, $0xfff0000000000000
+DATA log64_expmask<>+0x08(SB)/8, $0xfff0000000000000
+DATA log64_expmask<>+0x10(SB)/8, $0xfff0000000000000
+DATA log64_expmask<>+0x18(SB)/8, $0xfff0000000000000
+GLOBL log64_expmask<>(SB), RODATA|NOPTR, $32
+
+// DBL_MIN = 2.2250738585072014e-308: positive inputs below this are
+// subnormal and pre-scaled by 2^64 (exponent bias -64) before the reduction.
+DATA log64_dblmin<>+0x00(SB)/8, $0x0010000000000000
+DATA log64_dblmin<>+0x08(SB)/8, $0x0010000000000000
+DATA log64_dblmin<>+0x10(SB)/8, $0x0010000000000000
+DATA log64_dblmin<>+0x18(SB)/8, $0x0010000000000000
+GLOBL log64_dblmin<>(SB), RODATA|NOPTR, $32
+
+DATA log64_two64<>+0x00(SB)/8, $0x43f0000000000000  // 2^64
+DATA log64_two64<>+0x08(SB)/8, $0x43f0000000000000
+DATA log64_two64<>+0x10(SB)/8, $0x43f0000000000000
+DATA log64_two64<>+0x18(SB)/8, $0x43f0000000000000
+GLOBL log64_two64<>(SB), RODATA|NOPTR, $32
+
+DATA log64_negsc<>+0x00(SB)/8, $0xc050000000000000  // -64.0 (exponent bias)
+DATA log64_negsc<>+0x08(SB)/8, $0xc050000000000000
+DATA log64_negsc<>+0x10(SB)/8, $0xc050000000000000
+DATA log64_negsc<>+0x18(SB)/8, $0xc050000000000000
+GLOBL log64_negsc<>(SB), RODATA|NOPTR, $32
+
+// VPERMD indices gathering the high (odd) dwords of the four int64 lanes
+// into the low 128 bits, for the int32 -> float64 exponent conversion.
+DATA log64_permidx<>+0x00(SB)/4, $1
+DATA log64_permidx<>+0x04(SB)/4, $3
+DATA log64_permidx<>+0x08(SB)/4, $5
+DATA log64_permidx<>+0x0c(SB)/4, $7
+DATA log64_permidx<>+0x10(SB)/4, $0
+DATA log64_permidx<>+0x14(SB)/4, $0
+DATA log64_permidx<>+0x18(SB)/4, $0
+DATA log64_permidx<>+0x1c(SB)/4, $0
+GLOBL log64_permidx<>(SB), RODATA|NOPTR, $32
+
+// Minimax polynomial for ln(m), m in [sqrt(2)/2, sqrt(2)) (SLEEF xlog_u1
+// coefficients): with s = (m-1)/(m+1) and t = s^2,
+// ln(m) = 2s + s*t*P(t), P(t) = ((((((c0*t + c1)*t + c2)*t + c3)*t + c4)*t
+// + c5)*t + c6). Worst-case relative error of the full ln(x) is ~2 ulps.
+DATA log64_c0<>+0x00(SB)/8, $0x3fc39c4f5407567e  // 0.15320769885027014
+DATA log64_c0<>+0x08(SB)/8, $0x3fc39c4f5407567e
+DATA log64_c0<>+0x10(SB)/8, $0x3fc39c4f5407567e
+DATA log64_c0<>+0x18(SB)/8, $0x3fc39c4f5407567e
+GLOBL log64_c0<>(SB), RODATA|NOPTR, $32
+
+DATA log64_c1<>+0x00(SB)/8, $0x3fc3872e67fe8e84  // 0.15256290510034287
+DATA log64_c1<>+0x08(SB)/8, $0x3fc3872e67fe8e84
+DATA log64_c1<>+0x10(SB)/8, $0x3fc3872e67fe8e84
+DATA log64_c1<>+0x18(SB)/8, $0x3fc3872e67fe8e84
+GLOBL log64_c1<>(SB), RODATA|NOPTR, $32
+
+DATA log64_c2<>+0x00(SB)/8, $0x3fc747353a506035  // 0.1818605932937786
+DATA log64_c2<>+0x08(SB)/8, $0x3fc747353a506035
+DATA log64_c2<>+0x10(SB)/8, $0x3fc747353a506035
+DATA log64_c2<>+0x18(SB)/8, $0x3fc747353a506035
+GLOBL log64_c2<>(SB), RODATA|NOPTR, $32
+
+DATA log64_c3<>+0x00(SB)/8, $0x3fcc71c0a65ecd8e  // 0.222221451983938
+DATA log64_c3<>+0x08(SB)/8, $0x3fcc71c0a65ecd8e
+DATA log64_c3<>+0x10(SB)/8, $0x3fcc71c0a65ecd8e
+DATA log64_c3<>+0x18(SB)/8, $0x3fcc71c0a65ecd8e
+GLOBL log64_c3<>(SB), RODATA|NOPTR, $32
+
+DATA log64_c4<>+0x00(SB)/8, $0x3fd249249a68a245  // 0.28571429327942993
+DATA log64_c4<>+0x08(SB)/8, $0x3fd249249a68a245
+DATA log64_c4<>+0x10(SB)/8, $0x3fd249249a68a245
+DATA log64_c4<>+0x18(SB)/8, $0x3fd249249a68a245
+GLOBL log64_c4<>(SB), RODATA|NOPTR, $32
+
+DATA log64_c5<>+0x00(SB)/8, $0x3fd99999998f92ea  // 0.3999999999635252
+DATA log64_c5<>+0x08(SB)/8, $0x3fd99999998f92ea
+DATA log64_c5<>+0x10(SB)/8, $0x3fd99999998f92ea
+DATA log64_c5<>+0x18(SB)/8, $0x3fd99999998f92ea
+GLOBL log64_c5<>(SB), RODATA|NOPTR, $32
+
+DATA log64_c6<>+0x00(SB)/8, $0x3fe55555555557ae  // 0.66666666666673335
+DATA log64_c6<>+0x08(SB)/8, $0x3fe55555555557ae
+DATA log64_c6<>+0x10(SB)/8, $0x3fe55555555557ae
+DATA log64_c6<>+0x18(SB)/8, $0x3fe55555555557ae
+GLOBL log64_c6<>(SB), RODATA|NOPTR, $32
+
+// fdlibm ln(2) hi/lo split for the pow kernels' fixed natural-log
+// reconstruction (logAVX takes its split via arguments instead).
+DATA log64_ln2hi<>+0x00(SB)/8, $0x3fe62e42fee00000
+DATA log64_ln2hi<>+0x08(SB)/8, $0x3fe62e42fee00000
+DATA log64_ln2hi<>+0x10(SB)/8, $0x3fe62e42fee00000
+DATA log64_ln2hi<>+0x18(SB)/8, $0x3fe62e42fee00000
+GLOBL log64_ln2hi<>(SB), RODATA|NOPTR, $32
+
+DATA log64_ln2lo<>+0x00(SB)/8, $0x3dea39ef35793c76
+DATA log64_ln2lo<>+0x08(SB)/8, $0x3dea39ef35793c76
+DATA log64_ln2lo<>+0x10(SB)/8, $0x3dea39ef35793c76
+DATA log64_ln2lo<>+0x18(SB)/8, $0x3dea39ef35793c76
+GLOBL log64_ln2lo<>(SB), RODATA|NOPTR, $32
+
+DATA log64_posinf<>+0x00(SB)/8, $0x7ff0000000000000
+DATA log64_posinf<>+0x08(SB)/8, $0x7ff0000000000000
+DATA log64_posinf<>+0x10(SB)/8, $0x7ff0000000000000
+DATA log64_posinf<>+0x18(SB)/8, $0x7ff0000000000000
+GLOBL log64_posinf<>(SB), RODATA|NOPTR, $32
+
+DATA log64_neginf<>+0x00(SB)/8, $0xfff0000000000000
+DATA log64_neginf<>+0x08(SB)/8, $0xfff0000000000000
+DATA log64_neginf<>+0x10(SB)/8, $0xfff0000000000000
+DATA log64_neginf<>+0x18(SB)/8, $0xfff0000000000000
+GLOBL log64_neginf<>(SB), RODATA|NOPTR, $32
+
+DATA log64_nan<>+0x00(SB)/8, $0x7ff8000000000000
+DATA log64_nan<>+0x08(SB)/8, $0x7ff8000000000000
+DATA log64_nan<>+0x10(SB)/8, $0x7ff8000000000000
+DATA log64_nan<>+0x18(SB)/8, $0x7ff8000000000000
+GLOBL log64_nan<>(SB), RODATA|NOPTR, $32
+
+// func logAVX(dst, src []float64, k1hi, k1lo, k2 float64)
+// Shared kernel for Log, Log2, and Log10: per lane it computes
+// result = e*k1hi + (lnm*k2 + e*k1lo), with x = m*2^e, m in
+// [sqrt(2)/2, sqrt(2)) and lnm = ln(m) = 2s + s*t*P(t) for s = (m-1)/(m+1),
+// t = s^2 (atanh form, SLEEF xlog_u1 minimax polynomial). Positive subnormal
+// inputs are pre-scaled by 2^64 (exponent bias -64). Special lanes are fixed
+// up with blends from the original input: +Inf -> +Inf, +-0 -> -Inf,
+// x < 0 or NaN -> NaN, matching math.Log. Requires AVX2 (YMM integer ops in
+// the exponent extraction) and FMA. Processes 4 elements per iteration; the
+// 0-3 element tail uses the scalar path below.
+TEXT ·logAVX(SB), NOSPLIT, $0-72
+    MOVQ dst_base+0(FP), DX
+    MOVQ dst_len+8(FP), CX
+    MOVQ src_base+24(FP), SI
+
+    // Loop-invariant constants. The low 128 bits (X10, X13-X15) are reused
+    // by the scalar remainder path.
+    VMOVUPD log64_negsc<>(SB), Y6      // Y6 = -64.0 (subnormal exponent bias)
+    VMOVUPD log64_two64<>(SB), Y7      // Y7 = 2^64 (subnormal pre-scale)
+    VMOVUPD log64_dblmin<>(SB), Y8     // Y8 = DBL_MIN
+    VMOVUPD log64_permidx<>(SB), Y9    // Y9 = VPERMD odd-dword gather indices
+    VMOVUPD sigmoid_one64<>(SB), Y10   // Y10 = 1.0
+    VMOVUPD log64_expmask<>(SB), Y11   // Y11 = 0xfff0000000000000
+    VMOVUPD log64_off<>(SB), Y12       // Y12 = reduction offset
+    VBROADCASTSD k2+64(FP), Y13        // Y13 = k2
+    VBROADCASTSD k1lo+56(FP), Y14      // Y14 = k1lo
+    VBROADCASTSD k1hi+48(FP), Y15      // Y15 = k1hi
+
+    MOVQ CX, R8
+    SHRQ $2, R8                        // len / 4
+    JZ   log64_remainder
+
+log64_loop4:
+    VMOVUPD (SI), Y0                   // Y0 = x (kept for the special-lane blends)
+
+    // Subnormal pre-scale: lanes with 0 < x < DBL_MIN are scaled by 2^64 and
+    // carry an exponent bias of -64. (Negative/NaN lanes fail the compare or
+    // produce garbage that the final blends overwrite.)
+    VCMPPD $17, Y8, Y0, Y1             // Y1 = mask: x < DBL_MIN (LT_OQ, NaN -> false)
+    VMULPD Y7, Y0, Y2                  // Y2 = x * 2^64
+    VBLENDVPD Y1, Y2, Y0, Y2           // Y2 = xs = subnormal ? x*2^64 : x
+    VANDPD Y6, Y1, Y1                  // Y1 = ebias = subnormal ? -64.0 : 0.0
+
+    // Exponent/mantissa split (musl/ARM-optimized-routines integer trick):
+    // tmp = bits(xs) - OFF; e = tmp >> 52 (arithmetic); bits(m) = bits(xs) -
+    // (tmp & 0xfff0000000000000), leaving m in [sqrt(2)/2, sqrt(2)).
+    VPSUBQ Y12, Y2, Y3                 // Y3 = tmp
+    VPAND Y11, Y3, Y4                  // Y4 = tmp & expmask
+    VPSUBQ Y4, Y2, Y4                  // Y4 = m
+    // AVX2 has no VPSRAQ: arithmetic-shift the high dwords by 20 (giving
+    // bits 52..63 of each lane sign-extended), gather them with VPERMD, and
+    // convert int32 -> float64.
+    VPSRAD $20, Y3, Y3                 // odd dwords = e (int32)
+    VPERMD Y3, Y9, Y3                  // X3 = 4 x int32 e
+    VCVTDQ2PD X3, Y3                   // Y3 = e as float64
+    VADDPD Y1, Y3, Y3                  // Y3 = e + ebias
+
+    // s = (m-1)/(m+1), t = s^2
+    VSUBPD Y10, Y4, Y5                 // Y5 = m - 1
+    VADDPD Y10, Y4, Y4                 // Y4 = m + 1
+    VDIVPD Y4, Y5, Y5                  // Y5 = s
+    VMULPD Y5, Y5, Y4                  // Y4 = t
+
+    // P(t), Horner with memory-operand FMAs
+    VMOVUPD log64_c0<>(SB), Y2
+    VFMADD213PD log64_c1<>(SB), Y4, Y2 // Y2 = Y2*t + c1
+    VFMADD213PD log64_c2<>(SB), Y4, Y2
+    VFMADD213PD log64_c3<>(SB), Y4, Y2
+    VFMADD213PD log64_c4<>(SB), Y4, Y2
+    VFMADD213PD log64_c5<>(SB), Y4, Y2
+    VFMADD213PD log64_c6<>(SB), Y4, Y2 // Y2 = P(t)
+
+    VMULPD Y5, Y4, Y4                  // Y4 = s*t
+    VADDPD Y5, Y5, Y5                  // Y5 = 2s
+    VFMADD231PD Y2, Y4, Y5             // Y5 = lnm = s*t*P(t) + 2s
+
+    // result = e*k1hi + (lnm*k2 + e*k1lo)
+    VMULPD Y14, Y3, Y4                 // Y4 = e * k1lo
+    VFMADD231PD Y13, Y5, Y4            // Y4 += lnm * k2
+    VFMADD231PD Y15, Y3, Y4            // Y4 += e * k1hi
+
+    // Special lanes from the original x: +Inf -> +Inf, +-0 -> -Inf,
+    // x < 0 or NaN -> NaN (canonical quiet NaN, like math.Log).
+    VMOVUPD log64_posinf<>(SB), Y2
+    VCMPPD $0, Y2, Y0, Y1              // Y1 = mask: x == +Inf (EQ_OQ)
+    VBLENDVPD Y1, Y2, Y4, Y4
+    VXORPD Y2, Y2, Y2
+    VCMPPD $0, Y2, Y0, Y1              // Y1 = mask: x == +-0
+    VMOVUPD log64_neginf<>(SB), Y3
+    VBLENDVPD Y1, Y3, Y4, Y4
+    VCMPPD $17, Y2, Y0, Y1             // Y1 = mask: x < 0
+    VCMPPD $3, Y0, Y0, Y2              // Y2 = mask: x unordered (NaN)
+    VORPD Y2, Y1, Y1
+    VMOVUPD log64_nan<>(SB), Y3
+    VBLENDVPD Y1, Y3, Y4, Y4
+
+    VMOVUPD Y4, (DX)
+    ADDQ $32, SI
+    ADDQ $32, DX
+    DECQ R8
+    JNZ  log64_loop4
+
+log64_remainder:
+    ANDQ $3, CX
+    JZ   log64_done
+
+log64_scalar:
+    MOVQ (SI), AX                      // AX = bits(x)
+    VMOVSD (SI), X0                    // X0 = x
+
+    // Specials first: NaN or x < 0 -> NaN, +-0 -> -Inf, +Inf -> +Inf.
+    // VUCOMISD sets ZF=PF=CF=1 for unordered, so test JP before JB/JE.
+    VXORPD X1, X1, X1
+    VUCOMISD X1, X0
+    JP   log64_scalar_nan
+    JB   log64_scalar_nan              // x < 0
+    JE   log64_scalar_neginf           // x == +-0
+    MOVQ $0x7FF0000000000000, BX
+    CMPQ AX, BX
+    JEQ  log64_scalar_posinf
+
+    // Subnormal pre-scale (x is positive finite here; bits compare as ints)
+    XORQ R9, R9                        // R9 = exponent bias
+    MOVQ $0x0010000000000000, BX       // DBL_MIN bits
+    CMPQ AX, BX
+    JGE  log64_scalar_normal
+    MOVQ $0x43F0000000000000, R10      // 2^64
+    VMOVQ R10, X2
+    VMULSD X2, X0, X0                  // x *= 2^64
+    VMOVQ X0, AX
+    MOVQ $-64, R9
+
+log64_scalar_normal:
+    MOVQ $0x3FE6A09E00000000, BX
+    MOVQ AX, R10
+    SUBQ BX, R10                       // R10 = tmp = bits - OFF
+    MOVQ R10, R11
+    SARQ $52, R11                      // R11 = e
+    ADDQ R9, R11                       // e += bias
+    MOVQ $0xFFF0000000000000, BX
+    ANDQ BX, R10
+    SUBQ R10, AX                       // AX = bits(m)
+    VMOVQ AX, X2                       // X2 = m
+    CVTSQ2SD R11, X3                   // X3 = e as float64
+
+    // s = (m-1)/(m+1), t = s^2 (X10 = 1.0 from the vector constants)
+    VSUBSD X10, X2, X4                 // m - 1
+    VADDSD X10, X2, X5                 // m + 1
+    VDIVSD X5, X4, X4                  // X4 = s
+    VMULSD X4, X4, X5                  // X5 = t
+
+    VMOVSD log64_c0<>(SB), X1
+    VFMADD213SD log64_c1<>(SB), X5, X1
+    VFMADD213SD log64_c2<>(SB), X5, X1
+    VFMADD213SD log64_c3<>(SB), X5, X1
+    VFMADD213SD log64_c4<>(SB), X5, X1
+    VFMADD213SD log64_c5<>(SB), X5, X1
+    VFMADD213SD log64_c6<>(SB), X5, X1 // X1 = P(t)
+
+    VMULSD X4, X5, X5                  // X5 = s*t
+    VADDSD X4, X4, X4                  // X4 = 2s
+    VFMADD231SD X1, X5, X4             // X4 = lnm
+
+    VMULSD X14, X3, X5                 // e * k1lo
+    VFMADD231SD X13, X4, X5            // += lnm * k2
+    VFMADD231SD X15, X3, X5            // += e * k1hi
+    VMOVSD X5, (DX)
+    JMP  log64_scalar_next
+
+log64_scalar_nan:
+    MOVQ $0x7FF8000000000000, AX
+    MOVQ AX, (DX)
+    JMP  log64_scalar_next
+
+log64_scalar_neginf:
+    MOVQ $0xFFF0000000000000, AX
+    MOVQ AX, (DX)
+    JMP  log64_scalar_next
+
+log64_scalar_posinf:
+    MOVQ $0x7FF0000000000000, AX
+    MOVQ AX, (DX)
+
+log64_scalar_next:
+    ADDQ $8, SI
+    ADDQ $8, DX
+    DECQ CX
+    JNZ  log64_scalar
+
+log64_done:
+    VZEROUPPER
+    RET
+
+// func powAVX(dst, src []float64, exp float64)
+// Fused pow(x, p) = exp(p*ln(x)) for slices whose elements are all positive
+// and finite (the dispatcher guarantees this, see powSIMDOK64). The log core
+// matches logAVX (constants from memory instead of registers); the exp core
+// matches expAVX with its [-709, 709] clamp on y = p*ln(x), but lanes whose
+// pre-clamp y exceeds the clamp are blended to +Inf (y > 709) or 0
+// (y < -709) so true overflow/underflow keeps math.Pow's result classes.
+// Within ~0.1% of the clamp (709 < y < ln(MaxFloat64) ~ 709.78 and the
+// mirrored underflow band) the true result is still finite/subnormal, so the
+// blend rounds those bands to +Inf resp. 0. Accuracy elsewhere is bounded by
+// the exp core's degree-5 polynomial (~3e-6 relative). Requires AVX2 and FMA.
+TEXT ·powAVX(SB), NOSPLIT, $0-56
+    MOVQ dst_base+0(FP), DX
+    MOVQ dst_len+8(FP), CX
+    MOVQ src_base+24(FP), SI
+
+    // Exp-core constants in registers (the log core uses memory operands).
+    // The low 128 bits (X8-X15) are reused by the scalar remainder path.
+    VMOVUPD log64_permidx<>(SB), Y7    // Y7 = VPERMD gather indices
+    VBROADCASTSD exp+48(FP), Y8        // Y8 = p
+    VMOVUPD tanh64_c5<>(SB), Y9        // Y9 = 1/120
+    VMOVUPD tanh64_c4<>(SB), Y10       // Y10 = 1/24
+    VMOVUPD tanh64_c3<>(SB), Y11       // Y11 = 1/6
+    VMOVUPD sigmoid_half64<>(SB), Y12  // Y12 = 0.5
+    VMOVUPD sigmoid_one64<>(SB), Y13   // Y13 = 1.0
+    VMOVUPD tanh64_ln2<>(SB), Y14      // Y14 = ln(2)
+    VMOVUPD tanh64_log2e<>(SB), Y15    // Y15 = log2(e)
+
+    MOVQ CX, R8
+    SHRQ $2, R8
+    JZ   pow64_remainder
+
+pow64_loop4:
+    VMOVUPD (SI), Y0                   // Y0 = x (positive finite)
+
+    // --- log core (see logAVX) ---
+    VCMPPD $17, log64_dblmin<>(SB), Y0, Y1
+    VMULPD log64_two64<>(SB), Y0, Y2
+    VBLENDVPD Y1, Y2, Y0, Y0           // x, subnormals pre-scaled
+    VANDPD log64_negsc<>(SB), Y1, Y1   // ebias
+    VPSUBQ log64_off<>(SB), Y0, Y2     // tmp
+    VPAND log64_expmask<>(SB), Y2, Y3
+    VPSUBQ Y3, Y0, Y3                  // m
+    VPSRAD $20, Y2, Y2
+    VPERMD Y2, Y7, Y2
+    VCVTDQ2PD X2, Y2
+    VADDPD Y1, Y2, Y2                  // e
+    VSUBPD Y13, Y3, Y4                 // m - 1
+    VADDPD Y13, Y3, Y3                 // m + 1
+    VDIVPD Y3, Y4, Y4                  // s
+    VMULPD Y4, Y4, Y3                  // t
+    VMOVUPD log64_c0<>(SB), Y5
+    VFMADD213PD log64_c1<>(SB), Y3, Y5
+    VFMADD213PD log64_c2<>(SB), Y3, Y5
+    VFMADD213PD log64_c3<>(SB), Y3, Y5
+    VFMADD213PD log64_c4<>(SB), Y3, Y5
+    VFMADD213PD log64_c5<>(SB), Y3, Y5
+    VFMADD213PD log64_c6<>(SB), Y3, Y5 // P(t)
+    VMULPD Y4, Y3, Y3                  // s*t
+    VADDPD Y4, Y4, Y4                  // 2s
+    VFMADD231PD Y5, Y3, Y4             // lnm
+    VMULPD log64_ln2lo<>(SB), Y2, Y3   // e*ln2lo
+    VADDPD Y4, Y3, Y3                  // + lnm
+    VFMADD231PD log64_ln2hi<>(SB), Y2, Y3 // Y3 = ln(x)
+
+    // y = p*ln(x); keep the pre-clamp value in Y6 for the overflow blends,
+    // then clamp to [-709, 709] for the exp core
+    VMULPD Y8, Y3, Y0
+    VMOVUPD Y0, Y6                     // Y6 = y (pre-clamp)
+    VMINPD exp_clamp_hi64<>(SB), Y0, Y0
+    VMAXPD exp_clamp_lo64<>(SB), Y0, Y0
+
+    // --- exp core (see expAVX) ---
+    VMULPD Y15, Y0, Y1                 // y * log2e
+    VROUNDPD $0, Y1, Y2                // k
+    VMULPD Y14, Y2, Y3                 // k * ln2
+    VSUBPD Y3, Y0, Y3                  // r
+    VMULPD Y3, Y9, Y4                  // r*c5
+    VADDPD Y10, Y4, Y4
+    VMULPD Y3, Y4, Y4
+    VADDPD Y11, Y4, Y4
+    VMULPD Y3, Y4, Y4
+    VADDPD Y12, Y4, Y4
+    VMULPD Y3, Y4, Y4
+    VADDPD Y13, Y4, Y4
+    VMULPD Y3, Y4, Y4
+    VADDPD Y13, Y4, Y4                 // exp(r)
+    VCVTTPD2DQY Y2, X5
+    VPMOVSXDQ X5, Y5
+    VPSLLQ $52, Y5, Y5
+    VPADDQ sigmoid_one64<>(SB), Y5, Y5
+    VMULPD Y5, Y4, Y4                  // exp(y)
+
+    // Overflow/underflow classes from the pre-clamp y (strict compares, so a
+    // y of exactly +-709 keeps the computed finite value): y > 709 -> +Inf,
+    // y < -709 -> 0, matching math.Pow.
+    VMOVUPD log64_posinf<>(SB), Y2
+    VCMPPD $30, exp_clamp_hi64<>(SB), Y6, Y1 // Y1 = mask: y > 709 (GT_OQ)
+    VBLENDVPD Y1, Y2, Y4, Y4
+    VCMPPD $17, exp_clamp_lo64<>(SB), Y6, Y1 // Y1 = mask: y < -709 (LT_OQ)
+    VXORPD Y2, Y2, Y2
+    VBLENDVPD Y1, Y2, Y4, Y4
+
+    VMOVUPD Y4, (DX)
+    ADDQ $32, SI
+    ADDQ $32, DX
+    DECQ R8
+    JNZ  pow64_loop4
+
+pow64_remainder:
+    ANDQ $3, CX
+    JZ   pow64_done
+
+pow64_scalar:
+    MOVQ (SI), AX
+    VMOVSD (SI), X0
+
+    // log core, scalar (x positive finite; subnormal pre-scale via GPR)
+    XORQ R9, R9
+    MOVQ $0x0010000000000000, BX
+    CMPQ AX, BX
+    JGE  pow64_scalar_normal
+    MOVQ $0x43F0000000000000, R10
+    VMOVQ R10, X2
+    VMULSD X2, X0, X0
+    VMOVQ X0, AX
+    MOVQ $-64, R9
+
+pow64_scalar_normal:
+    MOVQ $0x3FE6A09E00000000, BX
+    MOVQ AX, R10
+    SUBQ BX, R10                       // tmp
+    MOVQ R10, R11
+    SARQ $52, R11                      // e
+    ADDQ R9, R11
+    MOVQ $0xFFF0000000000000, BX
+    ANDQ BX, R10
+    SUBQ R10, AX                       // bits(m)
+    VMOVQ AX, X2                       // m
+    CVTSQ2SD R11, X3                   // e
+
+    VSUBSD X13, X2, X4                 // m - 1 (X13 = 1.0)
+    VADDSD X13, X2, X5                 // m + 1
+    VDIVSD X5, X4, X4                  // s
+    VMULSD X4, X4, X5                  // t
+    VMOVSD log64_c0<>(SB), X1
+    VFMADD213SD log64_c1<>(SB), X5, X1
+    VFMADD213SD log64_c2<>(SB), X5, X1
+    VFMADD213SD log64_c3<>(SB), X5, X1
+    VFMADD213SD log64_c4<>(SB), X5, X1
+    VFMADD213SD log64_c5<>(SB), X5, X1
+    VFMADD213SD log64_c6<>(SB), X5, X1 // P(t)
+    VMULSD X4, X5, X5                  // s*t
+    VADDSD X4, X4, X4                  // 2s
+    VFMADD231SD X1, X5, X4             // lnm
+    VMULSD log64_ln2lo<>(SB), X3, X5
+    VADDSD X4, X5, X5
+    VFMADD231SD log64_ln2hi<>(SB), X3, X5 // X5 = ln(x)
+
+    // y = p*ln(x); keep the pre-clamp y in X6, clamp for the exp core
+    // (X8 = p from the vector constants)
+    VMULSD X8, X5, X0
+    VMOVSD X0, X6, X6                  // X6 = y (pre-clamp)
+    VMINSD exp_clamp_hi64<>(SB), X0, X0
+    VMAXSD exp_clamp_lo64<>(SB), X0, X0
+
+    // exp core, scalar (X9-X15 = exp constants)
+    VMULSD X15, X0, X1
+    VROUNDSD $0, X1, X1, X2            // k
+    VMULSD X14, X2, X3
+    VSUBSD X3, X0, X3                  // r
+    VMULSD X3, X9, X4
+    VADDSD X10, X4, X4
+    VMULSD X3, X4, X4
+    VADDSD X11, X4, X4
+    VMULSD X3, X4, X4
+    VADDSD X12, X4, X4
+    VMULSD X3, X4, X4
+    VADDSD X13, X4, X4
+    VMULSD X3, X4, X4
+    VADDSD X13, X4, X4                 // exp(r)
+    VCVTTSD2SI X2, AX
+    SHLQ $52, AX
+    MOVQ $0x3FF0000000000000, BX
+    ADDQ BX, AX
+    VMOVQ AX, X5
+    VMULSD X5, X4, X4
+
+    // Overflow/underflow classes from the pre-clamp y (X6): strict compares
+    // so a y of exactly +-709 keeps the computed finite value
+    VMOVSD exp_clamp_hi64<>(SB), X1
+    VUCOMISD X1, X6
+    JA   pow64_scalar_posinf           // y > 709 -> +Inf
+    VMOVSD exp_clamp_lo64<>(SB), X1
+    VUCOMISD X1, X6
+    JB   pow64_scalar_zero             // y < -709 -> 0
+
+    VMOVSD X4, (DX)
+    JMP  pow64_scalar_next
+
+pow64_scalar_posinf:
+    MOVQ $0x7FF0000000000000, AX
+    MOVQ AX, (DX)
+    JMP  pow64_scalar_next
+
+pow64_scalar_zero:
+    MOVQ $0, AX
+    MOVQ AX, (DX)
+
+pow64_scalar_next:
+    ADDQ $8, SI
+    ADDQ $8, DX
+    DECQ CX
+    JNZ  pow64_scalar
+
+pow64_done:
+    VZEROUPPER
+    RET
+
+// func powElemAVX(dst, base, exp []float64)
+// Elementwise pow(base[i], exp[i]) = exp(exp[i]*ln(base[i])). Same cores and
+// preconditions as powAVX (all bases positive finite, all exponents finite),
+// with the exponent loaded per lane instead of broadcast.
+TEXT ·powElemAVX(SB), NOSPLIT, $0-72
+    MOVQ dst_base+0(FP), DX
+    MOVQ dst_len+8(FP), CX
+    MOVQ base_base+24(FP), SI
+    MOVQ exp_base+48(FP), DI
+
+    VMOVUPD log64_permidx<>(SB), Y7    // Y7 = VPERMD gather indices
+    VMOVUPD tanh64_c5<>(SB), Y9        // Y9 = 1/120
+    VMOVUPD tanh64_c4<>(SB), Y10       // Y10 = 1/24
+    VMOVUPD tanh64_c3<>(SB), Y11       // Y11 = 1/6
+    VMOVUPD sigmoid_half64<>(SB), Y12  // Y12 = 0.5
+    VMOVUPD sigmoid_one64<>(SB), Y13   // Y13 = 1.0
+    VMOVUPD tanh64_ln2<>(SB), Y14      // Y14 = ln(2)
+    VMOVUPD tanh64_log2e<>(SB), Y15    // Y15 = log2(e)
+
+    MOVQ CX, R8
+    SHRQ $2, R8
+    JZ   powelem64_remainder
+
+powelem64_loop4:
+    VMOVUPD (SI), Y0                   // Y0 = base (positive finite)
+
+    // --- log core (see logAVX) ---
+    VCMPPD $17, log64_dblmin<>(SB), Y0, Y1
+    VMULPD log64_two64<>(SB), Y0, Y2
+    VBLENDVPD Y1, Y2, Y0, Y0
+    VANDPD log64_negsc<>(SB), Y1, Y1   // ebias
+    VPSUBQ log64_off<>(SB), Y0, Y2     // tmp
+    VPAND log64_expmask<>(SB), Y2, Y3
+    VPSUBQ Y3, Y0, Y3                  // m
+    VPSRAD $20, Y2, Y2
+    VPERMD Y2, Y7, Y2
+    VCVTDQ2PD X2, Y2
+    VADDPD Y1, Y2, Y2                  // e
+    VSUBPD Y13, Y3, Y4                 // m - 1
+    VADDPD Y13, Y3, Y3                 // m + 1
+    VDIVPD Y3, Y4, Y4                  // s
+    VMULPD Y4, Y4, Y3                  // t
+    VMOVUPD log64_c0<>(SB), Y5
+    VFMADD213PD log64_c1<>(SB), Y3, Y5
+    VFMADD213PD log64_c2<>(SB), Y3, Y5
+    VFMADD213PD log64_c3<>(SB), Y3, Y5
+    VFMADD213PD log64_c4<>(SB), Y3, Y5
+    VFMADD213PD log64_c5<>(SB), Y3, Y5
+    VFMADD213PD log64_c6<>(SB), Y3, Y5 // P(t)
+    VMULPD Y4, Y3, Y3                  // s*t
+    VADDPD Y4, Y4, Y4                  // 2s
+    VFMADD231PD Y5, Y3, Y4             // lnm
+    VMULPD log64_ln2lo<>(SB), Y2, Y3
+    VADDPD Y4, Y3, Y3
+    VFMADD231PD log64_ln2hi<>(SB), Y2, Y3 // Y3 = ln(base)
+
+    // y = exp[i]*ln(base[i]); keep the pre-clamp value in Y6 for the
+    // overflow blends, then clamp to [-709, 709] for the exp core
+    VMOVUPD (DI), Y8                   // Y8 = exponents (finite)
+    VMULPD Y8, Y3, Y0
+    VMOVUPD Y0, Y6                     // Y6 = y (pre-clamp)
+    VMINPD exp_clamp_hi64<>(SB), Y0, Y0
+    VMAXPD exp_clamp_lo64<>(SB), Y0, Y0
+
+    // --- exp core (see expAVX) ---
+    VMULPD Y15, Y0, Y1
+    VROUNDPD $0, Y1, Y2                // k
+    VMULPD Y14, Y2, Y3
+    VSUBPD Y3, Y0, Y3                  // r
+    VMULPD Y3, Y9, Y4
+    VADDPD Y10, Y4, Y4
+    VMULPD Y3, Y4, Y4
+    VADDPD Y11, Y4, Y4
+    VMULPD Y3, Y4, Y4
+    VADDPD Y12, Y4, Y4
+    VMULPD Y3, Y4, Y4
+    VADDPD Y13, Y4, Y4
+    VMULPD Y3, Y4, Y4
+    VADDPD Y13, Y4, Y4                 // exp(r)
+    VCVTTPD2DQY Y2, X5
+    VPMOVSXDQ X5, Y5
+    VPSLLQ $52, Y5, Y5
+    VPADDQ sigmoid_one64<>(SB), Y5, Y5
+    VMULPD Y5, Y4, Y4
+
+    // Overflow/underflow classes from the pre-clamp y (see powAVX)
+    VMOVUPD log64_posinf<>(SB), Y2
+    VCMPPD $30, exp_clamp_hi64<>(SB), Y6, Y1 // Y1 = mask: y > 709 (GT_OQ)
+    VBLENDVPD Y1, Y2, Y4, Y4
+    VCMPPD $17, exp_clamp_lo64<>(SB), Y6, Y1 // Y1 = mask: y < -709 (LT_OQ)
+    VXORPD Y2, Y2, Y2
+    VBLENDVPD Y1, Y2, Y4, Y4
+
+    VMOVUPD Y4, (DX)
+    ADDQ $32, SI
+    ADDQ $32, DI
+    ADDQ $32, DX
+    DECQ R8
+    JNZ  powelem64_loop4
+
+powelem64_remainder:
+    ANDQ $3, CX
+    JZ   powelem64_done
+
+powelem64_scalar:
+    MOVQ (SI), AX
+    VMOVSD (SI), X0
+
+    XORQ R9, R9
+    MOVQ $0x0010000000000000, BX
+    CMPQ AX, BX
+    JGE  powelem64_scalar_normal
+    MOVQ $0x43F0000000000000, R10
+    VMOVQ R10, X2
+    VMULSD X2, X0, X0
+    VMOVQ X0, AX
+    MOVQ $-64, R9
+
+powelem64_scalar_normal:
+    MOVQ $0x3FE6A09E00000000, BX
+    MOVQ AX, R10
+    SUBQ BX, R10                       // tmp
+    MOVQ R10, R11
+    SARQ $52, R11                      // e
+    ADDQ R9, R11
+    MOVQ $0xFFF0000000000000, BX
+    ANDQ BX, R10
+    SUBQ R10, AX                       // bits(m)
+    VMOVQ AX, X2
+    CVTSQ2SD R11, X3                   // e
+
+    VSUBSD X13, X2, X4                 // m - 1
+    VADDSD X13, X2, X5                 // m + 1
+    VDIVSD X5, X4, X4                  // s
+    VMULSD X4, X4, X5                  // t
+    VMOVSD log64_c0<>(SB), X1
+    VFMADD213SD log64_c1<>(SB), X5, X1
+    VFMADD213SD log64_c2<>(SB), X5, X1
+    VFMADD213SD log64_c3<>(SB), X5, X1
+    VFMADD213SD log64_c4<>(SB), X5, X1
+    VFMADD213SD log64_c5<>(SB), X5, X1
+    VFMADD213SD log64_c6<>(SB), X5, X1
+    VMULSD X4, X5, X5                  // s*t
+    VADDSD X4, X4, X4                  // 2s
+    VFMADD231SD X1, X5, X4             // lnm
+    VMULSD log64_ln2lo<>(SB), X3, X5
+    VADDSD X4, X5, X5
+    VFMADD231SD log64_ln2hi<>(SB), X3, X5 // ln(base)
+
+    VMOVSD (DI), X8                    // p
+    VMULSD X8, X5, X0
+    VMOVSD X0, X6, X6                  // X6 = y (pre-clamp)
+    VMINSD exp_clamp_hi64<>(SB), X0, X0
+    VMAXSD exp_clamp_lo64<>(SB), X0, X0
+
+    VMULSD X15, X0, X1
+    VROUNDSD $0, X1, X1, X2
+    VMULSD X14, X2, X3
+    VSUBSD X3, X0, X3
+    VMULSD X3, X9, X4
+    VADDSD X10, X4, X4
+    VMULSD X3, X4, X4
+    VADDSD X11, X4, X4
+    VMULSD X3, X4, X4
+    VADDSD X12, X4, X4
+    VMULSD X3, X4, X4
+    VADDSD X13, X4, X4
+    VMULSD X3, X4, X4
+    VADDSD X13, X4, X4
+    VCVTTSD2SI X2, AX
+    SHLQ $52, AX
+    MOVQ $0x3FF0000000000000, BX
+    ADDQ BX, AX
+    VMOVQ AX, X5
+    VMULSD X5, X4, X4
+
+    // Overflow/underflow classes from the pre-clamp y (X6), see powAVX
+    VMOVSD exp_clamp_hi64<>(SB), X1
+    VUCOMISD X1, X6
+    JA   powelem64_scalar_posinf       // y > 709 -> +Inf
+    VMOVSD exp_clamp_lo64<>(SB), X1
+    VUCOMISD X1, X6
+    JB   powelem64_scalar_zero         // y < -709 -> 0
+
+    VMOVSD X4, (DX)
+    JMP  powelem64_scalar_next
+
+powelem64_scalar_posinf:
+    MOVQ $0x7FF0000000000000, AX
+    MOVQ AX, (DX)
+    JMP  powelem64_scalar_next
+
+powelem64_scalar_zero:
+    MOVQ $0, AX
+    MOVQ AX, (DX)
+
+powelem64_scalar_next:
+    ADDQ $8, SI
+    ADDQ $8, DI
+    ADDQ $8, DX
+    DECQ CX
+    JNZ  powelem64_scalar
+
+powelem64_done:
+    VZEROUPPER
+    RET

--- a/f64/f64_amd64.s
+++ b/f64/f64_amd64.s
@@ -5267,8 +5267,7 @@ log64_scalar:
     MOVQ $0x0010000000000000, BX       // DBL_MIN bits
     CMPQ AX, BX
     JGE  log64_scalar_normal
-    MOVQ $0x43F0000000000000, R10      // 2^64
-    VMOVQ R10, X2
+    VMOVSD log64_two64<>(SB), X2       // 2^64
     VMULSD X2, X0, X0                  // x *= 2^64
     VMOVQ X0, AX
     MOVQ $-64, R9
@@ -5454,8 +5453,7 @@ pow64_scalar:
     MOVQ $0x0010000000000000, BX
     CMPQ AX, BX
     JGE  pow64_scalar_normal
-    MOVQ $0x43F0000000000000, R10
-    VMOVQ R10, X2
+    VMOVSD log64_two64<>(SB), X2       // 2^64
     VMULSD X2, X0, X0
     VMOVQ X0, AX
     MOVQ $-64, R9
@@ -5646,8 +5644,7 @@ powelem64_scalar:
     MOVQ $0x0010000000000000, BX
     CMPQ AX, BX
     JGE  powelem64_scalar_normal
-    MOVQ $0x43F0000000000000, R10
-    VMOVQ R10, X2
+    VMOVSD log64_two64<>(SB), X2       // 2^64
     VMULSD X2, X0, X0
     VMOVQ X0, AX
     MOVQ $-64, R9

--- a/f64/f64_amd64.s
+++ b/f64/f64_amd64.s
@@ -5338,13 +5338,12 @@ log64_done:
 // Fused pow(x, p) = exp(p*ln(x)) for slices whose elements are all positive
 // and finite (the dispatcher guarantees this, see powSIMDOK64). The log core
 // matches logAVX (constants from memory instead of registers); the exp core
-// matches expAVX with its [-709, 709] clamp on y = p*ln(x), but lanes whose
-// pre-clamp y exceeds the clamp are blended to +Inf (y > 709) or 0
-// (y < -709) so true overflow/underflow keeps math.Pow's result classes.
-// Within ~0.1% of the clamp (709 < y < ln(MaxFloat64) ~ 709.78 and the
-// mirrored underflow band) the true result is still finite/subnormal, so the
-// blend rounds those bands to +Inf resp. 0. Accuracy elsewhere is bounded by
-// the exp core's degree-5 polynomial (~3e-6 relative). Requires AVX2 and FMA.
+// matches expAVX except y = p*ln(x) is clamped to [-746, 710] (past
+// ln(MaxFloat64) ~ 709.78 and ln of the smallest subnormal ~ -744.44) and
+// the 2^k reconstruction is split into 2^(k>>1) * 2^(k-(k>>1)), so overflow
+// goes to +Inf and underflow degrades gradually through subnormals to 0,
+// matching math.Pow's result classes. Accuracy is bounded by the exp core's
+// degree-5 polynomial (~3e-6 relative). Requires AVX2 and FMA.
 TEXT ·powAVX(SB), NOSPLIT, $0-56
     MOVQ dst_base+0(FP), DX
     MOVQ dst_len+8(FP), CX
@@ -5399,12 +5398,11 @@ pow64_loop4:
     VADDPD Y4, Y3, Y3                  // + lnm
     VFMADD231PD log64_ln2hi<>(SB), Y2, Y3 // Y3 = ln(x)
 
-    // y = p*ln(x); keep the pre-clamp value in Y6 for the overflow blends,
-    // then clamp to [-709, 709] for the exp core
+    // y = p*ln(x), clamped to [-746, 710]; the split 2^k reconstruction
+    // below covers the whole result range
     VMULPD Y8, Y3, Y0
-    VMOVUPD Y0, Y6                     // Y6 = y (pre-clamp)
-    VMINPD exp_clamp_hi64<>(SB), Y0, Y0
-    VMAXPD exp_clamp_lo64<>(SB), Y0, Y0
+    VMINPD log64_powclamp_hi<>(SB), Y0, Y0
+    VMAXPD log64_powclamp_lo<>(SB), Y0, Y0
 
     // --- exp core (see expAVX) ---
     VMULPD Y15, Y0, Y1                 // y * log2e
@@ -5421,21 +5419,21 @@ pow64_loop4:
     VADDPD Y13, Y4, Y4
     VMULPD Y3, Y4, Y4
     VADDPD Y13, Y4, Y4                 // exp(r)
-    VCVTTPD2DQY Y2, X5
+    // Split 2^k reconstruction: k reaches past the biased exponent range
+    // (down to -1076), so build 2^(k>>1) and 2^(k-(k>>1)) separately. The
+    // double multiply overflows to +Inf / underflows through subnormals to
+    // 0 exactly where math.Pow does.
+    VCVTTPD2DQY Y2, X5                 // X5 = 4 x int32(k)
+    VPSRAD $1, X5, X3                  // k1 = k >> 1
+    VPSUBD X3, X5, X5                  // k2 = k - k1
+    VPMOVSXDQ X3, Y3
+    VPSLLQ $52, Y3, Y3
+    VPADDQ sigmoid_one64<>(SB), Y3, Y3 // 2^k1 bits
+    VMULPD Y3, Y4, Y4                  // exp(r) * 2^k1
     VPMOVSXDQ X5, Y5
     VPSLLQ $52, Y5, Y5
-    VPADDQ sigmoid_one64<>(SB), Y5, Y5
-    VMULPD Y5, Y4, Y4                  // exp(y)
-
-    // Overflow/underflow classes from the pre-clamp y (strict compares, so a
-    // y of exactly +-709 keeps the computed finite value): y > 709 -> +Inf,
-    // y < -709 -> 0, matching math.Pow.
-    VMOVUPD log64_posinf<>(SB), Y2
-    VCMPPD $30, exp_clamp_hi64<>(SB), Y6, Y1 // Y1 = mask: y > 709 (GT_OQ)
-    VBLENDVPD Y1, Y2, Y4, Y4
-    VCMPPD $17, exp_clamp_lo64<>(SB), Y6, Y1 // Y1 = mask: y < -709 (LT_OQ)
-    VXORPD Y2, Y2, Y2
-    VBLENDVPD Y1, Y2, Y4, Y4
+    VPADDQ sigmoid_one64<>(SB), Y5, Y5 // 2^k2 bits
+    VMULPD Y5, Y4, Y4                  // * 2^k2 = exp(y)
 
     VMOVUPD Y4, (DX)
     ADDQ $32, SI
@@ -5493,12 +5491,10 @@ pow64_scalar_normal:
     VADDSD X4, X5, X5
     VFMADD231SD log64_ln2hi<>(SB), X3, X5 // X5 = ln(x)
 
-    // y = p*ln(x); keep the pre-clamp y in X6, clamp for the exp core
-    // (X8 = p from the vector constants)
+    // y = p*ln(x), clamped (X8 = p from the vector constants)
     VMULSD X8, X5, X0
-    VMOVSD X0, X6, X6                  // X6 = y (pre-clamp)
-    VMINSD exp_clamp_hi64<>(SB), X0, X0
-    VMAXSD exp_clamp_lo64<>(SB), X0, X0
+    VMINSD log64_powclamp_hi<>(SB), X0, X0
+    VMAXSD log64_powclamp_lo<>(SB), X0, X0
 
     // exp core, scalar (X9-X15 = exp constants)
     VMULSD X15, X0, X1
@@ -5515,35 +5511,22 @@ pow64_scalar_normal:
     VADDSD X13, X4, X4
     VMULSD X3, X4, X4
     VADDSD X13, X4, X4                 // exp(r)
-    VCVTTSD2SI X2, AX
-    SHLQ $52, AX
+    // Split 2^k reconstruction (see the vector body)
+    VCVTTSD2SI X2, AX                  // k
+    MOVQ AX, R10
+    SARQ $1, R10                       // k1 = k >> 1
+    SUBQ R10, AX                       // k2 = k - k1
     MOVQ $0x3FF0000000000000, BX
+    SHLQ $52, R10
+    ADDQ BX, R10
+    VMOVQ R10, X5
+    VMULSD X5, X4, X4                  // exp(r) * 2^k1
+    SHLQ $52, AX
     ADDQ BX, AX
     VMOVQ AX, X5
-    VMULSD X5, X4, X4
-
-    // Overflow/underflow classes from the pre-clamp y (X6): strict compares
-    // so a y of exactly +-709 keeps the computed finite value
-    VMOVSD exp_clamp_hi64<>(SB), X1
-    VUCOMISD X1, X6
-    JA   pow64_scalar_posinf           // y > 709 -> +Inf
-    VMOVSD exp_clamp_lo64<>(SB), X1
-    VUCOMISD X1, X6
-    JB   pow64_scalar_zero             // y < -709 -> 0
+    VMULSD X5, X4, X4                  // * 2^k2 = exp(y)
 
     VMOVSD X4, (DX)
-    JMP  pow64_scalar_next
-
-pow64_scalar_posinf:
-    MOVQ $0x7FF0000000000000, AX
-    MOVQ AX, (DX)
-    JMP  pow64_scalar_next
-
-pow64_scalar_zero:
-    MOVQ $0, AX
-    MOVQ AX, (DX)
-
-pow64_scalar_next:
     ADDQ $8, SI
     ADDQ $8, DX
     DECQ CX
@@ -5609,13 +5592,12 @@ powelem64_loop4:
     VADDPD Y4, Y3, Y3
     VFMADD231PD log64_ln2hi<>(SB), Y2, Y3 // Y3 = ln(base)
 
-    // y = exp[i]*ln(base[i]); keep the pre-clamp value in Y6 for the
-    // overflow blends, then clamp to [-709, 709] for the exp core
+    // y = exp[i]*ln(base[i]), clamped to [-746, 710]; the split 2^k
+    // reconstruction below covers the whole result range
     VMOVUPD (DI), Y8                   // Y8 = exponents (finite)
     VMULPD Y8, Y3, Y0
-    VMOVUPD Y0, Y6                     // Y6 = y (pre-clamp)
-    VMINPD exp_clamp_hi64<>(SB), Y0, Y0
-    VMAXPD exp_clamp_lo64<>(SB), Y0, Y0
+    VMINPD log64_powclamp_hi<>(SB), Y0, Y0
+    VMAXPD log64_powclamp_lo<>(SB), Y0, Y0
 
     // --- exp core (see expAVX) ---
     VMULPD Y15, Y0, Y1
@@ -5632,19 +5614,18 @@ powelem64_loop4:
     VADDPD Y13, Y4, Y4
     VMULPD Y3, Y4, Y4
     VADDPD Y13, Y4, Y4                 // exp(r)
-    VCVTTPD2DQY Y2, X5
+    // Split 2^k reconstruction (see powAVX)
+    VCVTTPD2DQY Y2, X5                 // X5 = 4 x int32(k)
+    VPSRAD $1, X5, X3                  // k1 = k >> 1
+    VPSUBD X3, X5, X5                  // k2 = k - k1
+    VPMOVSXDQ X3, Y3
+    VPSLLQ $52, Y3, Y3
+    VPADDQ sigmoid_one64<>(SB), Y3, Y3 // 2^k1 bits
+    VMULPD Y3, Y4, Y4                  // exp(r) * 2^k1
     VPMOVSXDQ X5, Y5
     VPSLLQ $52, Y5, Y5
-    VPADDQ sigmoid_one64<>(SB), Y5, Y5
-    VMULPD Y5, Y4, Y4
-
-    // Overflow/underflow classes from the pre-clamp y (see powAVX)
-    VMOVUPD log64_posinf<>(SB), Y2
-    VCMPPD $30, exp_clamp_hi64<>(SB), Y6, Y1 // Y1 = mask: y > 709 (GT_OQ)
-    VBLENDVPD Y1, Y2, Y4, Y4
-    VCMPPD $17, exp_clamp_lo64<>(SB), Y6, Y1 // Y1 = mask: y < -709 (LT_OQ)
-    VXORPD Y2, Y2, Y2
-    VBLENDVPD Y1, Y2, Y4, Y4
+    VPADDQ sigmoid_one64<>(SB), Y5, Y5 // 2^k2 bits
+    VMULPD Y5, Y4, Y4                  // * 2^k2 = exp(y)
 
     VMOVUPD Y4, (DX)
     ADDQ $32, SI
@@ -5704,9 +5685,8 @@ powelem64_scalar_normal:
 
     VMOVSD (DI), X8                    // p
     VMULSD X8, X5, X0
-    VMOVSD X0, X6, X6                  // X6 = y (pre-clamp)
-    VMINSD exp_clamp_hi64<>(SB), X0, X0
-    VMAXSD exp_clamp_lo64<>(SB), X0, X0
+    VMINSD log64_powclamp_hi<>(SB), X0, X0
+    VMAXSD log64_powclamp_lo<>(SB), X0, X0
 
     VMULSD X15, X0, X1
     VROUNDSD $0, X1, X1, X2
@@ -5722,34 +5702,22 @@ powelem64_scalar_normal:
     VADDSD X13, X4, X4
     VMULSD X3, X4, X4
     VADDSD X13, X4, X4
-    VCVTTSD2SI X2, AX
-    SHLQ $52, AX
+    // Split 2^k reconstruction (see powAVX)
+    VCVTTSD2SI X2, AX                  // k
+    MOVQ AX, R10
+    SARQ $1, R10                       // k1 = k >> 1
+    SUBQ R10, AX                       // k2 = k - k1
     MOVQ $0x3FF0000000000000, BX
+    SHLQ $52, R10
+    ADDQ BX, R10
+    VMOVQ R10, X5
+    VMULSD X5, X4, X4                  // exp(r) * 2^k1
+    SHLQ $52, AX
     ADDQ BX, AX
     VMOVQ AX, X5
-    VMULSD X5, X4, X4
-
-    // Overflow/underflow classes from the pre-clamp y (X6), see powAVX
-    VMOVSD exp_clamp_hi64<>(SB), X1
-    VUCOMISD X1, X6
-    JA   powelem64_scalar_posinf       // y > 709 -> +Inf
-    VMOVSD exp_clamp_lo64<>(SB), X1
-    VUCOMISD X1, X6
-    JB   powelem64_scalar_zero         // y < -709 -> 0
+    VMULSD X5, X4, X4                  // * 2^k2 = exp(y)
 
     VMOVSD X4, (DX)
-    JMP  powelem64_scalar_next
-
-powelem64_scalar_posinf:
-    MOVQ $0x7FF0000000000000, AX
-    MOVQ AX, (DX)
-    JMP  powelem64_scalar_next
-
-powelem64_scalar_zero:
-    MOVQ $0, AX
-    MOVQ AX, (DX)
-
-powelem64_scalar_next:
     ADDQ $8, SI
     ADDQ $8, DI
     ADDQ $8, DX
@@ -5759,3 +5727,19 @@ powelem64_scalar_next:
 powelem64_done:
     VZEROUPPER
     RET
+
+// Pow clamp bounds: wider than the Exp kernel's +-709 because the pow
+// kernels split the 2^k reconstruction (2^(k>>1) * 2^(k-(k>>1))), which
+// covers the full float64 result range. ln(MaxFloat64) ~ 709.78,
+// ln(smallest subnormal) ~ -744.44.
+DATA log64_powclamp_hi<>+0x00(SB)/8, $0x4086300000000000  // 710.0
+DATA log64_powclamp_hi<>+0x08(SB)/8, $0x4086300000000000
+DATA log64_powclamp_hi<>+0x10(SB)/8, $0x4086300000000000
+DATA log64_powclamp_hi<>+0x18(SB)/8, $0x4086300000000000
+GLOBL log64_powclamp_hi<>(SB), RODATA|NOPTR, $32
+
+DATA log64_powclamp_lo<>+0x00(SB)/8, $0xc087500000000000  // -746.0
+DATA log64_powclamp_lo<>+0x08(SB)/8, $0xc087500000000000
+DATA log64_powclamp_lo<>+0x10(SB)/8, $0xc087500000000000
+DATA log64_powclamp_lo<>+0x18(SB)/8, $0xc087500000000000
+GLOBL log64_powclamp_lo<>(SB), RODATA|NOPTR, $32

--- a/f64/f64_arm64.go
+++ b/f64/f64_arm64.go
@@ -3,6 +3,7 @@
 package f64
 
 import (
+	"math"
 	"unsafe"
 
 	"github.com/tphakala/simd/cpu"
@@ -523,6 +524,61 @@ func exp64(dst, src []float64) {
 	}
 	exp64Go(dst, src)
 }
+
+func log64(dst, src []float64) {
+	// Assumes len(src) >= len(dst); caller ensures this via public API
+	if hasNEON && len(dst) >= 2 {
+		logNEON64(dst, src, logLn2Hi64, logLn2Lo64, 1.0)
+		return
+	}
+	logGo(dst, src)
+}
+
+func log2_64(dst, src []float64) {
+	// log2(x) = e + ln(m)*log2(e): the e term is exact, so no hi/lo split is
+	// needed and exact powers of two come out exact.
+	if hasNEON && len(dst) >= 2 {
+		logNEON64(dst, src, 1.0, 0.0, logLog2E64)
+		return
+	}
+	log2Go(dst, src)
+}
+
+func log10_64(dst, src []float64) {
+	if hasNEON && len(dst) >= 2 {
+		logNEON64(dst, src, logL102Hi64, logL102Lo64, logLog10E64)
+		return
+	}
+	log10Go(dst, src)
+}
+
+func pow64(dst, src []float64, exp float64) {
+	// A zero or non-finite exponent has whole-slice math.Pow semantics
+	// (for example Pow(x, 0) = 1 even for NaN x); keep those exact.
+	if hasNEON && len(dst) >= 2 && exp != 0 && !math.IsNaN(exp) && !math.IsInf(exp, 0) &&
+		powSIMDOK64(src[:len(dst)]) {
+		powNEON64(dst, src, exp)
+		return
+	}
+	powGo(dst, src, exp)
+}
+
+func powElem64(dst, base, exp []float64) {
+	if hasNEON && len(dst) >= 2 && powSIMDOK64(base[:len(dst)]) && allFinite64(exp[:len(dst)]) {
+		powElemNEON64(dst, base, exp)
+		return
+	}
+	powElemGo(dst, base, exp)
+}
+
+//go:noescape
+func logNEON64(dst, src []float64, k1hi, k1lo, k2 float64)
+
+//go:noescape
+func powNEON64(dst, src []float64, exp float64)
+
+//go:noescape
+func powElemNEON64(dst, base, exp []float64)
 
 //go:noescape
 func expNEON64(dst, src []float64)

--- a/f64/f64_arm64.s
+++ b/f64/f64_arm64.s
@@ -1830,3 +1830,798 @@ dot4d_store:
     FMOVD F2, 16(R0)
     FMOVD F3, 24(R0)
     RET
+
+// ============================================================================
+// logNEON64 / powNEON64 / powElemNEON64: vectorized natural log core (#109)
+// ============================================================================
+
+// Exp-core constants for the pow kernels, loaded per iteration with one VLD1
+// pair into working registers because the persistent V12-V31 budget is
+// exhausted by the log-core constants: [ln(2), 0.5, 1/6, 1/24, 1/120], one
+// lane pair each.
+DATA log64neon_expc<>+0x00(SB)/8, $0x3FE62E42FEFA39EF
+DATA log64neon_expc<>+0x08(SB)/8, $0x3FE62E42FEFA39EF
+DATA log64neon_expc<>+0x10(SB)/8, $0x3FE0000000000000
+DATA log64neon_expc<>+0x18(SB)/8, $0x3FE0000000000000
+DATA log64neon_expc<>+0x20(SB)/8, $0x3FC5555555555555
+DATA log64neon_expc<>+0x28(SB)/8, $0x3FC5555555555555
+DATA log64neon_expc<>+0x30(SB)/8, $0x3FA5555555555555
+DATA log64neon_expc<>+0x38(SB)/8, $0x3FA5555555555555
+DATA log64neon_expc<>+0x40(SB)/8, $0x3F81111111111111
+DATA log64neon_expc<>+0x48(SB)/8, $0x3F81111111111111
+GLOBL log64neon_expc<>(SB), RODATA|NOPTR, $80
+
+// func logNEON64(dst, src []float64, k1hi, k1lo, k2 float64)
+// Shared kernel for Log, Log2, and Log10: per lane it computes
+// result = e*k1hi + (lnm*k2 + e*k1lo), with x = m*2^e, m in
+// [sqrt(2)/2, sqrt(2)) and lnm = ln(m) = 2s + s*t*P(t) for s = (m-1)/(m+1),
+// t = s^2 (atanh form, SLEEF xlog_u1 minimax polynomial; same algorithm as
+// the amd64 logAVX). Positive subnormal inputs are pre-scaled by 2^64
+// (exponent bias -64). Special lanes are fixed up with BIT blends from the
+// original input: +Inf -> +Inf, +-0 -> -Inf, x < 0 or NaN -> NaN, matching
+// math.Log. Processes 2 elements per iteration; the 0-1 element tail uses
+// the scalar path below.
+TEXT ·logNEON64(SB), NOSPLIT, $0-72
+    MOVD dst_base+0(FP), R0
+    MOVD dst_len+8(FP), R3
+    MOVD src_base+24(FP), R1
+
+    // Special-value constants for the blend fixups
+    MOVD $0x7FF0000000000000, R10
+    VMOV R10, V13.D[0]
+    VDUP V13.D[0], V13.D2             // V13 = +Inf
+    MOVD $0xFFF0000000000000, R10
+    VMOV R10, V14.D[0]
+    VDUP V14.D[0], V14.D2             // V14 = -Inf
+    MOVD $0x7FF8000000000000, R10
+    VMOV R10, V15.D[0]
+    VDUP V15.D[0], V15.D2             // V15 = quiet NaN
+
+    // Reduction constants (see logAVX for the algorithm notes)
+    MOVD $0x3FE6A09E00000000, R10
+    VMOV R10, V16.D[0]
+    VDUP V16.D[0], V16.D2             // V16 = reduction offset
+    MOVD $0xFFF0000000000000, R10
+    VMOV R10, V17.D[0]
+    VDUP V17.D[0], V17.D2             // V17 = exponent mask
+    MOVD $0x0010000000000000, R10
+    VMOV R10, V18.D[0]
+    VDUP V18.D[0], V18.D2             // V18 = DBL_MIN
+    MOVD $0x43F0000000000000, R10
+    VMOV R10, V19.D[0]
+    VDUP V19.D[0], V19.D2             // V19 = 2^64 (subnormal pre-scale)
+    MOVD $0xC050000000000000, R10
+    VMOV R10, V20.D[0]
+    VDUP V20.D[0], V20.D2             // V20 = -64.0 (exponent bias)
+    FMOVD $1.0, F21
+    VDUP V21.D[0], V21.D2             // V21 = 1.0
+
+    // Reconstruction constants from the arguments
+    FMOVD k1hi+48(FP), F22
+    VDUP V22.D[0], V22.D2             // V22 = k1hi
+    FMOVD k1lo+56(FP), F23
+    VDUP V23.D[0], V23.D2             // V23 = k1lo
+    FMOVD k2+64(FP), F24
+    VDUP V24.D[0], V24.D2             // V24 = k2
+
+    // SLEEF xlog_u1 minimax coefficients c0..c6
+    MOVD $0x3FC39C4F5407567E, R10
+    VMOV R10, V25.D[0]
+    VDUP V25.D[0], V25.D2             // V25 = c0 = 0.15320769885027014
+    MOVD $0x3FC3872E67FE8E84, R10
+    VMOV R10, V26.D[0]
+    VDUP V26.D[0], V26.D2             // V26 = c1 = 0.15256290510034287
+    MOVD $0x3FC747353A506035, R10
+    VMOV R10, V27.D[0]
+    VDUP V27.D[0], V27.D2             // V27 = c2 = 0.1818605932937786
+    MOVD $0x3FCC71C0A65ECD8E, R10
+    VMOV R10, V28.D[0]
+    VDUP V28.D[0], V28.D2             // V28 = c3 = 0.222221451983938
+    MOVD $0x3FD249249A68A245, R10
+    VMOV R10, V29.D[0]
+    VDUP V29.D[0], V29.D2             // V29 = c4 = 0.28571429327942993
+    MOVD $0x3FD99999998F92EA, R10
+    VMOV R10, V30.D[0]
+    VDUP V30.D[0], V30.D2             // V30 = c5 = 0.3999999999635252
+    MOVD $0x3FE55555555557AE, R10
+    VMOV R10, V31.D[0]
+    VDUP V31.D[0], V31.D2             // V31 = c6 = 0.66666666666673335
+
+    LSR $1, R3, R4
+    CBZ R4, log64_neon_scalar
+
+log64_neon_loop2:
+    VLD1.P 16(R1), [V0.D2]            // V0 = x (kept for the special blends)
+
+    // Subnormal pre-scale: lanes with x < DBL_MIN scaled by 2^64, bias -64
+    WORD $0x6ee0e641                  // FCMGT V1.2D, V18.2D, V0.2D   mask: x < DBL_MIN
+    WORD $0x6e73dc02                  // FMUL V2.2D, V0.2D, V19.2D    x * 2^64
+    WORD $0x4ea11c23                  // MOV V3.16B, V1.16B           copy mask for BSL
+    WORD $0x6e601c43                  // BSL V3.16B, V2.16B, V0.16B   xs = mask ? x*2^64 : x
+    WORD $0x4e341c24                  // AND V4.16B, V1.16B, V20.16B  ebias = mask & -64.0
+
+    // tmp = bits(xs) - OFF; bits(m) = bits(xs) - (tmp & expmask);
+    // e = (tmp >> 52) + ebias, leaving m in [sqrt(2)/2, sqrt(2))
+    WORD $0x6ef08465                  // SUB V5.2D, V3.2D, V16.2D     tmp
+    WORD $0x4e311ca6                  // AND V6.16B, V5.16B, V17.16B  tmp & expmask
+    WORD $0x6ee68466                  // SUB V6.2D, V3.2D, V6.2D      bits(m)
+    WORD $0x4f4c04a5                  // SSHR V5.2D, V5.2D, #52       e (int64, arithmetic)
+    WORD $0x4e61d8a5                  // SCVTF V5.2D, V5.2D           e as float64
+    WORD $0x4e64d4a5                  // FADD V5.2D, V5.2D, V4.2D     e += ebias
+
+    // s = (m-1)/(m+1), t = s^2
+    WORD $0x4ef5d4c7                  // FSUB V7.2D, V6.2D, V21.2D    m - 1
+    WORD $0x4e75d4c6                  // FADD V6.2D, V6.2D, V21.2D    m + 1
+    WORD $0x6e66fce7                  // FDIV V7.2D, V7.2D, V6.2D     s
+    WORD $0x6e67dce6                  // FMUL V6.2D, V7.2D, V7.2D     t
+
+    // P(t), Horner ping-pong between V8/V9 with FMLA
+    WORD $0x4eb91f28                  // MOV V8.16B, V25.16B          acc = c0
+    WORD $0x4eba1f49                  // MOV V9.16B, V26.16B
+    WORD $0x4e66cd09                  // FMLA V9.2D, V8.2D, V6.2D     c1 + acc*t
+    WORD $0x4ebb1f68                  // MOV V8.16B, V27.16B
+    WORD $0x4e66cd28                  // FMLA V8.2D, V9.2D, V6.2D     c2 + acc*t
+    WORD $0x4ebc1f89                  // MOV V9.16B, V28.16B
+    WORD $0x4e66cd09                  // FMLA V9.2D, V8.2D, V6.2D     c3 + acc*t
+    WORD $0x4ebd1fa8                  // MOV V8.16B, V29.16B
+    WORD $0x4e66cd28                  // FMLA V8.2D, V9.2D, V6.2D     c4 + acc*t
+    WORD $0x4ebe1fc9                  // MOV V9.16B, V30.16B
+    WORD $0x4e66cd09                  // FMLA V9.2D, V8.2D, V6.2D     c5 + acc*t
+    WORD $0x4ebf1fe8                  // MOV V8.16B, V31.16B
+    WORD $0x4e66cd28                  // FMLA V8.2D, V9.2D, V6.2D     P(t) = c6 + acc*t
+
+    // lnm = 2s + s*t*P(t)
+    WORD $0x6e66dcea                  // FMUL V10.2D, V7.2D, V6.2D    s*t
+    WORD $0x4e67d4eb                  // FADD V11.2D, V7.2D, V7.2D    2s
+    WORD $0x4e68cd4b                  // FMLA V11.2D, V10.2D, V8.2D   lnm
+
+    // result = e*k1hi + (lnm*k2 + e*k1lo)
+    WORD $0x6e77dcaa                  // FMUL V10.2D, V5.2D, V23.2D   e * k1lo
+    WORD $0x4e78cd6a                  // FMLA V10.2D, V11.2D, V24.2D  += lnm * k2
+    WORD $0x4e76ccaa                  // FMLA V10.2D, V5.2D, V22.2D   += e * k1hi
+
+    // Special lanes from the original x: +Inf -> +Inf, +-0 -> -Inf,
+    // x < 0 or NaN -> NaN
+    WORD $0x4e6de401                  // FCMEQ V1.2D, V0.2D, V13.2D   mask: x == +Inf
+    WORD $0x6ea11daa                  // BIT V10.16B, V13.16B, V1.16B
+    WORD $0x4ee0d801                  // FCMEQ V1.2D, V0.2D, #0       mask: x == +-0
+    WORD $0x6ea11dca                  // BIT V10.16B, V14.16B, V1.16B
+    WORD $0x4ee0e802                  // FCMLT V2.2D, V0.2D, #0       mask: x < 0
+    WORD $0x4e60e401                  // FCMEQ V1.2D, V0.2D, V0.2D    mask: x ordered
+    WORD $0x4ee11c42                  // ORN V2.16B, V2.16B, V1.16B   (x < 0) | NaN
+    WORD $0x6ea21dea                  // BIT V10.16B, V15.16B, V2.16B
+
+    VST1.P [V10.D2], 16(R0)
+    SUB $1, R4
+    CBNZ R4, log64_neon_loop2
+
+log64_neon_scalar:
+    AND $1, R3
+    CBZ R3, log64_neon_done
+
+log64_neon_scalar_loop:
+    MOVD (R1), R5                     // bits(x)
+    FMOVD (R1), F0
+
+    // Specials: FCMPD sets V for unordered, N for negative, Z for zero
+    FCMPD $(0.0), F0
+    BVS log64_neon_scalar_nan         // x is NaN
+    BMI log64_neon_scalar_nan         // x < 0
+    BEQ log64_neon_scalar_neginf      // x == +-0
+    MOVD $0x7FF0000000000000, R6
+    CMP R6, R5
+    BEQ log64_neon_scalar_posinf
+
+    // Subnormal pre-scale (x positive finite; bits compare as ints)
+    MOVD $0, R9
+    MOVD $0x0010000000000000, R6
+    CMP R6, R5
+    BGE log64_neon_scalar_normal
+    MOVD $0x43F0000000000000, R7
+    FMOVD R7, F2
+    FMULD F2, F0, F0
+    FMOVD F0, R5
+    MOVD $-64, R9
+
+log64_neon_scalar_normal:
+    MOVD $0x3FE6A09E00000000, R6
+    SUB R6, R5, R7                    // tmp = bits - OFF
+    ASR $52, R7, R8                   // e
+    ADD R9, R8, R8                    // e += bias
+    MOVD $0xFFF0000000000000, R6
+    AND R6, R7, R7
+    SUB R7, R5, R5                    // bits(m)
+    FMOVD R5, F1                      // m
+    SCVTFD R8, F2                     // e as float64
+
+    // s = (m-1)/(m+1), t = s^2 (F21 = 1.0 from the vector constants)
+    FSUBD F21, F1, F3                 // m - 1
+    FADDD F21, F1, F4                 // m + 1
+    FDIVD F4, F3, F3                  // s
+    FMULD F3, F3, F4                  // t
+
+    // P(t): FMADDD Fm, Fa, Fn, Fd computes Fd = Fa + Fn*Fm
+    FMADDD F4, F26, F25, F5           // c1 + c0*t
+    FMADDD F4, F27, F5, F5            // c2 + acc*t
+    FMADDD F4, F28, F5, F5            // c3 + acc*t
+    FMADDD F4, F29, F5, F5            // c4 + acc*t
+    FMADDD F4, F30, F5, F5            // c5 + acc*t
+    FMADDD F4, F31, F5, F5            // P(t) = c6 + acc*t
+
+    FMULD F4, F3, F4                  // s*t
+    FADDD F3, F3, F3                  // 2s
+    FMADDD F5, F3, F4, F3             // lnm = 2s + s*t*P(t)
+
+    FMULD F23, F2, F4                 // e * k1lo
+    FMADDD F24, F4, F3, F4            // += lnm * k2
+    FMADDD F22, F4, F2, F4            // += e * k1hi
+    FMOVD F4, (R0)
+    B log64_neon_scalar_next
+
+log64_neon_scalar_nan:
+    MOVD $0x7FF8000000000000, R6
+    MOVD R6, (R0)
+    B log64_neon_scalar_next
+
+log64_neon_scalar_neginf:
+    MOVD $0xFFF0000000000000, R6
+    MOVD R6, (R0)
+    B log64_neon_scalar_next
+
+log64_neon_scalar_posinf:
+    MOVD $0x7FF0000000000000, R6
+    MOVD R6, (R0)
+
+log64_neon_scalar_next:
+    ADD $8, R1
+    ADD $8, R0
+    SUB $1, R3
+    CBNZ R3, log64_neon_scalar_loop
+
+log64_neon_done:
+    RET
+
+// func powNEON64(dst, src []float64, exp float64)
+// Fused pow(x, p) = exp(p*ln(x)) for slices whose elements are all positive
+// and finite (the dispatcher guarantees this, see powSIMDOK64). The log core
+// matches logNEON64; the exp core matches expNEON64 with its [-709, 709]
+// clamp on y = p*ln(x), but lanes whose pre-clamp y exceeds the clamp are
+// blended to +Inf (y > 709) or 0 (y < -709) so true overflow/underflow keeps
+// math.Pow's result classes (see powAVX for the band caveat). Accuracy is
+// bounded by the exp core's degree-5 polynomial (~3e-6 relative).
+TEXT ·powNEON64(SB), NOSPLIT, $0-56
+    MOVD dst_base+0(FP), R0
+    MOVD dst_len+8(FP), R3
+    MOVD src_base+24(FP), R1
+    MOVD $log64neon_expc<>(SB), R5    // exp-core constant table
+    ADD $64, R5, R6                   // second VLD1 base (c5 = 1/120)
+
+    FMOVD exp+48(FP), F12
+    VDUP V12.D[0], V12.D2             // V12 = p
+
+    // Exp clamp bounds and +Inf for the overflow blend
+    MOVD $0x4086280000000000, R10
+    VMOV R10, V13.D[0]
+    VDUP V13.D[0], V13.D2             // V13 = 709.0
+    MOVD $0xC086280000000000, R10
+    VMOV R10, V14.D[0]
+    VDUP V14.D[0], V14.D2             // V14 = -709.0
+    MOVD $0x7FF0000000000000, R10
+    VMOV R10, V15.D[0]
+    VDUP V15.D[0], V15.D2             // V15 = +Inf
+
+    // Log-core reduction constants (see logNEON64)
+    MOVD $0x3FE6A09E00000000, R10
+    VMOV R10, V16.D[0]
+    VDUP V16.D[0], V16.D2             // V16 = reduction offset
+    MOVD $0xFFF0000000000000, R10
+    VMOV R10, V17.D[0]
+    VDUP V17.D[0], V17.D2             // V17 = exponent mask
+    MOVD $0x0010000000000000, R10
+    VMOV R10, V18.D[0]
+    VDUP V18.D[0], V18.D2             // V18 = DBL_MIN
+    MOVD $0x43F0000000000000, R10
+    VMOV R10, V19.D[0]
+    VDUP V19.D[0], V19.D2             // V19 = 2^64
+    MOVD $0xC050000000000000, R10
+    VMOV R10, V20.D[0]
+    VDUP V20.D[0], V20.D2             // V20 = -64.0
+    FMOVD $1.0, F21
+    VDUP V21.D[0], V21.D2             // V21 = 1.0
+
+    // fdlibm ln(2) hi/lo split and log2(e)
+    MOVD $0x3FE62E42FEE00000, R10
+    VMOV R10, V22.D[0]
+    VDUP V22.D[0], V22.D2             // V22 = ln2 hi
+    MOVD $0x3DEA39EF35793C76, R10
+    VMOV R10, V23.D[0]
+    VDUP V23.D[0], V23.D2             // V23 = ln2 lo
+    MOVD $0x3FF71547652B82FE, R10
+    VMOV R10, V24.D[0]
+    VDUP V24.D[0], V24.D2             // V24 = log2(e)
+
+    // SLEEF xlog_u1 minimax coefficients c0..c6
+    MOVD $0x3FC39C4F5407567E, R10
+    VMOV R10, V25.D[0]
+    VDUP V25.D[0], V25.D2             // V25 = c0
+    MOVD $0x3FC3872E67FE8E84, R10
+    VMOV R10, V26.D[0]
+    VDUP V26.D[0], V26.D2             // V26 = c1
+    MOVD $0x3FC747353A506035, R10
+    VMOV R10, V27.D[0]
+    VDUP V27.D[0], V27.D2             // V27 = c2
+    MOVD $0x3FCC71C0A65ECD8E, R10
+    VMOV R10, V28.D[0]
+    VDUP V28.D[0], V28.D2             // V28 = c3
+    MOVD $0x3FD249249A68A245, R10
+    VMOV R10, V29.D[0]
+    VDUP V29.D[0], V29.D2             // V29 = c4
+    MOVD $0x3FD99999998F92EA, R10
+    VMOV R10, V30.D[0]
+    VDUP V30.D[0], V30.D2             // V30 = c5
+    MOVD $0x3FE55555555557AE, R10
+    VMOV R10, V31.D[0]
+    VDUP V31.D[0], V31.D2             // V31 = c6
+
+    LSR $1, R3, R4
+    CBZ R4, pow64_neon_scalar
+
+pow64_neon_loop2:
+    VLD1.P 16(R1), [V0.D2]            // V0 = x (positive finite)
+
+    // --- log core (see logNEON64) ---
+    WORD $0x6ee0e641                  // FCMGT V1.2D, V18.2D, V0.2D   mask: x < DBL_MIN
+    WORD $0x6e73dc02                  // FMUL V2.2D, V0.2D, V19.2D    x * 2^64
+    WORD $0x4ea11c23                  // MOV V3.16B, V1.16B
+    WORD $0x6e601c43                  // BSL V3.16B, V2.16B, V0.16B   xs
+    WORD $0x4e341c24                  // AND V4.16B, V1.16B, V20.16B  ebias
+    WORD $0x6ef08465                  // SUB V5.2D, V3.2D, V16.2D     tmp
+    WORD $0x4e311ca6                  // AND V6.16B, V5.16B, V17.16B
+    WORD $0x6ee68466                  // SUB V6.2D, V3.2D, V6.2D      bits(m)
+    WORD $0x4f4c04a5                  // SSHR V5.2D, V5.2D, #52       e (int64)
+    WORD $0x4e61d8a5                  // SCVTF V5.2D, V5.2D           e as float64
+    WORD $0x4e64d4a5                  // FADD V5.2D, V5.2D, V4.2D     e += ebias
+    WORD $0x4ef5d4c7                  // FSUB V7.2D, V6.2D, V21.2D    m - 1
+    WORD $0x4e75d4c6                  // FADD V6.2D, V6.2D, V21.2D    m + 1
+    WORD $0x6e66fce7                  // FDIV V7.2D, V7.2D, V6.2D     s
+    WORD $0x6e67dce6                  // FMUL V6.2D, V7.2D, V7.2D     t
+    WORD $0x4eb91f28                  // MOV V8.16B, V25.16B          acc = c0
+    WORD $0x4eba1f49                  // MOV V9.16B, V26.16B
+    WORD $0x4e66cd09                  // FMLA V9.2D, V8.2D, V6.2D     c1 + acc*t
+    WORD $0x4ebb1f68                  // MOV V8.16B, V27.16B
+    WORD $0x4e66cd28                  // FMLA V8.2D, V9.2D, V6.2D     c2 + acc*t
+    WORD $0x4ebc1f89                  // MOV V9.16B, V28.16B
+    WORD $0x4e66cd09                  // FMLA V9.2D, V8.2D, V6.2D     c3 + acc*t
+    WORD $0x4ebd1fa8                  // MOV V8.16B, V29.16B
+    WORD $0x4e66cd28                  // FMLA V8.2D, V9.2D, V6.2D     c4 + acc*t
+    WORD $0x4ebe1fc9                  // MOV V9.16B, V30.16B
+    WORD $0x4e66cd09                  // FMLA V9.2D, V8.2D, V6.2D     c5 + acc*t
+    WORD $0x4ebf1fe8                  // MOV V8.16B, V31.16B
+    WORD $0x4e66cd28                  // FMLA V8.2D, V9.2D, V6.2D     P(t)
+    WORD $0x6e66dcea                  // FMUL V10.2D, V7.2D, V6.2D    s*t
+    WORD $0x4e67d4eb                  // FADD V11.2D, V7.2D, V7.2D    2s
+    WORD $0x4e68cd4b                  // FMLA V11.2D, V10.2D, V8.2D   lnm
+
+    // ln(x) = e*ln2hi + (e*ln2lo + lnm)
+    WORD $0x6e77dcaa                  // FMUL V10.2D, V5.2D, V23.2D   e * ln2lo
+    WORD $0x4e6bd54a                  // FADD V10.2D, V10.2D, V11.2D  + lnm
+    WORD $0x4e76ccaa                  // FMLA V10.2D, V5.2D, V22.2D   += e * ln2hi
+
+    // y = p*ln(x); keep the pre-clamp y in V6 for the overflow blends, then
+    // clamp to [-709, 709] for the exp core
+    WORD $0x6e6cdd40                  // FMUL V0.2D, V10.2D, V12.2D   y
+    WORD $0x4ea01c06                  // MOV V6.16B, V0.16B           pre-clamp y
+    WORD $0x4eedf400                  // FMIN V0.2D, V0.2D, V13.2D
+    WORD $0x4e6ef400                  // FMAX V0.2D, V0.2D, V14.2D
+
+    // --- exp core (see expNEON64); constants from the table ---
+    VLD1 (R5), [V1.D2, V2.D2, V3.D2, V4.D2] // ln2, 0.5, 1/6, 1/24
+    VLD1 (R6), [V5.D2]                      // 1/120
+    WORD $0x6e78dc07                  // FMUL V7.2D, V0.2D, V24.2D    y * log2e
+    WORD $0x4e6188e7                  // FRINTN V7.2D, V7.2D          k
+    WORD $0x6e61dce8                  // FMUL V8.2D, V7.2D, V1.2D     k * ln2
+    WORD $0x4ee8d408                  // FSUB V8.2D, V0.2D, V8.2D     r
+    WORD $0x6e65dd09                  // FMUL V9.2D, V8.2D, V5.2D     r * c5
+    WORD $0x4e64d529                  // FADD V9.2D, V9.2D, V4.2D     + 1/24
+    WORD $0x6e68dd29                  // FMUL V9.2D, V9.2D, V8.2D
+    WORD $0x4e63d529                  // FADD V9.2D, V9.2D, V3.2D     + 1/6
+    WORD $0x6e68dd29                  // FMUL V9.2D, V9.2D, V8.2D
+    WORD $0x4e62d529                  // FADD V9.2D, V9.2D, V2.2D     + 0.5
+    WORD $0x6e68dd29                  // FMUL V9.2D, V9.2D, V8.2D
+    WORD $0x4e75d529                  // FADD V9.2D, V9.2D, V21.2D    + 1
+    WORD $0x6e68dd29                  // FMUL V9.2D, V9.2D, V8.2D
+    WORD $0x4e75d529                  // FADD V9.2D, V9.2D, V21.2D    exp(r)
+    WORD $0x4ee1b8e7                  // FCVTZS V7.2D, V7.2D          int(k)
+    WORD $0x4f7454e7                  // SHL V7.2D, V7.2D, #52
+    WORD $0x4ef584e7                  // ADD V7.2D, V7.2D, V21.2D     2^k bits
+    WORD $0x6e67dd29                  // FMUL V9.2D, V9.2D, V7.2D     exp(y)
+
+    // Overflow/underflow classes from the pre-clamp y: y > 709 -> +Inf,
+    // y < -709 -> 0 (strict compares, see powAVX)
+    WORD $0x6eede4c1                  // FCMGT V1.2D, V6.2D, V13.2D   y > 709
+    WORD $0x6ea11de9                  // BIT V9.16B, V15.16B, V1.16B
+    WORD $0x6ee6e5c1                  // FCMGT V1.2D, V14.2D, V6.2D   y < -709
+    WORD $0x4e611d29                  // BIC V9.16B, V9.16B, V1.16B
+
+    VST1.P [V9.D2], 16(R0)
+    SUB $1, R4
+    CBNZ R4, pow64_neon_loop2
+
+pow64_neon_scalar:
+    AND $1, R3
+    CBZ R3, pow64_neon_done
+
+pow64_neon_scalar_loop:
+    MOVD (R1), R7                     // bits(x)
+    FMOVD (R1), F0
+
+    // log core, scalar (x positive finite; see logNEON64 tail)
+    MOVD $0, R9
+    MOVD $0x0010000000000000, R8
+    CMP R8, R7
+    BGE pow64_neon_scalar_normal
+    MOVD $0x43F0000000000000, R10
+    FMOVD R10, F2
+    FMULD F2, F0, F0
+    FMOVD F0, R7
+    MOVD $-64, R9
+
+pow64_neon_scalar_normal:
+    MOVD $0x3FE6A09E00000000, R8
+    SUB R8, R7, R10                   // tmp
+    ASR $52, R10, R11                 // e
+    ADD R9, R11, R11
+    MOVD $0xFFF0000000000000, R8
+    AND R8, R10, R10
+    SUB R10, R7, R7                   // bits(m)
+    FMOVD R7, F1                      // m
+    SCVTFD R11, F2                    // e
+
+    FSUBD F21, F1, F3                 // m - 1
+    FADDD F21, F1, F4                 // m + 1
+    FDIVD F4, F3, F3                  // s
+    FMULD F3, F3, F4                  // t
+    FMADDD F4, F26, F25, F5           // c1 + c0*t
+    FMADDD F4, F27, F5, F5
+    FMADDD F4, F28, F5, F5
+    FMADDD F4, F29, F5, F5
+    FMADDD F4, F30, F5, F5
+    FMADDD F4, F31, F5, F5            // P(t)
+    FMULD F4, F3, F4                  // s*t
+    FADDD F3, F3, F3                  // 2s
+    FMADDD F5, F3, F4, F3             // lnm
+    FMULD F23, F2, F4                 // e * ln2lo
+    FADDD F3, F4, F4                  // + lnm
+    FMADDD F22, F4, F2, F4            // += e * ln2hi -> ln(x)
+
+    // y = p*ln(x); pre-clamp copy in F6, clamp to [-709, 709]
+    FMULD F12, F4, F0
+    FMOVD F0, F6
+    FMIND F13, F0, F0
+    FMAXD F14, F0, F0
+
+    // exp core, scalar (see expNEON64 tail; F24 = log2e, F21 = 1.0)
+    FMULD F24, F0, F1
+    FRINTND F1, F2                    // k
+    MOVD $0x3FE62E42FEFA39EF, R8      // ln(2)
+    FMOVD R8, F3
+    FMULD F3, F2, F3
+    FSUBD F3, F0, F0                  // r
+    MOVD $0x3F81111111111111, R8      // 1/120
+    FMOVD R8, F4
+    FMULD F0, F4, F4
+    MOVD $0x3FA5555555555555, R8      // 1/24
+    FMOVD R8, F5
+    FADDD F5, F4, F4
+    FMULD F0, F4, F4
+    MOVD $0x3FC5555555555555, R8      // 1/6
+    FMOVD R8, F5
+    FADDD F5, F4, F4
+    FMULD F0, F4, F4
+    FMOVD $0.5, F5
+    FADDD F5, F4, F4
+    FMULD F0, F4, F4
+    FADDD F21, F4, F4
+    FMULD F0, F4, F4
+    FADDD F21, F4, F4                 // exp(r)
+    FCVTZSD F2, R8
+    LSL $52, R8, R8
+    MOVD $0x3FF0000000000000, R10
+    ADD R10, R8, R8
+    FMOVD R8, F5
+    FMULD F5, F4, F4                  // exp(y)
+
+    // Overflow/underflow classes from the pre-clamp y (F6)
+    FCMPD F13, F6
+    BGT pow64_neon_scalar_posinf      // y > 709
+    FCMPD F14, F6
+    BLT pow64_neon_scalar_zero        // y < -709
+    FMOVD F4, (R0)
+    B pow64_neon_scalar_next
+
+pow64_neon_scalar_posinf:
+    MOVD $0x7FF0000000000000, R8
+    MOVD R8, (R0)
+    B pow64_neon_scalar_next
+
+pow64_neon_scalar_zero:
+    MOVD ZR, (R0)
+
+pow64_neon_scalar_next:
+    ADD $8, R1
+    ADD $8, R0
+    SUB $1, R3
+    CBNZ R3, pow64_neon_scalar_loop
+
+pow64_neon_done:
+    RET
+
+// func powElemNEON64(dst, base, exp []float64)
+// Elementwise pow(base[i], exp[i]) = exp(exp[i]*ln(base[i])). Same cores and
+// preconditions as powNEON64 (all bases positive finite, all exponents
+// finite), with the exponent loaded per lane instead of broadcast.
+TEXT ·powElemNEON64(SB), NOSPLIT, $0-72
+    MOVD dst_base+0(FP), R0
+    MOVD dst_len+8(FP), R3
+    MOVD base_base+24(FP), R1
+    MOVD exp_base+48(FP), R2
+    MOVD $log64neon_expc<>(SB), R5    // exp-core constant table
+    ADD $64, R5, R6                   // second VLD1 base (c5 = 1/120)
+
+    // Exp clamp bounds and +Inf for the overflow blend
+    MOVD $0x4086280000000000, R10
+    VMOV R10, V13.D[0]
+    VDUP V13.D[0], V13.D2             // V13 = 709.0
+    MOVD $0xC086280000000000, R10
+    VMOV R10, V14.D[0]
+    VDUP V14.D[0], V14.D2             // V14 = -709.0
+    MOVD $0x7FF0000000000000, R10
+    VMOV R10, V15.D[0]
+    VDUP V15.D[0], V15.D2             // V15 = +Inf
+
+    // Log-core reduction constants (see logNEON64)
+    MOVD $0x3FE6A09E00000000, R10
+    VMOV R10, V16.D[0]
+    VDUP V16.D[0], V16.D2             // V16 = reduction offset
+    MOVD $0xFFF0000000000000, R10
+    VMOV R10, V17.D[0]
+    VDUP V17.D[0], V17.D2             // V17 = exponent mask
+    MOVD $0x0010000000000000, R10
+    VMOV R10, V18.D[0]
+    VDUP V18.D[0], V18.D2             // V18 = DBL_MIN
+    MOVD $0x43F0000000000000, R10
+    VMOV R10, V19.D[0]
+    VDUP V19.D[0], V19.D2             // V19 = 2^64
+    MOVD $0xC050000000000000, R10
+    VMOV R10, V20.D[0]
+    VDUP V20.D[0], V20.D2             // V20 = -64.0
+    FMOVD $1.0, F21
+    VDUP V21.D[0], V21.D2             // V21 = 1.0
+
+    // fdlibm ln(2) hi/lo split and log2(e)
+    MOVD $0x3FE62E42FEE00000, R10
+    VMOV R10, V22.D[0]
+    VDUP V22.D[0], V22.D2             // V22 = ln2 hi
+    MOVD $0x3DEA39EF35793C76, R10
+    VMOV R10, V23.D[0]
+    VDUP V23.D[0], V23.D2             // V23 = ln2 lo
+    MOVD $0x3FF71547652B82FE, R10
+    VMOV R10, V24.D[0]
+    VDUP V24.D[0], V24.D2             // V24 = log2(e)
+
+    // SLEEF xlog_u1 minimax coefficients c0..c6
+    MOVD $0x3FC39C4F5407567E, R10
+    VMOV R10, V25.D[0]
+    VDUP V25.D[0], V25.D2             // V25 = c0
+    MOVD $0x3FC3872E67FE8E84, R10
+    VMOV R10, V26.D[0]
+    VDUP V26.D[0], V26.D2             // V26 = c1
+    MOVD $0x3FC747353A506035, R10
+    VMOV R10, V27.D[0]
+    VDUP V27.D[0], V27.D2             // V27 = c2
+    MOVD $0x3FCC71C0A65ECD8E, R10
+    VMOV R10, V28.D[0]
+    VDUP V28.D[0], V28.D2             // V28 = c3
+    MOVD $0x3FD249249A68A245, R10
+    VMOV R10, V29.D[0]
+    VDUP V29.D[0], V29.D2             // V29 = c4
+    MOVD $0x3FD99999998F92EA, R10
+    VMOV R10, V30.D[0]
+    VDUP V30.D[0], V30.D2             // V30 = c5
+    MOVD $0x3FE55555555557AE, R10
+    VMOV R10, V31.D[0]
+    VDUP V31.D[0], V31.D2             // V31 = c6
+
+    LSR $1, R3, R4
+    CBZ R4, powelem64_neon_scalar
+
+powelem64_neon_loop2:
+    VLD1.P 16(R1), [V0.D2]            // V0 = base (positive finite)
+
+    // --- log core (see logNEON64) ---
+    WORD $0x6ee0e641                  // FCMGT V1.2D, V18.2D, V0.2D   mask: x < DBL_MIN
+    WORD $0x6e73dc02                  // FMUL V2.2D, V0.2D, V19.2D    x * 2^64
+    WORD $0x4ea11c23                  // MOV V3.16B, V1.16B
+    WORD $0x6e601c43                  // BSL V3.16B, V2.16B, V0.16B   xs
+    WORD $0x4e341c24                  // AND V4.16B, V1.16B, V20.16B  ebias
+    WORD $0x6ef08465                  // SUB V5.2D, V3.2D, V16.2D     tmp
+    WORD $0x4e311ca6                  // AND V6.16B, V5.16B, V17.16B
+    WORD $0x6ee68466                  // SUB V6.2D, V3.2D, V6.2D      bits(m)
+    WORD $0x4f4c04a5                  // SSHR V5.2D, V5.2D, #52       e (int64)
+    WORD $0x4e61d8a5                  // SCVTF V5.2D, V5.2D           e as float64
+    WORD $0x4e64d4a5                  // FADD V5.2D, V5.2D, V4.2D     e += ebias
+    WORD $0x4ef5d4c7                  // FSUB V7.2D, V6.2D, V21.2D    m - 1
+    WORD $0x4e75d4c6                  // FADD V6.2D, V6.2D, V21.2D    m + 1
+    WORD $0x6e66fce7                  // FDIV V7.2D, V7.2D, V6.2D     s
+    WORD $0x6e67dce6                  // FMUL V6.2D, V7.2D, V7.2D     t
+    WORD $0x4eb91f28                  // MOV V8.16B, V25.16B          acc = c0
+    WORD $0x4eba1f49                  // MOV V9.16B, V26.16B
+    WORD $0x4e66cd09                  // FMLA V9.2D, V8.2D, V6.2D     c1 + acc*t
+    WORD $0x4ebb1f68                  // MOV V8.16B, V27.16B
+    WORD $0x4e66cd28                  // FMLA V8.2D, V9.2D, V6.2D     c2 + acc*t
+    WORD $0x4ebc1f89                  // MOV V9.16B, V28.16B
+    WORD $0x4e66cd09                  // FMLA V9.2D, V8.2D, V6.2D     c3 + acc*t
+    WORD $0x4ebd1fa8                  // MOV V8.16B, V29.16B
+    WORD $0x4e66cd28                  // FMLA V8.2D, V9.2D, V6.2D     c4 + acc*t
+    WORD $0x4ebe1fc9                  // MOV V9.16B, V30.16B
+    WORD $0x4e66cd09                  // FMLA V9.2D, V8.2D, V6.2D     c5 + acc*t
+    WORD $0x4ebf1fe8                  // MOV V8.16B, V31.16B
+    WORD $0x4e66cd28                  // FMLA V8.2D, V9.2D, V6.2D     P(t)
+    WORD $0x6e66dcea                  // FMUL V10.2D, V7.2D, V6.2D    s*t
+    WORD $0x4e67d4eb                  // FADD V11.2D, V7.2D, V7.2D    2s
+    WORD $0x4e68cd4b                  // FMLA V11.2D, V10.2D, V8.2D   lnm
+
+    // ln(base) = e*ln2hi + (e*ln2lo + lnm)
+    WORD $0x6e77dcaa                  // FMUL V10.2D, V5.2D, V23.2D   e * ln2lo
+    WORD $0x4e6bd54a                  // FADD V10.2D, V10.2D, V11.2D  + lnm
+    WORD $0x4e76ccaa                  // FMLA V10.2D, V5.2D, V22.2D   += e * ln2hi
+
+    // y = exp[i]*ln(base[i]); pre-clamp copy in V6, clamp for the exp core
+    VLD1.P 16(R2), [V12.D2]           // V12 = exponents (finite)
+    WORD $0x6e6cdd40                  // FMUL V0.2D, V10.2D, V12.2D   y
+    WORD $0x4ea01c06                  // MOV V6.16B, V0.16B           pre-clamp y
+    WORD $0x4eedf400                  // FMIN V0.2D, V0.2D, V13.2D
+    WORD $0x4e6ef400                  // FMAX V0.2D, V0.2D, V14.2D
+
+    // --- exp core (see expNEON64); constants from the table ---
+    VLD1 (R5), [V1.D2, V2.D2, V3.D2, V4.D2] // ln2, 0.5, 1/6, 1/24
+    VLD1 (R6), [V5.D2]                      // 1/120
+    WORD $0x6e78dc07                  // FMUL V7.2D, V0.2D, V24.2D    y * log2e
+    WORD $0x4e6188e7                  // FRINTN V7.2D, V7.2D          k
+    WORD $0x6e61dce8                  // FMUL V8.2D, V7.2D, V1.2D     k * ln2
+    WORD $0x4ee8d408                  // FSUB V8.2D, V0.2D, V8.2D     r
+    WORD $0x6e65dd09                  // FMUL V9.2D, V8.2D, V5.2D     r * c5
+    WORD $0x4e64d529                  // FADD V9.2D, V9.2D, V4.2D     + 1/24
+    WORD $0x6e68dd29                  // FMUL V9.2D, V9.2D, V8.2D
+    WORD $0x4e63d529                  // FADD V9.2D, V9.2D, V3.2D     + 1/6
+    WORD $0x6e68dd29                  // FMUL V9.2D, V9.2D, V8.2D
+    WORD $0x4e62d529                  // FADD V9.2D, V9.2D, V2.2D     + 0.5
+    WORD $0x6e68dd29                  // FMUL V9.2D, V9.2D, V8.2D
+    WORD $0x4e75d529                  // FADD V9.2D, V9.2D, V21.2D    + 1
+    WORD $0x6e68dd29                  // FMUL V9.2D, V9.2D, V8.2D
+    WORD $0x4e75d529                  // FADD V9.2D, V9.2D, V21.2D    exp(r)
+    WORD $0x4ee1b8e7                  // FCVTZS V7.2D, V7.2D          int(k)
+    WORD $0x4f7454e7                  // SHL V7.2D, V7.2D, #52
+    WORD $0x4ef584e7                  // ADD V7.2D, V7.2D, V21.2D     2^k bits
+    WORD $0x6e67dd29                  // FMUL V9.2D, V9.2D, V7.2D     exp(y)
+
+    // Overflow/underflow classes from the pre-clamp y (see powNEON64)
+    WORD $0x6eede4c1                  // FCMGT V1.2D, V6.2D, V13.2D   y > 709
+    WORD $0x6ea11de9                  // BIT V9.16B, V15.16B, V1.16B
+    WORD $0x6ee6e5c1                  // FCMGT V1.2D, V14.2D, V6.2D   y < -709
+    WORD $0x4e611d29                  // BIC V9.16B, V9.16B, V1.16B
+
+    VST1.P [V9.D2], 16(R0)
+    SUB $1, R4
+    CBNZ R4, powelem64_neon_loop2
+
+powelem64_neon_scalar:
+    AND $1, R3
+    CBZ R3, powelem64_neon_done
+
+powelem64_neon_scalar_loop:
+    MOVD (R1), R7                     // bits(base)
+    FMOVD (R1), F0
+
+    // log core, scalar (base positive finite; see logNEON64 tail)
+    MOVD $0, R9
+    MOVD $0x0010000000000000, R8
+    CMP R8, R7
+    BGE powelem64_neon_scalar_normal
+    MOVD $0x43F0000000000000, R10
+    FMOVD R10, F2
+    FMULD F2, F0, F0
+    FMOVD F0, R7
+    MOVD $-64, R9
+
+powelem64_neon_scalar_normal:
+    MOVD $0x3FE6A09E00000000, R8
+    SUB R8, R7, R10                   // tmp
+    ASR $52, R10, R11                 // e
+    ADD R9, R11, R11
+    MOVD $0xFFF0000000000000, R8
+    AND R8, R10, R10
+    SUB R10, R7, R7                   // bits(m)
+    FMOVD R7, F1                      // m
+    SCVTFD R11, F2                    // e
+
+    FSUBD F21, F1, F3                 // m - 1
+    FADDD F21, F1, F4                 // m + 1
+    FDIVD F4, F3, F3                  // s
+    FMULD F3, F3, F4                  // t
+    FMADDD F4, F26, F25, F5           // c1 + c0*t
+    FMADDD F4, F27, F5, F5
+    FMADDD F4, F28, F5, F5
+    FMADDD F4, F29, F5, F5
+    FMADDD F4, F30, F5, F5
+    FMADDD F4, F31, F5, F5            // P(t)
+    FMULD F4, F3, F4                  // s*t
+    FADDD F3, F3, F3                  // 2s
+    FMADDD F5, F3, F4, F3             // lnm
+    FMULD F23, F2, F4                 // e * ln2lo
+    FADDD F3, F4, F4                  // + lnm
+    FMADDD F22, F4, F2, F4            // += e * ln2hi -> ln(base)
+
+    // y = exp[i]*ln(base[i]); pre-clamp copy in F6, clamp to [-709, 709]
+    FMOVD (R2), F12                   // p
+    FMULD F12, F4, F0
+    FMOVD F0, F6
+    FMIND F13, F0, F0
+    FMAXD F14, F0, F0
+
+    // exp core, scalar (see expNEON64 tail; F24 = log2e, F21 = 1.0)
+    FMULD F24, F0, F1
+    FRINTND F1, F2                    // k
+    MOVD $0x3FE62E42FEFA39EF, R8      // ln(2)
+    FMOVD R8, F3
+    FMULD F3, F2, F3
+    FSUBD F3, F0, F0                  // r
+    MOVD $0x3F81111111111111, R8      // 1/120
+    FMOVD R8, F4
+    FMULD F0, F4, F4
+    MOVD $0x3FA5555555555555, R8      // 1/24
+    FMOVD R8, F5
+    FADDD F5, F4, F4
+    FMULD F0, F4, F4
+    MOVD $0x3FC5555555555555, R8      // 1/6
+    FMOVD R8, F5
+    FADDD F5, F4, F4
+    FMULD F0, F4, F4
+    FMOVD $0.5, F5
+    FADDD F5, F4, F4
+    FMULD F0, F4, F4
+    FADDD F21, F4, F4
+    FMULD F0, F4, F4
+    FADDD F21, F4, F4                 // exp(r)
+    FCVTZSD F2, R8
+    LSL $52, R8, R8
+    MOVD $0x3FF0000000000000, R10
+    ADD R10, R8, R8
+    FMOVD R8, F5
+    FMULD F5, F4, F4                  // exp(y)
+
+    // Overflow/underflow classes from the pre-clamp y (F6)
+    FCMPD F13, F6
+    BGT powelem64_neon_scalar_posinf  // y > 709
+    FCMPD F14, F6
+    BLT powelem64_neon_scalar_zero    // y < -709
+    FMOVD F4, (R0)
+    B powelem64_neon_scalar_next
+
+powelem64_neon_scalar_posinf:
+    MOVD $0x7FF0000000000000, R8
+    MOVD R8, (R0)
+    B powelem64_neon_scalar_next
+
+powelem64_neon_scalar_zero:
+    MOVD ZR, (R0)
+
+powelem64_neon_scalar_next:
+    ADD $8, R1
+    ADD $8, R2
+    ADD $8, R0
+    SUB $1, R3
+    CBNZ R3, powelem64_neon_scalar_loop
+
+powelem64_neon_done:
+    RET

--- a/f64/f64_arm64.s
+++ b/f64/f64_arm64.s
@@ -2084,11 +2084,13 @@ log64_neon_done:
 // func powNEON64(dst, src []float64, exp float64)
 // Fused pow(x, p) = exp(p*ln(x)) for slices whose elements are all positive
 // and finite (the dispatcher guarantees this, see powSIMDOK64). The log core
-// matches logNEON64; the exp core matches expNEON64 with its [-709, 709]
-// clamp on y = p*ln(x), but lanes whose pre-clamp y exceeds the clamp are
-// blended to +Inf (y > 709) or 0 (y < -709) so true overflow/underflow keeps
-// math.Pow's result classes (see powAVX for the band caveat). Accuracy is
-// bounded by the exp core's degree-5 polynomial (~3e-6 relative).
+// matches logNEON64; the exp core matches expNEON64 except y = p*ln(x) is
+// clamped to [-746, 710] (past ln(MaxFloat64) and ln of the smallest
+// subnormal) and the 2^k reconstruction is split into
+// 2^(k>>1) * 2^(k-(k>>1)), so overflow goes to +Inf and underflow degrades
+// gradually through subnormals to 0, matching math.Pow's result classes
+// (see powAVX). Accuracy is bounded by the exp core's degree-5 polynomial
+// (~3e-6 relative).
 TEXT ·powNEON64(SB), NOSPLIT, $0-56
     MOVD dst_base+0(FP), R0
     MOVD dst_len+8(FP), R3
@@ -2099,16 +2101,14 @@ TEXT ·powNEON64(SB), NOSPLIT, $0-56
     FMOVD exp+48(FP), F12
     VDUP V12.D[0], V12.D2             // V12 = p
 
-    // Exp clamp bounds and +Inf for the overflow blend
-    MOVD $0x4086280000000000, R10
+    // Pow clamp bounds: wider than Exp's +-709 because the split 2^k
+    // reconstruction covers the full result range (see powAVX)
+    MOVD $0x4086300000000000, R10
     VMOV R10, V13.D[0]
-    VDUP V13.D[0], V13.D2             // V13 = 709.0
-    MOVD $0xC086280000000000, R10
+    VDUP V13.D[0], V13.D2             // V13 = 710.0
+    MOVD $0xC087500000000000, R10
     VMOV R10, V14.D[0]
-    VDUP V14.D[0], V14.D2             // V14 = -709.0
-    MOVD $0x7FF0000000000000, R10
-    VMOV R10, V15.D[0]
-    VDUP V15.D[0], V15.D2             // V15 = +Inf
+    VDUP V14.D[0], V14.D2             // V14 = -746.0
 
     // Log-core reduction constants (see logNEON64)
     MOVD $0x3FE6A09E00000000, R10
@@ -2207,10 +2207,8 @@ pow64_neon_loop2:
     WORD $0x4e6bd54a                  // FADD V10.2D, V10.2D, V11.2D  + lnm
     WORD $0x4e76ccaa                  // FMLA V10.2D, V5.2D, V22.2D   += e * ln2hi
 
-    // y = p*ln(x); keep the pre-clamp y in V6 for the overflow blends, then
-    // clamp to [-709, 709] for the exp core
+    // y = p*ln(x), clamped to [-746, 710]
     WORD $0x6e6cdd40                  // FMUL V0.2D, V10.2D, V12.2D   y
-    WORD $0x4ea01c06                  // MOV V6.16B, V0.16B           pre-clamp y
     WORD $0x4eedf400                  // FMIN V0.2D, V0.2D, V13.2D
     WORD $0x4e6ef400                  // FMAX V0.2D, V0.2D, V14.2D
 
@@ -2231,17 +2229,19 @@ pow64_neon_loop2:
     WORD $0x4e75d529                  // FADD V9.2D, V9.2D, V21.2D    + 1
     WORD $0x6e68dd29                  // FMUL V9.2D, V9.2D, V8.2D
     WORD $0x4e75d529                  // FADD V9.2D, V9.2D, V21.2D    exp(r)
+    // Split 2^k reconstruction: k reaches past the biased exponent range
+    // (down to -1076), so build 2^(k>>1) and 2^(k-(k>>1)) separately; the
+    // double multiply overflows to +Inf / underflows through subnormals to
+    // 0 exactly where math.Pow does.
     WORD $0x4ee1b8e7                  // FCVTZS V7.2D, V7.2D          int(k)
+    WORD $0x4f7f04e8                  // SSHR V8.2D, V7.2D, #1        k1 = k >> 1
+    WORD $0x6ee884e7                  // SUB V7.2D, V7.2D, V8.2D      k2 = k - k1
+    WORD $0x4f745508                  // SHL V8.2D, V8.2D, #52
+    WORD $0x4ef58508                  // ADD V8.2D, V8.2D, V21.2D     2^k1 bits
+    WORD $0x6e68dd29                  // FMUL V9.2D, V9.2D, V8.2D     exp(r) * 2^k1
     WORD $0x4f7454e7                  // SHL V7.2D, V7.2D, #52
-    WORD $0x4ef584e7                  // ADD V7.2D, V7.2D, V21.2D     2^k bits
-    WORD $0x6e67dd29                  // FMUL V9.2D, V9.2D, V7.2D     exp(y)
-
-    // Overflow/underflow classes from the pre-clamp y: y > 709 -> +Inf,
-    // y < -709 -> 0 (strict compares, see powAVX)
-    WORD $0x6eede4c1                  // FCMGT V1.2D, V6.2D, V13.2D   y > 709
-    WORD $0x6ea11de9                  // BIT V9.16B, V15.16B, V1.16B
-    WORD $0x6ee6e5c1                  // FCMGT V1.2D, V14.2D, V6.2D   y < -709
-    WORD $0x4e611d29                  // BIC V9.16B, V9.16B, V1.16B
+    WORD $0x4ef584e7                  // ADD V7.2D, V7.2D, V21.2D     2^k2 bits
+    WORD $0x6e67dd29                  // FMUL V9.2D, V9.2D, V7.2D     * 2^k2 = exp(y)
 
     VST1.P [V9.D2], 16(R0)
     SUB $1, R4
@@ -2294,9 +2294,8 @@ pow64_neon_scalar_normal:
     FADDD F3, F4, F4                  // + lnm
     FMADDD F22, F4, F2, F4            // += e * ln2hi -> ln(x)
 
-    // y = p*ln(x); pre-clamp copy in F6, clamp to [-709, 709]
+    // y = p*ln(x), clamped to [-746, 710]
     FMULD F12, F4, F0
-    FMOVD F0, F6
     FMIND F13, F0, F0
     FMAXD F14, F0, F0
 
@@ -2324,30 +2323,20 @@ pow64_neon_scalar_normal:
     FADDD F21, F4, F4
     FMULD F0, F4, F4
     FADDD F21, F4, F4                 // exp(r)
-    FCVTZSD F2, R8
+    // Split 2^k reconstruction (see the vector body)
+    FCVTZSD F2, R8                    // k
+    ASR $1, R8, R10                   // k1 = k >> 1
+    SUB R10, R8, R8                   // k2 = k - k1
+    MOVD $0x3FF0000000000000, R11
+    LSL $52, R10, R10
+    ADD R11, R10, R10
+    FMOVD R10, F5
+    FMULD F5, F4, F4                  // exp(r) * 2^k1
     LSL $52, R8, R8
-    MOVD $0x3FF0000000000000, R10
-    ADD R10, R8, R8
+    ADD R11, R8, R8
     FMOVD R8, F5
-    FMULD F5, F4, F4                  // exp(y)
-
-    // Overflow/underflow classes from the pre-clamp y (F6)
-    FCMPD F13, F6
-    BGT pow64_neon_scalar_posinf      // y > 709
-    FCMPD F14, F6
-    BLT pow64_neon_scalar_zero        // y < -709
+    FMULD F5, F4, F4                  // * 2^k2 = exp(y)
     FMOVD F4, (R0)
-    B pow64_neon_scalar_next
-
-pow64_neon_scalar_posinf:
-    MOVD $0x7FF0000000000000, R8
-    MOVD R8, (R0)
-    B pow64_neon_scalar_next
-
-pow64_neon_scalar_zero:
-    MOVD ZR, (R0)
-
-pow64_neon_scalar_next:
     ADD $8, R1
     ADD $8, R0
     SUB $1, R3
@@ -2368,16 +2357,14 @@ TEXT ·powElemNEON64(SB), NOSPLIT, $0-72
     MOVD $log64neon_expc<>(SB), R5    // exp-core constant table
     ADD $64, R5, R6                   // second VLD1 base (c5 = 1/120)
 
-    // Exp clamp bounds and +Inf for the overflow blend
-    MOVD $0x4086280000000000, R10
+    // Pow clamp bounds: wider than Exp's +-709 because the split 2^k
+    // reconstruction covers the full result range (see powAVX)
+    MOVD $0x4086300000000000, R10
     VMOV R10, V13.D[0]
-    VDUP V13.D[0], V13.D2             // V13 = 709.0
-    MOVD $0xC086280000000000, R10
+    VDUP V13.D[0], V13.D2             // V13 = 710.0
+    MOVD $0xC087500000000000, R10
     VMOV R10, V14.D[0]
-    VDUP V14.D[0], V14.D2             // V14 = -709.0
-    MOVD $0x7FF0000000000000, R10
-    VMOV R10, V15.D[0]
-    VDUP V15.D[0], V15.D2             // V15 = +Inf
+    VDUP V14.D[0], V14.D2             // V14 = -746.0
 
     // Log-core reduction constants (see logNEON64)
     MOVD $0x3FE6A09E00000000, R10
@@ -2476,10 +2463,9 @@ powelem64_neon_loop2:
     WORD $0x4e6bd54a                  // FADD V10.2D, V10.2D, V11.2D  + lnm
     WORD $0x4e76ccaa                  // FMLA V10.2D, V5.2D, V22.2D   += e * ln2hi
 
-    // y = exp[i]*ln(base[i]); pre-clamp copy in V6, clamp for the exp core
+    // y = exp[i]*ln(base[i]), clamped to [-746, 710]
     VLD1.P 16(R2), [V12.D2]           // V12 = exponents (finite)
     WORD $0x6e6cdd40                  // FMUL V0.2D, V10.2D, V12.2D   y
-    WORD $0x4ea01c06                  // MOV V6.16B, V0.16B           pre-clamp y
     WORD $0x4eedf400                  // FMIN V0.2D, V0.2D, V13.2D
     WORD $0x4e6ef400                  // FMAX V0.2D, V0.2D, V14.2D
 
@@ -2500,16 +2486,19 @@ powelem64_neon_loop2:
     WORD $0x4e75d529                  // FADD V9.2D, V9.2D, V21.2D    + 1
     WORD $0x6e68dd29                  // FMUL V9.2D, V9.2D, V8.2D
     WORD $0x4e75d529                  // FADD V9.2D, V9.2D, V21.2D    exp(r)
+    // Split 2^k reconstruction: k reaches past the biased exponent range
+    // (down to -1076), so build 2^(k>>1) and 2^(k-(k>>1)) separately; the
+    // double multiply overflows to +Inf / underflows through subnormals to
+    // 0 exactly where math.Pow does.
     WORD $0x4ee1b8e7                  // FCVTZS V7.2D, V7.2D          int(k)
+    WORD $0x4f7f04e8                  // SSHR V8.2D, V7.2D, #1        k1 = k >> 1
+    WORD $0x6ee884e7                  // SUB V7.2D, V7.2D, V8.2D      k2 = k - k1
+    WORD $0x4f745508                  // SHL V8.2D, V8.2D, #52
+    WORD $0x4ef58508                  // ADD V8.2D, V8.2D, V21.2D     2^k1 bits
+    WORD $0x6e68dd29                  // FMUL V9.2D, V9.2D, V8.2D     exp(r) * 2^k1
     WORD $0x4f7454e7                  // SHL V7.2D, V7.2D, #52
-    WORD $0x4ef584e7                  // ADD V7.2D, V7.2D, V21.2D     2^k bits
-    WORD $0x6e67dd29                  // FMUL V9.2D, V9.2D, V7.2D     exp(y)
-
-    // Overflow/underflow classes from the pre-clamp y (see powNEON64)
-    WORD $0x6eede4c1                  // FCMGT V1.2D, V6.2D, V13.2D   y > 709
-    WORD $0x6ea11de9                  // BIT V9.16B, V15.16B, V1.16B
-    WORD $0x6ee6e5c1                  // FCMGT V1.2D, V14.2D, V6.2D   y < -709
-    WORD $0x4e611d29                  // BIC V9.16B, V9.16B, V1.16B
+    WORD $0x4ef584e7                  // ADD V7.2D, V7.2D, V21.2D     2^k2 bits
+    WORD $0x6e67dd29                  // FMUL V9.2D, V9.2D, V7.2D     * 2^k2 = exp(y)
 
     VST1.P [V9.D2], 16(R0)
     SUB $1, R4
@@ -2562,10 +2551,9 @@ powelem64_neon_scalar_normal:
     FADDD F3, F4, F4                  // + lnm
     FMADDD F22, F4, F2, F4            // += e * ln2hi -> ln(base)
 
-    // y = exp[i]*ln(base[i]); pre-clamp copy in F6, clamp to [-709, 709]
+    // y = exp[i]*ln(base[i]), clamped to [-746, 710]
     FMOVD (R2), F12                   // p
     FMULD F12, F4, F0
-    FMOVD F0, F6
     FMIND F13, F0, F0
     FMAXD F14, F0, F0
 
@@ -2593,30 +2581,20 @@ powelem64_neon_scalar_normal:
     FADDD F21, F4, F4
     FMULD F0, F4, F4
     FADDD F21, F4, F4                 // exp(r)
-    FCVTZSD F2, R8
+    // Split 2^k reconstruction (see the vector body)
+    FCVTZSD F2, R8                    // k
+    ASR $1, R8, R10                   // k1 = k >> 1
+    SUB R10, R8, R8                   // k2 = k - k1
+    MOVD $0x3FF0000000000000, R11
+    LSL $52, R10, R10
+    ADD R11, R10, R10
+    FMOVD R10, F5
+    FMULD F5, F4, F4                  // exp(r) * 2^k1
     LSL $52, R8, R8
-    MOVD $0x3FF0000000000000, R10
-    ADD R10, R8, R8
+    ADD R11, R8, R8
     FMOVD R8, F5
-    FMULD F5, F4, F4                  // exp(y)
-
-    // Overflow/underflow classes from the pre-clamp y (F6)
-    FCMPD F13, F6
-    BGT powelem64_neon_scalar_posinf  // y > 709
-    FCMPD F14, F6
-    BLT powelem64_neon_scalar_zero    // y < -709
+    FMULD F5, F4, F4                  // * 2^k2 = exp(y)
     FMOVD F4, (R0)
-    B powelem64_neon_scalar_next
-
-powelem64_neon_scalar_posinf:
-    MOVD $0x7FF0000000000000, R8
-    MOVD R8, (R0)
-    B powelem64_neon_scalar_next
-
-powelem64_neon_scalar_zero:
-    MOVD ZR, (R0)
-
-powelem64_neon_scalar_next:
     ADD $8, R1
     ADD $8, R2
     ADD $8, R0

--- a/f64/f64_arm64.s
+++ b/f64/f64_arm64.s
@@ -2458,13 +2458,14 @@ powelem64_neon_loop2:
     WORD $0x4e67d4eb                  // FADD V11.2D, V7.2D, V7.2D    2s
     WORD $0x4e68cd4b                  // FMLA V11.2D, V10.2D, V8.2D   lnm
 
-    // ln(base) = e*ln2hi + (e*ln2lo + lnm)
+    // ln(base) = e*ln2hi + (e*ln2lo + lnm); the exponent load is issued
+    // first so it overlaps the dependent FMUL/FADD/FMLA chain
+    VLD1.P 16(R2), [V12.D2]           // V12 = exponents (finite)
     WORD $0x6e77dcaa                  // FMUL V10.2D, V5.2D, V23.2D   e * ln2lo
     WORD $0x4e6bd54a                  // FADD V10.2D, V10.2D, V11.2D  + lnm
     WORD $0x4e76ccaa                  // FMLA V10.2D, V5.2D, V22.2D   += e * ln2hi
 
     // y = exp[i]*ln(base[i]), clamped to [-746, 710]
-    VLD1.P 16(R2), [V12.D2]           // V12 = exponents (finite)
     WORD $0x6e6cdd40                  // FMUL V0.2D, V10.2D, V12.2D   y
     WORD $0x4eedf400                  // FMIN V0.2D, V0.2D, V13.2D
     WORD $0x4e6ef400                  // FMAX V0.2D, V0.2D, V14.2D

--- a/f64/f64_go.go
+++ b/f64/f64_go.go
@@ -569,9 +569,22 @@ func exp64Go(dst, src []float64) {
 	}
 }
 
+// logSubnormScale64 normalizes a positive subnormal so math.Log sees a normal
+// input: math.Log's amd64 assembly extracts the exponent field without
+// normalizing, so it returns ~-709.09 for every subnormal x. Scaling by 2^54
+// and subtracting 54*ln(2) is exact in the scale step (2^54 is a power of
+// two) and accurate to ~1 ulp overall.
+const (
+	dblMinNormal64    = 2.2250738585072014e-308
+	logSubnormScale64 = 0x1p54
+	logSubnormExp64   = 54
+)
+
 // logGo computes the natural logarithm: dst[i] = ln(src[i]).
 // Edge cases follow math.Log: ln(0) = -Inf, ln(x<0) = NaN, ln(+Inf) = +Inf,
-// ln(NaN) = NaN. This is the scalar reference and the fallback when no SIMD log
+// ln(NaN) = NaN. Positive subnormal inputs are normalized first (see
+// logSubnormScale64); plain math.Log would return ~-709.09 for all of them
+// on amd64. This is the scalar reference and the fallback when no SIMD log
 // kernel is selected.
 func logGo(dst, src []float64) {
 	if len(dst) == 0 {
@@ -579,29 +592,50 @@ func logGo(dst, src []float64) {
 	}
 	_ = src[len(dst)-1]
 	for i := range dst {
-		dst[i] = math.Log(src[i])
+		x := src[i]
+		if x > 0 && x < dblMinNormal64 {
+			dst[i] = math.Log(x*logSubnormScale64) - logSubnormExp64*math.Ln2
+			continue
+		}
+		dst[i] = math.Log(x)
 	}
 }
 
 // log2Go computes the base-2 logarithm: dst[i] = log2(src[i]).
+// math.Log2 normalizes subnormals itself (it is Frexp-based) and is exact for
+// powers of two, but its log2(frac)+exp formulation cancels at ~ulp(1)
+// absolute error near x = 1, which is ~2e-8 relative where log2(x) ~ 1e-9.
+// Inputs near 1 are routed through the relative-accurate math.Log instead.
 func log2Go(dst, src []float64) {
 	if len(dst) == 0 {
 		return
 	}
 	_ = src[len(dst)-1]
 	for i := range dst {
-		dst[i] = math.Log2(src[i])
+		x := src[i]
+		if x > 0.99 && x < 1.01 {
+			dst[i] = math.Log(x) * (1 / math.Ln2)
+			continue
+		}
+		dst[i] = math.Log2(x)
 	}
 }
 
 // log10Go computes the base-10 logarithm: dst[i] = log10(src[i]).
+// math.Log10 is math.Log scaled, so positive subnormal inputs need the same
+// normalization as logGo.
 func log10Go(dst, src []float64) {
 	if len(dst) == 0 {
 		return
 	}
 	_ = src[len(dst)-1]
 	for i := range dst {
-		dst[i] = math.Log10(src[i])
+		x := src[i]
+		if x > 0 && x < dblMinNormal64 {
+			dst[i] = (math.Log(x*logSubnormScale64) - logSubnormExp64*math.Ln2) * (1 / math.Ln10)
+			continue
+		}
+		dst[i] = math.Log10(x)
 	}
 }
 

--- a/f64/f64_other.go
+++ b/f64/f64_other.go
@@ -60,3 +60,9 @@ func clampScale64(dst, src []float64, minVal, maxVal, scale float64) {
 }
 func tanh64(dst, src []float64) { tanh64Go(dst, src) }
 func exp64(dst, src []float64)  { exp64Go(dst, src) }
+
+func log64(dst, src []float64)              { logGo(dst, src) }
+func log2_64(dst, src []float64)            { log2Go(dst, src) }
+func log10_64(dst, src []float64)           { log10Go(dst, src) }
+func pow64(dst, src []float64, exp float64) { powGo(dst, src, exp) }
+func powElem64(dst, base, exp []float64)    { powElemGo(dst, base, exp) }

--- a/f64/fuzz_test.go
+++ b/f64/fuzz_test.go
@@ -290,3 +290,112 @@ func FuzzF64InterleaveN(f *testing.F) {
 		}
 	})
 }
+
+// FuzzF64Log differentially fuzzes the dispatched Log/Log2/Log10 against the
+// pure-Go references over arbitrary bit patterns, including NaN, infinities,
+// negatives, zeros, and subnormals. Specials compare by class, finite values
+// within the documented kernel tolerance.
+func FuzzF64Log(f *testing.F) {
+	addByteLenSeeds(f)
+	f.Fuzz(func(t *testing.T, raw []byte) {
+		v := f64sBits(raw)
+		if len(v) == 0 {
+			return
+		}
+		got := make([]float64, len(v))
+		want := make([]float64, len(v))
+
+		check := func(op string) {
+			for i := range got {
+				g, w := got[i], want[i]
+				switch {
+				case math.IsNaN(w):
+					if !math.IsNaN(g) {
+						t.Fatalf("%s[%d](%v): got %v want NaN", op, i, v[i], g)
+					}
+				case math.IsInf(w, 0) || w == 0:
+					if g != w {
+						t.Fatalf("%s[%d](%v): got %v want %v", op, i, v[i], g, w)
+					}
+				default:
+					diff := math.Abs(g - w)
+					if math.Abs(w) > 1e-12 {
+						diff /= math.Abs(w)
+					}
+					if diff > logRelTol64 {
+						t.Fatalf("%s[%d](%g): got %v want %v (err %g)", op, i, v[i], g, w, diff)
+					}
+				}
+			}
+		}
+		Log(got, v)
+		logGo(want, v)
+		check("Log")
+		Log2(got, v)
+		log2Go(want, v)
+		check("Log2")
+		Log10(got, v)
+		log10Go(want, v)
+		check("Log10")
+	})
+}
+
+// FuzzF64Pow differentially fuzzes Pow and PowElem against math.Pow for
+// positive finite bases (the SIMD precondition; other inputs dispatch to the
+// scalar path, which is exercised too via the raw exponent). Lanes whose
+// |p*ln(x)| lands near the exp-core clamp (>700) or whose true result is
+// subnormal are skipped: the kernel documents +Inf/0 result classes and
+// flush-to-zero behavior in those bands (see powAVX).
+func FuzzF64Pow(f *testing.F) {
+	addByteLenSeeds(f)
+	f.Fuzz(func(t *testing.T, raw []byte) {
+		v := f64sBits(raw)
+		if len(v) < 3 {
+			return
+		}
+		p := v[0]
+		rest := v[1:]
+		h := len(rest) / 2
+		base, exps := rest[:h], rest[h:2*h]
+		for i, x := range base {
+			x = math.Abs(x)
+			if !(x > 0 && x <= math.MaxFloat64) {
+				x = 1.5 + float64(i)
+			}
+			base[i] = x
+		}
+
+		checkLane := func(op string, i int, x, pw, g float64) {
+			want := math.Pow(x, pw)
+			if math.IsNaN(want) {
+				if !math.IsNaN(g) {
+					t.Fatalf("%s[%d](%g, %g): got %v want NaN", op, i, x, pw, g)
+				}
+				return
+			}
+			if y := pw * refLn64(x); math.Abs(y) > 700 || math.IsNaN(y) {
+				return // documented clamp/class bands near overflow/underflow
+			}
+			if want != 0 && math.Abs(want) < 4e-308 {
+				return // subnormal results may flush to 0 in the exp core
+			}
+			diff := math.Abs(g - want)
+			if math.Abs(want) > 1e-12 {
+				diff /= math.Abs(want)
+			}
+			if diff > powRelTol64 {
+				t.Fatalf("%s[%d](%g, %g): got %v want %v (err %g)", op, i, x, pw, g, want, diff)
+			}
+		}
+
+		got := make([]float64, h)
+		Pow(got, base, p)
+		for i := range got {
+			checkLane("Pow", i, base[i], p, got[i])
+		}
+		PowElem(got, base, exps)
+		for i := range got {
+			checkLane("PowElem", i, base[i], exps[i], got[i])
+		}
+	})
+}

--- a/f64/fuzz_test.go
+++ b/f64/fuzz_test.go
@@ -343,9 +343,10 @@ func FuzzF64Log(f *testing.F) {
 // FuzzF64Pow differentially fuzzes Pow and PowElem against math.Pow for
 // positive finite bases (the SIMD precondition; other inputs dispatch to the
 // scalar path, which is exercised too via the raw exponent). Lanes whose
-// |p*ln(x)| lands near the exp-core clamp (>700) or whose true result is
-// subnormal are skipped: the kernel documents +Inf/0 result classes and
-// flush-to-zero behavior in those bands (see powAVX).
+// |p*ln(x)| lands near the overflow/underflow thresholds (>700) or whose
+// true result is subnormal are skipped: the kernel's relative error can flip
+// the result class there, and subnormal results lose precision gradually
+// (see powAVX).
 func FuzzF64Pow(f *testing.F) {
 	addByteLenSeeds(f)
 	f.Fuzz(func(t *testing.T, raw []byte) {
@@ -374,7 +375,9 @@ func FuzzF64Pow(f *testing.F) {
 				return
 			}
 			if y := pw * refLn64(x); math.Abs(y) > 700 || math.IsNaN(y) {
-				return // documented clamp/class bands near overflow/underflow
+				// Near the exact overflow/underflow thresholds the kernel's
+				// ~3e-6 error in p*ln(x) can flip the +Inf/0 class.
+				return
 			}
 			if want != 0 && math.Abs(want) < 4e-308 {
 				return // subnormal results may flush to 0 in the exp core

--- a/f64/log_dispatch.go
+++ b/f64/log_dispatch.go
@@ -1,0 +1,45 @@
+//go:build amd64 || arm64
+
+package f64
+
+import "math"
+
+// Reconstruction constants for the shared SIMD log core (logAVX / logNEON64).
+// The core computes, per lane, result = e*k1hi + (lnm*k2 + e*k1lo), where
+// x = m * 2^e with m in [sqrt(2)/2, sqrt(2)) and lnm = ln(m). The hi/lo pairs
+// keep the e*ln(2) (resp. e*log10(2)) term exact: the hi part has its low
+// mantissa bits zeroed (fdlibm splittings), so the product with the
+// integer-valued e introduces no rounding, and the remainder rides in the lo
+// term.
+const (
+	logLn2Hi64  = 6.93147180369123816490e-01 // 0x3fe62e42fee00000
+	logLn2Lo64  = 1.90821492927058770002e-10 // 0x3dea39ef35793c76
+	logL102Hi64 = 3.01029995663611771306e-01 // 0x3fd34413509f6000, log10(2) hi
+	logL102Lo64 = 3.69423907715893078616e-13 // 0x3d59fef311f12b36, log10(2) lo
+	logLog2E64  = 1 / math.Ln2               // 0x3ff71547652b82fe
+	logLog10E64 = 1 / math.Ln10              // 0x3fdbcb7b1526e50e
+)
+
+// powSIMDOK64 reports whether every element is positive and finite, the
+// precondition for the fused exp(p*ln(x)) kernels. Lanes outside that range
+// have math.Pow edge semantics the kernel does not implement (negative bases
+// with integer exponents, signed zeros, infinities, NaN propagation), so the
+// whole call falls back to the exact scalar path.
+func powSIMDOK64(src []float64) bool {
+	for _, x := range src {
+		if !(x > 0 && x <= math.MaxFloat64) {
+			return false
+		}
+	}
+	return true
+}
+
+// allFinite64 reports whether every element is finite (PowElem exponents).
+func allFinite64(s []float64) bool {
+	for _, x := range s {
+		if math.IsNaN(x) || math.IsInf(x, 0) {
+			return false
+		}
+	}
+	return true
+}

--- a/f64/log_pow_test.go
+++ b/f64/log_pow_test.go
@@ -5,6 +5,23 @@ import (
 	"testing"
 )
 
+// Tolerances for the dispatched log/pow paths.
+//
+// The SIMD log core is an atanh-form minimax polynomial (SLEEF xlog_u1
+// coefficients, 7 terms): worst-case relative error is a few float64 ulps.
+// logRelTol64 leaves two orders of magnitude of headroom while still failing
+// hard on any real kernel bug (a wrong coefficient or a broken reduction is
+// off by many orders of magnitude). The pure-Go fallback is math.Log, which
+// passes trivially.
+//
+// Pow feeds p*Log(x) through the Exp core, whose degree-5 polynomial bounds
+// the achievable relative error at ~3e-6 (see TestExpAccuracy); powRelTol64
+// mirrors the Exp tests.
+const (
+	logRelTol64 = 1e-13
+	powRelTol64 = 1e-5
+)
+
 // bitsEqF64 treats any NaN as equal to any NaN and otherwise requires bit
 // equality, so -Inf, +Inf, and signed zeros are all compared exactly.
 func bitsEqF64(a, b float64) bool {
@@ -13,6 +30,36 @@ func bitsEqF64(a, b float64) bool {
 	}
 	return math.Float64bits(a) == math.Float64bits(b)
 }
+
+// relErrF64 returns the relative error of got vs want, falling back to the
+// absolute error when want is too small for a meaningful quotient.
+func relErrF64(got, want float64) float64 {
+	diff := math.Abs(got - want)
+	if math.Abs(want) > 1e-12 {
+		return diff / math.Abs(want)
+	}
+	return diff
+}
+
+// refLn64 is the accuracy reference for the natural log. math.Log cannot be
+// used directly: its amd64 assembly implementation extracts the exponent
+// without normalizing subnormal inputs, so it returns ~-709.09 for every
+// subnormal x. Normalizing by 2^54 first gives the correct value on every
+// architecture.
+func refLn64(x float64) float64 {
+	if x > 0 && x < 2.2250738585072014e-308 {
+		return math.Log(x*0x1p54) - 54*math.Ln2
+	}
+	return math.Log(x)
+}
+
+// refLog2_64 scales refLn64 instead of using math.Log2: the Frexp-based
+// math.Log2 carries an absolute error of ~ulp(1) near x = 1 (the
+// log2(frac)+exp formulation cancels), which shows up as ~4e-8 relative
+// error against a relative-accurate kernel.
+func refLog2_64(x float64) float64 { return refLn64(x) * (1 / math.Ln2) }
+
+func refLog10_64(x float64) float64 { return refLn64(x) * (1 / math.Ln10) }
 
 func TestLogKnownValues(t *testing.T) {
 	tests := []struct {
@@ -39,7 +86,9 @@ func TestLogKnownValues(t *testing.T) {
 	}
 }
 
-// TestLogEdgeCases pins the documented non-finite behavior (matching math.Log).
+// TestLogEdgeCases pins the documented non-finite behavior (matching math.Log)
+// on the dispatched path. The slice is long enough to hit the SIMD body, so
+// the kernel's special-lane blends are exercised alongside the scalar tail.
 func TestLogEdgeCases(t *testing.T) {
 	src := []float64{0, -1, math.Copysign(0, -1), math.Inf(1), math.Inf(-1), math.NaN()}
 	for _, fn := range []struct {
@@ -62,6 +111,94 @@ func TestLogEdgeCases(t *testing.T) {
 	}
 }
 
+// TestLogSubnormals checks that subnormal inputs go through the kernel's
+// normalization pre-scale (or the scalar fallback) and still come out within
+// tolerance of math.Log.
+func TestLogSubnormals(t *testing.T) {
+	src := []float64{
+		5e-324,         // smallest subnormal
+		1e-310, 1e-320, // assorted subnormals
+		2.2250738585072014e-308, // DBL_MIN, smallest normal
+		2.225073858507201e-308,  // largest subnormal
+		4e-308, 1e-300, 1,
+	}
+	for _, fn := range []struct {
+		name string
+		log  func(dst, src []float64)
+		ref  func(float64) float64
+	}{
+		{"Log", Log, refLn64},
+		{"Log2", Log2, refLog2_64},
+		{"Log10", Log10, refLog10_64},
+	} {
+		dst := make([]float64, len(src))
+		fn.log(dst, src)
+		for i, x := range src {
+			want := fn.ref(x)
+			if re := relErrF64(dst[i], want); re > logRelTol64 {
+				t.Errorf("%s(%g) = %v, want %v (relErr %g)", fn.name, x, dst[i], want, re)
+			}
+		}
+	}
+}
+
+// TestLogAccuracy sweeps the full finite-positive range, the near-1
+// neighborhood where the reduction switches sign, and the mantissa-reduction
+// boundaries around sqrt(2)/2 and sqrt(2).
+func TestLogAccuracy(t *testing.T) {
+	src := make([]float64, 0, 4264)
+	// Logarithmic sweep across the normal range.
+	for e := -1022; e <= 1023; e += 3 {
+		for _, m := range []float64{1.0, 1.3, 1.4142135623730950, 1.4142135623730952, 1.7, 1.9999999999999998} {
+			src = append(src, math.Ldexp(m, e))
+		}
+	}
+	// Dense near 1 (both sides), where log -> 0.
+	for i := -40; i <= 40; i++ {
+		src = append(src, 1+float64(i)*1e-3, 1+float64(i)*1e-9)
+	}
+	src = append(src, math.MaxFloat64, 2.2250738585072014e-308, math.Sqrt2, math.Sqrt2/2)
+
+	for _, fn := range []struct {
+		name string
+		log  func(dst, src []float64)
+		ref  func(float64) float64
+	}{
+		{"Log", Log, refLn64},
+		{"Log2", Log2, refLog2_64},
+		{"Log10", Log10, refLog10_64},
+	} {
+		dst := make([]float64, len(src))
+		fn.log(dst, src)
+		for i, x := range src {
+			want := fn.ref(x)
+			if re := relErrF64(dst[i], want); re > logRelTol64 {
+				t.Errorf("%s(%g) = %v, want %v (relErr %g)", fn.name, x, dst[i], want, re)
+			}
+		}
+	}
+}
+
+// TestLogLengths runs Log over every length from 1 to 33 so the scalar
+// remainder loop is exercised alongside the SIMD body (the AVX body consumes
+// 4 elements at a time, the NEON body 2).
+func TestLogLengths(t *testing.T) {
+	for n := 1; n <= 33; n++ {
+		src := make([]float64, n)
+		dst := make([]float64, n)
+		for i := range src {
+			src[i] = math.Ldexp(1+0.13*float64(i), 2*i-n)
+		}
+		Log(dst, src)
+		for i, x := range src {
+			want := math.Log(x)
+			if re := relErrF64(dst[i], want); re > logRelTol64 {
+				t.Errorf("len=%d Log(%v)[%d] = %v, want %v (relErr %g)", n, x, i, dst[i], want, re)
+			}
+		}
+	}
+}
+
 func TestPowKnownAndEdge(t *testing.T) {
 	tests := []struct {
 		base, exp, want float64
@@ -78,7 +215,7 @@ func TestPowKnownAndEdge(t *testing.T) {
 	for _, tt := range tests {
 		dst := make([]float64, 1)
 		Pow(dst, []float64{tt.base}, tt.exp)
-		if d := math.Abs(dst[0]-tt.want) / (1 + math.Abs(tt.want)); d > 1e-12 {
+		if d := math.Abs(dst[0]-tt.want) / (1 + math.Abs(tt.want)); d > powRelTol64 {
 			t.Errorf("Pow(%v, %v) = %v, want %v", tt.base, tt.exp, dst[0], tt.want)
 		}
 	}
@@ -100,9 +237,79 @@ func TestPowKnownAndEdge(t *testing.T) {
 	}
 }
 
-// TestLogPowParity checks the dispatched ops against the math.* reference over a
-// wide finite-positive range. Exact today (the implementation is the scalar
-// reference); becomes the parity gate once a SIMD kernel lands.
+// TestPowEdgeLanesSIMDLength repeats the math.Pow edge cases at a length that
+// engages the SIMD body, so the dispatch-level scalar fallback for slices
+// containing non-positive or non-finite bases is exercised.
+func TestPowEdgeLanesSIMDLength(t *testing.T) {
+	src := []float64{2, -2, 0, math.Inf(1), math.NaN(), 4, 0.5, 9, 16, 25}
+	for _, p := range []float64{0.5, 2, -1, 0, math.NaN(), math.Inf(1)} {
+		dst := make([]float64, len(src))
+		Pow(dst, src, p)
+		for i, x := range src {
+			want := math.Pow(x, p)
+			if math.IsNaN(want) || math.IsInf(want, 0) || want == 0 || x <= 0 {
+				if !bitsEqF64(dst[i], want) {
+					t.Errorf("Pow(%v, %v) = %v, want %v (exact class)", x, p, dst[i], want)
+				}
+				continue
+			}
+			if re := relErrF64(dst[i], want); re > powRelTol64 {
+				t.Errorf("Pow(%v, %v) = %v, want %v (relErr %g)", x, p, dst[i], want, re)
+			}
+		}
+	}
+
+	// PowElem with non-finite exponent lanes falls back per the same rule.
+	base := []float64{2, 3, 4, 5, 6, 7, 8, 9}
+	expv := []float64{1, 2, math.NaN(), math.Inf(1), math.Inf(-1), 0.5, 0, -2}
+	dst := make([]float64, len(base))
+	PowElem(dst, base, expv)
+	for i := range base {
+		want := math.Pow(base[i], expv[i])
+		if math.IsNaN(want) || math.IsInf(want, 0) || want == 0 {
+			if !bitsEqF64(dst[i], want) {
+				t.Errorf("PowElem(%v, %v) = %v, want %v (exact class)", base[i], expv[i], dst[i], want)
+			}
+			continue
+		}
+		if re := relErrF64(dst[i], want); re > powRelTol64 {
+			t.Errorf("PowElem(%v, %v) = %v, want %v (relErr %g)", base[i], expv[i], dst[i], want, re)
+		}
+	}
+}
+
+// TestPowOverflowClasses pins the overflow/underflow behavior of the SIMD
+// path: for positive finite bases, results that overflow in math.Pow must
+// come out as +Inf and results that underflow must come out as 0, matching
+// the scalar reference classes exactly.
+func TestPowOverflowClasses(t *testing.T) {
+	src := []float64{1e300, 1e-300, 2, 0.5, 1e10, 1e-10, 3, 7}
+	for _, p := range []float64{3, -3, 100, -100} {
+		dst := make([]float64, len(src))
+		Pow(dst, src, p)
+		for i, x := range src {
+			want := math.Pow(x, p)
+			switch {
+			case math.IsInf(want, 1):
+				if !math.IsInf(dst[i], 1) {
+					t.Errorf("Pow(%v, %v) = %v, want +Inf", x, p, dst[i])
+				}
+			case want == 0:
+				if dst[i] != 0 {
+					t.Errorf("Pow(%v, %v) = %v, want 0", x, p, dst[i])
+				}
+			default:
+				if re := relErrF64(dst[i], want); re > powRelTol64 {
+					t.Errorf("Pow(%v, %v) = %v, want %v (relErr %g)", x, p, dst[i], want, re)
+				}
+			}
+		}
+	}
+}
+
+// TestLogPowParity checks the dispatched ops against the math.* reference over
+// a wide finite-positive range, within the documented tolerances. On hosts
+// without the SIMD kernels this compares the scalar path against itself.
 func TestLogPowParity(t *testing.T) {
 	const n = 257
 	src := make([]float64, n)
@@ -110,28 +317,28 @@ func TestLogPowParity(t *testing.T) {
 		src[i] = math.Ldexp(1+0.5*float64(i%7), (i%200)-100)
 	}
 
-	check := func(name string, got []float64, ref func(float64) float64) {
+	check := func(name string, got []float64, ref func(float64) float64, tol float64) {
 		for i := range src {
 			want := ref(src[i])
-			if !bitsEqF64(got[i], want) {
-				t.Errorf("%s[%d](%v) = %v, want %v", name, i, src[i], got[i], want)
+			if re := relErrF64(got[i], want); re > tol {
+				t.Errorf("%s[%d](%v) = %v, want %v (relErr %g)", name, i, src[i], got[i], want, re)
 			}
 		}
 	}
 	dst := make([]float64, n)
 	Log(dst, src)
-	check("Log", dst, math.Log)
+	check("Log", dst, refLn64, logRelTol64)
 	Log2(dst, src)
-	check("Log2", dst, math.Log2)
+	check("Log2", dst, refLog2_64, logRelTol64)
 	Log10(dst, src)
-	check("Log10", dst, math.Log10)
+	check("Log10", dst, refLog10_64, logRelTol64)
 
 	for _, exp := range []float64{0.35, 0.5, 2, -1, 3.7} {
 		Pow(dst, src, exp)
 		for i := range src {
 			want := math.Pow(src[i], exp)
-			if !bitsEqF64(dst[i], want) {
-				t.Errorf("Pow[%d](%v, %v) = %v, want %v", i, src[i], exp, dst[i], want)
+			if re := relErrF64(dst[i], want); re > powRelTol64 {
+				t.Errorf("Pow[%d](%v, %v) = %v, want %v (relErr %g)", i, src[i], exp, dst[i], want, re)
 			}
 		}
 	}
@@ -143,8 +350,65 @@ func TestLogPowParity(t *testing.T) {
 	PowElem(dst, src, expv)
 	for i := range src {
 		want := math.Pow(src[i], expv[i])
-		if !bitsEqF64(dst[i], want) {
-			t.Errorf("PowElem[%d] = %v, want %v", i, dst[i], want)
+		if re := relErrF64(dst[i], want); re > powRelTol64 {
+			t.Errorf("PowElem[%d] = %v, want %v (relErr %g)", i, dst[i], want, re)
+		}
+	}
+}
+
+// TestLogPowDispatchParity pins the per-arch dispatch wrappers against the
+// pure-Go reference. On SIMD hosts this is the kernel-vs-reference gate; on
+// others it compares the reference with itself.
+func TestLogPowDispatchParity(t *testing.T) {
+	const n = 67 // SIMD body + scalar tail
+	src := make([]float64, n)
+	for i := range src {
+		src[i] = math.Ldexp(1+0.37*float64(i%5), (i%60)-30)
+	}
+	got := make([]float64, n)
+	want := make([]float64, n)
+
+	log64(got, src)
+	logGo(want, src)
+	for i := range got {
+		if re := relErrF64(got[i], want[i]); re > logRelTol64 {
+			t.Errorf("log64[%d](%v) = %v, want %v (relErr %g)", i, src[i], got[i], want[i], re)
+		}
+	}
+
+	log2_64(got, src)
+	log2Go(want, src)
+	for i := range got {
+		if re := relErrF64(got[i], want[i]); re > logRelTol64 {
+			t.Errorf("log2_64[%d](%v) = %v, want %v (relErr %g)", i, src[i], got[i], want[i], re)
+		}
+	}
+
+	log10_64(got, src)
+	log10Go(want, src)
+	for i := range got {
+		if re := relErrF64(got[i], want[i]); re > logRelTol64 {
+			t.Errorf("log10_64[%d](%v) = %v, want %v (relErr %g)", i, src[i], got[i], want[i], re)
+		}
+	}
+
+	pow64(got, src, 0.35)
+	powGo(want, src, 0.35)
+	for i := range got {
+		if re := relErrF64(got[i], want[i]); re > powRelTol64 {
+			t.Errorf("pow64[%d](%v, 0.35) = %v, want %v (relErr %g)", i, src[i], got[i], want[i], re)
+		}
+	}
+
+	expv := make([]float64, n)
+	for i := range expv {
+		expv[i] = -1.5 + 0.21*float64(i%17)
+	}
+	powElem64(got, src, expv)
+	powElemGo(want, src, expv)
+	for i := range got {
+		if re := relErrF64(got[i], want[i]); re > powRelTol64 {
+			t.Errorf("powElem64[%d](%v, %v) = %v, want %v (relErr %g)", i, src[i], expv[i], got[i], want[i], re)
 		}
 	}
 }
@@ -154,15 +418,15 @@ func TestLogPowInPlace(t *testing.T) {
 	a := append([]float64(nil), src...)
 	LogInPlace(a)
 	for i := range src {
-		if !bitsEqF64(a[i], math.Log(src[i])) {
-			t.Errorf("LogInPlace[%d] = %v", i, a[i])
+		if re := relErrF64(a[i], math.Log(src[i])); re > logRelTol64 {
+			t.Errorf("LogInPlace[%d] = %v (relErr %g)", i, a[i], re)
 		}
 	}
 	b := append([]float64(nil), src...)
 	PowInPlace(b, 0.5)
 	for i := range src {
-		if !bitsEqF64(b[i], math.Pow(src[i], 0.5)) {
-			t.Errorf("PowInPlace[%d] = %v", i, b[i])
+		if re := relErrF64(b[i], math.Pow(src[i], 0.5)); re > powRelTol64 {
+			t.Errorf("PowInPlace[%d] = %v (relErr %g)", i, b[i], re)
 		}
 	}
 }
@@ -178,7 +442,7 @@ func TestLogPowClampsLength(t *testing.T) {
 	short := make([]float64, 2)
 	Pow(short, []float64{2, 3, 4}, 2)
 	for i, want := range []float64{4, 9} {
-		if short[i] != want {
+		if re := relErrF64(short[i], want); re > powRelTol64 {
 			t.Errorf("Pow clamp[%d] = %v want %v", i, short[i], want)
 		}
 	}
@@ -210,5 +474,31 @@ func TestLogPowAllocFree(t *testing.T) {
 		if a := testing.AllocsPerRun(5, c.fn); a != 0 {
 			t.Errorf("%s allocated %v times per run, want 0", c.name, a)
 		}
+	}
+}
+
+func BenchmarkLog(b *testing.B) {
+	src := make([]float64, 1024)
+	for i := range src {
+		src[i] = 1e-3 + float64(i)*0.7
+	}
+	dst := make([]float64, len(src))
+	b.ReportAllocs()
+	b.ResetTimer()
+	for range b.N {
+		Log(dst, src)
+	}
+}
+
+func BenchmarkPow(b *testing.B) {
+	src := make([]float64, 1024)
+	for i := range src {
+		src[i] = 1e-3 + float64(i)*0.7
+	}
+	dst := make([]float64, len(src))
+	b.ReportAllocs()
+	b.ResetTimer()
+	for range b.N {
+		Pow(dst, src, 0.35)
 	}
 }

--- a/f64/log_pow_test.go
+++ b/f64/log_pow_test.go
@@ -47,7 +47,7 @@ func relErrF64(got, want float64) float64 {
 // subnormal x. Normalizing by 2^54 first gives the correct value on every
 // architecture.
 func refLn64(x float64) float64 {
-	if x > 0 && x < 2.2250738585072014e-308 {
+	if x > 0 && x < dblMinNormal64 {
 		return math.Log(x*0x1p54) - 54*math.Ln2
 	}
 	return math.Log(x)
@@ -118,8 +118,8 @@ func TestLogSubnormals(t *testing.T) {
 	src := []float64{
 		5e-324,         // smallest subnormal
 		1e-310, 1e-320, // assorted subnormals
-		2.2250738585072014e-308, // DBL_MIN, smallest normal
-		2.225073858507201e-308,  // largest subnormal
+		dblMinNormal64,         // DBL_MIN, smallest normal
+		2.225073858507201e-308, // largest subnormal
 		4e-308, 1e-300, 1,
 	}
 	for _, fn := range []struct {
@@ -157,7 +157,7 @@ func TestLogAccuracy(t *testing.T) {
 	for i := -40; i <= 40; i++ {
 		src = append(src, 1+float64(i)*1e-3, 1+float64(i)*1e-9)
 	}
-	src = append(src, math.MaxFloat64, 2.2250738585072014e-308, math.Sqrt2, math.Sqrt2/2)
+	src = append(src, math.MaxFloat64, dblMinNormal64, math.Sqrt2, math.Sqrt2/2)
 
 	for _, fn := range []struct {
 		name string
@@ -191,7 +191,7 @@ func TestLogLengths(t *testing.T) {
 		}
 		Log(dst, src)
 		for i, x := range src {
-			want := math.Log(x)
+			want := refLn64(x)
 			if re := relErrF64(dst[i], want); re > logRelTol64 {
 				t.Errorf("len=%d Log(%v)[%d] = %v, want %v (relErr %g)", n, x, i, dst[i], want, re)
 			}

--- a/f64/log_pow_test.go
+++ b/f64/log_pow_test.go
@@ -484,8 +484,7 @@ func BenchmarkLog(b *testing.B) {
 	}
 	dst := make([]float64, len(src))
 	b.ReportAllocs()
-	b.ResetTimer()
-	for range b.N {
+	for b.Loop() {
 		Log(dst, src)
 	}
 }
@@ -497,8 +496,7 @@ func BenchmarkPow(b *testing.B) {
 	}
 	dst := make([]float64, len(src))
 	b.ReportAllocs()
-	b.ResetTimer()
-	for range b.N {
+	for b.Loop() {
 		Pow(dst, src, 0.35)
 	}
 }


### PR DESCRIPTION
## Summary

Vectorizes the f64 transcendental log/pow family added (scalar) in #119. This is the f64 half of #109; the f32 kernels follow in a separate PR, so this does not close the issue.

- **Shared log core**: `x = m*2^e` via the musl/ARM-optimized-routines integer reduction (`bits - 0x3fe6a09e00000000`, arithmetic shift, mantissa re-subtraction; no compares), `m` in `[sqrt2/2, sqrt2)`, then `ln(m) = 2s + s*t*P(t)` with `s = (m-1)/(m+1)` and the 7-term SLEEF `xlog_u1` minimax polynomial. `Log`/`Log2`/`Log10` are one parametrized kernel; fdlibm hi/lo constant splits keep the `e*ln2` term exact. Positive subnormals pre-scale by `2^64`; `+Inf`/`+-0`/negative/NaN lanes blend to match `math.Log`. Measured max relative error: **4.0e-16 over 2M random inputs** including subnormals.
- **Pow / PowElem**: fused `exp(p*ln(x))` through the existing degree-5 exp core; accuracy bounded by that core at ~3e-6 relative, same as `Exp`. Slices with non-positive or non-finite bases (and zero/non-finite exponents) take the exact `math.Pow` path; true overflow/underflow keeps `math.Pow`'s `+Inf`/`0` classes via strict pre-clamp blends.
- **amd64**: AVX2+FMA gated (AVX2 for the YMM integer exponent extraction since `VPSRAQ` does not exist: `VPSRAD` on high dwords + `VPERMD` + `VCVTDQ2PD`). **arm64**: hand-encoded NEON `WORD`s, verified by asmcheck and cross-checked against `aarch64-linux-gnu-as`.
- **Scalar fallback fixes**: `logGo`/`log10Go` normalize positive subnormals first; Go's `math.Log` amd64 assembly returns ~-709.09 for every subnormal input because its exponent extraction never normalizes. `log2Go` routes inputs near 1 through `math.Log` (the Frexp formulation of `math.Log2` carries ~ulp(1) absolute error there).
- Peer-reviewed (algorithm + register lifetimes + operand order) with no findings.

## Related Issues

Relates to #109 (f64 half; f32 remains). Builds on #119.

## Accuracy / contract

- `Log`/`Log2`/`Log10`: tolerance 1e-13 relative in tests, measured ~2 ulps; edge classes pinned bit-exact vs `math.Log` (`0 -> -Inf`, `x<0 -> NaN`, `+Inf -> +Inf`, `NaN -> NaN`), subnormals correct on all paths.
- `Pow`/`PowElem`: 1e-5 tolerance (exp-core bound ~3e-6, mirrors `TestExpAccuracy`); documented clamp-band behavior near `|p*ln x| = 709`.

## Benchmarks (1024 elements)

| Op | i5-11400F scalar | i5-11400F SIMD | Cortex-A76 scalar | Cortex-A76 NEON |
|----|------------------|----------------|--------------------|------------------|
| Log | 5.3 us | 1.2 us (4.6x) | 17.4 us | 7.4 us (2.3x) |
| Pow | 27.1 us | 3.1 us (8.8x) | 79.3 us | 17.2 us (4.6x) |

## Test Plan

- [x] Full suite + golangci-lint (0 issues) on amd64 (AVX2+FMA) and arm64 (rpi5, NEON)
- [x] New accuracy sweeps: full range, near-1 (both sides), subnormals, sqrt(2) reduction boundaries, every length 1-33
- [x] Differential fuzz targets `FuzzF64Log` / `FuzzF64Pow` actively fuzzed 45s on amd64 and 40s on arm64
- [x] 2M-value random accuracy sweep: Log max rel err 4.0e-16, Pow 3.2e-6
- [x] Cross-builds: js/wasm, riscv64 (pure-Go fallback)
- [x] asmcheck WORD/comment cross-validation