### PR TITLE
f32: add SIMD Log, Log2, Log10, Pow, PowElem kernels (AVX2+FMA, NEON)

### DIFF
--- a/README.md
+++ b/README.md
@@ -188,10 +188,10 @@ live in `f32` instead, so the two float surfaces are intentionally asymmetric.
 |                 | `Tanh(dst, src)`                    | Hyperbolic tangent            | 4x (AVX2) / 2x (NEON)               |
 |                 | `Exp(dst, src)`                     | Exponential e^x               | 4x (AVX2) / 2x (NEON)               |
 |                 | `ClampScale(dst, src, min, max, s)` | Fused clamp and scale         | 4x (AVX) / 2x (NEON)                |
-| **Transcendental** | `Log(dst, src)`                  | Natural log ln(x)             | f64: 4x (AVX2+FMA) / 2x (NEON); f32 pure Go |
-|                 | `Log2(dst, src)` / `Log10(dst, src)`| Base-2 / base-10 log          | f64: 4x (AVX2+FMA) / 2x (NEON); f32 pure Go |
-|                 | `Pow(dst, src, exp)`                | Scalar power x^exp (PCEN, dB) | f64: 4x (AVX2+FMA) / 2x (NEON); f32 pure Go |
-|                 | `PowElem(dst, base, exp)`           | Elementwise base^exp          | f64: 4x (AVX2+FMA) / 2x (NEON); f32 pure Go |
+| **Transcendental** | `Log(dst, src)`                  | Natural log ln(x)             | 8x / 4x (AVX2+FMA) / 4x / 2x (NEON) |
+|                 | `Log2(dst, src)` / `Log10(dst, src)`| Base-2 / base-10 log          | 8x / 4x (AVX2+FMA) / 4x / 2x (NEON) |
+|                 | `Pow(dst, src, exp)`                | Scalar power x^exp (PCEN, dB) | 8x / 4x (AVX2+FMA) / 4x / 2x (NEON) |
+|                 | `PowElem(dst, base, exp)`           | Elementwise base^exp          | 8x / 4x (AVX2+FMA) / 4x / 2x (NEON) |
 | **Batch**       | `DotProductBatch(r, rows, v)`       | Multiple dot products         | 8x / 4x / 2x                        |
 | **Signal**      | `ConvolveValid(dst, sig, k)`        | FIR filter / convolution      | 8x / 4x / 2x                        |
 |                 | `ConvolveValidMulti(dsts, sig, ks)` | Multi-kernel convolution      | 8x / 4x / 2x                        |

--- a/doc.go
+++ b/doc.go
@@ -77,8 +77,8 @@
 //
 // Activation functions: Sigmoid, ReLU, Tanh, Exp, ClampScale
 //
-// Transcendental (f32/f64): Log, Log2, Log10, Pow, PowElem (plus LogInPlace, PowInPlace);
-// f64 is SIMD-accelerated on AVX2+FMA and NEON (f32 kernels tracked in #109)
+// Transcendental (f32/f64): Log, Log2, Log10, Pow, PowElem (plus LogInPlace, PowInPlace),
+// SIMD-accelerated on AVX2+FMA and NEON
 //
 // Audio DSP: Interleave2, Deinterleave2, ConvolveValid, ConvolveValidMulti, ConvolveDecimate, AccumulateAdd, CumulativeSum, CubicInterpDot, Int32ToFloat32Scale, Int16ToFloat32Scale, Float32ToInt16Scale
 //

