### PR TITLE
f64: fix stale STFT doc comment and make reference reflect independent

### DIFF
--- a/f64/stft.go
+++ b/f64/stft.go
@@ -299,11 +299,12 @@ func (p *STFTPlan) unravelBin(k int) (re, im float64) {
 }
 
 // STFT computes the real-input STFT of signal and writes one Hermitian
-// half-spectrum (NumBins complex128 values) per frame into dst. Frame f is
-// signal[f*hop : f*hop+nfft], windowed by window when non-nil (which must have
-// length nfft). This is the center=false / no-padding convention (matching
-// librosa stft(..., center=False)); pre-pad the signal yourself for centered
-// frames.
+// half-spectrum (NumBins complex128 values) per frame into dst. window, when
+// non-nil, must have length nfft. The pad argument selects the framing
+// convention: NoPad applies no padding (frame f is signal[f*hop : f*hop+nfft],
+// matching librosa stft(..., center=False)); PadZero and PadReflect center each
+// frame with nfft/2 of zero or reflect padding per side, matching librosa
+// center=True. See PadMode and NumFrames.
 //
 // It writes min(len(dst), NumFrames) frames and, per frame, min(len(dst[f]),
 // NumBins) bins, and returns the number of frames written. It is allocation-free

--- a/f64/stft_test.go
+++ b/f64/stft_test.go
@@ -437,6 +437,25 @@ func TestReflectIndex(t *testing.T) {
 	}
 }
 
+// refReflectIndex reimplements numpy "reflect" index folding locally, kept
+// deliberately independent of the production reflectIndex so the centered
+// reference and the fuzz target would catch a regression in either one (rather
+// than sharing the same mapping bug).
+func refReflectIndex(idx, n int) int {
+	if n == 1 {
+		return 0
+	}
+	period := (n - 1) << 1
+	m := idx % period
+	if m < 0 {
+		m += period
+	}
+	if m < n {
+		return m
+	}
+	return period - m
+}
+
 // refSampleAt and stftRef independently re-implement centering, windowing, and
 // the DFT (via dftBin), as a cross-check on the FFT-based centered STFT. They are
 // deliberately a separate implementation from the package's sampleAt/packFrameAt
@@ -446,7 +465,7 @@ func refSampleAt(signal []float64, idx int, pad PadMode) float64 {
 		return signal[idx]
 	}
 	if pad == PadReflect {
-		return signal[reflectIndex(idx, len(signal))]
+		return signal[refReflectIndex(idx, len(signal))]
 	}
 	return 0
 }


### PR DESCRIPTION
Small follow-up to #126 (raised during the #127 review).

- The exported `STFT` doc comment in `f64/stft.go` still described the old `center=false` / "pre-pad the signal yourself for centered frames" behavior. Since #126 added the `pad` argument, that wording sends callers to the wrong semantics. The doc now documents `NoPad` vs `PadZero`/`PadReflect` centering.
- The centered test reference (`refSampleAt`) called the production `reflectIndex`, so a bug in that mapping could slip past both the reference and the fuzz target. Added a test-local `refReflectIndex` so the reference is independent, matching the f32 package (#127).

Doc and test only; no functional change. Refs #108.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified STFT output format and spectrum bin descriptions.
  * Documented window length requirements for STFT processing.
  * Improved padding behavior documentation, including specification details for different padding modes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->