--- a/f32/f32.go
+++ b/f32/f32.go
@@ -727,15 +727,17 @@ func ExpInPlace(a []float32) {
 // Processes min(len(dst), len(src)) elements. Edge cases match math.Log:
 // Log(0) = -Inf, Log(x < 0) = NaN, Log(+Inf) = +Inf, Log(NaN) = NaN.
 //
-// The implementation is currently the accurate pure-Go reference on every
-// architecture; a vectorized kernel is a profiled follow-up (see issue #109).
-// Allocation-free and safe for concurrent use on disjoint buffers.
+// On AVX2+FMA and NEON hosts a vectorized kernel is used (Cephes logf
+// degree-8 minimax polynomial; worst-case relative error ~1.4e-7, about one
+// float32 ulp, including subnormal inputs). Elsewhere it falls back to the
+// float64-accurate Go path. Allocation-free and safe for concurrent use on
+// disjoint buffers.
 func Log(dst, src []float32) {
 	n := min(len(dst), len(src))
 	if n == 0 {
 		return
 	}
-	logGo(dst[:n], src[:n])
+	log32(dst[:n], src[:n])
 }
 
 // LogInPlace computes the natural logarithm in place: a[i] = ln(a[i]).
@@ -743,7 +745,7 @@ func LogInPlace(a []float32) {
 	if len(a) == 0 {
 		return
 	}
-	logGo(a, a)
+	log32(a, a)
 }
 
 // Log2 computes the base-2 logarithm elementwise: dst[i] = log2(src[i]).
@@ -754,7 +756,7 @@ func Log2(dst, src []float32) {
 	if n == 0 {
 		return
 	}
-	log2Go(dst[:n], src[:n])
+	log2_32(dst[:n], src[:n])
 }
 
 // Log10 computes the base-10 logarithm elementwise: dst[i] = log10(src[i]).
@@ -766,20 +768,27 @@ func Log10(dst, src []float32) {
 	if n == 0 {
 		return
 	}
-	log10Go(dst[:n], src[:n])
+	log10_32(dst[:n], src[:n])
 }
 
 // Pow raises each element to a scalar power: dst[i] = src[i]**exp. The scalar
 // exponent is the common DSP case (for example the ^0.35 power-law compression
 // in PCEN). Processes min(len(dst), len(src)) elements; edge cases match
 // math.Pow (Pow(x, 0) = 1, Pow(negative, non-integer) = NaN, Pow(0, negative)
-// = +Inf). Allocation-free; a vectorized kernel is a profiled follow-up (#109).
+// = +Inf).
+//
+// On AVX2+FMA and NEON hosts, slices whose elements are all positive and
+// finite are computed with a fused exp(exp*ln(x)) kernel (relative error
+// ~1.4e-5, mirroring the Exp core); overflow yields +Inf and underflow 0,
+// matching math.Pow. Slices containing non-positive, infinite, or NaN bases,
+// and calls with a zero or non-finite exponent, take the exact scalar path.
+// Allocation-free and safe for concurrent use on disjoint buffers.
 func Pow(dst, src []float32, exp float32) {
 	n := min(len(dst), len(src))
 	if n == 0 {
 		return
 	}
-	powGo(dst[:n], src[:n], exp)
+	pow32(dst[:n], src[:n], exp)
 }
 
 // PowInPlace raises each element to a scalar power in place: a[i] = a[i]**exp.
@@ -787,18 +796,19 @@ func PowInPlace(a []float32, exp float32) {
 	if len(a) == 0 {
 		return
 	}
-	powGo(a, a, exp)
+	pow32(a, a, exp)
 }
 
 // PowElem raises each base to its own exponent: dst[i] = base[i]**exp[i].
 // Processes min(len(dst), len(base), len(exp)) elements; edge cases match
-// math.Pow.
+// math.Pow. The SIMD fast path and its fallback rules match Pow, with the
+// additional requirement that every exponent is finite.
 func PowElem(dst, base, exp []float32) {
 	n := min(len(dst), len(base), len(exp))
 	if n == 0 {
 		return
 	}
-	powElemGo(dst[:n], base[:n], exp[:n])
+	powElem32(dst[:n], base[:n], exp[:n])
 }
 
 // Int32ToFloat32Scale converts int32 samples to float32 and scales in one pass.

--- a/f32/f32_amd64.go
+++ b/f32/f32_amd64.go
@@ -3,6 +3,7 @@
 package f32
 
 import (
+	"math"
 	"unsafe"
 
 	"github.com/tphakala/simd/cpu"
@@ -978,6 +979,68 @@ func exp32(dst, src []float32) {
 
 //go:noescape
 func expAVX(dst, src []float32)
+
+// logSIMDOK32 reports whether the AVX log/pow kernels can run: they need
+// AVX2 (YMM integer ops for the exponent extraction) and FMA (polynomial
+// evaluation). AVX1-only or FMA-less CPUs use the accurate Go path.
+func logSIMDOK32(n int) bool {
+	return cpu.X86.AVX2 && cpu.X86.FMA && n >= minAVXElements
+}
+
+func log32(dst, src []float32) {
+	if logSIMDOK32(len(dst)) {
+		logAVX(dst, src, logLn2Hi32, logLn2Lo32, 1.0)
+		return
+	}
+	logGo(dst, src)
+}
+
+func log2_32(dst, src []float32) {
+	// log2(x) = e + ln(m)*log2(e): the e term is exact, so no hi/lo split is
+	// needed and exact powers of two come out exact.
+	if logSIMDOK32(len(dst)) {
+		logAVX(dst, src, 1.0, 0.0, logLog2E32)
+		return
+	}
+	log2Go(dst, src)
+}
+
+func log10_32(dst, src []float32) {
+	if logSIMDOK32(len(dst)) {
+		logAVX(dst, src, logL102Hi32, logL102Lo32, logLog10E32)
+		return
+	}
+	log10Go(dst, src)
+}
+
+func pow32(dst, src []float32, exp float32) {
+	// A zero or non-finite exponent has whole-slice math.Pow semantics
+	// (for example Pow(x, 0) = 1 even for NaN x); keep those exact.
+	e := float64(exp)
+	if logSIMDOK32(len(dst)) && exp != 0 && !math.IsNaN(e) && !math.IsInf(e, 0) &&
+		powSIMDOK32(src[:len(dst)]) {
+		powAVX(dst, src, exp)
+		return
+	}
+	powGo(dst, src, exp)
+}
+
+func powElem32(dst, base, exp []float32) {
+	if logSIMDOK32(len(dst)) && powSIMDOK32(base[:len(dst)]) && allFinite32(exp[:len(dst)]) {
+		powElemAVX(dst, base, exp)
+		return
+	}
+	powElemGo(dst, base, exp)
+}
+
+//go:noescape
+func logAVX(dst, src []float32, k1hi, k1lo, k2 float32)
+
+//go:noescape
+func powAVX(dst, src []float32, exp float32)
+
+//go:noescape
+func powElemAVX(dst, base, exp []float32)
 
 func int32ToFloat32Scale(dst []float32, src []int32, scale float32) {
 	// Use AVX if available and have enough elements

--- a/f32/f32_amd64.s
+++ b/f32/f32_amd64.s
@@ -6210,3 +6210,815 @@ euclid32_avx_sqrt:
     VMOVSS X0, ret+48(FP)
     VZEROUPPER
     RET
+
+// ============================================================================
+// logAVX / powAVX / powElemAVX (f32): vectorized natural log core (issue #109)
+// ============================================================================
+
+// Mantissa reduction offset: bits(x) - log32_off puts the biased exponent of
+// m = x / 2^e in the tmp exponent field such that m in [sqrt(2)/2, sqrt(2)),
+// with e = tmp >> 23 (arithmetic) and bits(m) = bits(x) - (tmp & 0xff800000).
+DATA log32_off<>+0x00(SB)/4, $0x3f350000
+DATA log32_off<>+0x04(SB)/4, $0x3f350000
+DATA log32_off<>+0x08(SB)/4, $0x3f350000
+DATA log32_off<>+0x0c(SB)/4, $0x3f350000
+DATA log32_off<>+0x10(SB)/4, $0x3f350000
+DATA log32_off<>+0x14(SB)/4, $0x3f350000
+DATA log32_off<>+0x18(SB)/4, $0x3f350000
+DATA log32_off<>+0x1c(SB)/4, $0x3f350000
+GLOBL log32_off<>(SB), RODATA|NOPTR, $32
+
+DATA log32_expmask<>+0x00(SB)/4, $0xff800000
+DATA log32_expmask<>+0x04(SB)/4, $0xff800000
+DATA log32_expmask<>+0x08(SB)/4, $0xff800000
+DATA log32_expmask<>+0x0c(SB)/4, $0xff800000
+DATA log32_expmask<>+0x10(SB)/4, $0xff800000
+DATA log32_expmask<>+0x14(SB)/4, $0xff800000
+DATA log32_expmask<>+0x18(SB)/4, $0xff800000
+DATA log32_expmask<>+0x1c(SB)/4, $0xff800000
+GLOBL log32_expmask<>(SB), RODATA|NOPTR, $32
+
+// FLT_MIN = 1.1754944e-38: positive inputs below this are subnormal and
+// pre-scaled by 2^32 (exponent bias -32) before the reduction.
+DATA log32_fltmin<>+0x00(SB)/4, $0x00800000
+DATA log32_fltmin<>+0x04(SB)/4, $0x00800000
+DATA log32_fltmin<>+0x08(SB)/4, $0x00800000
+DATA log32_fltmin<>+0x0c(SB)/4, $0x00800000
+DATA log32_fltmin<>+0x10(SB)/4, $0x00800000
+DATA log32_fltmin<>+0x14(SB)/4, $0x00800000
+DATA log32_fltmin<>+0x18(SB)/4, $0x00800000
+DATA log32_fltmin<>+0x1c(SB)/4, $0x00800000
+GLOBL log32_fltmin<>(SB), RODATA|NOPTR, $32
+
+DATA log32_two32<>+0x00(SB)/4, $0x4f800000  // 2^32
+DATA log32_two32<>+0x04(SB)/4, $0x4f800000
+DATA log32_two32<>+0x08(SB)/4, $0x4f800000
+DATA log32_two32<>+0x0c(SB)/4, $0x4f800000
+DATA log32_two32<>+0x10(SB)/4, $0x4f800000
+DATA log32_two32<>+0x14(SB)/4, $0x4f800000
+DATA log32_two32<>+0x18(SB)/4, $0x4f800000
+DATA log32_two32<>+0x1c(SB)/4, $0x4f800000
+GLOBL log32_two32<>(SB), RODATA|NOPTR, $32
+
+DATA log32_negsc<>+0x00(SB)/4, $0xc2000000  // -32.0 (exponent bias)
+DATA log32_negsc<>+0x04(SB)/4, $0xc2000000
+DATA log32_negsc<>+0x08(SB)/4, $0xc2000000
+DATA log32_negsc<>+0x0c(SB)/4, $0xc2000000
+DATA log32_negsc<>+0x10(SB)/4, $0xc2000000
+DATA log32_negsc<>+0x14(SB)/4, $0xc2000000
+DATA log32_negsc<>+0x18(SB)/4, $0xc2000000
+DATA log32_negsc<>+0x1c(SB)/4, $0xc2000000
+GLOBL log32_negsc<>(SB), RODATA|NOPTR, $32
+
+// Cephes logf minimax polynomial for ln(m), m in [sqrt(2)/2, sqrt(2)):
+// with z = m-1, ln(m) = z - 0.5*z^2 + z^3*P(z),
+// P(z) = ((((((((p0*z + p1)*z + p2)*z + p3)*z + p4)*z + p5)*z + p6)*z
+// + p7)*z + p8). Worst-case relative error of the full ln(x) is ~1.2 ulps.
+DATA log32_p0<>+0x00(SB)/4, $0x3d9021bb  // +7.0376836292e-2
+DATA log32_p0<>+0x04(SB)/4, $0x3d9021bb
+DATA log32_p0<>+0x08(SB)/4, $0x3d9021bb
+DATA log32_p0<>+0x0c(SB)/4, $0x3d9021bb
+DATA log32_p0<>+0x10(SB)/4, $0x3d9021bb
+DATA log32_p0<>+0x14(SB)/4, $0x3d9021bb
+DATA log32_p0<>+0x18(SB)/4, $0x3d9021bb
+DATA log32_p0<>+0x1c(SB)/4, $0x3d9021bb
+GLOBL log32_p0<>(SB), RODATA|NOPTR, $32
+
+DATA log32_p1<>+0x00(SB)/4, $0xbdebd1b8  // -1.1514610310e-1
+DATA log32_p1<>+0x04(SB)/4, $0xbdebd1b8
+DATA log32_p1<>+0x08(SB)/4, $0xbdebd1b8
+DATA log32_p1<>+0x0c(SB)/4, $0xbdebd1b8
+DATA log32_p1<>+0x10(SB)/4, $0xbdebd1b8
+DATA log32_p1<>+0x14(SB)/4, $0xbdebd1b8
+DATA log32_p1<>+0x18(SB)/4, $0xbdebd1b8
+DATA log32_p1<>+0x1c(SB)/4, $0xbdebd1b8
+GLOBL log32_p1<>(SB), RODATA|NOPTR, $32
+
+DATA log32_p2<>+0x00(SB)/4, $0x3def251a  // +1.1676998740e-1
+DATA log32_p2<>+0x04(SB)/4, $0x3def251a
+DATA log32_p2<>+0x08(SB)/4, $0x3def251a
+DATA log32_p2<>+0x0c(SB)/4, $0x3def251a
+DATA log32_p2<>+0x10(SB)/4, $0x3def251a
+DATA log32_p2<>+0x14(SB)/4, $0x3def251a
+DATA log32_p2<>+0x18(SB)/4, $0x3def251a
+DATA log32_p2<>+0x1c(SB)/4, $0x3def251a
+GLOBL log32_p2<>(SB), RODATA|NOPTR, $32
+
+DATA log32_p3<>+0x00(SB)/4, $0xbdfe5d4f  // -1.2420140846e-1
+DATA log32_p3<>+0x04(SB)/4, $0xbdfe5d4f
+DATA log32_p3<>+0x08(SB)/4, $0xbdfe5d4f
+DATA log32_p3<>+0x0c(SB)/4, $0xbdfe5d4f
+DATA log32_p3<>+0x10(SB)/4, $0xbdfe5d4f
+DATA log32_p3<>+0x14(SB)/4, $0xbdfe5d4f
+DATA log32_p3<>+0x18(SB)/4, $0xbdfe5d4f
+DATA log32_p3<>+0x1c(SB)/4, $0xbdfe5d4f
+GLOBL log32_p3<>(SB), RODATA|NOPTR, $32
+
+DATA log32_p4<>+0x00(SB)/4, $0x3e11e9bf  // +1.4249322787e-1
+DATA log32_p4<>+0x04(SB)/4, $0x3e11e9bf
+DATA log32_p4<>+0x08(SB)/4, $0x3e11e9bf
+DATA log32_p4<>+0x0c(SB)/4, $0x3e11e9bf
+DATA log32_p4<>+0x10(SB)/4, $0x3e11e9bf
+DATA log32_p4<>+0x14(SB)/4, $0x3e11e9bf
+DATA log32_p4<>+0x18(SB)/4, $0x3e11e9bf
+DATA log32_p4<>+0x1c(SB)/4, $0x3e11e9bf
+GLOBL log32_p4<>(SB), RODATA|NOPTR, $32
+
+DATA log32_p5<>+0x00(SB)/4, $0xbe2aae50  // -1.6668057665e-1
+DATA log32_p5<>+0x04(SB)/4, $0xbe2aae50
+DATA log32_p5<>+0x08(SB)/4, $0xbe2aae50
+DATA log32_p5<>+0x0c(SB)/4, $0xbe2aae50
+DATA log32_p5<>+0x10(SB)/4, $0xbe2aae50
+DATA log32_p5<>+0x14(SB)/4, $0xbe2aae50
+DATA log32_p5<>+0x18(SB)/4, $0xbe2aae50
+DATA log32_p5<>+0x1c(SB)/4, $0xbe2aae50
+GLOBL log32_p5<>(SB), RODATA|NOPTR, $32
+
+DATA log32_p6<>+0x00(SB)/4, $0x3e4cceac  // +2.0000714765e-1
+DATA log32_p6<>+0x04(SB)/4, $0x3e4cceac
+DATA log32_p6<>+0x08(SB)/4, $0x3e4cceac
+DATA log32_p6<>+0x0c(SB)/4, $0x3e4cceac
+DATA log32_p6<>+0x10(SB)/4, $0x3e4cceac
+DATA log32_p6<>+0x14(SB)/4, $0x3e4cceac
+DATA log32_p6<>+0x18(SB)/4, $0x3e4cceac
+DATA log32_p6<>+0x1c(SB)/4, $0x3e4cceac
+GLOBL log32_p6<>(SB), RODATA|NOPTR, $32
+
+DATA log32_p7<>+0x00(SB)/4, $0xbe7ffffc  // -2.4999993993e-1
+DATA log32_p7<>+0x04(SB)/4, $0xbe7ffffc
+DATA log32_p7<>+0x08(SB)/4, $0xbe7ffffc
+DATA log32_p7<>+0x0c(SB)/4, $0xbe7ffffc
+DATA log32_p7<>+0x10(SB)/4, $0xbe7ffffc
+DATA log32_p7<>+0x14(SB)/4, $0xbe7ffffc
+DATA log32_p7<>+0x18(SB)/4, $0xbe7ffffc
+DATA log32_p7<>+0x1c(SB)/4, $0xbe7ffffc
+GLOBL log32_p7<>(SB), RODATA|NOPTR, $32
+
+DATA log32_p8<>+0x00(SB)/4, $0x3eaaaaaa  // +3.3333331174e-1
+DATA log32_p8<>+0x04(SB)/4, $0x3eaaaaaa
+DATA log32_p8<>+0x08(SB)/4, $0x3eaaaaaa
+DATA log32_p8<>+0x0c(SB)/4, $0x3eaaaaaa
+DATA log32_p8<>+0x10(SB)/4, $0x3eaaaaaa
+DATA log32_p8<>+0x14(SB)/4, $0x3eaaaaaa
+DATA log32_p8<>+0x18(SB)/4, $0x3eaaaaaa
+DATA log32_p8<>+0x1c(SB)/4, $0x3eaaaaaa
+GLOBL log32_p8<>(SB), RODATA|NOPTR, $32
+
+// Cephes logf ln(2) hi/lo split for the pow kernels' fixed natural-log
+// reconstruction (logAVX takes its split via arguments instead).
+DATA log32_ln2hi<>+0x00(SB)/4, $0x3f318000  // 0.693359375
+DATA log32_ln2hi<>+0x04(SB)/4, $0x3f318000
+DATA log32_ln2hi<>+0x08(SB)/4, $0x3f318000
+DATA log32_ln2hi<>+0x0c(SB)/4, $0x3f318000
+DATA log32_ln2hi<>+0x10(SB)/4, $0x3f318000
+DATA log32_ln2hi<>+0x14(SB)/4, $0x3f318000
+DATA log32_ln2hi<>+0x18(SB)/4, $0x3f318000
+DATA log32_ln2hi<>+0x1c(SB)/4, $0x3f318000
+GLOBL log32_ln2hi<>(SB), RODATA|NOPTR, $32
+
+DATA log32_ln2lo<>+0x00(SB)/4, $0xb95e8083  // -2.12194440e-4
+DATA log32_ln2lo<>+0x04(SB)/4, $0xb95e8083
+DATA log32_ln2lo<>+0x08(SB)/4, $0xb95e8083
+DATA log32_ln2lo<>+0x0c(SB)/4, $0xb95e8083
+DATA log32_ln2lo<>+0x10(SB)/4, $0xb95e8083
+DATA log32_ln2lo<>+0x14(SB)/4, $0xb95e8083
+DATA log32_ln2lo<>+0x18(SB)/4, $0xb95e8083
+DATA log32_ln2lo<>+0x1c(SB)/4, $0xb95e8083
+GLOBL log32_ln2lo<>(SB), RODATA|NOPTR, $32
+
+DATA log32_posinf<>+0x00(SB)/4, $0x7f800000
+DATA log32_posinf<>+0x04(SB)/4, $0x7f800000
+DATA log32_posinf<>+0x08(SB)/4, $0x7f800000
+DATA log32_posinf<>+0x0c(SB)/4, $0x7f800000
+DATA log32_posinf<>+0x10(SB)/4, $0x7f800000
+DATA log32_posinf<>+0x14(SB)/4, $0x7f800000
+DATA log32_posinf<>+0x18(SB)/4, $0x7f800000
+DATA log32_posinf<>+0x1c(SB)/4, $0x7f800000
+GLOBL log32_posinf<>(SB), RODATA|NOPTR, $32
+
+DATA log32_neginf<>+0x00(SB)/4, $0xff800000
+DATA log32_neginf<>+0x04(SB)/4, $0xff800000
+DATA log32_neginf<>+0x08(SB)/4, $0xff800000
+DATA log32_neginf<>+0x0c(SB)/4, $0xff800000
+DATA log32_neginf<>+0x10(SB)/4, $0xff800000
+DATA log32_neginf<>+0x14(SB)/4, $0xff800000
+DATA log32_neginf<>+0x18(SB)/4, $0xff800000
+DATA log32_neginf<>+0x1c(SB)/4, $0xff800000
+GLOBL log32_neginf<>(SB), RODATA|NOPTR, $32
+
+DATA log32_nan<>+0x00(SB)/4, $0x7fc00000
+DATA log32_nan<>+0x04(SB)/4, $0x7fc00000
+DATA log32_nan<>+0x08(SB)/4, $0x7fc00000
+DATA log32_nan<>+0x0c(SB)/4, $0x7fc00000
+DATA log32_nan<>+0x10(SB)/4, $0x7fc00000
+DATA log32_nan<>+0x14(SB)/4, $0x7fc00000
+DATA log32_nan<>+0x18(SB)/4, $0x7fc00000
+DATA log32_nan<>+0x1c(SB)/4, $0x7fc00000
+GLOBL log32_nan<>(SB), RODATA|NOPTR, $32
+
+// func logAVX(dst, src []float32, k1hi, k1lo, k2 float32)
+// Shared kernel for Log, Log2, and Log10: per lane it computes
+// result = e*k1hi + (lnm*k2 + e*k1lo), with x = m*2^e, m in
+// [sqrt(2)/2, sqrt(2)) and lnm = ln(m) = z - 0.5*z^2 + z^3*P(z) for
+// z = m-1 (Cephes logf degree-8 minimax polynomial). Positive subnormal
+// inputs are pre-scaled by 2^32 (exponent bias -32). Special lanes are fixed
+// up with blends from the original input: +Inf -> +Inf, +-0 -> -Inf,
+// x < 0 or NaN -> NaN, matching math.Log. Requires AVX2 (YMM integer ops in
+// the exponent extraction) and FMA. Processes 8 elements per iteration; the
+// 0-7 element tail uses the scalar path below.
+TEXT ·logAVX(SB), NOSPLIT, $0-60
+    MOVQ dst_base+0(FP), DX
+    MOVQ dst_len+8(FP), CX
+    MOVQ src_base+24(FP), SI
+
+    // Loop-invariant constants. The low 128 bits (X7-X15) are reused by the
+    // scalar remainder path.
+    VMOVUPS log32_negsc<>(SB), Y7      // Y7 = -32.0 (subnormal exponent bias)
+    VMOVUPS log32_two32<>(SB), Y8      // Y8 = 2^32 (subnormal pre-scale)
+    VMOVUPS log32_fltmin<>(SB), Y9     // Y9 = FLT_MIN
+    VMOVUPS exp_one<>(SB), Y10         // Y10 = 1.0
+    VMOVUPS log32_expmask<>(SB), Y11   // Y11 = 0xff800000
+    VMOVUPS log32_off<>(SB), Y12       // Y12 = reduction offset
+    VBROADCASTSS k2+56(FP), Y13        // Y13 = k2
+    VBROADCASTSS k1lo+52(FP), Y14      // Y14 = k1lo
+    VBROADCASTSS k1hi+48(FP), Y15      // Y15 = k1hi
+
+    MOVQ CX, R8
+    SHRQ $3, R8                        // len / 8
+    JZ   log32_remainder
+
+log32_loop8:
+    VMOVUPS (SI), Y0                   // Y0 = x (kept for the special-lane blends)
+
+    // Subnormal pre-scale: lanes with 0 < x < FLT_MIN are scaled by 2^32 and
+    // carry an exponent bias of -32. (Negative/NaN lanes fail the compare or
+    // produce garbage that the final blends overwrite.)
+    VCMPPS $17, Y9, Y0, Y1             // Y1 = mask: x < FLT_MIN (LT_OQ)
+    VMULPS Y8, Y0, Y2                  // Y2 = x * 2^32
+    VBLENDVPS Y1, Y2, Y0, Y2           // Y2 = xs
+    VANDPS Y7, Y1, Y1                  // Y1 = ebias = subnormal ? -32.0 : 0.0
+
+    // Exponent/mantissa split: tmp = bits(xs) - OFF; e = tmp >> 23
+    // (arithmetic, directly on the 32-bit lanes); bits(m) = bits(xs) -
+    // (tmp & 0xff800000), leaving m in [sqrt(2)/2, sqrt(2)).
+    VPSUBD Y12, Y2, Y3                 // Y3 = tmp
+    VPAND Y11, Y3, Y4                  // Y4 = tmp & expmask
+    VPSUBD Y4, Y2, Y4                  // Y4 = m
+    VPSRAD $23, Y3, Y3                 // Y3 = e (int32)
+    VCVTDQ2PS Y3, Y3                   // Y3 = e as float32
+    VADDPS Y1, Y3, Y3                  // Y3 = e + ebias
+
+    // z = m - 1, zz = z^2
+    VSUBPS Y10, Y4, Y5                 // Y5 = z
+    VMULPS Y5, Y5, Y4                  // Y4 = zz
+
+    // P(z), Horner with memory-operand FMAs
+    VMOVUPS log32_p0<>(SB), Y2
+    VFMADD213PS log32_p1<>(SB), Y5, Y2 // Y2 = Y2*z + p1
+    VFMADD213PS log32_p2<>(SB), Y5, Y2
+    VFMADD213PS log32_p3<>(SB), Y5, Y2
+    VFMADD213PS log32_p4<>(SB), Y5, Y2
+    VFMADD213PS log32_p5<>(SB), Y5, Y2
+    VFMADD213PS log32_p6<>(SB), Y5, Y2
+    VFMADD213PS log32_p7<>(SB), Y5, Y2
+    VFMADD213PS log32_p8<>(SB), Y5, Y2 // Y2 = P(z)
+
+    // lnm = z + (z^3*P(z) - 0.5*zz)
+    VMULPS Y5, Y4, Y6                  // Y6 = z^3
+    VMULPS Y6, Y2, Y2                  // Y2 = z^3 * P(z)
+    VFNMADD231PS exp_half<>(SB), Y4, Y2 // Y2 -= 0.5*zz
+    VADDPS Y5, Y2, Y2                  // Y2 = lnm
+
+    // result = e*k1hi + (lnm*k2 + e*k1lo)
+    VMULPS Y14, Y3, Y4                 // Y4 = e * k1lo
+    VFMADD231PS Y13, Y2, Y4            // Y4 += lnm * k2
+    VFMADD231PS Y15, Y3, Y4            // Y4 += e * k1hi
+
+    // Special lanes from the original x: +Inf -> +Inf, +-0 -> -Inf,
+    // x < 0 or NaN -> NaN (canonical quiet NaN, like math.Log).
+    VMOVUPS log32_posinf<>(SB), Y2
+    VCMPPS $0, Y2, Y0, Y1              // Y1 = mask: x == +Inf (EQ_OQ)
+    VBLENDVPS Y1, Y2, Y4, Y4
+    VXORPS Y2, Y2, Y2
+    VCMPPS $0, Y2, Y0, Y1              // Y1 = mask: x == +-0
+    VMOVUPS log32_neginf<>(SB), Y3
+    VBLENDVPS Y1, Y3, Y4, Y4
+    VCMPPS $17, Y2, Y0, Y1             // Y1 = mask: x < 0
+    VCMPPS $3, Y0, Y0, Y2              // Y2 = mask: x unordered (NaN)
+    VORPS Y2, Y1, Y1
+    VMOVUPS log32_nan<>(SB), Y3
+    VBLENDVPS Y1, Y3, Y4, Y4
+
+    VMOVUPS Y4, (DX)
+    ADDQ $32, SI
+    ADDQ $32, DX
+    DECQ R8
+    JNZ  log32_loop8
+
+log32_remainder:
+    ANDQ $7, CX
+    JZ   log32_done
+
+log32_scalar:
+    MOVL (SI), AX                      // AX = bits(x)
+    VMOVSS (SI), X0                    // X0 = x
+
+    // Specials first (JP before JB/JE: unordered sets ZF=PF=CF=1)
+    VXORPS X1, X1, X1
+    VUCOMISS X1, X0
+    JP   log32_scalar_nan
+    JB   log32_scalar_nan              // x < 0
+    JE   log32_scalar_neginf           // x == +-0
+    MOVL $0x7F800000, BX
+    CMPL AX, BX
+    JEQ  log32_scalar_posinf
+
+    // Subnormal pre-scale (x positive finite; bits compare as ints)
+    XORL R9, R9
+    MOVL $0x00800000, BX
+    CMPL AX, BX
+    JGE  log32_scalar_normal
+    VMOVSS log32_two32<>(SB), X2       // 2^32
+    VMULSS X2, X0, X0
+    VMOVD X0, AX
+    MOVL $-32, R9
+
+log32_scalar_normal:
+    MOVL $0x3F350000, BX
+    MOVL AX, R10
+    SUBL BX, R10                       // R10 = tmp = bits - OFF
+    MOVL R10, R11
+    SARL $23, R11                      // R11 = e
+    ADDL R9, R11                       // e += bias
+    MOVL $0xFF800000, BX
+    ANDL BX, R10
+    SUBL R10, AX                       // AX = bits(m)
+    VMOVD AX, X2                       // X2 = m
+    CVTSL2SS R11, X3                   // X3 = e as float32
+
+    // z = m - 1, zz = z^2 (X10 = 1.0 from the vector constants)
+    VSUBSS X10, X2, X4                 // X4 = z
+    VMULSS X4, X4, X5                  // X5 = zz
+
+    VMOVSS log32_p0<>(SB), X1
+    VFMADD213SS log32_p1<>(SB), X4, X1
+    VFMADD213SS log32_p2<>(SB), X4, X1
+    VFMADD213SS log32_p3<>(SB), X4, X1
+    VFMADD213SS log32_p4<>(SB), X4, X1
+    VFMADD213SS log32_p5<>(SB), X4, X1
+    VFMADD213SS log32_p6<>(SB), X4, X1
+    VFMADD213SS log32_p7<>(SB), X4, X1
+    VFMADD213SS log32_p8<>(SB), X4, X1 // X1 = P(z)
+
+    VMULSS X4, X5, X6                  // X6 = z^3
+    VMULSS X6, X1, X1                  // X1 = z^3*P(z)
+    VFNMADD231SS exp_half<>(SB), X5, X1 // X1 -= 0.5*zz
+    VADDSS X4, X1, X1                  // X1 = lnm
+
+    VMULSS X14, X3, X5                 // e * k1lo
+    VFMADD231SS X13, X1, X5            // += lnm * k2
+    VFMADD231SS X15, X3, X5            // += e * k1hi
+    VMOVSS X5, (DX)
+    JMP  log32_scalar_next
+
+log32_scalar_nan:
+    MOVL $0x7FC00000, AX
+    MOVL AX, (DX)
+    JMP  log32_scalar_next
+
+log32_scalar_neginf:
+    MOVL $0xFF800000, AX
+    MOVL AX, (DX)
+    JMP  log32_scalar_next
+
+log32_scalar_posinf:
+    MOVL $0x7F800000, AX
+    MOVL AX, (DX)
+
+log32_scalar_next:
+    ADDQ $4, SI
+    ADDQ $4, DX
+    DECQ CX
+    JNZ  log32_scalar
+
+log32_done:
+    VZEROUPPER
+    RET
+
+// func powAVX(dst, src []float32, exp float32)
+// Fused pow(x, p) = exp(p*ln(x)) for slices whose elements are all positive
+// and finite (the dispatcher guarantees this, see powSIMDOK32). The log core
+// matches logAVX (constants from memory instead of registers); the exp core
+// matches expAVX except y = p*ln(x) is clamped to [-104, 89] (past
+// ln(MaxFloat32) and ln of the smallest subnormal) and the 2^k
+// reconstruction is split into 2^(k>>1) * 2^(k-(k>>1)), so overflow goes to
+// +Inf and underflow degrades gradually through subnormals to 0, matching
+// math.Pow's result classes. Accuracy is ~1.4e-5 relative (log error
+// amplified by |y|, then the exp polynomial). Requires AVX2 and FMA.
+TEXT ·powAVX(SB), NOSPLIT, $0-52
+    MOVQ dst_base+0(FP), DX
+    MOVQ dst_len+8(FP), CX
+    MOVQ src_base+24(FP), SI
+
+    // Exp-core constants in registers (the log core uses memory operands).
+    // The low 128 bits (X7-X15) are reused by the scalar remainder path.
+    VBROADCASTSS exp+48(FP), Y7        // Y7 = p
+    VMOVUPS exp_c5<>(SB), Y8           // Y8 = 1/120
+    VMOVUPS exp_c4<>(SB), Y9           // Y9 = 1/24
+    VMOVUPS exp_c3<>(SB), Y10          // Y10 = 1/6
+    VMOVUPS exp_c2<>(SB), Y11          // Y11 = 0.5
+    VMOVUPS exp_one<>(SB), Y12         // Y12 = 1.0
+    VMOVUPS exp_magic<>(SB), Y13       // Y13 = rounding magic
+    VMOVUPS exp_ln2<>(SB), Y14         // Y14 = ln(2)
+    VMOVUPS exp_log2e<>(SB), Y15       // Y15 = log2(e)
+
+    MOVQ CX, R8
+    SHRQ $3, R8
+    JZ   pow32_remainder
+
+pow32_loop8:
+    VMOVUPS (SI), Y0                   // Y0 = x (positive finite)
+
+    // --- log core (see logAVX) ---
+    VCMPPS $17, log32_fltmin<>(SB), Y0, Y1
+    VMULPS log32_two32<>(SB), Y0, Y2
+    VBLENDVPS Y1, Y2, Y0, Y0           // x, subnormals pre-scaled
+    VANDPS log32_negsc<>(SB), Y1, Y1   // ebias
+    VPSUBD log32_off<>(SB), Y0, Y2     // tmp
+    VPAND log32_expmask<>(SB), Y2, Y3
+    VPSUBD Y3, Y0, Y3                  // m
+    VPSRAD $23, Y2, Y2
+    VCVTDQ2PS Y2, Y2
+    VADDPS Y1, Y2, Y2                  // e
+    VSUBPS Y12, Y3, Y5                 // z = m - 1
+    VMULPS Y5, Y5, Y4                  // zz
+    VMOVUPS log32_p0<>(SB), Y3
+    VFMADD213PS log32_p1<>(SB), Y5, Y3
+    VFMADD213PS log32_p2<>(SB), Y5, Y3
+    VFMADD213PS log32_p3<>(SB), Y5, Y3
+    VFMADD213PS log32_p4<>(SB), Y5, Y3
+    VFMADD213PS log32_p5<>(SB), Y5, Y3
+    VFMADD213PS log32_p6<>(SB), Y5, Y3
+    VFMADD213PS log32_p7<>(SB), Y5, Y3
+    VFMADD213PS log32_p8<>(SB), Y5, Y3 // P(z)
+    VMULPS Y5, Y4, Y6                  // z^3
+    VMULPS Y6, Y3, Y3                  // z^3*P(z)
+    VFNMADD231PS exp_half<>(SB), Y4, Y3 // -= 0.5*zz
+    VADDPS Y5, Y3, Y3                  // lnm
+    VMULPS log32_ln2lo<>(SB), Y2, Y4   // e*ln2lo
+    VADDPS Y3, Y4, Y4                  // + lnm
+    VFMADD231PS log32_ln2hi<>(SB), Y2, Y4 // Y4 = ln(x)
+
+    // y = p*ln(x); keep the pre-clamp y in Y6 for the overflow blends, then
+    // clamp to [-88, 88] for the exp core
+    VMULPS Y7, Y4, Y0
+    VMINPS log32_powclamp_hi<>(SB), Y0, Y0
+    VMAXPS log32_powclamp_lo<>(SB), Y0, Y0
+
+    // --- exp core (see expAVX) ---
+    VMULPS Y15, Y0, Y1                 // y * log2e
+    VADDPS Y13, Y1, Y2                 // + magic
+    VSUBPS Y13, Y2, Y3                 // Y3 = k = round(y * log2e)
+    VMULPS Y14, Y3, Y4                 // k * ln2
+    VSUBPS Y4, Y0, Y0                  // r
+    VMULPS Y0, Y8, Y1                  // r*c5
+    VADDPS Y9, Y1, Y1
+    VMULPS Y0, Y1, Y1
+    VADDPS Y10, Y1, Y1
+    VMULPS Y0, Y1, Y1
+    VADDPS Y11, Y1, Y1
+    VMULPS Y0, Y1, Y1
+    VADDPS Y12, Y1, Y1
+    VMULPS Y0, Y1, Y1
+    VADDPS Y12, Y1, Y1                 // exp(r)
+    // Split 2^k reconstruction: k can reach +-150 here, past the biased
+    // exponent range, so build 2^(k>>1) and 2^(k-(k>>1)) separately. The
+    // double multiply overflows to +Inf / underflows through subnormals to 0
+    // exactly where math.Pow does.
+    VCVTPS2DQ Y3, Y4                   // int(k)
+    VPSRAD $1, Y4, Y3                  // k1 = k >> 1
+    VPSUBD Y3, Y4, Y4                  // k2 = k - k1
+    VPSLLD $23, Y3, Y3
+    VPADDD Y12, Y3, Y3                 // 2^k1 bits
+    VPSLLD $23, Y4, Y4
+    VPADDD Y12, Y4, Y4                 // 2^k2 bits
+    VMULPS Y3, Y1, Y1                  // exp(r) * 2^k1
+    VMULPS Y4, Y1, Y1                  // * 2^k2 = exp(y)
+
+    VMOVUPS Y1, (DX)
+    ADDQ $32, SI
+    ADDQ $32, DX
+    DECQ R8
+    JNZ  pow32_loop8
+
+pow32_remainder:
+    ANDQ $7, CX
+    JZ   pow32_done
+
+pow32_scalar:
+    MOVL (SI), AX
+    VMOVSS (SI), X0
+
+    // log core, scalar (x positive finite; subnormal pre-scale via GPR)
+    XORL R9, R9
+    MOVL $0x00800000, BX
+    CMPL AX, BX
+    JGE  pow32_scalar_normal
+    VMOVSS log32_two32<>(SB), X2       // 2^32
+    VMULSS X2, X0, X0
+    VMOVD X0, AX
+    MOVL $-32, R9
+
+pow32_scalar_normal:
+    MOVL $0x3F350000, BX
+    MOVL AX, R10
+    SUBL BX, R10                       // tmp
+    MOVL R10, R11
+    SARL $23, R11                      // e
+    ADDL R9, R11
+    MOVL $0xFF800000, BX
+    ANDL BX, R10
+    SUBL R10, AX                       // bits(m)
+    VMOVD AX, X2                       // m
+    CVTSL2SS R11, X3                   // e
+
+    VSUBSS X12, X2, X4                 // z = m - 1 (X12 = 1.0)
+    VMULSS X4, X4, X5                  // zz
+    VMOVSS log32_p0<>(SB), X1
+    VFMADD213SS log32_p1<>(SB), X4, X1
+    VFMADD213SS log32_p2<>(SB), X4, X1
+    VFMADD213SS log32_p3<>(SB), X4, X1
+    VFMADD213SS log32_p4<>(SB), X4, X1
+    VFMADD213SS log32_p5<>(SB), X4, X1
+    VFMADD213SS log32_p6<>(SB), X4, X1
+    VFMADD213SS log32_p7<>(SB), X4, X1
+    VFMADD213SS log32_p8<>(SB), X4, X1 // P(z)
+    VMULSS X4, X5, X6                  // z^3
+    VMULSS X6, X1, X1
+    VFNMADD231SS exp_half<>(SB), X5, X1 // -= 0.5*zz
+    VADDSS X4, X1, X1                  // lnm
+    VMULSS log32_ln2lo<>(SB), X3, X5
+    VADDSS X1, X5, X5
+    VFMADD231SS log32_ln2hi<>(SB), X3, X5 // X5 = ln(x)
+
+    // y = p*ln(x); pre-clamp copy in X6, clamp (X7 = p)
+    VMULSS X7, X5, X0
+    VMINSS log32_powclamp_hi<>(SB), X0, X0
+    VMAXSS log32_powclamp_lo<>(SB), X0, X0
+
+    // exp core, scalar (X8-X15 = exp constants)
+    VMULSS X15, X0, X1
+    VADDSS X13, X1, X2
+    VSUBSS X13, X2, X3                 // k
+    VMULSS X14, X3, X4
+    VSUBSS X4, X0, X0                  // r
+    VMULSS X0, X8, X1
+    VADDSS X9, X1, X1
+    VMULSS X0, X1, X1
+    VADDSS X10, X1, X1
+    VMULSS X0, X1, X1
+    VADDSS X11, X1, X1
+    VMULSS X0, X1, X1
+    VADDSS X12, X1, X1
+    VMULSS X0, X1, X1
+    VADDSS X12, X1, X1                 // exp(r)
+    // Split 2^k reconstruction (see the vector body)
+    VCVTSS2SI X3, AX                   // k
+    MOVL AX, R10
+    SARL $1, R10                       // k1 = k >> 1
+    SUBL R10, AX                       // k2 = k - k1
+    MOVL $0x3F800000, BX
+    SHLL $23, R10
+    ADDL BX, R10
+    VMOVD R10, X4
+    VMULSS X4, X1, X1                  // exp(r) * 2^k1
+    SHLL $23, AX
+    ADDL BX, AX
+    VMOVD AX, X4
+    VMULSS X4, X1, X1                  // * 2^k2 = exp(y)
+
+    VMOVSS X1, (DX)
+    ADDQ $4, SI
+    ADDQ $4, DX
+    DECQ CX
+    JNZ  pow32_scalar
+
+pow32_done:
+    VZEROUPPER
+    RET
+
+// func powElemAVX(dst, base, exp []float32)
+// Elementwise pow(base[i], exp[i]) = exp(exp[i]*ln(base[i])). Same cores and
+// preconditions as powAVX (all bases positive finite, all exponents finite),
+// with the exponent loaded per lane instead of broadcast.
+TEXT ·powElemAVX(SB), NOSPLIT, $0-72
+    MOVQ dst_base+0(FP), DX
+    MOVQ dst_len+8(FP), CX
+    MOVQ base_base+24(FP), SI
+    MOVQ exp_base+48(FP), DI
+
+    VMOVUPS exp_c5<>(SB), Y8           // Y8 = 1/120
+    VMOVUPS exp_c4<>(SB), Y9           // Y9 = 1/24
+    VMOVUPS exp_c3<>(SB), Y10          // Y10 = 1/6
+    VMOVUPS exp_c2<>(SB), Y11          // Y11 = 0.5
+    VMOVUPS exp_one<>(SB), Y12         // Y12 = 1.0
+    VMOVUPS exp_magic<>(SB), Y13       // Y13 = rounding magic
+    VMOVUPS exp_ln2<>(SB), Y14         // Y14 = ln(2)
+    VMOVUPS exp_log2e<>(SB), Y15       // Y15 = log2(e)
+
+    MOVQ CX, R8
+    SHRQ $3, R8
+    JZ   powelem32_remainder
+
+powelem32_loop8:
+    VMOVUPS (SI), Y0                   // Y0 = base (positive finite)
+
+    // --- log core (see logAVX) ---
+    VCMPPS $17, log32_fltmin<>(SB), Y0, Y1
+    VMULPS log32_two32<>(SB), Y0, Y2
+    VBLENDVPS Y1, Y2, Y0, Y0
+    VANDPS log32_negsc<>(SB), Y1, Y1   // ebias
+    VPSUBD log32_off<>(SB), Y0, Y2     // tmp
+    VPAND log32_expmask<>(SB), Y2, Y3
+    VPSUBD Y3, Y0, Y3                  // m
+    VPSRAD $23, Y2, Y2
+    VCVTDQ2PS Y2, Y2
+    VADDPS Y1, Y2, Y2                  // e
+    VSUBPS Y12, Y3, Y5                 // z = m - 1
+    VMULPS Y5, Y5, Y4                  // zz
+    VMOVUPS log32_p0<>(SB), Y3
+    VFMADD213PS log32_p1<>(SB), Y5, Y3
+    VFMADD213PS log32_p2<>(SB), Y5, Y3
+    VFMADD213PS log32_p3<>(SB), Y5, Y3
+    VFMADD213PS log32_p4<>(SB), Y5, Y3
+    VFMADD213PS log32_p5<>(SB), Y5, Y3
+    VFMADD213PS log32_p6<>(SB), Y5, Y3
+    VFMADD213PS log32_p7<>(SB), Y5, Y3
+    VFMADD213PS log32_p8<>(SB), Y5, Y3 // P(z)
+    VMULPS Y5, Y4, Y6                  // z^3
+    VMULPS Y6, Y3, Y3
+    VFNMADD231PS exp_half<>(SB), Y4, Y3 // -= 0.5*zz
+    VADDPS Y5, Y3, Y3                  // lnm
+    VMULPS log32_ln2lo<>(SB), Y2, Y4
+    VADDPS Y3, Y4, Y4
+    VFMADD231PS log32_ln2hi<>(SB), Y2, Y4 // Y4 = ln(base)
+
+    // y = exp[i]*ln(base[i]); pre-clamp copy in Y6, clamp for the exp core
+    VMOVUPS (DI), Y7                   // Y7 = exponents (finite)
+    VMULPS Y7, Y4, Y0
+    VMINPS log32_powclamp_hi<>(SB), Y0, Y0
+    VMAXPS log32_powclamp_lo<>(SB), Y0, Y0
+
+    // --- exp core (see expAVX) ---
+    VMULPS Y15, Y0, Y1
+    VADDPS Y13, Y1, Y2
+    VSUBPS Y13, Y2, Y3                 // k
+    VMULPS Y14, Y3, Y4
+    VSUBPS Y4, Y0, Y0                  // r
+    VMULPS Y0, Y8, Y1
+    VADDPS Y9, Y1, Y1
+    VMULPS Y0, Y1, Y1
+    VADDPS Y10, Y1, Y1
+    VMULPS Y0, Y1, Y1
+    VADDPS Y11, Y1, Y1
+    VMULPS Y0, Y1, Y1
+    VADDPS Y12, Y1, Y1
+    VMULPS Y0, Y1, Y1
+    VADDPS Y12, Y1, Y1                 // exp(r)
+    // Split 2^k reconstruction (see powAVX)
+    VCVTPS2DQ Y3, Y4                   // int(k)
+    VPSRAD $1, Y4, Y3                  // k1 = k >> 1
+    VPSUBD Y3, Y4, Y4                  // k2 = k - k1
+    VPSLLD $23, Y3, Y3
+    VPADDD Y12, Y3, Y3                 // 2^k1 bits
+    VPSLLD $23, Y4, Y4
+    VPADDD Y12, Y4, Y4                 // 2^k2 bits
+    VMULPS Y3, Y1, Y1                  // exp(r) * 2^k1
+    VMULPS Y4, Y1, Y1                  // * 2^k2 = exp(y)
+
+    VMOVUPS Y1, (DX)
+    ADDQ $32, SI
+    ADDQ $32, DI
+    ADDQ $32, DX
+    DECQ R8
+    JNZ  powelem32_loop8
+
+powelem32_remainder:
+    ANDQ $7, CX
+    JZ   powelem32_done
+
+powelem32_scalar:
+    MOVL (SI), AX
+    VMOVSS (SI), X0
+
+    XORL R9, R9
+    MOVL $0x00800000, BX
+    CMPL AX, BX
+    JGE  powelem32_scalar_normal
+    VMOVSS log32_two32<>(SB), X2       // 2^32
+    VMULSS X2, X0, X0
+    VMOVD X0, AX
+    MOVL $-32, R9
+
+powelem32_scalar_normal:
+    MOVL $0x3F350000, BX
+    MOVL AX, R10
+    SUBL BX, R10                       // tmp
+    MOVL R10, R11
+    SARL $23, R11                      // e
+    ADDL R9, R11
+    MOVL $0xFF800000, BX
+    ANDL BX, R10
+    SUBL R10, AX                       // bits(m)
+    VMOVD AX, X2
+    CVTSL2SS R11, X3                   // e
+
+    VSUBSS X12, X2, X4                 // z
+    VMULSS X4, X4, X5                  // zz
+    VMOVSS log32_p0<>(SB), X1
+    VFMADD213SS log32_p1<>(SB), X4, X1
+    VFMADD213SS log32_p2<>(SB), X4, X1
+    VFMADD213SS log32_p3<>(SB), X4, X1
+    VFMADD213SS log32_p4<>(SB), X4, X1
+    VFMADD213SS log32_p5<>(SB), X4, X1
+    VFMADD213SS log32_p6<>(SB), X4, X1
+    VFMADD213SS log32_p7<>(SB), X4, X1
+    VFMADD213SS log32_p8<>(SB), X4, X1
+    VMULSS X4, X5, X6                  // z^3
+    VMULSS X6, X1, X1
+    VFNMADD231SS exp_half<>(SB), X5, X1
+    VADDSS X4, X1, X1                  // lnm
+    VMULSS log32_ln2lo<>(SB), X3, X5
+    VADDSS X1, X5, X5
+    VFMADD231SS log32_ln2hi<>(SB), X3, X5 // ln(base)
+
+    VMOVSS (DI), X7                    // p
+    VMULSS X7, X5, X0
+    VMINSS log32_powclamp_hi<>(SB), X0, X0
+    VMAXSS log32_powclamp_lo<>(SB), X0, X0
+
+    VMULSS X15, X0, X1
+    VADDSS X13, X1, X2
+    VSUBSS X13, X2, X3                 // k
+    VMULSS X14, X3, X4
+    VSUBSS X4, X0, X0                  // r
+    VMULSS X0, X8, X1
+    VADDSS X9, X1, X1
+    VMULSS X0, X1, X1
+    VADDSS X10, X1, X1
+    VMULSS X0, X1, X1
+    VADDSS X11, X1, X1
+    VMULSS X0, X1, X1
+    VADDSS X12, X1, X1
+    VMULSS X0, X1, X1
+    VADDSS X12, X1, X1                 // exp(r)
+    // Split 2^k reconstruction (see the vector body)
+    VCVTSS2SI X3, AX                   // k
+    MOVL AX, R10
+    SARL $1, R10                       // k1 = k >> 1
+    SUBL R10, AX                       // k2 = k - k1
+    MOVL $0x3F800000, BX
+    SHLL $23, R10
+    ADDL BX, R10
+    VMOVD R10, X4
+    VMULSS X4, X1, X1                  // exp(r) * 2^k1
+    SHLL $23, AX
+    ADDL BX, AX
+    VMOVD AX, X4
+    VMULSS X4, X1, X1                  // * 2^k2 = exp(y)
+
+    VMOVSS X1, (DX)
+    ADDQ $4, SI
+    ADDQ $4, DI
+    ADDQ $4, DX
+    DECQ CX
+    JNZ  powelem32_scalar
+
+powelem32_done:
+    VZEROUPPER
+    RET
+
+// Pow clamp bounds: wider than the Exp kernel's +-88 because the pow kernels
+// split the 2^k reconstruction (2^(k>>1) * 2^(k-(k>>1))), which covers the
+// full float32 result range: overflow goes to +Inf and underflow degrades
+// gradually through subnormals to 0, matching math.Pow's classes.
+// ln(MaxFloat32) ~ 88.72, ln(min subnormal) ~ -103.28.
+DATA log32_powclamp_hi<>+0x00(SB)/4, $0x42b20000  // 89.0
+DATA log32_powclamp_hi<>+0x04(SB)/4, $0x42b20000
+DATA log32_powclamp_hi<>+0x08(SB)/4, $0x42b20000
+DATA log32_powclamp_hi<>+0x0c(SB)/4, $0x42b20000
+DATA log32_powclamp_hi<>+0x10(SB)/4, $0x42b20000
+DATA log32_powclamp_hi<>+0x14(SB)/4, $0x42b20000
+DATA log32_powclamp_hi<>+0x18(SB)/4, $0x42b20000
+DATA log32_powclamp_hi<>+0x1c(SB)/4, $0x42b20000
+GLOBL log32_powclamp_hi<>(SB), RODATA|NOPTR, $32
+
+DATA log32_powclamp_lo<>+0x00(SB)/4, $0xc2d00000  // -104.0
+DATA log32_powclamp_lo<>+0x04(SB)/4, $0xc2d00000
+DATA log32_powclamp_lo<>+0x08(SB)/4, $0xc2d00000
+DATA log32_powclamp_lo<>+0x0c(SB)/4, $0xc2d00000
+DATA log32_powclamp_lo<>+0x10(SB)/4, $0xc2d00000
+DATA log32_powclamp_lo<>+0x14(SB)/4, $0xc2d00000
+DATA log32_powclamp_lo<>+0x18(SB)/4, $0xc2d00000
+DATA log32_powclamp_lo<>+0x1c(SB)/4, $0xc2d00000
+GLOBL log32_powclamp_lo<>(SB), RODATA|NOPTR, $32

--- a/f32/f32_amd64.s
+++ b/f32/f32_amd64.s
@@ -6554,7 +6554,7 @@ log32_scalar_normal:
     ANDL BX, R10
     SUBL R10, AX                       // AX = bits(m)
     VMOVD AX, X2                       // X2 = m
-    CVTSL2SS R11, X3                   // X3 = e as float32
+    VCVTSI2SSL R11, X3, X3             // X3 = e as float32
 
     // z = m - 1, zz = z^2 (X10 = 1.0 from the vector constants)
     VSUBSS X10, X2, X4                 // X4 = z
@@ -6740,7 +6740,7 @@ pow32_scalar_normal:
     ANDL BX, R10
     SUBL R10, AX                       // bits(m)
     VMOVD AX, X2                       // m
-    CVTSL2SS R11, X3                   // e
+    VCVTSI2SSL R11, X3, X3             // e
 
     VSUBSS X12, X2, X4                 // z = m - 1 (X12 = 1.0)
     VMULSS X4, X4, X5                  // zz
@@ -6931,7 +6931,7 @@ powelem32_scalar_normal:
     ANDL BX, R10
     SUBL R10, AX                       // bits(m)
     VMOVD AX, X2
-    CVTSL2SS R11, X3                   // e
+    VCVTSI2SSL R11, X3, X3             // e
 
     VSUBSS X12, X2, X4                 // z
     VMULSS X4, X4, X5                  // zz

--- a/f32/f32_amd64.s
+++ b/f32/f32_amd64.s
@@ -6582,18 +6582,15 @@ log32_scalar_normal:
     JMP  log32_scalar_next
 
 log32_scalar_nan:
-    MOVL $0x7FC00000, AX
-    MOVL AX, (DX)
+    MOVL $0x7FC00000, (DX)
     JMP  log32_scalar_next
 
 log32_scalar_neginf:
-    MOVL $0xFF800000, AX
-    MOVL AX, (DX)
+    MOVL $0xFF800000, (DX)
     JMP  log32_scalar_next
 
 log32_scalar_posinf:
-    MOVL $0x7F800000, AX
-    MOVL AX, (DX)
+    MOVL $0x7F800000, (DX)
 
 log32_scalar_next:
     ADDQ $4, SI

--- a/f32/f32_arm64.go
+++ b/f32/f32_arm64.go
@@ -3,6 +3,7 @@
 package f32
 
 import (
+	"math"
 	"unsafe"
 
 	"github.com/tphakala/simd/cpu"
@@ -640,6 +641,62 @@ func exp32(dst, src []float32) {
 
 //go:noescape
 func expNEON(dst, src []float32)
+
+func log32(dst, src []float32) {
+	// Assumes len(src) >= len(dst); caller ensures this via public API
+	if hasNEON && len(dst) >= 4 {
+		logNEON32(dst, src, logLn2Hi32, logLn2Lo32, 1.0)
+		return
+	}
+	logGo(dst, src)
+}
+
+func log2_32(dst, src []float32) {
+	// log2(x) = e + ln(m)*log2(e): the e term is exact, so no hi/lo split is
+	// needed and exact powers of two come out exact.
+	if hasNEON && len(dst) >= 4 {
+		logNEON32(dst, src, 1.0, 0.0, logLog2E32)
+		return
+	}
+	log2Go(dst, src)
+}
+
+func log10_32(dst, src []float32) {
+	if hasNEON && len(dst) >= 4 {
+		logNEON32(dst, src, logL102Hi32, logL102Lo32, logLog10E32)
+		return
+	}
+	log10Go(dst, src)
+}
+
+func pow32(dst, src []float32, exp float32) {
+	// A zero or non-finite exponent has whole-slice math.Pow semantics
+	// (for example Pow(x, 0) = 1 even for NaN x); keep those exact.
+	e := float64(exp)
+	if hasNEON && len(dst) >= 4 && exp != 0 && !math.IsNaN(e) && !math.IsInf(e, 0) &&
+		powSIMDOK32(src[:len(dst)]) {
+		powNEON32(dst, src, exp)
+		return
+	}
+	powGo(dst, src, exp)
+}
+
+func powElem32(dst, base, exp []float32) {
+	if hasNEON && len(dst) >= 4 && powSIMDOK32(base[:len(dst)]) && allFinite32(exp[:len(dst)]) {
+		powElemNEON32(dst, base, exp)
+		return
+	}
+	powElemGo(dst, base, exp)
+}
+
+//go:noescape
+func logNEON32(dst, src []float32, k1hi, k1lo, k2 float32)
+
+//go:noescape
+func powNEON32(dst, src []float32, exp float32)
+
+//go:noescape
+func powElemNEON32(dst, base, exp []float32)
 
 func int32ToFloat32Scale(dst []float32, src []int32, scale float32) {
 	if hasNEON && len(dst) >= 4 {

--- a/f32/f32_arm64.s
+++ b/f32/f32_arm64.s
@@ -3157,3 +3157,814 @@ deinterleave8_neon_tail1:
 
 deinterleave8_neon_done:
     RET
+
+// ============================================================================
+// logNEON32 / powNEON32 / powElemNEON32: vectorized natural log core (#109)
+// ============================================================================
+
+// High-order Cephes logf coefficients p7/p8 plus the exp-core constants for
+// the pow kernels, loaded per iteration with VLD1 into working registers
+// because the persistent V12-V31 budget is exhausted: [p7, p8] and
+// [ln(2), 1/120, 1/24, 1/6], one lane quad each.
+DATA log32neon_p78<>+0x00(SB)/4, $0xbe7ffffc  // p7 = -2.4999993993e-1
+DATA log32neon_p78<>+0x04(SB)/4, $0xbe7ffffc
+DATA log32neon_p78<>+0x08(SB)/4, $0xbe7ffffc
+DATA log32neon_p78<>+0x0c(SB)/4, $0xbe7ffffc
+DATA log32neon_p78<>+0x10(SB)/4, $0x3eaaaaaa  // p8 = +3.3333331174e-1
+DATA log32neon_p78<>+0x14(SB)/4, $0x3eaaaaaa
+DATA log32neon_p78<>+0x18(SB)/4, $0x3eaaaaaa
+DATA log32neon_p78<>+0x1c(SB)/4, $0x3eaaaaaa
+GLOBL log32neon_p78<>(SB), RODATA|NOPTR, $32
+
+DATA log32neon_expc<>+0x00(SB)/4, $0x3f317218  // ln(2)
+DATA log32neon_expc<>+0x04(SB)/4, $0x3f317218
+DATA log32neon_expc<>+0x08(SB)/4, $0x3f317218
+DATA log32neon_expc<>+0x0c(SB)/4, $0x3f317218
+DATA log32neon_expc<>+0x10(SB)/4, $0x3c088889  // 1/120
+DATA log32neon_expc<>+0x14(SB)/4, $0x3c088889
+DATA log32neon_expc<>+0x18(SB)/4, $0x3c088889
+DATA log32neon_expc<>+0x1c(SB)/4, $0x3c088889
+DATA log32neon_expc<>+0x20(SB)/4, $0x3d2aaaab  // 1/24
+DATA log32neon_expc<>+0x24(SB)/4, $0x3d2aaaab
+DATA log32neon_expc<>+0x28(SB)/4, $0x3d2aaaab
+DATA log32neon_expc<>+0x2c(SB)/4, $0x3d2aaaab
+DATA log32neon_expc<>+0x30(SB)/4, $0x3e2aaaab  // 1/6
+DATA log32neon_expc<>+0x34(SB)/4, $0x3e2aaaab
+DATA log32neon_expc<>+0x38(SB)/4, $0x3e2aaaab
+DATA log32neon_expc<>+0x3c(SB)/4, $0x3e2aaaab
+GLOBL log32neon_expc<>(SB), RODATA|NOPTR, $64
+
+// func logNEON32(dst, src []float32, k1hi, k1lo, k2 float32)
+// Shared kernel for Log, Log2, and Log10: per lane it computes
+// result = e*k1hi + (lnm*k2 + e*k1lo), with x = m*2^e, m in
+// [sqrt(2)/2, sqrt(2)) and lnm = ln(m) = z - 0.5*z^2 + z^3*P(z) for z = m-1
+// (Cephes logf degree-8 minimax polynomial; same algorithm as the amd64
+// logAVX). Positive subnormal inputs are pre-scaled by 2^32 (exponent bias
+// -32). Special lanes are fixed up with BIT blends from the original input:
+// +Inf -> +Inf, +-0 -> -Inf, x < 0 or NaN -> NaN, matching math.Log.
+// Processes 4 elements per iteration; the 0-3 element tail uses the scalar
+// path below.
+TEXT ·logNEON32(SB), NOSPLIT, $0-60
+    MOVD dst_base+0(FP), R0
+    MOVD dst_len+8(FP), R3
+    MOVD src_base+24(FP), R1
+    MOVD $log32neon_p78<>(SB), R5     // p7/p8 table base
+    ADD $16, R5, R6                   // p8 base
+
+    // Special-value constants for the blend fixups
+    MOVW $0x7f800000, R10
+    VMOV R10, V12.S[0]
+    VDUP V12.S[0], V12.S4             // V12 = +Inf
+    MOVW $0xff800000, R10
+    VMOV R10, V13.S[0]
+    VDUP V13.S[0], V13.S4             // V13 = -Inf
+    MOVW $0x7fc00000, R10
+    VMOV R10, V14.S[0]
+    VDUP V14.S[0], V14.S4             // V14 = quiet NaN
+
+    // Reduction constants (see logAVX for the algorithm notes)
+    MOVW $0x3f350000, R10
+    VMOV R10, V15.S[0]
+    VDUP V15.S[0], V15.S4             // V15 = reduction offset
+    MOVW $0xff800000, R10
+    VMOV R10, V16.S[0]
+    VDUP V16.S[0], V16.S4             // V16 = exponent mask
+    MOVW $0x00800000, R10
+    VMOV R10, V17.S[0]
+    VDUP V17.S[0], V17.S4             // V17 = FLT_MIN
+    MOVW $0x4f800000, R10
+    VMOV R10, V18.S[0]
+    VDUP V18.S[0], V18.S4             // V18 = 2^32 (subnormal pre-scale)
+    MOVW $0xc2000000, R10
+    VMOV R10, V19.S[0]
+    VDUP V19.S[0], V19.S4             // V19 = -32.0 (exponent bias)
+    FMOVS $1.0, F20
+    VDUP V20.S[0], V20.S4             // V20 = 1.0
+    FMOVS $0.5, F21
+    VDUP V21.S[0], V21.S4             // V21 = 0.5
+
+    // Reconstruction constants from the arguments
+    FMOVS k1hi+48(FP), F22
+    VDUP V22.S[0], V22.S4             // V22 = k1hi
+    FMOVS k1lo+52(FP), F23
+    VDUP V23.S[0], V23.S4             // V23 = k1lo
+    FMOVS k2+56(FP), F24
+    VDUP V24.S[0], V24.S4             // V24 = k2
+
+    // Cephes logf coefficients p0..p6 (p7/p8 come from the table)
+    MOVW $0x3d9021bb, R10
+    VMOV R10, V25.S[0]
+    VDUP V25.S[0], V25.S4             // V25 = p0 = +7.0376836292e-2
+    MOVW $0xbdebd1b8, R10
+    VMOV R10, V26.S[0]
+    VDUP V26.S[0], V26.S4             // V26 = p1 = -1.1514610310e-1
+    MOVW $0x3def251a, R10
+    VMOV R10, V27.S[0]
+    VDUP V27.S[0], V27.S4             // V27 = p2 = +1.1676998740e-1
+    MOVW $0xbdfe5d4f, R10
+    VMOV R10, V28.S[0]
+    VDUP V28.S[0], V28.S4             // V28 = p3 = -1.2420140846e-1
+    MOVW $0x3e11e9bf, R10
+    VMOV R10, V29.S[0]
+    VDUP V29.S[0], V29.S4             // V29 = p4 = +1.4249322787e-1
+    MOVW $0xbe2aae50, R10
+    VMOV R10, V30.S[0]
+    VDUP V30.S[0], V30.S4             // V30 = p5 = -1.6668057665e-1
+    MOVW $0x3e4cceac, R10
+    VMOV R10, V31.S[0]
+    VDUP V31.S[0], V31.S4             // V31 = p6 = +2.0000714765e-1
+
+    LSR $2, R3, R4
+    CBZ R4, log32_neon_scalar
+
+log32_neon_loop4:
+    VLD1.P 16(R1), [V0.S4]            // V0 = x (kept for the special blends)
+    VLD1 (R5), [V10.S4]               // V10 = p7
+    VLD1 (R6), [V11.S4]               // V11 = p8
+
+    // Subnormal pre-scale: lanes with x < FLT_MIN scaled by 2^32, bias -32
+    WORD $0x6ea0e621                  // FCMGT V1.4S, V17.4S, V0.4S   mask: x < FLT_MIN
+    WORD $0x6e32dc02                  // FMUL V2.4S, V0.4S, V18.4S    x * 2^32
+    WORD $0x4ea11c23                  // MOV V3.16B, V1.16B           copy mask for BSL
+    WORD $0x6e601c43                  // BSL V3.16B, V2.16B, V0.16B   xs
+    WORD $0x4e331c24                  // AND V4.16B, V1.16B, V19.16B  ebias
+
+    // tmp = bits(xs) - OFF; bits(m) = bits(xs) - (tmp & expmask);
+    // e = (tmp >> 23) + ebias, leaving m in [sqrt(2)/2, sqrt(2))
+    WORD $0x6eaf8465                  // SUB V5.4S, V3.4S, V15.4S     tmp
+    WORD $0x4e301ca6                  // AND V6.16B, V5.16B, V16.16B  tmp & expmask
+    WORD $0x6ea68466                  // SUB V6.4S, V3.4S, V6.4S      bits(m)
+    WORD $0x4f2904a5                  // SSHR V5.4S, V5.4S, #23       e (int32, arithmetic)
+    WORD $0x4e21d8a5                  // SCVTF V5.4S, V5.4S           e as float32
+    WORD $0x4e24d4a4                  // FADD V4.4S, V5.4S, V4.4S     e = e + ebias
+
+    // z = m - 1, zz = z^2
+    WORD $0x4eb4d4c7                  // FSUB V7.4S, V6.4S, V20.4S    z
+    WORD $0x6e27dce6                  // FMUL V6.4S, V7.4S, V7.4S     zz
+
+    // P(z), Horner ping-pong between V8/V9 with FMLA
+    WORD $0x4eb91f28                  // MOV V8.16B, V25.16B          acc = p0
+    WORD $0x4eba1f49                  // MOV V9.16B, V26.16B
+    WORD $0x4e27cd09                  // FMLA V9.4S, V8.4S, V7.4S     p1 + acc*z
+    WORD $0x4ebb1f68                  // MOV V8.16B, V27.16B
+    WORD $0x4e27cd28                  // FMLA V8.4S, V9.4S, V7.4S     p2 + acc*z
+    WORD $0x4ebc1f89                  // MOV V9.16B, V28.16B
+    WORD $0x4e27cd09                  // FMLA V9.4S, V8.4S, V7.4S     p3 + acc*z
+    WORD $0x4ebd1fa8                  // MOV V8.16B, V29.16B
+    WORD $0x4e27cd28                  // FMLA V8.4S, V9.4S, V7.4S     p4 + acc*z
+    WORD $0x4ebe1fc9                  // MOV V9.16B, V30.16B
+    WORD $0x4e27cd09                  // FMLA V9.4S, V8.4S, V7.4S     p5 + acc*z
+    WORD $0x4ebf1fe8                  // MOV V8.16B, V31.16B
+    WORD $0x4e27cd28                  // FMLA V8.4S, V9.4S, V7.4S     p6 + acc*z
+    WORD $0x4eaa1d49                  // MOV V9.16B, V10.16B
+    WORD $0x4e27cd09                  // FMLA V9.4S, V8.4S, V7.4S     p7 + acc*z
+    WORD $0x4eab1d68                  // MOV V8.16B, V11.16B
+    WORD $0x4e27cd28                  // FMLA V8.4S, V9.4S, V7.4S     P(z) = p8 + acc*z
+
+    // lnm = z + (z^3*P(z) - 0.5*zz)
+    WORD $0x6e26dcea                  // FMUL V10.4S, V7.4S, V6.4S    z^3
+    WORD $0x6e28dd4a                  // FMUL V10.4S, V10.4S, V8.4S   z^3 * P(z)
+    WORD $0x4eb5ccca                  // FMLS V10.4S, V6.4S, V21.4S   -= 0.5*zz
+    WORD $0x4e27d54a                  // FADD V10.4S, V10.4S, V7.4S   lnm
+
+    // result = e*k1hi + (lnm*k2 + e*k1lo)
+    WORD $0x6e37dc8b                  // FMUL V11.4S, V4.4S, V23.4S   e * k1lo
+    WORD $0x4e38cd4b                  // FMLA V11.4S, V10.4S, V24.4S  += lnm * k2
+    WORD $0x4e36cc8b                  // FMLA V11.4S, V4.4S, V22.4S   += e * k1hi
+
+    // Special lanes from the original x
+    WORD $0x4e2ce401                  // FCMEQ V1.4S, V0.4S, V12.4S   mask: x == +Inf
+    WORD $0x6ea11d8b                  // BIT V11.16B, V12.16B, V1.16B
+    WORD $0x4ea0d801                  // FCMEQ V1.4S, V0.4S, #0       mask: x == +-0
+    WORD $0x6ea11dab                  // BIT V11.16B, V13.16B, V1.16B
+    WORD $0x4ea0e802                  // FCMLT V2.4S, V0.4S, #0       mask: x < 0
+    WORD $0x4e20e401                  // FCMEQ V1.4S, V0.4S, V0.4S    mask: x ordered
+    WORD $0x4ee11c42                  // ORN V2.16B, V2.16B, V1.16B   (x < 0) | NaN
+    WORD $0x6ea21dcb                  // BIT V11.16B, V14.16B, V2.16B
+
+    VST1.P [V11.S4], 16(R0)
+    SUB $1, R4
+    CBNZ R4, log32_neon_loop4
+
+log32_neon_scalar:
+    AND $3, R3
+    CBZ R3, log32_neon_done
+
+log32_neon_scalar_loop:
+    MOVWU (R1), R7                    // R7 = bits(x)
+    FMOVS (R1), F0
+
+    // Specials: FCMPS sets V for unordered, N for negative, Z for zero
+    FCMPS $(0.0), F0
+    BVS log32_neon_scalar_nan
+    BMI log32_neon_scalar_nan         // x < 0
+    BEQ log32_neon_scalar_neginf      // x == +-0
+    MOVD $0x7F800000, R8
+    CMP R8, R7
+    BEQ log32_neon_scalar_posinf
+
+    // Subnormal pre-scale (x positive finite)
+    MOVD $0, R9
+    MOVD $0x00800000, R8
+    CMP R8, R7
+    BGE log32_neon_scalar_normal
+    FMULS F18, F0, F0                 // x *= 2^32 (F18 from the vector constants)
+    FMOVS F0, R7
+    MOVD $-32, R9
+
+log32_neon_scalar_normal:
+    MOVD $0x3F350000, R8
+    SUB R8, R7, R10                   // tmp = bits - OFF
+    MOVW R10, R10                     // sign-extend the 32-bit tmp
+    ASR $23, R10, R11                 // e
+    ADD R9, R11, R11
+    MOVD $0xFF800000, R8
+    AND R8, R10, R10
+    SUB R10, R7, R7                   // bits(m)
+    FMOVS R7, F1                      // m
+    SCVTFWS R11, F2                   // e as float32
+
+    // z = m - 1, zz = z^2 (F20 = 1.0, F21 = 0.5 from the vector constants)
+    FSUBS F20, F1, F3                 // z
+    FMULS F3, F3, F4                  // zz
+
+    // P(z): FMADDS Fm, Fa, Fn, Fd computes Fd = Fa + Fn*Fm
+    FMADDS F3, F26, F25, F5           // p1 + p0*z
+    FMADDS F3, F27, F5, F5            // p2 + acc*z
+    FMADDS F3, F28, F5, F5
+    FMADDS F3, F29, F5, F5
+    FMADDS F3, F30, F5, F5
+    FMADDS F3, F31, F5, F5            // p6 + acc*z
+    FMOVS log32neon_p78<>(SB), F6
+    FMADDS F3, F6, F5, F5             // p7 + acc*z
+    FMOVS log32neon_p78<>+16(SB), F6
+    FMADDS F3, F6, F5, F5             // P(z) = p8 + acc*z
+
+    FMULS F3, F4, F6                  // z^3
+    FMULS F6, F5, F5                  // z^3*P(z)
+    FMSUBS F4, F5, F21, F5            // -= 0.5*zz: F5 = F5 - F21*F4
+    FADDS F3, F5, F5                  // lnm
+
+    FMULS F23, F2, F6                 // e * k1lo
+    FMADDS F24, F6, F5, F6            // += lnm * k2
+    FMADDS F22, F6, F2, F6            // += e * k1hi
+    FMOVS F6, (R0)
+    B log32_neon_scalar_next
+
+log32_neon_scalar_nan:
+    MOVD $0x7FC00000, R8
+    MOVW R8, (R0)
+    B log32_neon_scalar_next
+
+log32_neon_scalar_neginf:
+    MOVD $0xFF800000, R8
+    MOVW R8, (R0)
+    B log32_neon_scalar_next
+
+log32_neon_scalar_posinf:
+    MOVD $0x7F800000, R8
+    MOVW R8, (R0)
+
+log32_neon_scalar_next:
+    ADD $4, R1
+    ADD $4, R0
+    SUB $1, R3
+    CBNZ R3, log32_neon_scalar_loop
+
+log32_neon_done:
+    RET
+
+// func powNEON32(dst, src []float32, exp float32)
+// Fused pow(x, p) = exp(p*ln(x)) for slices whose elements are all positive
+// and finite (the dispatcher guarantees this, see powSIMDOK32). The log core
+// matches logNEON32; the exp core matches expNEON except y = p*ln(x) is
+// clamped to [-104, 89] (past ln(MaxFloat32) and ln of the smallest
+// subnormal) and the 2^k reconstruction is split into
+// 2^(k>>1) * 2^(k-(k>>1)), so overflow goes to +Inf and underflow degrades
+// gradually through subnormals to 0, matching math.Pow's result classes.
+// Accuracy is ~1.4e-5 relative (log error amplified by |y|, then the exp
+// polynomial).
+TEXT ·powNEON32(SB), NOSPLIT, $0-52
+    MOVD dst_base+0(FP), R0
+    MOVD dst_len+8(FP), R3
+    MOVD src_base+24(FP), R1
+    MOVD $log32neon_p78<>(SB), R5     // p7/p8 table base
+    ADD $16, R5, R6                   // p8 base
+    MOVD $log32neon_expc<>(SB), R7    // exp-core constant table
+
+    FMOVS exp+48(FP), F12
+    VDUP V12.S[0], V12.S4             // V12 = p
+
+    // Pow clamp bounds (see the kernel comment)
+    MOVW $0x42b20000, R10
+    VMOV R10, V13.S[0]
+    VDUP V13.S[0], V13.S4             // V13 = 89.0
+    MOVW $0xc2d00000, R10
+    VMOV R10, V14.S[0]
+    VDUP V14.S[0], V14.S4             // V14 = -104.0
+
+    // Log-core reduction constants (see logNEON32)
+    MOVW $0x3f350000, R10
+    VMOV R10, V15.S[0]
+    VDUP V15.S[0], V15.S4             // V15 = reduction offset
+    MOVW $0xff800000, R10
+    VMOV R10, V16.S[0]
+    VDUP V16.S[0], V16.S4             // V16 = exponent mask
+    MOVW $0x00800000, R10
+    VMOV R10, V17.S[0]
+    VDUP V17.S[0], V17.S4             // V17 = FLT_MIN
+    MOVW $0x4f800000, R10
+    VMOV R10, V18.S[0]
+    VDUP V18.S[0], V18.S4             // V18 = 2^32
+    MOVW $0xc2000000, R10
+    VMOV R10, V19.S[0]
+    VDUP V19.S[0], V19.S4             // V19 = -32.0
+    FMOVS $1.0, F20
+    VDUP V20.S[0], V20.S4             // V20 = 1.0
+    FMOVS $0.5, F21
+    VDUP V21.S[0], V21.S4             // V21 = 0.5
+
+    // Cephes logf ln(2) hi/lo split and log2(e)
+    MOVW $0x3f318000, R10
+    VMOV R10, V22.S[0]
+    VDUP V22.S[0], V22.S4             // V22 = ln2 hi
+    MOVW $0xb95e8083, R10
+    VMOV R10, V23.S[0]
+    VDUP V23.S[0], V23.S4             // V23 = ln2 lo
+    MOVW $0x3fb8aa3b, R10
+    VMOV R10, V24.S[0]
+    VDUP V24.S[0], V24.S4             // V24 = log2(e)
+
+    // Cephes logf coefficients p0..p6 (p7/p8 from the table)
+    MOVW $0x3d9021bb, R10
+    VMOV R10, V25.S[0]
+    VDUP V25.S[0], V25.S4             // V25 = p0
+    MOVW $0xbdebd1b8, R10
+    VMOV R10, V26.S[0]
+    VDUP V26.S[0], V26.S4             // V26 = p1
+    MOVW $0x3def251a, R10
+    VMOV R10, V27.S[0]
+    VDUP V27.S[0], V27.S4             // V27 = p2
+    MOVW $0xbdfe5d4f, R10
+    VMOV R10, V28.S[0]
+    VDUP V28.S[0], V28.S4             // V28 = p3
+    MOVW $0x3e11e9bf, R10
+    VMOV R10, V29.S[0]
+    VDUP V29.S[0], V29.S4             // V29 = p4
+    MOVW $0xbe2aae50, R10
+    VMOV R10, V30.S[0]
+    VDUP V30.S[0], V30.S4             // V30 = p5
+    MOVW $0x3e4cceac, R10
+    VMOV R10, V31.S[0]
+    VDUP V31.S[0], V31.S4             // V31 = p6
+
+    LSR $2, R3, R4
+    CBZ R4, pow32_neon_scalar
+
+pow32_neon_loop4:
+    VLD1.P 16(R1), [V0.S4]            // V0 = x (positive finite)
+    VLD1 (R5), [V10.S4]               // V10 = p7
+    VLD1 (R6), [V11.S4]               // V11 = p8
+
+    // --- log core (see logNEON32) ---
+    WORD $0x6ea0e621                  // FCMGT V1.4S, V17.4S, V0.4S   mask: x < FLT_MIN
+    WORD $0x6e32dc02                  // FMUL V2.4S, V0.4S, V18.4S    x * 2^32
+    WORD $0x4ea11c23                  // MOV V3.16B, V1.16B
+    WORD $0x6e601c43                  // BSL V3.16B, V2.16B, V0.16B   xs
+    WORD $0x4e331c24                  // AND V4.16B, V1.16B, V19.16B  ebias
+    WORD $0x6eaf8465                  // SUB V5.4S, V3.4S, V15.4S     tmp
+    WORD $0x4e301ca6                  // AND V6.16B, V5.16B, V16.16B
+    WORD $0x6ea68466                  // SUB V6.4S, V3.4S, V6.4S      bits(m)
+    WORD $0x4f2904a5                  // SSHR V5.4S, V5.4S, #23       e (int32)
+    WORD $0x4e21d8a5                  // SCVTF V5.4S, V5.4S           e as float32
+    WORD $0x4e24d4a4                  // FADD V4.4S, V5.4S, V4.4S     e = e + ebias
+    WORD $0x4eb4d4c7                  // FSUB V7.4S, V6.4S, V20.4S    z
+    WORD $0x6e27dce6                  // FMUL V6.4S, V7.4S, V7.4S     zz
+    WORD $0x4eb91f28                  // MOV V8.16B, V25.16B          acc = p0
+    WORD $0x4eba1f49                  // MOV V9.16B, V26.16B
+    WORD $0x4e27cd09                  // FMLA V9.4S, V8.4S, V7.4S     p1 + acc*z
+    WORD $0x4ebb1f68                  // MOV V8.16B, V27.16B
+    WORD $0x4e27cd28                  // FMLA V8.4S, V9.4S, V7.4S     p2 + acc*z
+    WORD $0x4ebc1f89                  // MOV V9.16B, V28.16B
+    WORD $0x4e27cd09                  // FMLA V9.4S, V8.4S, V7.4S     p3 + acc*z
+    WORD $0x4ebd1fa8                  // MOV V8.16B, V29.16B
+    WORD $0x4e27cd28                  // FMLA V8.4S, V9.4S, V7.4S     p4 + acc*z
+    WORD $0x4ebe1fc9                  // MOV V9.16B, V30.16B
+    WORD $0x4e27cd09                  // FMLA V9.4S, V8.4S, V7.4S     p5 + acc*z
+    WORD $0x4ebf1fe8                  // MOV V8.16B, V31.16B
+    WORD $0x4e27cd28                  // FMLA V8.4S, V9.4S, V7.4S     p6 + acc*z
+    WORD $0x4eaa1d49                  // MOV V9.16B, V10.16B
+    WORD $0x4e27cd09                  // FMLA V9.4S, V8.4S, V7.4S     p7 + acc*z
+    WORD $0x4eab1d68                  // MOV V8.16B, V11.16B
+    WORD $0x4e27cd28                  // FMLA V8.4S, V9.4S, V7.4S     P(z)
+    WORD $0x6e26dcea                  // FMUL V10.4S, V7.4S, V6.4S    z^3
+    WORD $0x6e28dd4a                  // FMUL V10.4S, V10.4S, V8.4S   z^3 * P(z)
+    WORD $0x4eb5ccca                  // FMLS V10.4S, V6.4S, V21.4S   -= 0.5*zz
+    WORD $0x4e27d54a                  // FADD V10.4S, V10.4S, V7.4S   lnm
+
+    // ln(x) = e*ln2hi + (e*ln2lo + lnm)
+    WORD $0x6e37dc8b                  // FMUL V11.4S, V4.4S, V23.4S   e * ln2lo
+    WORD $0x4e2ad56b                  // FADD V11.4S, V11.4S, V10.4S  + lnm
+    WORD $0x4e36cc8b                  // FMLA V11.4S, V4.4S, V22.4S   += e * ln2hi
+
+    // y = p*ln(x), clamped to [-104, 89]
+    WORD $0x6e2cdd60                  // FMUL V0.4S, V11.4S, V12.4S   y
+    WORD $0x4eadf400                  // FMIN V0.4S, V0.4S, V13.4S
+    WORD $0x4e2ef400                  // FMAX V0.4S, V0.4S, V14.4S
+
+    // --- exp core (see expNEON); constants from the table ---
+    VLD1 (R7), [V1.S4, V2.S4, V3.S4, V4.S4] // ln2, 1/120, 1/24, 1/6
+    WORD $0x6e38dc05                  // FMUL V5.4S, V0.4S, V24.4S    y * log2e
+    WORD $0x4e2188a5                  // FRINTN V5.4S, V5.4S          k
+    WORD $0x6e21dca6                  // FMUL V6.4S, V5.4S, V1.4S     k * ln2
+    WORD $0x4ea6d406                  // FSUB V6.4S, V0.4S, V6.4S     r
+    WORD $0x6e22dcc7                  // FMUL V7.4S, V6.4S, V2.4S     r * 1/120
+    WORD $0x4e23d4e7                  // FADD V7.4S, V7.4S, V3.4S     + 1/24
+    WORD $0x6e26dce7                  // FMUL V7.4S, V7.4S, V6.4S
+    WORD $0x4e24d4e7                  // FADD V7.4S, V7.4S, V4.4S     + 1/6
+    WORD $0x6e26dce7                  // FMUL V7.4S, V7.4S, V6.4S
+    WORD $0x4e35d4e7                  // FADD V7.4S, V7.4S, V21.4S    + 0.5
+    WORD $0x6e26dce7                  // FMUL V7.4S, V7.4S, V6.4S
+    WORD $0x4e34d4e7                  // FADD V7.4S, V7.4S, V20.4S    + 1
+    WORD $0x6e26dce7                  // FMUL V7.4S, V7.4S, V6.4S
+    WORD $0x4e34d4e7                  // FADD V7.4S, V7.4S, V20.4S    exp(r)
+    // Split 2^k reconstruction (see powAVX in the f64 package)
+    WORD $0x4ea1b8a5                  // FCVTZS V5.4S, V5.4S          int(k)
+    WORD $0x4f3f04a8                  // SSHR V8.4S, V5.4S, #1        k1 = k >> 1
+    WORD $0x6ea884a5                  // SUB V5.4S, V5.4S, V8.4S      k2 = k - k1
+    WORD $0x4f375508                  // SHL V8.4S, V8.4S, #23
+    WORD $0x4eb48508                  // ADD V8.4S, V8.4S, V20.4S     2^k1 bits
+    WORD $0x6e28dce7                  // FMUL V7.4S, V7.4S, V8.4S     exp(r) * 2^k1
+    WORD $0x4f3754a5                  // SHL V5.4S, V5.4S, #23
+    WORD $0x4eb484a5                  // ADD V5.4S, V5.4S, V20.4S     2^k2 bits
+    WORD $0x6e25dce7                  // FMUL V7.4S, V7.4S, V5.4S     * 2^k2 = exp(y)
+
+    VST1.P [V7.S4], 16(R0)
+    SUB $1, R4
+    CBNZ R4, pow32_neon_loop4
+
+pow32_neon_scalar:
+    AND $3, R3
+    CBZ R3, pow32_neon_done
+
+pow32_neon_scalar_loop:
+    MOVWU (R1), R8                    // bits(x)
+    FMOVS (R1), F0
+
+    // log core, scalar (x positive finite)
+    MOVD $0, R9
+    MOVD $0x00800000, R10
+    CMP R10, R8
+    BGE pow32_neon_scalar_normal
+    FMULS F18, F0, F0                 // x *= 2^32
+    FMOVS F0, R8
+    MOVD $-32, R9
+
+pow32_neon_scalar_normal:
+    MOVD $0x3F350000, R10
+    SUB R10, R8, R11                  // tmp
+    MOVW R11, R11                     // sign-extend
+    ASR $23, R11, R12                 // e
+    ADD R9, R12, R12
+    MOVD $0xFF800000, R10
+    AND R10, R11, R11
+    SUB R11, R8, R8                   // bits(m)
+    FMOVS R8, F1                      // m
+    SCVTFWS R12, F2                   // e
+
+    FSUBS F20, F1, F3                 // z
+    FMULS F3, F3, F4                  // zz
+    FMADDS F3, F26, F25, F5           // p1 + p0*z
+    FMADDS F3, F27, F5, F5
+    FMADDS F3, F28, F5, F5
+    FMADDS F3, F29, F5, F5
+    FMADDS F3, F30, F5, F5
+    FMADDS F3, F31, F5, F5            // p6 + acc*z
+    FMOVS log32neon_p78<>(SB), F6
+    FMADDS F3, F6, F5, F5             // p7 + acc*z
+    FMOVS log32neon_p78<>+16(SB), F6
+    FMADDS F3, F6, F5, F5             // P(z)
+    FMULS F3, F4, F6                  // z^3
+    FMULS F6, F5, F5                  // z^3*P(z)
+    FMSUBS F4, F5, F21, F5            // -= 0.5*zz
+    FADDS F3, F5, F5                  // lnm
+    FMULS F23, F2, F6                 // e * ln2lo
+    FADDS F5, F6, F6                  // + lnm
+    FMADDS F22, F6, F2, F6            // += e * ln2hi -> ln(x)
+
+    // y = p*ln(x), clamped (F12 = p, F13/F14 = clamp bounds)
+    FMULS F12, F6, F0
+    FMINS F13, F0, F0
+    FMAXS F14, F0, F0
+
+    // exp core, scalar (F24 = log2e, F20 = 1.0, F21 = 0.5)
+    FMULS F24, F0, F1
+    FRINTNS F1, F2                    // k
+    MOVW $0x3f317218, R10             // ln(2)
+    FMOVS R10, F3
+    FMULS F3, F2, F3
+    FSUBS F3, F0, F0                  // r
+    MOVW $0x3c088889, R10             // 1/120
+    FMOVS R10, F4
+    FMULS F0, F4, F4
+    MOVW $0x3d2aaaab, R10             // 1/24
+    FMOVS R10, F5
+    FADDS F5, F4, F4
+    FMULS F0, F4, F4
+    MOVW $0x3e2aaaab, R10             // 1/6
+    FMOVS R10, F5
+    FADDS F5, F4, F4
+    FMULS F0, F4, F4
+    FADDS F21, F4, F4                 // + 0.5
+    FMULS F0, F4, F4
+    FADDS F20, F4, F4                 // + 1
+    FMULS F0, F4, F4
+    FADDS F20, F4, F4                 // exp(r)
+    // Split 2^k reconstruction (see the vector body)
+    FCVTZSSW F2, R8                   // k
+    MOVW R8, R8                       // sign-extend
+    ASR $1, R8, R10                   // k1 = k >> 1
+    SUB R10, R8, R8                   // k2 = k - k1
+    MOVD $0x3F800000, R11
+    LSL $23, R10, R10
+    ADD R11, R10, R10
+    FMOVS R10, F5
+    FMULS F5, F4, F4                  // exp(r) * 2^k1
+    LSL $23, R8, R8
+    ADD R11, R8, R8
+    FMOVS R8, F5
+    FMULS F5, F4, F4                  // * 2^k2 = exp(y)
+    FMOVS F4, (R0)
+
+    ADD $4, R1
+    ADD $4, R0
+    SUB $1, R3
+    CBNZ R3, pow32_neon_scalar_loop
+
+pow32_neon_done:
+    RET
+
+// func powElemNEON32(dst, base, exp []float32)
+// Elementwise pow(base[i], exp[i]) = exp(exp[i]*ln(base[i])). Same cores and
+// preconditions as powNEON32 (all bases positive finite, all exponents
+// finite), with the exponent loaded per lane instead of broadcast.
+TEXT ·powElemNEON32(SB), NOSPLIT, $0-72
+    MOVD dst_base+0(FP), R0
+    MOVD dst_len+8(FP), R3
+    MOVD base_base+24(FP), R1
+    MOVD exp_base+48(FP), R2
+    MOVD $log32neon_p78<>(SB), R5     // p7/p8 table base
+    ADD $16, R5, R6                   // p8 base
+    MOVD $log32neon_expc<>(SB), R7    // exp-core constant table
+
+    // Pow clamp bounds
+    MOVW $0x42b20000, R10
+    VMOV R10, V13.S[0]
+    VDUP V13.S[0], V13.S4             // V13 = 89.0
+    MOVW $0xc2d00000, R10
+    VMOV R10, V14.S[0]
+    VDUP V14.S[0], V14.S4             // V14 = -104.0
+
+    // Log-core reduction constants (see logNEON32)
+    MOVW $0x3f350000, R10
+    VMOV R10, V15.S[0]
+    VDUP V15.S[0], V15.S4             // V15 = reduction offset
+    MOVW $0xff800000, R10
+    VMOV R10, V16.S[0]
+    VDUP V16.S[0], V16.S4             // V16 = exponent mask
+    MOVW $0x00800000, R10
+    VMOV R10, V17.S[0]
+    VDUP V17.S[0], V17.S4             // V17 = FLT_MIN
+    MOVW $0x4f800000, R10
+    VMOV R10, V18.S[0]
+    VDUP V18.S[0], V18.S4             // V18 = 2^32
+    MOVW $0xc2000000, R10
+    VMOV R10, V19.S[0]
+    VDUP V19.S[0], V19.S4             // V19 = -32.0
+    FMOVS $1.0, F20
+    VDUP V20.S[0], V20.S4             // V20 = 1.0
+    FMOVS $0.5, F21
+    VDUP V21.S[0], V21.S4             // V21 = 0.5
+
+    // Cephes logf ln(2) hi/lo split and log2(e)
+    MOVW $0x3f318000, R10
+    VMOV R10, V22.S[0]
+    VDUP V22.S[0], V22.S4             // V22 = ln2 hi
+    MOVW $0xb95e8083, R10
+    VMOV R10, V23.S[0]
+    VDUP V23.S[0], V23.S4             // V23 = ln2 lo
+    MOVW $0x3fb8aa3b, R10
+    VMOV R10, V24.S[0]
+    VDUP V24.S[0], V24.S4             // V24 = log2(e)
+
+    // Cephes logf coefficients p0..p6 (p7/p8 from the table)
+    MOVW $0x3d9021bb, R10
+    VMOV R10, V25.S[0]
+    VDUP V25.S[0], V25.S4             // V25 = p0
+    MOVW $0xbdebd1b8, R10
+    VMOV R10, V26.S[0]
+    VDUP V26.S[0], V26.S4             // V26 = p1
+    MOVW $0x3def251a, R10
+    VMOV R10, V27.S[0]
+    VDUP V27.S[0], V27.S4             // V27 = p2
+    MOVW $0xbdfe5d4f, R10
+    VMOV R10, V28.S[0]
+    VDUP V28.S[0], V28.S4             // V28 = p3
+    MOVW $0x3e11e9bf, R10
+    VMOV R10, V29.S[0]
+    VDUP V29.S[0], V29.S4             // V29 = p4
+    MOVW $0xbe2aae50, R10
+    VMOV R10, V30.S[0]
+    VDUP V30.S[0], V30.S4             // V30 = p5
+    MOVW $0x3e4cceac, R10
+    VMOV R10, V31.S[0]
+    VDUP V31.S[0], V31.S4             // V31 = p6
+
+    LSR $2, R3, R4
+    CBZ R4, powelem32_neon_scalar
+
+powelem32_neon_loop4:
+    VLD1.P 16(R1), [V0.S4]            // V0 = base (positive finite)
+    VLD1 (R5), [V10.S4]               // V10 = p7
+    VLD1 (R6), [V11.S4]               // V11 = p8
+
+    // --- log core (see logNEON32) ---
+    WORD $0x6ea0e621                  // FCMGT V1.4S, V17.4S, V0.4S   mask: x < FLT_MIN
+    WORD $0x6e32dc02                  // FMUL V2.4S, V0.4S, V18.4S    x * 2^32
+    WORD $0x4ea11c23                  // MOV V3.16B, V1.16B
+    WORD $0x6e601c43                  // BSL V3.16B, V2.16B, V0.16B   xs
+    WORD $0x4e331c24                  // AND V4.16B, V1.16B, V19.16B  ebias
+    WORD $0x6eaf8465                  // SUB V5.4S, V3.4S, V15.4S     tmp
+    WORD $0x4e301ca6                  // AND V6.16B, V5.16B, V16.16B
+    WORD $0x6ea68466                  // SUB V6.4S, V3.4S, V6.4S      bits(m)
+    WORD $0x4f2904a5                  // SSHR V5.4S, V5.4S, #23       e (int32)
+    WORD $0x4e21d8a5                  // SCVTF V5.4S, V5.4S           e as float32
+    WORD $0x4e24d4a4                  // FADD V4.4S, V5.4S, V4.4S     e = e + ebias
+    WORD $0x4eb4d4c7                  // FSUB V7.4S, V6.4S, V20.4S    z
+    WORD $0x6e27dce6                  // FMUL V6.4S, V7.4S, V7.4S     zz
+    WORD $0x4eb91f28                  // MOV V8.16B, V25.16B          acc = p0
+    WORD $0x4eba1f49                  // MOV V9.16B, V26.16B
+    WORD $0x4e27cd09                  // FMLA V9.4S, V8.4S, V7.4S     p1 + acc*z
+    WORD $0x4ebb1f68                  // MOV V8.16B, V27.16B
+    WORD $0x4e27cd28                  // FMLA V8.4S, V9.4S, V7.4S     p2 + acc*z
+    WORD $0x4ebc1f89                  // MOV V9.16B, V28.16B
+    WORD $0x4e27cd09                  // FMLA V9.4S, V8.4S, V7.4S     p3 + acc*z
+    WORD $0x4ebd1fa8                  // MOV V8.16B, V29.16B
+    WORD $0x4e27cd28                  // FMLA V8.4S, V9.4S, V7.4S     p4 + acc*z
+    WORD $0x4ebe1fc9                  // MOV V9.16B, V30.16B
+    WORD $0x4e27cd09                  // FMLA V9.4S, V8.4S, V7.4S     p5 + acc*z
+    WORD $0x4ebf1fe8                  // MOV V8.16B, V31.16B
+    WORD $0x4e27cd28                  // FMLA V8.4S, V9.4S, V7.4S     p6 + acc*z
+    WORD $0x4eaa1d49                  // MOV V9.16B, V10.16B
+    WORD $0x4e27cd09                  // FMLA V9.4S, V8.4S, V7.4S     p7 + acc*z
+    WORD $0x4eab1d68                  // MOV V8.16B, V11.16B
+    WORD $0x4e27cd28                  // FMLA V8.4S, V9.4S, V7.4S     P(z)
+    WORD $0x6e26dcea                  // FMUL V10.4S, V7.4S, V6.4S    z^3
+    WORD $0x6e28dd4a                  // FMUL V10.4S, V10.4S, V8.4S   z^3 * P(z)
+    WORD $0x4eb5ccca                  // FMLS V10.4S, V6.4S, V21.4S   -= 0.5*zz
+    WORD $0x4e27d54a                  // FADD V10.4S, V10.4S, V7.4S   lnm
+
+    // ln(base) = e*ln2hi + (e*ln2lo + lnm); the exponent load is issued
+    // first so it overlaps the dependent FMUL/FADD/FMLA chain
+    VLD1.P 16(R2), [V12.S4]           // V12 = exponents (finite)
+    WORD $0x6e37dc8b                  // FMUL V11.4S, V4.4S, V23.4S   e * ln2lo
+    WORD $0x4e2ad56b                  // FADD V11.4S, V11.4S, V10.4S  + lnm
+    WORD $0x4e36cc8b                  // FMLA V11.4S, V4.4S, V22.4S   += e * ln2hi
+
+    // y = exp[i]*ln(base[i]), clamped to [-104, 89]
+    WORD $0x6e2cdd60                  // FMUL V0.4S, V11.4S, V12.4S   y
+    WORD $0x4eadf400                  // FMIN V0.4S, V0.4S, V13.4S
+    WORD $0x4e2ef400                  // FMAX V0.4S, V0.4S, V14.4S
+
+    // --- exp core (see expNEON); constants from the table ---
+    VLD1 (R7), [V1.S4, V2.S4, V3.S4, V4.S4] // ln2, 1/120, 1/24, 1/6
+    WORD $0x6e38dc05                  // FMUL V5.4S, V0.4S, V24.4S    y * log2e
+    WORD $0x4e2188a5                  // FRINTN V5.4S, V5.4S          k
+    WORD $0x6e21dca6                  // FMUL V6.4S, V5.4S, V1.4S     k * ln2
+    WORD $0x4ea6d406                  // FSUB V6.4S, V0.4S, V6.4S     r
+    WORD $0x6e22dcc7                  // FMUL V7.4S, V6.4S, V2.4S     r * 1/120
+    WORD $0x4e23d4e7                  // FADD V7.4S, V7.4S, V3.4S     + 1/24
+    WORD $0x6e26dce7                  // FMUL V7.4S, V7.4S, V6.4S
+    WORD $0x4e24d4e7                  // FADD V7.4S, V7.4S, V4.4S     + 1/6
+    WORD $0x6e26dce7                  // FMUL V7.4S, V7.4S, V6.4S
+    WORD $0x4e35d4e7                  // FADD V7.4S, V7.4S, V21.4S    + 0.5
+    WORD $0x6e26dce7                  // FMUL V7.4S, V7.4S, V6.4S
+    WORD $0x4e34d4e7                  // FADD V7.4S, V7.4S, V20.4S    + 1
+    WORD $0x6e26dce7                  // FMUL V7.4S, V7.4S, V6.4S
+    WORD $0x4e34d4e7                  // FADD V7.4S, V7.4S, V20.4S    exp(r)
+    // Split 2^k reconstruction (see powNEON32)
+    WORD $0x4ea1b8a5                  // FCVTZS V5.4S, V5.4S          int(k)
+    WORD $0x4f3f04a8                  // SSHR V8.4S, V5.4S, #1        k1 = k >> 1
+    WORD $0x6ea884a5                  // SUB V5.4S, V5.4S, V8.4S      k2 = k - k1
+    WORD $0x4f375508                  // SHL V8.4S, V8.4S, #23
+    WORD $0x4eb48508                  // ADD V8.4S, V8.4S, V20.4S     2^k1 bits
+    WORD $0x6e28dce7                  // FMUL V7.4S, V7.4S, V8.4S     exp(r) * 2^k1
+    WORD $0x4f3754a5                  // SHL V5.4S, V5.4S, #23
+    WORD $0x4eb484a5                  // ADD V5.4S, V5.4S, V20.4S     2^k2 bits
+    WORD $0x6e25dce7                  // FMUL V7.4S, V7.4S, V5.4S     * 2^k2 = exp(y)
+
+    VST1.P [V7.S4], 16(R0)
+    SUB $1, R4
+    CBNZ R4, powelem32_neon_loop4
+
+powelem32_neon_scalar:
+    AND $3, R3
+    CBZ R3, powelem32_neon_done
+
+powelem32_neon_scalar_loop:
+    MOVWU (R1), R8                    // bits(base)
+    FMOVS (R1), F0
+
+    MOVD $0, R9
+    MOVD $0x00800000, R10
+    CMP R10, R8
+    BGE powelem32_neon_scalar_normal
+    FMULS F18, F0, F0                 // x *= 2^32
+    FMOVS F0, R8
+    MOVD $-32, R9
+
+powelem32_neon_scalar_normal:
+    MOVD $0x3F350000, R10
+    SUB R10, R8, R11                  // tmp
+    MOVW R11, R11                     // sign-extend
+    ASR $23, R11, R12                 // e
+    ADD R9, R12, R12
+    MOVD $0xFF800000, R10
+    AND R10, R11, R11
+    SUB R11, R8, R8                   // bits(m)
+    FMOVS R8, F1                      // m
+    SCVTFWS R12, F2                   // e
+
+    FSUBS F20, F1, F3                 // z
+    FMULS F3, F3, F4                  // zz
+    FMADDS F3, F26, F25, F5           // p1 + p0*z
+    FMADDS F3, F27, F5, F5
+    FMADDS F3, F28, F5, F5
+    FMADDS F3, F29, F5, F5
+    FMADDS F3, F30, F5, F5
+    FMADDS F3, F31, F5, F5            // p6 + acc*z
+    FMOVS log32neon_p78<>(SB), F6
+    FMADDS F3, F6, F5, F5             // p7 + acc*z
+    FMOVS log32neon_p78<>+16(SB), F6
+    FMADDS F3, F6, F5, F5             // P(z)
+    FMULS F3, F4, F6                  // z^3
+    FMULS F6, F5, F5                  // z^3*P(z)
+    FMSUBS F4, F5, F21, F5            // -= 0.5*zz
+    FADDS F3, F5, F5                  // lnm
+    FMULS F23, F2, F6                 // e * ln2lo
+    FADDS F5, F6, F6                  // + lnm
+    FMADDS F22, F6, F2, F6            // += e * ln2hi -> ln(base)
+
+    // y = exp[i]*ln(base[i]), clamped
+    FMOVS (R2), F12                   // p
+    FMULS F12, F6, F0
+    FMINS F13, F0, F0
+    FMAXS F14, F0, F0
+
+    // exp core, scalar (see powNEON32 tail)
+    FMULS F24, F0, F1
+    FRINTNS F1, F2                    // k
+    MOVW $0x3f317218, R10             // ln(2)
+    FMOVS R10, F3
+    FMULS F3, F2, F3
+    FSUBS F3, F0, F0                  // r
+    MOVW $0x3c088889, R10             // 1/120
+    FMOVS R10, F4
+    FMULS F0, F4, F4
+    MOVW $0x3d2aaaab, R10             // 1/24
+    FMOVS R10, F5
+    FADDS F5, F4, F4
+    FMULS F0, F4, F4
+    MOVW $0x3e2aaaab, R10             // 1/6
+    FMOVS R10, F5
+    FADDS F5, F4, F4
+    FMULS F0, F4, F4
+    FADDS F21, F4, F4                 // + 0.5
+    FMULS F0, F4, F4
+    FADDS F20, F4, F4                 // + 1
+    FMULS F0, F4, F4
+    FADDS F20, F4, F4                 // exp(r)
+    // Split 2^k reconstruction (see the vector body)
+    FCVTZSSW F2, R8                   // k
+    MOVW R8, R8                       // sign-extend
+    ASR $1, R8, R10                   // k1 = k >> 1
+    SUB R10, R8, R8                   // k2 = k - k1
+    MOVD $0x3F800000, R11
+    LSL $23, R10, R10
+    ADD R11, R10, R10
+    FMOVS R10, F5
+    FMULS F5, F4, F4                  // exp(r) * 2^k1
+    LSL $23, R8, R8
+    ADD R11, R8, R8
+    FMOVS R8, F5
+    FMULS F5, F4, F4                  // * 2^k2 = exp(y)
+    FMOVS F4, (R0)
+
+    ADD $4, R1
+    ADD $4, R2
+    ADD $4, R0
+    SUB $1, R3
+    CBNZ R3, powelem32_neon_scalar_loop
+
+powelem32_neon_done:
+    RET

--- a/f32/f32_other.go
+++ b/f32/f32_other.go
@@ -83,3 +83,9 @@ func realFFTUnpack32(outRe, outIm, zRe, zIm, twRe, twIm []float32, n int) {
 }
 func reverse32(dst, src []float32)             { reverse32Go(dst, src) }
 func addSub32(sumDst, diffDst, a, b []float32) { addSub32Go(sumDst, diffDst, a, b) }
+
+func log32(dst, src []float32)              { logGo(dst, src) }
+func log2_32(dst, src []float32)            { log2Go(dst, src) }
+func log10_32(dst, src []float32)           { log10Go(dst, src) }
+func pow32(dst, src []float32, exp float32) { powGo(dst, src, exp) }
+func powElem32(dst, base, exp []float32)    { powElemGo(dst, base, exp) }

--- a/f32/fuzz_test.go
+++ b/f32/fuzz_test.go
@@ -329,3 +329,116 @@ func FuzzF32InterleaveN(f *testing.F) {
 		}
 	})
 }
+
+// FuzzF32Log differentially fuzzes the dispatched Log/Log2/Log10 against the
+// pure-Go references over arbitrary bit patterns, including NaN, infinities,
+// negatives, zeros, and subnormals. Specials compare by class, finite values
+// within the documented kernel tolerance.
+func FuzzF32Log(f *testing.F) {
+	addByteLenSeeds(f)
+	f.Fuzz(func(t *testing.T, raw []byte) {
+		v := f32sBits(raw)
+		if len(v) == 0 {
+			return
+		}
+		got := make([]float32, len(v))
+		want := make([]float32, len(v))
+
+		check := func(op string) {
+			for i := range got {
+				g, w := float64(got[i]), float64(want[i])
+				switch {
+				case math.IsNaN(w):
+					if !math.IsNaN(g) {
+						t.Fatalf("%s[%d](%v): got %v want NaN", op, i, v[i], g)
+					}
+				case math.IsInf(w, 0) || w == 0:
+					if g != w {
+						t.Fatalf("%s[%d](%v): got %v want %v", op, i, v[i], g, w)
+					}
+				default:
+					diff := math.Abs(g - w)
+					if math.Abs(w) > 1e-6 {
+						diff /= math.Abs(w)
+					}
+					if diff > logRelTol32 {
+						t.Fatalf("%s[%d](%g): got %v want %v (err %g)", op, i, v[i], g, w, diff)
+					}
+				}
+			}
+		}
+		Log(got, v)
+		logGo(want, v)
+		check("Log")
+		Log2(got, v)
+		log2Go(want, v)
+		check("Log2")
+		Log10(got, v)
+		log10Go(want, v)
+		check("Log10")
+	})
+}
+
+// FuzzF32Pow differentially fuzzes Pow and PowElem against math.Pow for
+// positive finite bases (the SIMD precondition; other inputs dispatch to the
+// scalar path, which is exercised too via the raw exponent). Lanes whose
+// |p*ln(x)| lands near the overflow/underflow thresholds (>87) or whose true
+// result is subnormal are skipped: the kernel's relative error can flip the
+// result class there, and subnormal results lose precision gradually (see
+// powAVX).
+func FuzzF32Pow(f *testing.F) {
+	addByteLenSeeds(f)
+	f.Fuzz(func(t *testing.T, raw []byte) {
+		v := f32sBits(raw)
+		if len(v) < 3 {
+			return
+		}
+		p := v[0]
+		rest := v[1:]
+		h := len(rest) / 2
+		base, exps := rest[:h], rest[h:2*h]
+		for i, x := range base {
+			x = float32(math.Abs(float64(x)))
+			if !(x > 0 && x <= math.MaxFloat32) {
+				x = 1.5 + float32(i)
+			}
+			base[i] = x
+		}
+
+		checkLane := func(op string, i int, x, pw, g float32) {
+			want := math.Pow(float64(x), float64(pw))
+			if math.IsNaN(want) {
+				if !math.IsNaN(float64(g)) {
+					t.Fatalf("%s[%d](%g, %g): got %v want NaN", op, i, x, pw, g)
+				}
+				return
+			}
+			if y := float64(pw) * math.Log(float64(x)); math.Abs(y) > 87 || math.IsNaN(y) {
+				// Near the exact overflow/underflow thresholds the kernel's
+				// ~1.4e-5 error in p*ln(x) can flip the +Inf/0 class.
+				return
+			}
+			if want != 0 && math.Abs(want) < 2.4e-38 {
+				return // subnormal results lose precision gradually
+			}
+			w := float32(want)
+			diff := math.Abs(float64(g - w))
+			if math.Abs(float64(w)) > 1e-6 {
+				diff /= math.Abs(float64(w))
+			}
+			if diff > powRelTol32 {
+				t.Fatalf("%s[%d](%g, %g): got %v want %v (err %g)", op, i, x, pw, g, w, diff)
+			}
+		}
+
+		got := make([]float32, h)
+		Pow(got, base, p)
+		for i := range got {
+			checkLane("Pow", i, base[i], p, got[i])
+		}
+		PowElem(got, base, exps)
+		for i := range got {
+			checkLane("PowElem", i, base[i], exps[i], got[i])
+		}
+	})
+}

--- a/f32/log_dispatch.go
+++ b/f32/log_dispatch.go
@@ -1,0 +1,46 @@
+//go:build amd64 || arm64
+
+package f32
+
+import "math"
+
+// Reconstruction constants for the shared SIMD log core (logAVX / logNEON32).
+// The core computes, per lane, result = e*k1hi + ((z + lnmLo)*k2 + e*k1lo),
+// where x = m * 2^e with m in [sqrt(2)/2, sqrt(2)), z = m-1, and
+// z + lnmLo = ln(m) (Cephes logf polynomial). The hi/lo pairs keep the
+// e*ln(2) (resp. e*log10(2)) term accurate: the hi part has its low mantissa
+// bits zeroed (Cephes logf splitting), so the product with the integer-valued
+// e is exact, and the remainder rides in the lo term.
+const (
+	logLn2Hi32  = 0.693359375    // 0x3f318000
+	logLn2Lo32  = -2.12194440e-4 // 0xb95e8083
+	logL102Hi32 = 0.301025390625 // 0x3e9a2000, log10(2) hi
+	logL102Lo32 = 4.6050389811952e-6
+	logLog2E32  = 1.4426950408889634 // 1/ln(2), rounds to 0x3fb8aa3b
+	logLog10E32 = 0.4342944819032518 // 1/ln(10), rounds to 0x3ede5bd9
+)
+
+// powSIMDOK32 reports whether every element is positive and finite, the
+// precondition for the fused exp(p*ln(x)) kernels. Lanes outside that range
+// have math.Pow edge semantics the kernel does not implement (negative bases
+// with integer exponents, signed zeros, infinities, NaN propagation), so the
+// whole call falls back to the exact scalar path.
+func powSIMDOK32(src []float32) bool {
+	for _, x := range src {
+		if !(x > 0 && x <= math.MaxFloat32) {
+			return false
+		}
+	}
+	return true
+}
+
+// allFinite32 reports whether every element is finite (PowElem exponents).
+func allFinite32(s []float32) bool {
+	for _, x := range s {
+		d := float64(x)
+		if math.IsNaN(d) || math.IsInf(d, 0) {
+			return false
+		}
+	}
+	return true
+}

--- a/f32/log_pow_test.go
+++ b/f32/log_pow_test.go
@@ -5,6 +5,26 @@ import (
 	"testing"
 )
 
+// Tolerances for the dispatched log/pow paths.
+//
+// The SIMD log core is the Cephes logf degree-8 polynomial in z = m-1 over
+// [sqrt(2)/2, sqrt(2)): measured worst-case relative error is ~1.4e-7
+// (about 1.2 float32 ulps) across the full range including subnormals.
+// logRelTol32 leaves ~3x headroom while still failing hard on any real
+// kernel bug. The pure-Go fallback computes through float64 math and passes
+// trivially.
+//
+// Pow feeds p*Log(x) through the Exp core: the dominant error is the log's
+// relative error amplified by |p*ln(x)| <= 88, ~1.4e-5 measured; powRelTol32
+// mirrors the Exp tests' 1e-4.
+const (
+	logRelTol32 = 5e-7
+	powRelTol32 = 1e-4
+
+	// fltMinNormal32 is FLT_MIN, the smallest normal float32.
+	fltMinNormal32 = 1.1754943508222875e-38
+)
+
 // bitsEqF32 treats any NaN as equal to any NaN and otherwise requires bit
 // equality, so -Inf, +Inf, and signed zeros are all compared exactly.
 func bitsEqF32(a, b float32) bool {
@@ -22,7 +42,7 @@ func TestLogKnownValues(t *testing.T) {
 		want float32
 	}{
 		{"Log(1)=0", Log, 1, 0},
-		{"Log(e)=1", Log, float32(math.E), 1},
+		{"Log(e)=1", Log, math.E, 1},
 		{"Log2(8)=3", Log2, 8, 3},
 		{"Log2(1)=0", Log2, 1, 0},
 		{"Log10(100)=2", Log10, 100, 2},
@@ -39,9 +59,14 @@ func TestLogKnownValues(t *testing.T) {
 	}
 }
 
-// TestLogEdgeCases pins the documented non-finite behavior (matching math.Log).
+// TestLogEdgeCases pins the documented non-finite behavior (matching math.Log)
+// on the dispatched path. The slice is long enough to hit the SIMD body, so
+// the kernel's special-lane blends are exercised alongside the scalar tail.
 func TestLogEdgeCases(t *testing.T) {
-	src := []float32{0, -1, float32(math.Copysign(0, -1)), float32(math.Inf(1)), float32(math.Inf(-1)), float32(math.NaN())}
+	src := []float32{
+		0, -1, float32(math.Copysign(0, -1)), float32(math.Inf(1)), float32(math.Inf(-1)), float32(math.NaN()),
+		2, 4, 8, 16, // pad past one 8-lane block so blends and tail both run
+	}
 	for _, fn := range []struct {
 		name string
 		log  func(dst, src []float32)
@@ -55,8 +80,101 @@ func TestLogEdgeCases(t *testing.T) {
 		fn.log(dst, src)
 		for i, x := range src {
 			want := float32(fn.ref(float64(x)))
-			if !bitsEqF32(dst[i], want) {
-				t.Errorf("%s(%v) = %v, want %v", fn.name, x, dst[i], want)
+			if math.IsNaN(float64(want)) || math.IsInf(float64(want), 0) {
+				if !bitsEqF32(dst[i], want) {
+					t.Errorf("%s(%v) = %v, want %v", fn.name, x, dst[i], want)
+				}
+				continue
+			}
+			if re := relErrF32(dst[i], want); re > logRelTol32 {
+				t.Errorf("%s(%v) = %v, want %v (relErr %g)", fn.name, x, dst[i], want, re)
+			}
+		}
+	}
+}
+
+// TestLogSubnormals checks that subnormal inputs go through the kernel's
+// normalization pre-scale (or the scalar fallback) and still come out within
+// tolerance.
+func TestLogSubnormals(t *testing.T) {
+	src := []float32{
+		1.401298464324817e-45, // smallest subnormal
+		1e-44, 1e-40, 3e-39,   // assorted subnormals
+		fltMinNormal32,         // FLT_MIN, smallest normal
+		1.1754942106924411e-38, // largest subnormal
+		1e-30, 1,
+	}
+	for _, fn := range []struct {
+		name string
+		log  func(dst, src []float32)
+		ref  func(float64) float64
+	}{
+		{"Log", Log, math.Log},
+		{"Log2", Log2, math.Log2},
+		{"Log10", Log10, math.Log10},
+	} {
+		dst := make([]float32, len(src))
+		fn.log(dst, src)
+		for i, x := range src {
+			want := float32(fn.ref(float64(x)))
+			if re := relErrF32(dst[i], want); re > logRelTol32 {
+				t.Errorf("%s(%g) = %v, want %v (relErr %g)", fn.name, x, dst[i], want, re)
+			}
+		}
+	}
+}
+
+// TestLogAccuracy sweeps the full finite-positive range, the near-1
+// neighborhood where the reduction switches sign, and the mantissa-reduction
+// boundaries around sqrt(2)/2 and sqrt(2).
+func TestLogAccuracy(t *testing.T) {
+	src := make([]float32, 0, 1330)
+	for e := -126; e <= 127; e++ {
+		for _, m := range []float64{1.0, 1.3, 1.4142134, 1.4142137, 1.7, 1.9999999} {
+			src = append(src, float32(math.Ldexp(m, e)))
+		}
+	}
+	// Dense near 1 (both sides), where log -> 0.
+	for i := -40; i <= 40; i++ {
+		src = append(src, 1+float32(i)*1e-4, 1+float32(i)*1e-7)
+	}
+	src = append(src, math.MaxFloat32, fltMinNormal32, math.Sqrt2, math.Sqrt2/2)
+
+	for _, fn := range []struct {
+		name string
+		log  func(dst, src []float32)
+		ref  func(float64) float64
+	}{
+		{"Log", Log, math.Log},
+		{"Log2", Log2, math.Log2},
+		{"Log10", Log10, math.Log10},
+	} {
+		dst := make([]float32, len(src))
+		fn.log(dst, src)
+		for i, x := range src {
+			want := float32(fn.ref(float64(x)))
+			if re := relErrF32(dst[i], want); re > logRelTol32 {
+				t.Errorf("%s(%g) = %v, want %v (relErr %g)", fn.name, x, dst[i], want, re)
+			}
+		}
+	}
+}
+
+// TestLogLengths runs Log over every length from 1 to 40 so the scalar
+// remainder loop is exercised alongside the SIMD body (the AVX body consumes
+// 8 elements at a time, the NEON body 4).
+func TestLogLengths(t *testing.T) {
+	for n := 1; n <= 40; n++ {
+		src := make([]float32, n)
+		dst := make([]float32, n)
+		for i := range src {
+			src[i] = float32(math.Ldexp(1+0.13*float64(i), 2*i%50-25))
+		}
+		Log(dst, src)
+		for i, x := range src {
+			want := float32(math.Log(float64(x)))
+			if re := relErrF32(dst[i], want); re > logRelTol32 {
+				t.Errorf("len=%d Log(%v)[%d] = %v, want %v (relErr %g)", n, x, i, dst[i], want, re)
 			}
 		}
 	}
@@ -69,27 +187,26 @@ func TestPowKnownAndEdge(t *testing.T) {
 		{2, 10, 1024},
 		{9, 0.5, 3},
 		{4, -1, 0.25},
-		{2, 0, 1},     // anything^0 = 1
-		{0, 0, 1},     // 0^0 = 1 (matches math.Pow)
-		{0, 2, 0},     // 0^positive = 0
-		{2, 1, 2},     // x^1 = x
-		{10, 3, 1000}, // exact integer power
+		{2, 0, 1},
+		{0, 0, 1},
+		{0, 2, 0},
+		{2, 1, 2},
+		{10, 3, 1000},
 	}
 	for _, tt := range tests {
 		dst := make([]float32, 1)
 		Pow(dst, []float32{tt.base}, tt.exp)
-		if d := math.Abs(float64(dst[0]-tt.want)) / (1 + math.Abs(float64(tt.want))); d > 1e-6 {
+		if d := math.Abs(float64(dst[0]-tt.want)) / (1 + math.Abs(float64(tt.want))); d > powRelTol32 {
 			t.Errorf("Pow(%v, %v) = %v, want %v", tt.base, tt.exp, dst[0], tt.want)
 		}
 	}
 
-	// Non-finite / domain-error edges must match math.Pow exactly.
 	edges := []struct{ base, exp float32 }{
-		{-2, 0.5},                 // negative base, non-integer exp -> NaN
-		{0, -1},                   // 0^negative -> +Inf
-		{float32(math.Inf(1)), 2}, // +Inf
-		{float32(math.NaN()), 1},  // NaN propagation
-		{2, float32(math.Inf(1))}, // 2^+Inf -> +Inf
+		{-2, 0.5},
+		{0, -1},
+		{float32(math.Inf(1)), 2},
+		{float32(math.NaN()), 1},
+		{2, float32(math.Inf(1))},
 	}
 	for _, e := range edges {
 		dst := make([]float32, 1)
@@ -101,44 +218,114 @@ func TestPowKnownAndEdge(t *testing.T) {
 	}
 }
 
-// TestLogPowParity checks the dispatched ops against the math.* reference over a
-// wide finite-positive range. It is exact today (the implementation is the
-// scalar reference) and becomes the parity gate once a SIMD kernel lands.
+// TestPowEdgeLanesSIMDLength repeats the math.Pow edge cases at a length that
+// engages the SIMD body, so the dispatch-level scalar fallback for slices
+// containing non-positive or non-finite bases is exercised.
+func TestPowEdgeLanesSIMDLength(t *testing.T) {
+	src := []float32{2, -2, 0, float32(math.Inf(1)), float32(math.NaN()), 4, 0.5, 9, 16, 25}
+	for _, p := range []float32{0.5, 2, -1, 0, float32(math.NaN()), float32(math.Inf(1))} {
+		dst := make([]float32, len(src))
+		Pow(dst, src, p)
+		for i, x := range src {
+			want := float32(math.Pow(float64(x), float64(p)))
+			if math.IsNaN(float64(want)) || math.IsInf(float64(want), 0) || want == 0 || x <= 0 {
+				if !bitsEqF32(dst[i], want) {
+					t.Errorf("Pow(%v, %v) = %v, want %v (exact class)", x, p, dst[i], want)
+				}
+				continue
+			}
+			if re := relErrF32(dst[i], want); re > powRelTol32 {
+				t.Errorf("Pow(%v, %v) = %v, want %v (relErr %g)", x, p, dst[i], want, re)
+			}
+		}
+	}
+
+	base := []float32{2, 3, 4, 5, 6, 7, 8, 9, 10, 11}
+	expv := []float32{1, 2, float32(math.NaN()), float32(math.Inf(1)), float32(math.Inf(-1)), 0.5, 0, -2, 3, 1.5}
+	dst := make([]float32, len(base))
+	PowElem(dst, base, expv)
+	for i := range base {
+		want := float32(math.Pow(float64(base[i]), float64(expv[i])))
+		if math.IsNaN(float64(want)) || math.IsInf(float64(want), 0) || want == 0 {
+			if !bitsEqF32(dst[i], want) {
+				t.Errorf("PowElem(%v, %v) = %v, want %v (exact class)", base[i], expv[i], dst[i], want)
+			}
+			continue
+		}
+		if re := relErrF32(dst[i], want); re > powRelTol32 {
+			t.Errorf("PowElem(%v, %v) = %v, want %v (relErr %g)", base[i], expv[i], dst[i], want, re)
+		}
+	}
+}
+
+// TestPowOverflowClasses pins the overflow/underflow behavior of the SIMD
+// path: for positive finite bases, results that overflow in math.Pow must
+// come out as +Inf and results that underflow must come out as 0.
+func TestPowOverflowClasses(t *testing.T) {
+	src := []float32{1e30, 1e-30, 2, 0.5, 1e10, 1e-10, 3, 7}
+	for _, p := range []float32{3, -3, 20, -20} {
+		dst := make([]float32, len(src))
+		Pow(dst, src, p)
+		for i, x := range src {
+			want := math.Pow(float64(x), float64(p))
+			switch {
+			case want > math.MaxFloat32*2: // clearly past float32 overflow
+				if !math.IsInf(float64(dst[i]), 1) {
+					t.Errorf("Pow(%v, %v) = %v, want +Inf", x, p, dst[i])
+				}
+			case want != 0 && want < 1e-40: // clearly past float32 underflow
+				if dst[i] != 0 {
+					t.Errorf("Pow(%v, %v) = %v, want 0", x, p, dst[i])
+				}
+			case float32(want) == 0 || math.IsInf(float64(float32(want)), 0):
+				// borderline class, skip
+			default:
+				if re := relErrF32(dst[i], float32(want)); re > powRelTol32 {
+					t.Errorf("Pow(%v, %v) = %v, want %v (relErr %g)", x, p, dst[i], want, re)
+				}
+			}
+		}
+	}
+}
+
+// TestLogPowParity checks the dispatched ops against the float64 math
+// reference over a wide finite-positive range, within the documented
+// tolerances. On hosts without the SIMD kernels this exercises the scalar
+// path, which matches the reference exactly.
 func TestLogPowParity(t *testing.T) {
-	const n = 257 // odd, exercises any future vector tail
+	const n = 257 // odd, exercises the vector tail
 	src := make([]float32, n)
 	for i := range src {
 		// Logarithmically spread positives across denormal-to-large magnitudes.
 		src[i] = float32(math.Ldexp(1+0.5*float64(i%7), (i%80)-40))
 	}
 
-	check := func(name string, got []float32, ref func(float64) float64) {
+	check := func(name string, got []float32, ref func(float64) float64, tol float64) {
 		for i := range src {
 			want := float32(ref(float64(src[i])))
-			if !bitsEqF32(got[i], want) {
-				t.Errorf("%s[%d](%v) = %v, want %v", name, i, src[i], got[i], want)
+			if re := relErrF32(got[i], want); re > tol {
+				t.Errorf("%s[%d](%v) = %v, want %v (relErr %g)", name, i, src[i], got[i], want, re)
 			}
 		}
 	}
 	dst := make([]float32, n)
 	Log(dst, src)
-	check("Log", dst, math.Log)
+	check("Log", dst, math.Log, logRelTol32)
 	Log2(dst, src)
-	check("Log2", dst, math.Log2)
+	check("Log2", dst, math.Log2, logRelTol32)
 	Log10(dst, src)
-	check("Log10", dst, math.Log10)
+	check("Log10", dst, math.Log10, logRelTol32)
 
 	for _, exp := range []float32{0.35, 0.5, 2, -1, 3.7} {
 		Pow(dst, src, exp)
 		for i := range src {
 			want := float32(math.Pow(float64(src[i]), float64(exp)))
-			if !bitsEqF32(dst[i], want) {
-				t.Errorf("Pow[%d](%v, %v) = %v, want %v", i, src[i], exp, dst[i], want)
+			if re := relErrF32(dst[i], want); re > powRelTol32 {
+				t.Errorf("Pow[%d](%v, %v) = %v, want %v (relErr %g)", i, src[i], exp, dst[i], want, re)
 			}
 		}
 	}
 
-	// PowElem against a per-element exponent.
 	expv := make([]float32, n)
 	for i := range expv {
 		expv[i] = float32(0.1 + 0.05*float64(i%13))
@@ -146,8 +333,65 @@ func TestLogPowParity(t *testing.T) {
 	PowElem(dst, src, expv)
 	for i := range src {
 		want := float32(math.Pow(float64(src[i]), float64(expv[i])))
-		if !bitsEqF32(dst[i], want) {
-			t.Errorf("PowElem[%d] = %v, want %v", i, dst[i], want)
+		if re := relErrF32(dst[i], want); re > powRelTol32 {
+			t.Errorf("PowElem[%d] = %v, want %v (relErr %g)", i, dst[i], want, re)
+		}
+	}
+}
+
+// TestLogPowDispatchParity pins the per-arch dispatch wrappers against the
+// pure-Go reference. On SIMD hosts this is the kernel-vs-reference gate; on
+// others it compares the reference with itself.
+func TestLogPowDispatchParity(t *testing.T) {
+	const n = 67 // SIMD body + scalar tail
+	src := make([]float32, n)
+	for i := range src {
+		src[i] = float32(math.Ldexp(1+0.37*float64(i%5), (i%60)-30))
+	}
+	got := make([]float32, n)
+	want := make([]float32, n)
+
+	log32(got, src)
+	logGo(want, src)
+	for i := range got {
+		if re := relErrF32(got[i], want[i]); re > logRelTol32 {
+			t.Errorf("log32[%d](%v) = %v, want %v (relErr %g)", i, src[i], got[i], want[i], re)
+		}
+	}
+
+	log2_32(got, src)
+	log2Go(want, src)
+	for i := range got {
+		if re := relErrF32(got[i], want[i]); re > logRelTol32 {
+			t.Errorf("log2_32[%d](%v) = %v, want %v (relErr %g)", i, src[i], got[i], want[i], re)
+		}
+	}
+
+	log10_32(got, src)
+	log10Go(want, src)
+	for i := range got {
+		if re := relErrF32(got[i], want[i]); re > logRelTol32 {
+			t.Errorf("log10_32[%d](%v) = %v, want %v (relErr %g)", i, src[i], got[i], want[i], re)
+		}
+	}
+
+	pow32(got, src, 0.35)
+	powGo(want, src, 0.35)
+	for i := range got {
+		if re := relErrF32(got[i], want[i]); re > powRelTol32 {
+			t.Errorf("pow32[%d](%v, 0.35) = %v, want %v (relErr %g)", i, src[i], got[i], want[i], re)
+		}
+	}
+
+	expv := make([]float32, n)
+	for i := range expv {
+		expv[i] = float32(-1.5 + 0.21*float64(i%17))
+	}
+	powElem32(got, src, expv)
+	powElemGo(want, src, expv)
+	for i := range got {
+		if re := relErrF32(got[i], want[i]); re > powRelTol32 {
+			t.Errorf("powElem32[%d](%v, %v) = %v, want %v (relErr %g)", i, src[i], expv[i], got[i], want[i], re)
 		}
 	}
 }
@@ -157,20 +401,19 @@ func TestLogPowInPlace(t *testing.T) {
 	a := append([]float32(nil), src...)
 	LogInPlace(a)
 	for i := range src {
-		if !bitsEqF32(a[i], float32(math.Log(float64(src[i])))) {
-			t.Errorf("LogInPlace[%d] = %v", i, a[i])
+		if re := relErrF32(a[i], float32(math.Log(float64(src[i])))); re > logRelTol32 {
+			t.Errorf("LogInPlace[%d] = %v (relErr %g)", i, a[i], re)
 		}
 	}
 	b := append([]float32(nil), src...)
-	PowInPlace(b, 2)
+	PowInPlace(b, 0.5)
 	for i := range src {
-		if !bitsEqF32(b[i], float32(math.Pow(float64(src[i]), 2))) {
-			t.Errorf("PowInPlace[%d] = %v", i, b[i])
+		if re := relErrF32(b[i], float32(math.Pow(float64(src[i]), 0.5))); re > powRelTol32 {
+			t.Errorf("PowInPlace[%d] = %v (relErr %g)", i, b[i], re)
 		}
 	}
 }
 
-// TestLogPowClampsLength verifies the public ops honor min(len(dst), len(src)).
 func TestLogPowClampsLength(t *testing.T) {
 	dst := make([]float32, 3)
 	Log(dst, []float32{1, math.E, 10, 100, 1000}) // src longer than dst: only 3 written
@@ -183,7 +426,7 @@ func TestLogPowClampsLength(t *testing.T) {
 	short := make([]float32, 2)
 	Pow(short, []float32{2, 3, 4}, 2)
 	for i, want := range []float32{4, 9} {
-		if short[i] != want {
+		if re := relErrF32(short[i], want); re > powRelTol32 {
 			t.Errorf("Pow clamp[%d] = %v want %v", i, short[i], want)
 		}
 	}
@@ -215,5 +458,29 @@ func TestLogPowAllocFree(t *testing.T) {
 		if a := testing.AllocsPerRun(5, c.fn); a != 0 {
 			t.Errorf("%s allocated %v times per run, want 0", c.name, a)
 		}
+	}
+}
+
+func BenchmarkLog(b *testing.B) {
+	src := make([]float32, 1024)
+	for i := range src {
+		src[i] = 1e-3 + float32(i)*0.7
+	}
+	dst := make([]float32, len(src))
+	b.ReportAllocs()
+	for b.Loop() {
+		Log(dst, src)
+	}
+}
+
+func BenchmarkPow(b *testing.B) {
+	src := make([]float32, 1024)
+	for i := range src {
+		src[i] = 1e-3 + float32(i)*0.7
+	}
+	dst := make([]float32, len(src))
+	b.ReportAllocs()
+	for b.Loop() {
+		Pow(dst, src, 0.35)
 	}
 }

--- a/f64/f64_amd64.s
+++ b/f64/f64_amd64.s
@@ -5283,7 +5283,7 @@ log64_scalar_normal:
     ANDQ BX, R10
     SUBQ R10, AX                       // AX = bits(m)
     VMOVQ AX, X2                       // X2 = m
-    CVTSQ2SD R11, X3                   // X3 = e as float64
+    VCVTSI2SDQ R11, X3, X3             // X3 = e as float64
 
     // s = (m-1)/(m+1), t = s^2 (X10 = 1.0 from the vector constants)
     VSUBSD X10, X2, X4                 // m - 1
@@ -5469,7 +5469,7 @@ pow64_scalar_normal:
     ANDQ BX, R10
     SUBQ R10, AX                       // bits(m)
     VMOVQ AX, X2                       // m
-    CVTSQ2SD R11, X3                   // e
+    VCVTSI2SDQ R11, X3, X3             // e
 
     VSUBSD X13, X2, X4                 // m - 1 (X13 = 1.0)
     VADDSD X13, X2, X5                 // m + 1
@@ -5660,7 +5660,7 @@ powelem64_scalar_normal:
     ANDQ BX, R10
     SUBQ R10, AX                       // bits(m)
     VMOVQ AX, X2
-    CVTSQ2SD R11, X3                   // e
+    VCVTSI2SDQ R11, X3, X3             // e
 
     VSUBSD X13, X2, X4                 // m - 1
     VADDSD X13, X2, X5                 // m + 1


### PR DESCRIPTION
## Summary

Vectorizes the f32 transcendental log/pow family from #119, completing #109 (the f64 half landed in #123).

- **Log core**: the same `x = m*2^e` integer reduction as the f64 kernels (offset `0x3f350000`, arithmetic shift 23), `m` in `[sqrt2/2, sqrt2)`, then the Cephes logf form `ln(m) = z - 0.5*z^2 + z^3*P(z)` with `z = m-1` and the degree-8 minimax polynomial. Unlike the f64 atanh form this needs no division. One parametrized kernel serves `Log`/`Log2`/`Log10` via hi/lo reconstruction constants. Measured max relative error **~1.4e-7 (about 1.2 float32 ulps)** over 3M random inputs including subnormals (pre-scaled by `2^32`). Specials blend to match `math.Log`.
- **Pow / PowElem**: fused `exp(p*ln(x))` through the existing degree-5 exp core, `y` clamped to `[-104, 89]` with the same split `2^k` reconstruction as the f64 kernels (#123), so overflow goes to `+Inf` and underflow degrades gradually through subnormals to 0, matching `math.Pow`'s classes. Accuracy ~1.4e-5 relative (log error amplified by `|y| <= 88`). Non-positive/non-finite bases and zero/non-finite exponents dispatch to the exact scalar path.
- The f32 scalar references need no subnormal fixes: they compute through float64 math, where float32 subnormals are normal values (unlike the f64 case fixed in #123).
- amd64: 8-lane AVX2+FMA; arm64: 4-lane hand-encoded NEON `WORD`s verified by asmcheck and cross-checked against `aarch64-linux-gnu-as`.

## Related Issues

Closes #109. Builds on #119 and #123.

## Benchmarks (1024 elements)

| Op | i5-11400F scalar | i5-11400F SIMD | Cortex-A76 scalar | Cortex-A76 NEON |
|----|------------------|----------------|--------------------|------------------|
| Log | 6.1 us | 0.56 us (10.8x) | 17.3 us | 3.6 us (4.8x) |
| Pow | 57.6 us | 1.7 us (34x) | 78.9 us | 9.2 us (8.5x) |

## Test Plan

- [x] Full suite + golangci-lint (0 issues) on amd64 (AVX2+FMA) and arm64 (rpi5, NEON), rebased onto post-#123 main
- [x] Tolerance-based parity (5e-7 log, 1e-4 pow), accuracy sweeps (full range, near-1, subnormals, sqrt(2) boundaries), edge-class pins, lengths 1-40, overflow classes
- [x] Differential fuzz targets `FuzzF32Log` / `FuzzF32Pow` actively fuzzed 40s on amd64 and 30s on arm64
- [x] asmcheck WORD/comment cross-validation

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Performance Improvements**
  * Accelerated logarithm and power transcendental operations (log, log2, log10, pow) using SIMD vectorization on AVX2+FMA and NEON-capable processors for improved computational speed.

* **Tests**
  * Added comprehensive test coverage for logarithm and power operations including edge cases, accuracy validation, and fuzz testing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->