### PR TITLE
i8: add int8 SIMD package (saturating arith, int32 reductions, widening)

### DIFF
--- a/README.md
+++ b/README.md
@@ -580,6 +580,42 @@ i16.Deinterleave2(left, right, stereo) // inverse: split back to channels
 
 Like the `i32` interleave kernels, these are pure 16-bit-lane movement (AVX2/SSE2 word unpacks plus a lane permute, NEON `ZIP`/`UZP` on `.8H`), so the bit pattern of each lane is irrelevant and every value round-trips exactly: negative values and the int16 extremes are preserved. Both kernels are zero-allocation.
 
+### `i8` - int8 Operations
+
+SIMD-accelerated int8 operations for quantized numeric pipelines. The narrow `-128..127` range makes element-wise arithmetic overflow almost immediately, so this package does not mirror the wrapping arithmetic of `i16`/`i32`. It ships the operations that are genuinely high-impact and well-defined at 8-bit width: saturating arithmetic, int32-accumulated reductions, signed min/max, and sign-extending widening.
+
+| Category       | Function                   | Description                                                    | SIMD Width             |
+| -------------- | -------------------------- | -------------------------------------------------------------- | ---------------------- |
+| **Arithmetic** | `AddSaturate(dst, a, b)`   | Element-wise add, clamped to `[-128, 127]`                     | 32x (AVX2) / 16x (NEON)|
+|                | `SubSaturate(dst, a, b)`   | Element-wise subtract, clamped to `[-128, 127]`                | 32x (AVX2) / 16x (NEON)|
+| **Widening**   | `ToInt16(dst, src)`        | Sign-extend `int8` to `int16`                                  | 16x (AVX2) / 16x (NEON)|
+|                | `ToInt32(dst, src)`        | Sign-extend `int8` to `int32`                                  | 8x (AVX2) / 8x (NEON)  |
+| **Reduction**  | `Sum(a) int32`             | int32-accumulated sum                                          | 16x (AVX2) / 16x (NEON)|
+|                | `DotProduct(a, b) int32`   | int32-accumulated dot product (quantized matmul inner loop)    | 16x (AVX2) / 16x (NEON, SDOT)|
+|                | `MinMax(a) (min, max)`     | Signed int8 per-slice minimum and maximum in one pass          | 32x (AVX2) / 16x (NEON)|
+
+```go
+import "github.com/tphakala/simd/i8"
+
+a := []int8{ /* ... */ }
+b := []int8{ /* ... */ }
+
+dst := make([]int8, len(a))
+i8.AddSaturate(dst, a, b) // saturating dst = clamp(a + b, -128, 127)
+i8.SubSaturate(dst, a, b) // saturating dst = clamp(a - b, -128, 127)
+
+dot := i8.DotProduct(a, b) // int32-accumulated sum(a[i]*b[i])
+sum := i8.Sum(a)           // int32-accumulated sum
+mn, mx := i8.MinMax(a)     // smallest and largest value in one signed pass
+
+w16 := make([]int16, len(a))
+i8.ToInt16(w16, a) // sign-extend to int16 (exact)
+```
+
+`AddSaturate`/`SubSaturate` use single saturating instructions (`VPADDSB`/`VPSUBSB` on AVX2, `SQADD`/`SQSUB` on NEON) and clamp instead of wrapping, which is what 8-bit arithmetic almost always wants. `Sum` and `DotProduct` accumulate in int32 with two's-complement wraparound; since int32 wrapping addition is associative, the lane-parallel SIMD reductions are bit-identical to the scalar reference regardless of summation order, and the int8 products never overflow their lane (`|int8 * int8| <= 16384`). `DotProduct` is the inner loop of quantized matmul/convolution: on AVX2 it widens with `VPMOVSXBW` and reduces with `VPMADDWD`; on ARM64 with `FEAT_DotProd` it uses `SDOT` (16 multiply-accumulates per instruction), falling back to a `SMULL`/`SADALP` base-NEON path on cores without it. All operations are zero-allocation and bit-exact against the pure-Go reference.
+
+> **Planned follow-ups:** `float32 <-> int8` affine `Quantize`/`Dequantize` (scale + zero-point), an AVX-512 VNNI (`VPDPBUSD`) `DotProduct` fast path, and 8-bit channel `Interleave2`/`Deinterleave2`.
+
 ## Performance
 
 ### AMD64 (Intel Core i7-1260P, AVX+FMA)
@@ -835,6 +871,7 @@ each package's `*_amd64.go` dispatch):
 | `c64`   | SSE4.1 (BLENDPS)        | AVX+FMA, AVX-512        | pure Go |
 | `i16`   | SSE2                    | AVX2                    | pure Go (baseline guarantees SSE2) |
 | `i32`   | AVX (interleave), AVX2 (arithmetic) | -           | pure Go |
+| `i8`    | AVX2                    | -                       | pure Go |
 | `f16`   | F16C (slice conversions only) | -                 | pure Go (all f16 compute is pure Go on amd64) |
 | `crc`   | PCLMULQDQ               | -                       | scalar slice-by-16 |
 
@@ -845,7 +882,8 @@ AVX+FMA / AVX / SSE2 / scalar); a package whose minimum is above that tier (e.g.
 `i32` on an SSE-only host) runs pure Go even though `Info()` shows SSE2.
 
 ARM64 runs NEON kernels throughout, with an FP16 (FEAT_FP16) fast path in `f16`
-and FP16-widened variants elsewhere. **SVE/SVE2 is detected but unused:** there are
+and FP16-widened variants elsewhere, plus an SDOT (FEAT_DotProd) fast path for
+`i8.DotProduct` (base-NEON `SMULL`/`SADALP` on cores without it). **SVE/SVE2 is detected but unused:** there are
 no SVE kernels yet, so an SVE-capable host (Graviton 3, Neoverse V1) still runs the
 NEON path, and `cpu.Info()` annotates this as `ARM64 NEON+FP16 (SVE detected, unused)`.
 

--- a/asmcheck_test.go
+++ b/asmcheck_test.go
@@ -42,22 +42,35 @@ func findArm64Asm(t *testing.T) []string {
 	return files
 }
 
-// fp16Directive is a WORD directive that golang.org/x/arch/arm64asm cannot
-// decode (an ARMv8.2 half-precision .8H FP16 SIMD instruction), deferred to the
-// objdump cross-check.
-type fp16Directive struct {
+// objdumpDirective is a WORD directive that golang.org/x/arch/arm64asm cannot
+// decode (an ARMv8.2 half-precision .8H FP16 SIMD instruction, or a FEAT_DotProd
+// SDOT/UDOT dot product), deferred to the objdump cross-check.
+type objdumpDirective struct {
 	line    int
 	hex     uint32
 	comment string
 }
 
+// deferredToObjdump reports whether a WORD directive that arm64asm cannot decode
+// is nonetheless a sanctioned encoding to be cross-checked with objdump: an
+// ARMv8.2 FP16 (.8H) SIMD instruction, or a FEAT_DotProd dot product (SDOT/UDOT,
+// which arm64asm does not know). Anything else is treated as a real error.
+func deferredToObjdump(comment string) bool {
+	u := strings.ToUpper(comment)
+	if strings.Contains(u, ".8H") {
+		return true
+	}
+	mnem, _, _ := strings.Cut(strings.TrimSpace(u), " ")
+	return mnem == "SDOT" || mnem == "UDOT"
+}
+
 // TestArm64WordEncodings decodes every hand-encoded WORD directive in the ARM64
 // assembly and asserts it matches the instruction named in its comment.
-// Instructions arm64asm can decode are checked directly; ARMv8.2 FP16 (.8H)
-// instructions, which it cannot decode, are cross-checked with an aarch64
-// objdump when one is available. Without objdump the FP16 directives are
-// accepted unchecked (so the test stays green on machines lacking cross
-// binutils) unless SIMD_REQUIRE_OBJDUMP is set, which CI does.
+// Instructions arm64asm can decode are checked directly; ARMv8.2 FP16 (.8H) and
+// FEAT_DotProd (SDOT/UDOT) instructions, which it cannot decode, are
+// cross-checked with an aarch64 objdump when one is available. Without objdump
+// these directives are accepted unchecked (so the test stays green on machines
+// lacking cross binutils) unless SIMD_REQUIRE_OBJDUMP is set, which CI does.
 func TestArm64WordEncodings(t *testing.T) {
 	tool := asmcheck.FindObjdump()
 	if os.Getenv(requireObjdumpEnv) != "" && tool == "" {
@@ -86,10 +99,11 @@ func checkArm64File(t *testing.T, file, tool string) {
 	// arm64asm or cross-checked by objdump. Uncommented repeats of a matched
 	// hex are then accepted.
 	matched := map[uint32]bool{}
-	var fp16 []fp16Directive
+	var deferred []objdumpDirective
 
 	// Pass 1: every commented directive. Decodable ones are verified now;
-	// undecodable ones (FP16 .8H) are deferred to the objdump cross-check.
+	// undecodable ones (FP16 .8H, or SDOT/UDOT) are deferred to the objdump
+	// cross-check.
 	for _, d := range directives {
 		if d.Source == asmcheck.NoComment {
 			continue
@@ -101,20 +115,21 @@ func checkArm64File(t *testing.T, file, tool string) {
 		case asmcheck.Mismatch:
 			t.Errorf("%s:%d  0x%08X  claims=%q  decodes=%q", file, d.Line, d.Hex, res.Claimed, res.Decoded)
 		case asmcheck.Undecodable:
-			// ARMv8.2 FP16 (.8H) SIMD is the only sanctioned reason arm64asm
-			// cannot decode a directive here. Any other undecodable WORD (a
-			// malformed encoding, or a future extension) is a real problem:
-			// fail loudly instead of funneling it into the objdump fallback,
-			// which is lenient when no objdump is installed.
-			if !strings.Contains(strings.ToUpper(d.Comment), ".8H") {
-				t.Errorf("%s:%d  0x%08X  undecodable WORD that is not FP16 (.8H): %q", file, d.Line, d.Hex, d.Comment)
+			// ARMv8.2 FP16 (.8H) SIMD and FEAT_DotProd (SDOT/UDOT) are the only
+			// sanctioned reasons arm64asm cannot decode a directive here; both are
+			// cross-checked with objdump. Any other undecodable WORD (a malformed
+			// encoding, or a future extension) is a real problem: fail loudly
+			// instead of funneling it into the objdump fallback, which is lenient
+			// when no objdump is installed.
+			if !deferredToObjdump(d.Comment) {
+				t.Errorf("%s:%d  0x%08X  undecodable WORD that is neither FP16 (.8H) nor DotProd (SDOT/UDOT): %q", file, d.Line, d.Hex, d.Comment)
 				continue
 			}
-			fp16 = append(fp16, fp16Directive{line: d.Line, hex: d.Hex, comment: d.Comment})
+			deferred = append(deferred, objdumpDirective{line: d.Line, hex: d.Hex, comment: d.Comment})
 		}
 	}
 
-	crossCheckFP16(t, file, tool, fp16, matched)
+	crossCheckObjdump(t, file, tool, deferred, matched)
 
 	// Pass 2: uncommented directives must reuse a hex proven above.
 	for _, d := range directives {
@@ -128,25 +143,25 @@ func checkArm64File(t *testing.T, file, tool string) {
 	}
 }
 
-// crossCheckFP16 verifies FP16 (.8H) directives that arm64asm cannot decode by
-// disassembling them with aarch64 objdump and comparing against their comments.
-// When no objdump is available it accepts them (marking each hex matched so
-// uncommented repeats pass) and relies on the warning and SIMD_REQUIRE_OBJDUMP
-// gate in TestArm64WordEncodings.
-func crossCheckFP16(t *testing.T, file, tool string, fp16 []fp16Directive, matched map[uint32]bool) {
+// crossCheckObjdump verifies directives that arm64asm cannot decode (FP16 .8H,
+// or SDOT/UDOT) by disassembling them with aarch64 objdump and comparing against
+// their comments. When no objdump is available it accepts them (marking each hex
+// matched so uncommented repeats pass) and relies on the warning and
+// SIMD_REQUIRE_OBJDUMP gate in TestArm64WordEncodings.
+func crossCheckObjdump(t *testing.T, file, tool string, deferred []objdumpDirective, matched map[uint32]bool) {
 	t.Helper()
-	if len(fp16) == 0 {
+	if len(deferred) == 0 {
 		return
 	}
 	if tool == "" {
-		for _, d := range fp16 {
+		for _, d := range deferred {
 			matched[d.hex] = true
 		}
 		return
 	}
 
-	hexes := make([]uint32, 0, len(fp16))
-	for _, d := range fp16 {
+	hexes := make([]uint32, 0, len(deferred))
+	for _, d := range deferred {
 		hexes = append(hexes, d.hex)
 	}
 	decoded, err := asmcheck.DisassembleWords(context.Background(), tool, hexes)
@@ -154,7 +169,7 @@ func crossCheckFP16(t *testing.T, file, tool string, fp16 []fp16Directive, match
 		t.Fatalf("objdump cross-check of %s failed: %v", file, err)
 	}
 
-	for _, d := range fp16 {
+	for _, d := range deferred {
 		got, ok := decoded[d.hex]
 		if !ok {
 			t.Errorf("%s:%d  0x%08X  objdump produced no disassembly", file, d.line, d.hex)

--- a/cpu/cpu.go
+++ b/cpu/cpu.go
@@ -24,11 +24,12 @@ type Features struct {
 	F16C      bool // half<->single float conversion (VCVTPH2PS/VCVTPS2PH)
 
 	// ARM64 features
-	NEON  bool
-	FP16  bool // ARM64 half-precision floating point (FEAT_FP16)
-	SVE   bool
-	SVE2  bool
-	PMULL bool // polynomial multiply (FEAT_PMULL) - used for CRC folding
+	NEON    bool
+	FP16    bool // ARM64 half-precision floating point (FEAT_FP16)
+	SVE     bool
+	SVE2    bool
+	PMULL   bool // polynomial multiply (FEAT_PMULL) - used for CRC folding
+	DOTPROD bool // int8 dot product (FEAT_DotProd) - SDOT/UDOT
 }
 
 // X86 contains x86/AMD64 CPU features (populated on amd64).
@@ -62,6 +63,11 @@ func HasF16C() bool { return X86.F16C }
 // is available. It is used to accelerate CRC folding.
 func HasPMULL() bool { return ARM64.PMULL }
 
+// HasDOTPROD returns true if the ARM64 int8 dot-product instructions
+// (SDOT/UDOT, FEAT_DotProd) are available. They accelerate int8 dot products
+// and quantized matmul inner loops.
+func HasDOTPROD() bool { return ARM64.DOTPROD }
+
 // HasFP16 returns true if ARM FP16 (half-precision) is available.
 func HasFP16() bool { return ARM64.FP16 }
 
@@ -91,10 +97,11 @@ func Info() string {
 //	ssse3      SSSE3 and the sse41 set
 //	sse3       SSE3 and the ssse3 set
 //	pclmulqdq  PCLMULQDQ only
-//	neon       NEON, FP16, SVE, SVE2, PMULL
+//	neon       NEON, FP16, SVE, SVE2, PMULL, DOTPROD
 //	fp16       FP16 only
 //	sve        SVE, SVE2
 //	pmull      PMULL only
+//	dotprod    DOTPROD only
 //	all        every flag (forces the pure-Go path everywhere)
 func applyDisable(f *Features, spec string) {
 	if spec == "" {
@@ -130,6 +137,8 @@ func applyDisable(f *Features, spec string) {
 			clearSVE(f)
 		case "pmull":
 			f.PMULL = false
+		case "dotprod":
+			f.DOTPROD = false
 		case "all":
 			*f = Features{}
 		default:
@@ -190,6 +199,7 @@ func clearNEON(f *Features) {
 	f.SVE = false
 	f.SVE2 = false
 	f.PMULL = false
+	f.DOTPROD = false
 }
 
 // clearSVE disables the scalable-vector tiers without touching NEON.

--- a/cpu/cpu_arm64.go
+++ b/cpu/cpu_arm64.go
@@ -13,7 +13,8 @@ func init() {
 	ARM64.FP16 = cpu.ARM64.HasASIMDHP // FEAT_FP16 - half-precision SIMD
 	ARM64.SVE = cpu.ARM64.HasSVE
 	ARM64.SVE2 = cpu.ARM64.HasSVE2
-	ARM64.PMULL = cpu.ARM64.HasPMULL // FEAT_PMULL - polynomial multiply
+	ARM64.PMULL = cpu.ARM64.HasPMULL     // FEAT_PMULL - polynomial multiply
+	ARM64.DOTPROD = cpu.ARM64.HasASIMDDP // FEAT_DotProd - SDOT/UDOT int8 dot product
 
 	// Honor SIMD_DISABLE last, so the env var can mask any detected feature.
 	applyDisable(&ARM64, os.Getenv("SIMD_DISABLE"))

--- a/cpu/cpu_arm64_darwin.go
+++ b/cpu/cpu_arm64_darwin.go
@@ -8,16 +8,18 @@ import (
 	"golang.org/x/sys/cpu"
 )
 
-// Apple Silicon (M1/M2/M3/M4) all support FEAT_FP16 (half-precision floating point)
-// and FEAT_PMULL (polynomial multiply). The golang.org/x/sys/cpu package doesn't
-// properly detect these on macOS, so we enable them unconditionally on darwin/arm64.
+// Apple Silicon (M1/M2/M3/M4) all support FEAT_FP16 (half-precision floating point),
+// FEAT_PMULL (polynomial multiply), and FEAT_DotProd (int8 dot product). The
+// golang.org/x/sys/cpu package doesn't properly detect these on macOS, so we enable
+// them unconditionally on darwin/arm64.
 
 func init() {
 	ARM64.NEON = cpu.ARM64.HasASIMD
 	ARM64.FP16 = true // All Apple Silicon chips support FP16
 	ARM64.SVE = cpu.ARM64.HasSVE
 	ARM64.SVE2 = cpu.ARM64.HasSVE2
-	ARM64.PMULL = true // All Apple Silicon chips support PMULL
+	ARM64.PMULL = true   // All Apple Silicon chips support PMULL
+	ARM64.DOTPROD = true // All Apple Silicon chips support FEAT_DotProd
 
 	// Honor SIMD_DISABLE last, so the env var can mask any detected feature.
 	applyDisable(&ARM64, os.Getenv("SIMD_DISABLE"))

--- a/cpu/cpu_test.go
+++ b/cpu/cpu_test.go
@@ -106,4 +106,5 @@ func TestFeatures(_ *testing.T) {
 	_ = ARM64.SVE
 	_ = ARM64.SVE2
 	_ = ARM64.PMULL
+	_ = ARM64.DOTPROD
 }

--- a/cpu/cpu_test.go
+++ b/cpu/cpu_test.go
@@ -49,6 +49,12 @@ func TestHasPMULL(_ *testing.T) {
 	_ = got
 }
 
+// TestHasDOTPROD tests the HasDOTPROD function
+func TestHasDOTPROD(_ *testing.T) {
+	got := HasDOTPROD()
+	_ = got
+}
+
 // TestHasAVX512VL tests the HasAVX512VL function
 func TestHasAVX512VL(_ *testing.T) {
 	got := HasAVX512VL()

--- a/cpu/disable_test.go
+++ b/cpu/disable_test.go
@@ -56,10 +56,11 @@ func TestApplyDisable(t *testing.T) {
 		{"ssse3", []string{"AVX", "AVX2", "AVX512F", "AVX512VL", "F16C", "FMA", "SSE41", "SSE42", "SSSE3"}},
 		{"sse3", []string{"AVX", "AVX2", "AVX512F", "AVX512VL", "F16C", "FMA", "SSE3", "SSE41", "SSE42", "SSSE3"}},
 		{"pclmulqdq", []string{"PCLMULQDQ"}},
-		{"neon", []string{"FP16", "NEON", "PMULL", "SVE", "SVE2"}},
+		{"neon", []string{"DOTPROD", "FP16", "NEON", "PMULL", "SVE", "SVE2"}},
 		{"fp16", []string{"FP16"}},
 		{"sve", []string{"SVE", "SVE2"}},
 		{"pmull", []string{"PMULL"}},
+		{"dotprod", []string{"DOTPROD"}},
 		// Case-insensitivity and surrounding whitespace.
 		{"AVX512", []string{"AVX512F", "AVX512VL"}},
 		{"  avx512  ", []string{"AVX512F", "AVX512VL"}},
@@ -68,9 +69,9 @@ func TestApplyDisable(t *testing.T) {
 		{"foobar", nil},
 		{"avx512,foobar", []string{"AVX512F", "AVX512VL"}},
 		// Empty tokens between commas are ignored.
-		{"avx512,,neon", []string{"AVX512F", "AVX512VL", "FP16", "NEON", "PMULL", "SVE", "SVE2"}},
+		{"avx512,,neon", []string{"AVX512F", "AVX512VL", "DOTPROD", "FP16", "NEON", "PMULL", "SVE", "SVE2"}},
 		// Multiple tokens combine.
-		{"avx512,neon", []string{"AVX512F", "AVX512VL", "FP16", "NEON", "PMULL", "SVE", "SVE2"}},
+		{"avx512,neon", []string{"AVX512F", "AVX512VL", "DOTPROD", "FP16", "NEON", "PMULL", "SVE", "SVE2"}},
 	}
 	for _, tt := range tests {
 		f := fullFeatures()

--- a/doc.go
+++ b/doc.go
@@ -9,6 +9,7 @@
 //   - [github.com/tphakala/simd/f16] - float16 storage type (ARM64 NEON+FP16 compute; amd64 F16C slice conversions)
 //   - [github.com/tphakala/simd/i32] - int32 SIMD operations (integer DSP)
 //   - [github.com/tphakala/simd/i16] - int16 SIMD operations (movement only; widen to i32 for arithmetic)
+//   - [github.com/tphakala/simd/i8] - int8 SIMD operations (saturating arithmetic, int32-accumulated reductions, quantized DSP)
 //   - [github.com/tphakala/simd/c64] - complex64 SIMD operations (FFT-pipeline helpers)
 //   - [github.com/tphakala/simd/c128] - complex128 SIMD operations (FFT-pipeline helpers)
 //   - [github.com/tphakala/simd/crc] - CRC checksums (carry-less-multiply folding)
@@ -21,12 +22,14 @@
 //
 //   - AMD64: AVX-512 (8x float64, 16x float32) > AVX+FMA (4x float64, 8x float32) >
 //     AVX (no FMA, f64/c128) > SSE2 (f32/f64/c128/i16) or SSE4.1 (c64) > pure Go.
-//     i32 needs AVX/AVX2, crc needs PCLMULQDQ, and f16 uses F16C for its slice
-//     conversions only (every other f16 op is pure Go on amd64). SSE2 is part of
-//     the amd64 baseline, so f32/f64/c128/i16 always get SIMD on amd64.
+//     i32 needs AVX/AVX2, i8 needs AVX2, crc needs PCLMULQDQ, and f16 uses F16C
+//     for its slice conversions only (every other f16 op is pure Go on amd64).
+//     SSE2 is part of the amd64 baseline, so f32/f64/c128/i16 always get SIMD on
+//     amd64.
 //   - ARM64: NEON/ASIMD throughout (2x float64, 4x float32), with an FP16
-//     (FEAT_FP16) fast path in the f16 package. SVE/SVE2 is detected by cpu.Info()
-//     but no SVE kernels exist yet, so SVE hosts run the NEON path.
+//     (FEAT_FP16) fast path in the f16 package and an SDOT (FEAT_DotProd) fast
+//     path for i8.DotProduct. SVE/SVE2 is detected by cpu.Info() but no SVE
+//     kernels exist yet, so SVE hosts run the NEON path.
 //   - Other: Pure Go fallback
 //
 // f16 is a storage type: SIMD acceleration is ARM64-only for compute (NEON+FP16),
@@ -85,6 +88,8 @@
 // Spectral (f64, f32): STFTPlan (NewSTFTPlan, STFT, STFTPower, STFTPowerInto, NumFrames) - fused real-input short-time Fourier transform with optional librosa-style center=true framing (PadMode: NoPad/PadZero/PadReflect)
 //
 // Integer DSP (i32): Interleave2, Deinterleave2, Add, Sub, MinMax
+//
+// Integer DSP (i8): AddSaturate, SubSaturate, ToInt16, ToInt32, Sum, MinMax, DotProduct (int32-accumulated; ARM64 SDOT / amd64 VPMADDWD)
 //
 // Complex (c64/c128): Add, Sub, Mul, MulConj, DotProduct, DotProductConj, Conj, Abs, AbsSq, Scale
 //

--- a/docs/superpowers/specs/2026-06-13-i8-primitives-design.md
+++ b/docs/superpowers/specs/2026-06-13-i8-primitives-design.md
@@ -1,0 +1,212 @@
+# i8: high-impact int8 SIMD primitives (v1)
+
+Date: 2026-06-13
+Status: approved (Approach A, seven-op v1)
+Branch: `i8-primitives`
+
+## Goal
+
+Add an `i8` package providing SIMD-accelerated operations on `[]int8`, mirroring
+the existing per-type packages (`i16`, `i32`, `f32`) in structure, conventions,
+and test discipline. int8 has a hard constraint that shapes the API: at 8-bit
+width arithmetic overflows almost immediately (`-128..127`), so the operations
+that make sense are not a 1:1 copy of `i32`. v1 ships the genuinely high-impact,
+clearly-int8-shaped kernels and defers float-quantization (which needs its own
+scale/zero-point convention design) and 8-bit movement to follow-ups.
+
+## Scope: seven operations
+
+| Function | Signature | Semantics |
+|----------|-----------|-----------|
+| `AddSaturate` | `func AddSaturate(dst, a, b []int8)` | `dst[i] = clamp(int(a[i])+int(b[i]), -128, 127)` |
+| `SubSaturate` | `func SubSaturate(dst, a, b []int8)` | `dst[i] = clamp(int(a[i])-int(b[i]), -128, 127)` |
+| `ToInt16` | `func ToInt16(dst []int16, src []int8)` | `dst[i] = int16(src[i])` (sign-extend, exact) |
+| `ToInt32` | `func ToInt32(dst []int32, src []int8)` | `dst[i] = int32(src[i])` (sign-extend, exact) |
+| `Sum` | `func Sum(a []int8) int32` | `sum_i int32(a[i])`, int32 two's-complement accumulation |
+| `MinMax` | `func MinMax(a []int8) (min, max int8)` | signed per-slice min and max; empty returns `(0,0)` |
+| `DotProduct` | `func DotProduct(a, b []int8) int32` | `sum_i int32(a[i])*int32(b[i])`, int32 two's-complement accumulation |
+
+`DotProduct` is the marquee int8 kernel: it is the inner loop of quantized
+matmul/conv. On ARM64 with `FEAT_DotProd` a single `SDOT` does 16 int8 MACs into
+4 int32 lanes; on AVX2 `VPMADDWD` over sign-extended bytes does the same work
+without a new instruction-set tier.
+
+### API conventions (match i16/i32)
+
+- Binary ops (`AddSaturate`, `SubSaturate`) clamp `n := min(len(dst), len(a),
+  len(b))`, operate on `dst[:n]/a[:n]/b[:n]`, and leave trailing `dst` capacity
+  untouched. Conversions clamp `n := min(len(dst), len(src))`.
+- Reductions (`Sum`, `DotProduct`) operate over `min`-clamped lengths; `Sum([])
+  == 0`, `DotProduct` over empty `== 0`.
+- `MinMax` guards the empty case in the public function (returns `(0,0)`), so the
+  dispatch and kernels always see a non-empty slice, matching `i32.MinMax`.
+- **No `Unsafe` variants.** The integer packages (`i16`, `i32`) ship none; v1
+  follows that precedent. (The `Unsafe` convention is f32/f64-only today.)
+- Zero allocations; all results write into caller-provided slices or are scalar
+  returns. Thread-safe (read-only inputs, no shared state).
+
+### Accumulation and bit-exactness
+
+`Sum` and `DotProduct` accumulate in `int32` with two's-complement wraparound,
+exactly like their pure-Go references. int32 wrapping addition is associative and
+commutative mod 2^32, so every SIMD reduction order (lane-parallel accumulate
+then horizontal fold) yields the identical result to the scalar left-to-right
+reference. This makes the SIMD paths bit-exact by construction, not just
+approximately equal, and is the property the parity tests assert.
+
+Intermediate products never overflow their SIMD lane: `|int8 * int8| <= 16384`,
+so the int16 products from `SMULL`/`VPMOVSXBW`+multiply are exact, and a
+`VPMADDWD`/`SADALP` pair-sum (`<= 32768`) is exact in int32. Only the final
+running total can wrap, and it wraps identically to the reference.
+
+## File layout (mirrors i32)
+
+```
+i8/
+  i8.go              public API (AddSaturate, SubSaturate, ToInt16, ToInt32,
+                     Sum, MinMax, DotProduct) + package doc + dispatch helpers
+                     that live on no specific arch
+  i8_go.go           pure-Go reference kernels (source of truth, compiled on all
+                     arches, used as the fallback)
+  i8_amd64.go        amd64 dispatch: var hasAVX2 = cpu.X86.AVX2, per-op gates,
+                     //go:noescape decls
+  i8_amd64.s         AVX2 kernels
+  i8_arm64.go        arm64 dispatch: var hasNEON, var hasDotProd, per-op gates,
+                     //go:noescape decls
+  i8_arm64.s         NEON kernels (base + SDOT fast path for DotProduct)
+  i8_other.go        //go:build !amd64 && !arm64 -> calls the Go reference
+  i8_test.go         parity + bit-exact + zero-alloc + edge-case tests
+  i8_simd_test.go    SIMD-path-specific assertions (force lengths past thresholds)
+  fuzz_test.go       differential fuzz vs the Go reference
+  benchmark_test.go  benchmarks per op
+  example_test.go    runnable example
+```
+
+## Backends
+
+### amd64 (gate on AVX2, Go fallback below; mirrors i32)
+
+All AVX2 mnemonics are expressible by the Go assembler (no hand-encoded BYTE/WORD
+directives, so `TestNoUncheckedAmd64Encodings` stays clean).
+
+| Op | AVX2 kernel | bytes/iter |
+|----|-------------|------------|
+| AddSaturate | `VPADDSB` (ymm) | 32 |
+| SubSaturate | `VPSUBSB` (ymm) | 32 |
+| ToInt16 | `VPMOVSXBW` (xmm->ymm) | 16 |
+| ToInt32 | `VPMOVSXBD` (xmm->ymm) | 8 |
+| Sum | `VPMOVSXBW` then `VPMADDWD` with an all-ones int16 vector (pair-sum to int32), `VPADDD` accumulate; horizontal-sum tail | 16 |
+| MinMax | `VPMINSB`/`VPMAXSB` running over blocks, horizontal fold | 32 |
+| DotProduct | `VPMOVSXBW` both operands, `VPMADDWD`, `VPADDD` accumulate; horizontal-sum tail | 16 |
+
+Each kernel has a scalar tail for `n mod blocksize`. AVX-512 VNNI (`VPDPBUSD`)
+for DotProduct is a deliberate follow-up, not v1.
+
+### arm64 (gate on NEON; DotProduct gets an SDOT fast path under FEAT_DotProd)
+
+NEON instructions are hand-encoded `WORD $0x...` with the decoded mnemonic in the
+trailing comment, cross-checked by `asmcheck_test.go`. Confirmed encodings
+(verified with `aarch64-linux-gnu-objdump`):
+
+| Mnemonic | Encoding (example operands) | Hex |
+|----------|------------------------------|-----|
+| `SQADD Vd.16B, Vn.16B, Vm.16B` | V2,V0,V1 | `0x4E210C02` |
+| `SQSUB Vd.16B, Vn.16B, Vm.16B` | V2,V0,V1 | `0x4E212C02` |
+| `SXTL Vd.8H, Vn.8B` | V2,V0 | `0x0F08A402` |
+| `SXTL2 Vd.8H, Vn.16B` | V3,V0 | `0x4F08A403` |
+| `SMIN Vd.16B, Vn.16B, Vm.16B` | V0,V0,V2 | `0x4E226C00` |
+| `SMAX Vd.16B, Vn.16B, Vm.16B` | V1,V1,V2 | `0x4E226421` |
+| `SMINV Bd, Vn.16B` | B3,V0 | `0x4E31A803` |
+| `SMAXV Bd, Vn.16B` | B4,V1 | `0x4E30A824` |
+| `SADDLP Vd.8H, Vn.16B` | V5,V0 | `0x4E202805` |
+| `SADALP Vd.4S, Vn.8H` | V4,V2 | `0x4E606844` |
+| `SMULL Vd.8H, Vn.8B, Vm.8B` | V2,V0,V1 | `0x0E21C002` |
+| `SMULL2 Vd.8H, Vn.16B, Vm.16B` | V3,V0,V1 | `0x4E21C003` |
+| `SDOT Vd.4S, Vn.16B, Vm.16B` | V0,V0,V1 | `0x4E819400` |
+
+(`ZIP`/`UZP`-style `ADDV Sd, Vn.4S` for the horizontal fold is likewise hand-
+encoded; exact value confirmed during implementation.)
+
+| Op | base-NEON kernel | SDOT fast path |
+|----|------------------|----------------|
+| AddSaturate | `SQADD .16B` (16/iter) | n/a |
+| SubSaturate | `SQSUB .16B` | n/a |
+| ToInt16 | `SXTL`/`SXTL2 .8H` (16/iter) | n/a |
+| ToInt32 | `SXTL .8H` then widen `.8H->.4S` (8/iter) | n/a |
+| Sum | `SADDLP .16B->.8H` then `SADALP` accumulate `.8H->.4S`; `ADDV` fold | n/a |
+| MinMax | `SMIN`/`SMAX .16B` running; `SMINV`/`SMAXV` fold | n/a |
+| DotProduct | `SMULL`/`SMULL2 .8H` then `SADALP` accumulate `.4S`; `ADDV` fold (16/iter) | `SDOT .4S` accumulate (16/iter); `ADDV` fold |
+
+DotProduct dispatch: `hasDotProd` selects the `SDOT` kernel, else `hasNEON`
+selects the `SMULL`/`SADALP` base kernel, else Go. The base path runs on any
+NEON core (Cortex-A53/A72), the SDOT path on cores with `FEAT_DotProd` (the
+Pi 5's Cortex-A76, our arm64 test host).
+
+## cpu package change
+
+Add `FEAT_DotProd` detection:
+
+- `cpu.Features.DOTPROD bool` field (comment: `FEAT_DotProd - SDOT/UDOT int8 dot
+  product`).
+- `cpu.HasDOTPROD() bool` accessor.
+- `cpu_arm64.go` (non-darwin): `ARM64.DOTPROD = cpu.ARM64.HasASIMDDP`.
+- darwin arm64 path: set from its existing detection source (Apple M1+ has it);
+  match how the file already sets NEON/FP16.
+- `SIMD_DISABLE`: add a `dotprod` token, and have `clearNEON` also clear DOTPROD
+  (it is a NEON extension, so disabling NEON must disable it). `Info()` is left
+  reporting the broad tier; DOTPROD is an op-level fast path, not a tier.
+- amd64 leaves `DOTPROD` false (ARM-only feature), like NEON.
+
+## asmcheck change
+
+`arm64asm` (golang.org/x/arch) cannot decode `SDOT`/`UDOT` (FEAT_DotProd), so a
+raw `SDOT` WORD currently trips the "undecodable WORD that is not FP16 (.8H)"
+hard failure in `asmcheck_test.go`. Extend the sanctioned-undecodable predicate:
+a WORD whose comment names a DotProd mnemonic (`SDOT`/`UDOT`) is deferred to the
+objdump cross-check exactly like `.8H` FP16 directives. `aarch64-linux-gnu-
+objdump -D -b binary -m aarch64 -EL` decodes `SDOT` with no march flag (verified),
+so the existing `DisassembleWords` path needs no change; only the predicate and a
+rename of the `fp16`-specific identifiers/messages to a neutral "deferred to
+objdump" naming. Behavior when objdump is absent stays lenient (accept unchecked);
+CI's `SIMD_REQUIRE_OBJDUMP` enforces it.
+
+## Testing strategy
+
+Per the repo convention, every primitive ships:
+
+1. A pure-Go reference (the source of truth).
+2. Parity tests asserting the active SIMD path is bit-identical to the reference,
+   across lengths that exercise full vector blocks, partial tails, and the
+   sub-threshold (scalar) path. Include boundary values: `-128`, `127`, `0`, and
+   `abs(-128)` overflow cases for saturating add/sub.
+3. A `testing.AllocsPerRun == 0` allocation-free assertion per op.
+4. Differential fuzzing of the SIMD path against the reference (`fuzz_test.go`).
+5. `asmcheck_test.go` cross-checks every new `WORD` encoding (arm64asm directly,
+   or objdump for SDOT).
+
+Test execution:
+
+- amd64: natively on this host (with and without `SIMD_DISABLE=avx2` to exercise
+  the Go fallback).
+- arm64: cross-compile here, run the test binary on `thakala@rpi5.local` (Cortex-
+  A76, `asimddp` present, go1.26.1). Run with `SIMD_DISABLE=dotprod` too, to
+  exercise the base-NEON DotProduct path on the same host.
+
+## Docs
+
+- `doc.go`: add the `i8` package to the subpackage list and the operation
+  summary.
+- `README.md`: add an `i8` section mirroring the `i16`/`i32` tables (operations,
+  per-arch tiers, scope note explaining saturating arithmetic and int32-
+  accumulated reductions, and that quantize/dequantize + movement are planned
+  follow-ups).
+
+## Out of scope (explicit follow-ups)
+
+- `Quantize`/`Dequantize` (`float32 <-> int8` affine with scale + zero-point):
+  needs a dedicated design for symmetric vs asymmetric and per-tensor vs per-
+  channel conventions.
+- AVX-512 VNNI (`VPDPBUSD`) DotProduct fast path (needs AVX512VNNI detection).
+- AVX-512 BW wide paths for the saturating arithmetic and reductions.
+- 8-bit movement (`Interleave2`/`Deinterleave2`), lower impact than the above.
+- SSE2-tier saturating arithmetic (`PADDSB`/`PSUBSB`) for non-AVX2 amd64.

--- a/docs/superpowers/specs/2026-06-13-i8-primitives-design.md
+++ b/docs/superpowers/specs/2026-06-13-i8-primitives-design.md
@@ -61,7 +61,7 @@ running total can wrap, and it wraps identically to the reference.
 
 ## File layout (mirrors i32)
 
-```
+```text
 i8/
   i8.go              public API (AddSaturate, SubSaturate, ToInt16, ToInt32,
                      Sum, MinMax, DotProduct) + package doc + dispatch helpers

--- a/i8/benchmark_test.go
+++ b/i8/benchmark_test.go
@@ -1,0 +1,72 @@
+package i8
+
+import "testing"
+
+const benchN = 4096
+
+func BenchmarkAddSaturate(b *testing.B) {
+	a, c := genI8(benchN, 1), genI8(benchN, 2)
+	dst := make([]int8, benchN)
+	b.SetBytes(benchN)
+	b.ResetTimer()
+	for b.Loop() {
+		AddSaturate(dst, a, c)
+	}
+}
+
+func BenchmarkSubSaturate(b *testing.B) {
+	a, c := genI8(benchN, 1), genI8(benchN, 2)
+	dst := make([]int8, benchN)
+	b.SetBytes(benchN)
+	b.ResetTimer()
+	for b.Loop() {
+		SubSaturate(dst, a, c)
+	}
+}
+
+func BenchmarkToInt16(b *testing.B) {
+	src := genI8(benchN, 1)
+	dst := make([]int16, benchN)
+	b.SetBytes(benchN)
+	b.ResetTimer()
+	for b.Loop() {
+		ToInt16(dst, src)
+	}
+}
+
+func BenchmarkToInt32(b *testing.B) {
+	src := genI8(benchN, 1)
+	dst := make([]int32, benchN)
+	b.SetBytes(benchN)
+	b.ResetTimer()
+	for b.Loop() {
+		ToInt32(dst, src)
+	}
+}
+
+func BenchmarkSum(b *testing.B) {
+	a := genI8(benchN, 1)
+	b.SetBytes(benchN)
+	b.ResetTimer()
+	for b.Loop() {
+		_ = Sum(a)
+	}
+}
+
+func BenchmarkDotProduct(b *testing.B) {
+	a, c := genI8(benchN, 1), genI8(benchN, 2)
+	b.SetBytes(benchN)
+	b.ResetTimer()
+	for b.Loop() {
+		_ = DotProduct(a, c)
+	}
+}
+
+func BenchmarkMinMax(b *testing.B) {
+	a := genI8(benchN, 1)
+	b.SetBytes(benchN)
+	b.ResetTimer()
+	for b.Loop() {
+		_, _ = MinMax(a)
+	}
+}

--- a/i8/example_test.go
+++ b/i8/example_test.go
@@ -1,0 +1,29 @@
+package i8_test
+
+import (
+	"fmt"
+
+	"github.com/tphakala/simd/i8"
+)
+
+func ExampleDotProduct() {
+	a := []int8{1, 2, 3, 4, -5}
+	b := []int8{10, 20, 30, 40, 50}
+	// int32 accumulation: 10 + 40 + 90 + 160 - 250 = 50.
+	fmt.Println(i8.DotProduct(a, b))
+	// Output: 50
+}
+
+func ExampleAddSaturate() {
+	dst := make([]int8, 3)
+	i8.AddSaturate(dst, []int8{100, -100, 1}, []int8{100, -100, 2})
+	// Saturates to the int8 range instead of wrapping.
+	fmt.Println(dst)
+	// Output: [127 -128 3]
+}
+
+func ExampleMinMax() {
+	lo, hi := i8.MinMax([]int8{0, -128, 127, 3, -1})
+	fmt.Println(lo, hi)
+	// Output: -128 127
+}

--- a/i8/fuzz_test.go
+++ b/i8/fuzz_test.go
@@ -1,0 +1,107 @@
+package i8
+
+import "testing"
+
+// Differential fuzz targets for the i8 primitives. Every i8 kernel is bit-exact
+// against its pure-Go reference by construction (saturating arithmetic is
+// deterministic; the int32-accumulated reductions wrap identically regardless of
+// summation order), so each target asserts exact equality. The high-value bug
+// class is tail/remainder handling at arbitrary lengths around the 8/16/32-byte
+// unrolls and the SIMD dispatch thresholds; the seeds bracket those boundaries
+// and the fuzzer widens the length space. Seeds run under plain `go test`;
+// `go test -fuzz=FuzzXxx` explores further.
+
+// i8FromBytes reinterprets raw bytes as int8s (the full -128..127 range,
+// including the saturation and sign-extension extremes).
+func i8FromBytes(raw []byte) []int8 {
+	out := make([]int8, len(raw))
+	for i, b := range raw {
+		out[i] = int8(b)
+	}
+	return out
+}
+
+// lenSeeds seeds raw byte buffers whose lengths cover 0 through ~70, hitting
+// every remainder around the 8/16/32-byte unrolls, plus a couple larger blocks.
+func lenSeeds(f *testing.F) {
+	f.Helper()
+	lens := []int{0, 1, 2, 3, 7, 8, 9, 15, 16, 17, 23, 31, 32, 33, 47, 48, 63, 64, 65, 70, 128, 257}
+	for _, n := range lens {
+		raw := make([]byte, n)
+		for i := range raw {
+			raw[i] = byte(i*37 + 11)
+		}
+		f.Add(raw)
+	}
+}
+
+func FuzzI8Saturate(f *testing.F) {
+	lenSeeds(f)
+	f.Fuzz(func(t *testing.T, raw []byte) {
+		v := i8FromBytes(raw)
+		h := len(v) / 2
+		a, b := v[:h], v[h:2*h]
+		got := make([]int8, h)
+		want := make([]int8, h)
+
+		AddSaturate(got, a, b)
+		addSatGo(want, a, b)
+		assertI8Eq(t, "AddSaturate", h, got, want)
+
+		SubSaturate(got, a, b)
+		subSatGo(want, a, b)
+		assertI8Eq(t, "SubSaturate", h, got, want)
+	})
+}
+
+func FuzzI8Reduce(f *testing.F) {
+	lenSeeds(f)
+	f.Fuzz(func(t *testing.T, raw []byte) {
+		v := i8FromBytes(raw)
+		h := len(v) / 2
+		a, b := v[:h], v[h:2*h]
+
+		if got, want := Sum(v), sumGo(v); got != want {
+			t.Fatalf("Sum: got %d want %d (len=%d)", got, want, len(v))
+		}
+		if got, want := DotProduct(a, b), dotGo(a, b); got != want {
+			t.Fatalf("DotProduct: got %d want %d (len=%d)", got, want, h)
+		}
+	})
+}
+
+func FuzzI8MinMax(f *testing.F) {
+	lenSeeds(f)
+	f.Fuzz(func(t *testing.T, raw []byte) {
+		v := i8FromBytes(raw)
+		if len(v) == 0 {
+			return
+		}
+		gotMin, gotMax := MinMax(v)
+		wantMin, wantMax := minMaxGo(v)
+		if gotMin != wantMin || gotMax != wantMax {
+			t.Fatalf("MinMax got (%d,%d) want (%d,%d) (len=%d)", gotMin, gotMax, wantMin, wantMax, len(v))
+		}
+	})
+}
+
+func FuzzI8Convert(f *testing.F) {
+	lenSeeds(f)
+	f.Fuzz(func(t *testing.T, raw []byte) {
+		v := i8FromBytes(raw)
+		d16 := make([]int16, len(v))
+		ToInt16(d16, v)
+		for i := range v {
+			if d16[i] != int16(v[i]) {
+				t.Fatalf("ToInt16: index %d got %d want %d (len=%d)", i, d16[i], int16(v[i]), len(v))
+			}
+		}
+		d32 := make([]int32, len(v))
+		ToInt32(d32, v)
+		for i := range v {
+			if d32[i] != int32(v[i]) {
+				t.Fatalf("ToInt32: index %d got %d want %d (len=%d)", i, d32[i], int32(v[i]), len(v))
+			}
+		}
+	})
+}

--- a/i8/i8.go
+++ b/i8/i8.go
@@ -1,0 +1,117 @@
+// Package i8 provides SIMD-accelerated operations on int8 slices.
+//
+// int8 is the 8-bit signed integer workhorse of quantized numeric pipelines.
+// Its narrow range (-128..127) makes element-wise arithmetic overflow almost
+// immediately, so this package does not mirror the wrapping arithmetic of the
+// i16/i32 packages one-to-one. Instead it ships the operations that are
+// genuinely high-impact and well-defined at 8-bit width:
+//
+//   - Saturating arithmetic (AddSaturate, SubSaturate): single hardware
+//     instructions (PADDSB/PSUBSB, SQADD/SQSUB) that clamp to [-128, 127]
+//     instead of wrapping, which is what 8-bit arithmetic almost always wants.
+//   - int32-accumulated reductions (Sum, DotProduct): widen to int32 so the
+//     running total has headroom. DotProduct is the inner loop of quantized
+//     matmul/conv; it uses ARM64 SDOT (FEAT_DotProd) where available and AVX2
+//     VPMADDWD otherwise.
+//   - Signed min/max (MinMax).
+//   - Sign-extending widening (ToInt16, ToInt32) to hand off to the wider
+//     integer or float packages.
+//
+// Sum and DotProduct accumulate in int32 with two's-complement wraparound,
+// exactly like their pure-Go references. int32 wrapping addition is associative
+// and commutative modulo 2^32, so the lane-parallel SIMD reductions are
+// bit-identical to the scalar reference regardless of summation order. The
+// intermediate products never overflow their SIMD lane (|int8 * int8| <= 16384),
+// so only the final running total can wrap, and it wraps identically.
+//
+// All functions automatically select the optimal implementation based on
+// runtime CPU feature detection and fall back to a pure-Go implementation on
+// unsupported architectures.
+//
+// Thread Safety: All functions are safe for concurrent use.
+// Memory: All functions are zero-allocation (no heap allocations).
+package i8
+
+// AddSaturate writes dst[i] = clamp(int(a[i]) + int(b[i]), -128, 127) for i in
+// [0, n), n = min(len(dst), len(a), len(b)). The add saturates to the int8
+// range instead of wrapping, so 100 + 100 = 127 and -100 + -100 = -128. Any
+// trailing capacity in dst is left untouched.
+func AddSaturate(dst, a, b []int8) {
+	n := min(len(dst), len(a), len(b))
+	if n == 0 {
+		return
+	}
+	addSatI8(dst[:n], a[:n], b[:n])
+}
+
+// SubSaturate writes dst[i] = clamp(int(a[i]) - int(b[i]), -128, 127) for i in
+// [0, n), n = min(len(dst), len(a), len(b)). The subtract saturates to the int8
+// range instead of wrapping. Any trailing capacity in dst is left untouched.
+func SubSaturate(dst, a, b []int8) {
+	n := min(len(dst), len(a), len(b))
+	if n == 0 {
+		return
+	}
+	subSatI8(dst[:n], a[:n], b[:n])
+}
+
+// ToInt16 sign-extends src into dst: dst[i] = int16(src[i]) for i in [0, n),
+// n = min(len(dst), len(src)). It is exact (int8 fits in int16). Any trailing
+// capacity in dst is left untouched.
+func ToInt16(dst []int16, src []int8) {
+	n := min(len(dst), len(src))
+	if n == 0 {
+		return
+	}
+	toI16(dst[:n], src[:n])
+}
+
+// ToInt32 sign-extends src into dst: dst[i] = int32(src[i]) for i in [0, n),
+// n = min(len(dst), len(src)). It is exact (int8 fits in int32). Any trailing
+// capacity in dst is left untouched.
+func ToInt32(dst []int32, src []int8) {
+	n := min(len(dst), len(src))
+	if n == 0 {
+		return
+	}
+	toI32(dst[:n], src[:n])
+}
+
+// Sum returns the sum of all elements of a, accumulated in int32 with
+// two's-complement wraparound. An empty a returns 0. a is read-only; the call
+// allocates nothing.
+func Sum(a []int8) int32 {
+	if len(a) == 0 {
+		return 0
+	}
+	return sumI8(a)
+}
+
+// DotProduct returns sum_i int32(a[i]) * int32(b[i]) over i in [0, n),
+// n = min(len(a), len(b)), accumulated in int32 with two's-complement
+// wraparound. An empty operand returns 0. a and b are read-only; the call
+// allocates nothing.
+//
+// This is the inner loop of quantized matmul/convolution. On ARM64 with
+// FEAT_DotProd it uses SDOT (16 int8 multiply-accumulates per instruction); on
+// AVX2 it widens with VPMOVSXBW and reduces with VPMADDWD.
+func DotProduct(a, b []int8) int32 {
+	n := min(len(a), len(b))
+	if n == 0 {
+		return 0
+	}
+	return dotI8(a[:n], b[:n])
+}
+
+// MinMax returns the smallest and largest int8 in a:
+//
+//	minVal = min_i a[i],  maxVal = max_i a[i]
+//
+// Both are signed comparisons. An empty a returns (0, 0). a is read-only; the
+// call allocates nothing.
+func MinMax(a []int8) (minVal, maxVal int8) {
+	if len(a) == 0 {
+		return 0, 0
+	}
+	return minMaxI8(a)
+}

--- a/i8/i8_amd64.go
+++ b/i8/i8_amd64.go
@@ -1,0 +1,95 @@
+//go:build amd64
+
+package i8
+
+import "github.com/tphakala/simd/cpu"
+
+// The int8 kernels operate on 256-bit integer lanes (VPADDSB/VPSUBSB/VPMINSB/
+// VPMAXSB/VPMOVSXB*/VPMADDWD), which require AVX2. They gate on AVX2 explicitly
+// and fall back to the pure-Go reference on the (now rare) AVX-less baseline and
+// for slices shorter than one vector block.
+var hasAVX2 = cpu.X86.AVX2
+
+// Per-kernel minimum element counts: one full vector iteration's worth of int8
+// inputs. Shorter slices use the pure-Go reference.
+const (
+	blockSat32   = 32 // VPADDSB/VPSUBSB process 32 bytes per iteration
+	blockMinMax  = 32 // VPMINSB/VPMAXSB process 32 bytes per iteration
+	blockReduce  = 16 // Sum/DotProduct widen 16 bytes per iteration (VPMOVSXBW)
+	blockWiden16 = 16 // ToInt16 widens 16 bytes per iteration (VPMOVSXBW)
+	blockWiden32 = 8  // ToInt32 widens 8 bytes per iteration (VPMOVSXBD)
+)
+
+func addSatI8(dst, a, b []int8) {
+	if hasAVX2 && len(dst) >= blockSat32 {
+		addSatAVX2(dst, a, b)
+		return
+	}
+	addSatGo(dst, a, b)
+}
+
+func subSatI8(dst, a, b []int8) {
+	if hasAVX2 && len(dst) >= blockSat32 {
+		subSatAVX2(dst, a, b)
+		return
+	}
+	subSatGo(dst, a, b)
+}
+
+func toI16(dst []int16, src []int8) {
+	if hasAVX2 && len(src) >= blockWiden16 {
+		toI16AVX2(dst, src)
+		return
+	}
+	toI16Go(dst, src)
+}
+
+func toI32(dst []int32, src []int8) {
+	if hasAVX2 && len(src) >= blockWiden32 {
+		toI32AVX2(dst, src)
+		return
+	}
+	toI32Go(dst, src)
+}
+
+func sumI8(a []int8) int32 {
+	if hasAVX2 && len(a) >= blockReduce {
+		return sumAVX2(a)
+	}
+	return sumGo(a)
+}
+
+func dotI8(a, b []int8) int32 {
+	if hasAVX2 && len(a) >= blockReduce {
+		return dotAVX2(a, b)
+	}
+	return dotGo(a, b)
+}
+
+func minMaxI8(a []int8) (minVal, maxVal int8) {
+	if hasAVX2 && len(a) >= blockMinMax {
+		return minMaxAVX2(a)
+	}
+	return minMaxGo(a)
+}
+
+//go:noescape
+func addSatAVX2(dst, a, b []int8)
+
+//go:noescape
+func subSatAVX2(dst, a, b []int8)
+
+//go:noescape
+func toI16AVX2(dst []int16, src []int8)
+
+//go:noescape
+func toI32AVX2(dst []int32, src []int8)
+
+//go:noescape
+func sumAVX2(a []int8) int32
+
+//go:noescape
+func dotAVX2(a, b []int8) int32
+
+//go:noescape
+func minMaxAVX2(a []int8) (minVal, maxVal int8)

--- a/i8/i8_amd64.s
+++ b/i8/i8_amd64.s
@@ -1,0 +1,371 @@
+//go:build amd64
+
+#include "textflag.h"
+
+// int8 SIMD kernels on AMD64 (AVX2).
+//
+// All kernels gate on AVX2 in i8_amd64.go and run at least one full vector
+// block (the dispatch guards the minimum length), with a scalar tail for the
+// (n mod block) remainder. The Go assembler's 3-operand AVX order is dst-last:
+// VPSUBSB a, b, c is c = b - a, and VPMADDWD a, b, c is c = madd(b, a). No
+// hand-encoded directives are used; every mnemonic is one the Go assembler
+// emits directly, so TestNoUncheckedAmd64Encodings stays clean.
+//
+// Saturating arithmetic (VPADDSB/VPSUBSB) clamps each byte lane to [-128, 127];
+// the scalar tail reproduces that with a widened add/sub and an explicit clamp.
+// The reductions (Sum, DotProduct) widen bytes to int16 with VPMOVSXBW and pair-
+// reduce to int32 with VPMADDWD, accumulating in int32 lanes; since int32
+// wrapping addition is associative, the lane-parallel total matches the scalar
+// reference modulo 2^32. Intermediate products never overflow an int32 lane
+// (|int8 * int8| <= 16384).
+
+// func addSatAVX2(dst, a, b []int8)
+TEXT ·addSatAVX2(SB), NOSPLIT, $0-72
+    MOVQ dst_base+0(FP), DX
+    MOVQ dst_len+8(FP), CX
+    MOVQ a_base+24(FP), SI
+    MOVQ b_base+48(FP), DI
+
+    MOVQ CX, AX
+    SHRQ $5, AX                // AX = n / 32
+    JZ   addsat_remainder
+
+addsat_loop32:
+    VMOVDQU (SI), Y0
+    VMOVDQU (DI), Y1
+    VPADDSB Y1, Y0, Y2         // Y2 = saturating(a + b)
+    VMOVDQU Y2, (DX)
+    ADDQ $32, SI
+    ADDQ $32, DI
+    ADDQ $32, DX
+    DECQ AX
+    JNZ  addsat_loop32
+
+addsat_remainder:
+    ANDQ $31, CX
+    JZ   addsat_done
+
+addsat_scalar:
+    MOVBLSX (SI), AX           // a (sign-extended to int32)
+    MOVBLSX (DI), BX           // b
+    ADDL BX, AX                // a + b in int32 (no overflow: |sum| <= 254)
+    CMPL AX, $127
+    JLE  addsat_chklo
+    MOVL $127, AX
+addsat_chklo:
+    CMPL AX, $-128
+    JGE  addsat_store
+    MOVL $-128, AX
+addsat_store:
+    MOVB AX, (DX)
+    INCQ SI
+    INCQ DI
+    INCQ DX
+    DECQ CX
+    JNZ  addsat_scalar
+
+addsat_done:
+    VZEROUPPER
+    RET
+
+// func subSatAVX2(dst, a, b []int8)
+TEXT ·subSatAVX2(SB), NOSPLIT, $0-72
+    MOVQ dst_base+0(FP), DX
+    MOVQ dst_len+8(FP), CX
+    MOVQ a_base+24(FP), SI
+    MOVQ b_base+48(FP), DI
+
+    MOVQ CX, AX
+    SHRQ $5, AX
+    JZ   subsat_remainder
+
+subsat_loop32:
+    VMOVDQU (SI), Y0
+    VMOVDQU (DI), Y1
+    VPSUBSB Y1, Y0, Y2         // Y2 = saturating(a - b)
+    VMOVDQU Y2, (DX)
+    ADDQ $32, SI
+    ADDQ $32, DI
+    ADDQ $32, DX
+    DECQ AX
+    JNZ  subsat_loop32
+
+subsat_remainder:
+    ANDQ $31, CX
+    JZ   subsat_done
+
+subsat_scalar:
+    MOVBLSX (SI), AX
+    MOVBLSX (DI), BX
+    SUBL BX, AX                // a - b in int32 (|diff| <= 255)
+    CMPL AX, $127
+    JLE  subsat_chklo
+    MOVL $127, AX
+subsat_chklo:
+    CMPL AX, $-128
+    JGE  subsat_store
+    MOVL $-128, AX
+subsat_store:
+    MOVB AX, (DX)
+    INCQ SI
+    INCQ DI
+    INCQ DX
+    DECQ CX
+    JNZ  subsat_scalar
+
+subsat_done:
+    VZEROUPPER
+    RET
+
+// func toI16AVX2(dst []int16, src []int8)
+// Sign-extends 16 int8 -> 16 int16 (256-bit) per iteration with VPMOVSXBW.
+TEXT ·toI16AVX2(SB), NOSPLIT, $0-48
+    MOVQ dst_base+0(FP), DX
+    MOVQ src_base+24(FP), SI
+    MOVQ src_len+32(FP), CX
+
+    MOVQ CX, AX
+    SHRQ $4, AX                // AX = n / 16
+    JZ   toi16_remainder
+
+toi16_loop16:
+    VPMOVSXBW (SI), Y0         // 16 bytes -> 16 int16
+    VMOVDQU Y0, (DX)
+    ADDQ $16, SI
+    ADDQ $32, DX
+    DECQ AX
+    JNZ  toi16_loop16
+
+toi16_remainder:
+    ANDQ $15, CX
+    JZ   toi16_done
+
+toi16_scalar:
+    MOVBLSX (SI), AX
+    MOVW AX, (DX)
+    INCQ SI
+    ADDQ $2, DX
+    DECQ CX
+    JNZ  toi16_scalar
+
+toi16_done:
+    VZEROUPPER
+    RET
+
+// func toI32AVX2(dst []int32, src []int8)
+// Sign-extends 8 int8 -> 8 int32 (256-bit) per iteration with VPMOVSXBD.
+TEXT ·toI32AVX2(SB), NOSPLIT, $0-48
+    MOVQ dst_base+0(FP), DX
+    MOVQ src_base+24(FP), SI
+    MOVQ src_len+32(FP), CX
+
+    MOVQ CX, AX
+    SHRQ $3, AX                // AX = n / 8
+    JZ   toi32_remainder
+
+toi32_loop8:
+    VPMOVSXBD (SI), Y0         // 8 bytes -> 8 int32
+    VMOVDQU Y0, (DX)
+    ADDQ $8, SI
+    ADDQ $32, DX
+    DECQ AX
+    JNZ  toi32_loop8
+
+toi32_remainder:
+    ANDQ $7, CX
+    JZ   toi32_done
+
+toi32_scalar:
+    MOVBLSX (SI), AX
+    MOVL AX, (DX)
+    INCQ SI
+    ADDQ $4, DX
+    DECQ CX
+    JNZ  toi32_scalar
+
+toi32_done:
+    VZEROUPPER
+    RET
+
+// func sumAVX2(a []int8) int32
+// Widens 16 bytes/iter to int16 (VPMOVSXBW) and pair-reduces to int32 with
+// VPMADDWD against an all-ones int16 vector, accumulating in Y2; a horizontal
+// add then folds the 8 int32 lanes and a scalar tail adds the remainder.
+TEXT ·sumAVX2(SB), NOSPLIT, $0-28
+    MOVQ a_base+0(FP), SI
+    MOVQ a_len+8(FP), CX
+
+    VPXOR Y2, Y2, Y2           // int32 accumulator = 0
+    VPCMPEQW Y4, Y4, Y4        // all ones (each int16 lane = -1)
+    VPXOR Y5, Y5, Y5
+    VPSUBW Y4, Y5, Y3          // Y3 = 0 - (-1) = +1 per int16 lane
+
+    MOVQ CX, AX
+    SHRQ $4, AX                // AX = n / 16
+    JZ   sum_reduce
+
+sum_loop16:
+    VPMOVSXBW (SI), Y0         // 16 int16
+    VPMADDWD Y3, Y0, Y1        // Y1 = pairwise (x*1 + x*1) -> 8 int32
+    VPADDD Y1, Y2, Y2          // accumulate
+    ADDQ $16, SI
+    DECQ AX
+    JNZ  sum_loop16
+
+sum_reduce:
+    VEXTRACTI128 $1, Y2, X3
+    VPADDD X3, X2, X2          // fold 8 -> 4 int32
+    VPSHUFD $0x4E, X2, X3      // swap 64-bit halves
+    VPADDD X3, X2, X2
+    VPSHUFD $0xB1, X2, X3      // swap 32-bit within pairs
+    VPADDD X3, X2, X2
+    MOVQ X2, AX                // low int32 = vector total (in EAX)
+
+    ANDQ $15, CX
+    JZ   sum_done
+
+sum_scalar:
+    MOVBLSX (SI), BX
+    ADDL BX, AX
+    INCQ SI
+    DECQ CX
+    JNZ  sum_scalar
+
+sum_done:
+    MOVL AX, ret+24(FP)
+    VZEROUPPER
+    RET
+
+// func dotAVX2(a, b []int8) int32
+// Widens 16 bytes/iter of each operand to int16 (VPMOVSXBW) and reduces the
+// products to int32 with VPMADDWD, accumulating in Y2; a horizontal add folds
+// the lanes and a scalar tail adds the remaining products.
+TEXT ·dotAVX2(SB), NOSPLIT, $0-52
+    MOVQ a_base+0(FP), SI
+    MOVQ a_len+8(FP), CX
+    MOVQ b_base+24(FP), DI
+
+    VPXOR Y2, Y2, Y2           // int32 accumulator = 0
+
+    MOVQ CX, AX
+    SHRQ $4, AX                // AX = n / 16
+    JZ   dot_reduce
+
+dot_loop16:
+    VPMOVSXBW (SI), Y0         // a -> 16 int16
+    VPMOVSXBW (DI), Y1         // b -> 16 int16
+    VPMADDWD Y1, Y0, Y4        // Y4 = pairwise (a*b) sums -> 8 int32
+    VPADDD Y4, Y2, Y2          // accumulate
+    ADDQ $16, SI
+    ADDQ $16, DI
+    DECQ AX
+    JNZ  dot_loop16
+
+dot_reduce:
+    VEXTRACTI128 $1, Y2, X3
+    VPADDD X3, X2, X2
+    VPSHUFD $0x4E, X2, X3
+    VPADDD X3, X2, X2
+    VPSHUFD $0xB1, X2, X3
+    VPADDD X3, X2, X2
+    MOVQ X2, AX                // EAX = vector total
+
+    ANDQ $15, CX
+    JZ   dot_done
+
+dot_scalar:
+    MOVBLSX (SI), BX
+    MOVBLSX (DI), R8
+    IMULL R8, BX               // a*b (signed, fits int32)
+    ADDL BX, AX
+    INCQ SI
+    INCQ DI
+    DECQ CX
+    JNZ  dot_scalar
+
+dot_done:
+    MOVL AX, ret+48(FP)
+    VZEROUPPER
+    RET
+
+// func minMaxAVX2(a []int8) (minVal, maxVal int8)
+// Signed byte min and max in one pass: VPMINSB/VPMAXSB fold 32-byte blocks into
+// running accumulators, a per-lane cascade reduces a 128-bit lane to a single
+// byte, and a scalar tail folds the (n mod 32) remainder. The dispatch gates
+// n >= 32, so at least one full block exists.
+TEXT ·minMaxAVX2(SB), NOSPLIT, $0-26
+    MOVQ a_base+0(FP), SI
+    MOVQ a_len+8(FP), CX
+
+    VMOVDQU (SI), Y0           // min acc = block 0
+    VMOVDQU (SI), Y1           // max acc = block 0
+    MOVQ CX, AX
+    SHRQ $5, AX                // AX = full 32-byte blocks (>=1)
+    DECQ AX                    // blocks remaining after block 0
+    JZ   mm_reduce
+    LEAQ 32(SI), DI            // working ptr at block 1
+
+mm_loop:
+    VMOVDQU (DI), Y2
+    VPMINSB Y2, Y0, Y0
+    VPMAXSB Y2, Y1, Y1
+    ADDQ $32, DI
+    DECQ AX
+    JNZ  mm_loop
+
+mm_reduce:
+    // Fold the 256-bit min accumulator to one byte.
+    VEXTRACTI128 $1, Y0, X3
+    VPMINSB X3, X0, X0         // 16 bytes
+    VPSRLDQ $8, X0, X3
+    VPMINSB X3, X0, X0         // 8 bytes
+    VPSRLDQ $4, X0, X3
+    VPMINSB X3, X0, X0         // 4 bytes
+    VPSRLDQ $2, X0, X3
+    VPMINSB X3, X0, X0         // 2 bytes
+    VPSRLDQ $1, X0, X3
+    VPMINSB X3, X0, X0         // 1 byte
+    MOVD X0, AX                // AL = running min
+
+    // Fold the 256-bit max accumulator to one byte.
+    VEXTRACTI128 $1, Y1, X3
+    VPMAXSB X3, X1, X1
+    VPSRLDQ $8, X1, X3
+    VPMAXSB X3, X1, X1
+    VPSRLDQ $4, X1, X3
+    VPMAXSB X3, X1, X1
+    VPSRLDQ $2, X1, X3
+    VPMAXSB X3, X1, X1
+    VPSRLDQ $1, X1, X3
+    VPMAXSB X3, X1, X1
+    MOVD X1, DX                // DL = running max
+
+    // scalar tail: (n mod 32) residuals at &a[fullBlocks*32]
+    MOVQ CX, BX
+    ANDQ $31, BX
+    JZ   mm_done
+    MOVQ CX, R9
+    ANDQ $-32, R9              // fullBlocks*32 bytes
+    ADDQ SI, R9               // tail ptr
+
+mm_tail:
+    MOVBLSX (R9), R10          // r (sign-extended)
+    MOVBLSX AX, R11            // current min (sign-extend AL)
+    CMPL R10, R11
+    JGE  mm_tail_max
+    MOVB R10, AX              // r < min -> new min (low byte)
+mm_tail_max:
+    MOVBLSX DX, R11            // current max (sign-extend DL)
+    CMPL R10, R11
+    JLE  mm_tail_next
+    MOVB R10, DX              // r > max -> new max
+mm_tail_next:
+    INCQ R9
+    DECQ BX
+    JNZ  mm_tail
+
+mm_done:
+    MOVB AX, minVal+24(FP)
+    MOVB DX, maxVal+25(FP)
+    VZEROUPPER
+    RET

--- a/i8/i8_amd64.s
+++ b/i8/i8_amd64.s
@@ -275,8 +275,8 @@ dot_reduce:
 
 dot_scalar:
     MOVBLSX (SI), BX
-    MOVBLSX (DI), R8
-    IMULL R8, BX               // a*b (signed, fits int32)
+    MOVBLSX (DI), DX
+    IMULL DX, BX               // a*b (signed, fits int32)
     ADDL BX, AX
     INCQ SI
     INCQ DI
@@ -340,27 +340,28 @@ mm_reduce:
     VPMAXSB X3, X1, X1
     MOVD X1, DX                // DL = running max
 
-    // scalar tail: (n mod 32) residuals at &a[fullBlocks*32]
+    // scalar tail: (n mod 32) residuals at &a[fullBlocks*32]. Legacy GPRs only:
+    // DI = tail ptr (SI free after), SI = loaded byte, CX = sign-extend temp.
     MOVQ CX, BX
     ANDQ $31, BX
     JZ   mm_done
-    MOVQ CX, R9
-    ANDQ $-32, R9              // fullBlocks*32 bytes
-    ADDQ SI, R9               // tail ptr
+    MOVQ CX, DI
+    ANDQ $-32, DI              // fullBlocks*32 bytes
+    ADDQ SI, DI               // tail ptr
 
 mm_tail:
-    MOVBLSX (R9), R10          // r (sign-extended)
-    MOVBLSX AX, R11            // current min (sign-extend AL)
-    CMPL R10, R11
+    MOVBLSX (DI), SI           // r (sign-extended)
+    MOVBLSX AX, CX             // current min (sign-extend AL)
+    CMPL SI, CX
     JGE  mm_tail_max
-    MOVB R10, AX              // r < min -> new min (low byte)
+    MOVB SI, AX               // r < min -> new min (low byte)
 mm_tail_max:
-    MOVBLSX DX, R11            // current max (sign-extend DL)
-    CMPL R10, R11
+    MOVBLSX DX, CX             // current max (sign-extend DL)
+    CMPL SI, CX
     JLE  mm_tail_next
-    MOVB R10, DX              // r > max -> new max
+    MOVB SI, DX               // r > max -> new max
 mm_tail_next:
-    INCQ R9
+    INCQ DI
     DECQ BX
     JNZ  mm_tail
 

--- a/i8/i8_arm64.go
+++ b/i8/i8_arm64.go
@@ -1,0 +1,98 @@
+//go:build arm64
+
+package i8
+
+import "github.com/tphakala/simd/cpu"
+
+// NEON processes 16 int8 (one .16B register) per iteration; ToInt32 widens 8.
+const (
+	minNEON16 = 16
+	minNEON8  = 8
+)
+
+var hasNEON = cpu.ARM64.NEON
+
+// hasDotProd selects the SDOT DotProduct kernel. FEAT_DotProd is a NEON
+// extension, so it implies NEON, but require both explicitly to be safe.
+var hasDotProd = cpu.ARM64.NEON && cpu.ARM64.DOTPROD
+
+func addSatI8(dst, a, b []int8) {
+	if hasNEON && len(dst) >= minNEON16 {
+		addSatNEON(dst, a, b)
+		return
+	}
+	addSatGo(dst, a, b)
+}
+
+func subSatI8(dst, a, b []int8) {
+	if hasNEON && len(dst) >= minNEON16 {
+		subSatNEON(dst, a, b)
+		return
+	}
+	subSatGo(dst, a, b)
+}
+
+func toI16(dst []int16, src []int8) {
+	if hasNEON && len(src) >= minNEON16 {
+		toI16NEON(dst, src)
+		return
+	}
+	toI16Go(dst, src)
+}
+
+func toI32(dst []int32, src []int8) {
+	if hasNEON && len(src) >= minNEON8 {
+		toI32NEON(dst, src)
+		return
+	}
+	toI32Go(dst, src)
+}
+
+func sumI8(a []int8) int32 {
+	if hasNEON && len(a) >= minNEON16 {
+		return sumNEON(a)
+	}
+	return sumGo(a)
+}
+
+func dotI8(a, b []int8) int32 {
+	switch {
+	case hasDotProd && len(a) >= minNEON16:
+		return dotSDOT(a, b)
+	case hasNEON && len(a) >= minNEON16:
+		return dotNEON(a, b)
+	default:
+		return dotGo(a, b)
+	}
+}
+
+func minMaxI8(a []int8) (minVal, maxVal int8) {
+	if hasNEON && len(a) >= minNEON16 {
+		return minMaxNEON(a)
+	}
+	return minMaxGo(a)
+}
+
+//go:noescape
+func addSatNEON(dst, a, b []int8)
+
+//go:noescape
+func subSatNEON(dst, a, b []int8)
+
+//go:noescape
+func toI16NEON(dst []int16, src []int8)
+
+//go:noescape
+func toI32NEON(dst []int32, src []int8)
+
+//go:noescape
+func sumNEON(a []int8) int32
+
+//go:noescape
+func dotNEON(a, b []int8) int32
+
+//go:noescape
+func dotSDOT(a, b []int8) int32
+
+//go:noescape
+func minMaxNEON(a []int8) (minVal, maxVal int8)

--- a/i8/i8_arm64.s
+++ b/i8/i8_arm64.s
@@ -1,0 +1,341 @@
+//go:build arm64
+
+#include "textflag.h"
+
+// int8 SIMD kernels on ARM64 (NEON / ASIMD), with an SDOT (FEAT_DotProd) fast
+// path for DotProduct.
+//
+// NEON instructions without a Go assembler mnemonic are hand-encoded as WORD
+// with the decoded GNU form in the trailing comment; asmcheck_test.go
+// cross-checks every WORD (arm64asm directly, or aarch64 objdump for SDOT, which
+// arm64asm cannot decode). All encodings were verified with aarch64-linux-gnu-as
+// + objdump. Scratch lives in R0-R10 and V0-V5; R28 (g), R18, R27, R16/R17, and
+// the frame/link registers are left untouched (see CLAUDE.md).
+//
+// Saturating arithmetic (SQADD/SQSUB) clamps each byte lane to [-128, 127]; the
+// scalar tail reproduces that with a widened add/sub and a CSEL clamp. The
+// reductions widen to int16/int32 and accumulate in int32 lanes; int32 wrapping
+// addition is associative, so the lane-parallel total matches the scalar
+// reference modulo 2^32, and the int8 products never overflow their lane.
+
+// func addSatNEON(dst, a, b []int8)
+TEXT ·addSatNEON(SB), NOSPLIT, $0-72
+    MOVD dst_base+0(FP), R0
+    MOVD dst_len+8(FP), R3
+    MOVD a_base+24(FP), R1
+    MOVD b_base+48(FP), R2
+
+    LSR  $4, R3, R4               // R4 = n / 16
+    CBZ  R4, addsat_remainder
+
+addsat_loop16:
+    VLD1.P 16(R1), [V0.B16]
+    VLD1.P 16(R2), [V1.B16]
+    WORD $0x4E210C02              // SQADD V2.16B, V0.16B, V1.16B
+    VST1.P [V2.B16], 16(R0)
+    SUB  $1, R4
+    CBNZ R4, addsat_loop16
+
+addsat_remainder:
+    AND  $15, R3
+    CBZ  R3, addsat_done
+
+addsat_scalar:
+    MOVB (R1), R5                 // a (sign-extended)
+    MOVB (R2), R6                 // b
+    ADD  R6, R5, R5               // a + b (exact in 64-bit)
+    MOVD $127, R7
+    CMP  R7, R5
+    CSEL GT, R7, R5, R5           // clamp high
+    MOVD $-128, R7
+    CMP  R7, R5
+    CSEL LT, R7, R5, R5           // clamp low
+    MOVB R5, (R0)
+    ADD  $1, R1
+    ADD  $1, R2
+    ADD  $1, R0
+    SUB  $1, R3
+    CBNZ R3, addsat_scalar
+
+addsat_done:
+    RET
+
+// func subSatNEON(dst, a, b []int8)
+TEXT ·subSatNEON(SB), NOSPLIT, $0-72
+    MOVD dst_base+0(FP), R0
+    MOVD dst_len+8(FP), R3
+    MOVD a_base+24(FP), R1
+    MOVD b_base+48(FP), R2
+
+    LSR  $4, R3, R4
+    CBZ  R4, subsat_remainder
+
+subsat_loop16:
+    VLD1.P 16(R1), [V0.B16]
+    VLD1.P 16(R2), [V1.B16]
+    WORD $0x4E212C02              // SQSUB V2.16B, V0.16B, V1.16B
+    VST1.P [V2.B16], 16(R0)
+    SUB  $1, R4
+    CBNZ R4, subsat_loop16
+
+subsat_remainder:
+    AND  $15, R3
+    CBZ  R3, subsat_done
+
+subsat_scalar:
+    MOVB (R1), R5
+    MOVB (R2), R6
+    SUB  R6, R5, R5               // a - b
+    MOVD $127, R7
+    CMP  R7, R5
+    CSEL GT, R7, R5, R5
+    MOVD $-128, R7
+    CMP  R7, R5
+    CSEL LT, R7, R5, R5
+    MOVB R5, (R0)
+    ADD  $1, R1
+    ADD  $1, R2
+    ADD  $1, R0
+    SUB  $1, R3
+    CBNZ R3, subsat_scalar
+
+subsat_done:
+    RET
+
+// func toI16NEON(dst []int16, src []int8)
+// Sign-extends 16 int8 -> 16 int16 per iteration (SXTL low half, SXTL2 high half).
+TEXT ·toI16NEON(SB), NOSPLIT, $0-48
+    MOVD dst_base+0(FP), R0
+    MOVD src_base+24(FP), R1
+    MOVD src_len+32(FP), R3
+
+    LSR  $4, R3, R4               // R4 = n / 16
+    CBZ  R4, toi16_remainder
+
+toi16_loop16:
+    VLD1.P 16(R1), [V0.B16]
+    WORD $0x0F08A401             // SXTL  V1.8H, V0.8B   (low 8 -> int16)
+    WORD $0x4F08A402             // SXTL2 V2.8H, V0.16B  (high 8 -> int16)
+    VST1.P [V1.H8], 16(R0)
+    VST1.P [V2.H8], 16(R0)
+    SUB  $1, R4
+    CBNZ R4, toi16_loop16
+
+toi16_remainder:
+    AND  $15, R3
+    CBZ  R3, toi16_done
+
+toi16_scalar:
+    MOVB (R1), R5
+    MOVH R5, (R0)
+    ADD  $1, R1
+    ADD  $2, R0
+    SUB  $1, R3
+    CBNZ R3, toi16_scalar
+
+toi16_done:
+    RET
+
+// func toI32NEON(dst []int32, src []int8)
+// Sign-extends 8 int8 -> 8 int32 per iteration: SXTL to int16, then SXTL/SXTL2
+// to int32 for the low and high halves.
+TEXT ·toI32NEON(SB), NOSPLIT, $0-48
+    MOVD dst_base+0(FP), R0
+    MOVD src_base+24(FP), R1
+    MOVD src_len+32(FP), R3
+
+    LSR  $3, R3, R4               // R4 = n / 8
+    CBZ  R4, toi32_remainder
+
+toi32_loop8:
+    VLD1.P 8(R1), [V0.B8]
+    WORD $0x0F08A401             // SXTL  V1.8H, V0.8B   (8 int8 -> 8 int16)
+    WORD $0x0F10A422             // SXTL  V2.4S, V1.4H   (low 4 -> int32)
+    WORD $0x4F10A423             // SXTL2 V3.4S, V1.8H   (high 4 -> int32)
+    VST1.P [V2.S4], 16(R0)
+    VST1.P [V3.S4], 16(R0)
+    SUB  $1, R4
+    CBNZ R4, toi32_loop8
+
+toi32_remainder:
+    AND  $7, R3
+    CBZ  R3, toi32_done
+
+toi32_scalar:
+    MOVB (R1), R5
+    MOVW R5, (R0)
+    ADD  $1, R1
+    ADD  $4, R0
+    SUB  $1, R3
+    CBNZ R3, toi32_scalar
+
+toi32_done:
+    RET
+
+// func sumNEON(a []int8) int32
+// Pairwise widen-accumulate: SADDLP folds 16 int8 to 8 int16, SADALP accumulates
+// those into a 4-lane int32 accumulator; ADDV folds the lanes and a scalar tail
+// adds the (n mod 16) remainder.
+TEXT ·sumNEON(SB), NOSPLIT, $0-28
+    MOVD a_base+0(FP), R1
+    MOVD a_len+8(FP), R3
+
+    VEOR V2.B16, V2.B16, V2.B16   // int32 accumulator = 0
+    LSR  $4, R3, R4               // R4 = n / 16
+    CBZ  R4, sum_reduce
+
+sum_loop16:
+    VLD1.P 16(R1), [V0.B16]
+    WORD $0x4E202801             // SADDLP V1.8H, V0.16B
+    WORD $0x4E606822             // SADALP V2.4S, V1.8H
+    SUB  $1, R4
+    CBNZ R4, sum_loop16
+
+sum_reduce:
+    WORD $0x4EB1B843             // ADDV S3, V2.4S
+    FMOVS F3, R5                  // R5 = vector total (low 32)
+
+    AND  $15, R3
+    CBZ  R3, sum_done
+
+sum_scalar:
+    MOVB.P 1(R1), R6
+    ADDW R6, R5, R5               // 32-bit wrapping add
+    SUB  $1, R3
+    CBNZ R3, sum_scalar
+
+sum_done:
+    MOVW R5, ret+24(FP)
+    RET
+
+// func dotNEON(a, b []int8) int32
+// Base-NEON dot product: SMULL/SMULL2 multiply 8-bit lanes into int16 products,
+// SADALP pairwise-accumulates them into a 4-lane int32 accumulator; ADDV folds
+// the lanes and a scalar tail adds the remaining products.
+TEXT ·dotNEON(SB), NOSPLIT, $0-52
+    MOVD a_base+0(FP), R1
+    MOVD a_len+8(FP), R3
+    MOVD b_base+24(FP), R2
+
+    VEOR V4.B16, V4.B16, V4.B16   // int32 accumulator = 0
+    LSR  $4, R3, R4
+    CBZ  R4, dotn_reduce
+
+dotn_loop16:
+    VLD1.P 16(R1), [V0.B16]
+    VLD1.P 16(R2), [V1.B16]
+    WORD $0x0E21C002             // SMULL  V2.8H, V0.8B,  V1.8B
+    WORD $0x4E21C003             // SMULL2 V3.8H, V0.16B, V1.16B
+    WORD $0x4E606844             // SADALP V4.4S, V2.8H
+    WORD $0x4E606864             // SADALP V4.4S, V3.8H
+    SUB  $1, R4
+    CBNZ R4, dotn_loop16
+
+dotn_reduce:
+    WORD $0x4EB1B885             // ADDV S5, V4.4S
+    FMOVS F5, R5
+
+    AND  $15, R3
+    CBZ  R3, dotn_done
+
+dotn_scalar:
+    MOVB.P 1(R1), R6
+    MOVB.P 1(R2), R7
+    MUL  R7, R6, R6               // signed product (low 32 valid)
+    ADDW R6, R5, R5
+    SUB  $1, R3
+    CBNZ R3, dotn_scalar
+
+dotn_done:
+    MOVW R5, ret+48(FP)
+    RET
+
+// func dotSDOT(a, b []int8) int32
+// FEAT_DotProd fast path: SDOT accumulates 16 int8 multiply-adds into a 4-lane
+// int32 accumulator per iteration; ADDV folds the lanes and a scalar tail adds
+// the remainder. arm64asm cannot decode SDOT, so asmcheck cross-checks it via
+// objdump.
+TEXT ·dotSDOT(SB), NOSPLIT, $0-52
+    MOVD a_base+0(FP), R1
+    MOVD a_len+8(FP), R3
+    MOVD b_base+24(FP), R2
+
+    VEOR V2.B16, V2.B16, V2.B16   // int32 accumulator = 0
+    LSR  $4, R3, R4
+    CBZ  R4, dots_reduce
+
+dots_loop16:
+    VLD1.P 16(R1), [V0.B16]
+    VLD1.P 16(R2), [V1.B16]
+    WORD $0x4E819402             // SDOT V2.4S, V0.16B, V1.16B
+    SUB  $1, R4
+    CBNZ R4, dots_loop16
+
+dots_reduce:
+    WORD $0x4EB1B843             // ADDV S3, V2.4S
+    FMOVS F3, R5
+
+    AND  $15, R3
+    CBZ  R3, dots_done
+
+dots_scalar:
+    MOVB.P 1(R1), R6
+    MOVB.P 1(R2), R7
+    MUL  R7, R6, R6
+    ADDW R6, R5, R5
+    SUB  $1, R3
+    CBNZ R3, dots_scalar
+
+dots_done:
+    MOVW R5, ret+48(FP)
+    RET
+
+// func minMaxNEON(a []int8) (minVal, maxVal int8)
+// Signed byte min and max in one pass: SMIN/SMAX fold 16-byte blocks into running
+// accumulators, SMINV/SMAXV reduce each across its 16 lanes to a byte, and a
+// scalar tail folds the (n mod 16) remainder. The dispatch gates n >= 16, so at
+// least one full block exists.
+TEXT ·minMaxNEON(SB), NOSPLIT, $0-26
+    MOVD a_base+0(FP), R2
+    MOVD a_len+8(FP), R3
+
+    LSR  $4, R3, R4               // R4 = full 16-byte blocks (>=1)
+    VLD1 (R2), [V0.B16]           // min acc = block 0 (no advance)
+    VLD1.P 16(R2), [V1.B16]       // max acc = block 0 (advance to block 1)
+    SUB  $1, R4
+    CBZ  R4, mm_reduce
+
+mm_loop:
+    VLD1.P 16(R2), [V2.B16]
+    WORD $0x4E226C00             // SMIN V0.16B, V0.16B, V2.16B
+    WORD $0x4E226421             // SMAX V1.16B, V1.16B, V2.16B
+    SUB  $1, R4
+    CBNZ R4, mm_loop
+
+mm_reduce:
+    WORD $0x4E31A803             // SMINV B3, V0.16B
+    WORD $0x4E30A824             // SMAXV B4, V1.16B
+    FMOVS F3, R5                  // min byte (zero-extended)
+    FMOVS F4, R6                  // max byte
+    LSLW $24, R5, R5
+    ASRW $24, R5, R5              // sign-extend low byte -> int32 min
+    LSLW $24, R6, R6
+    ASRW $24, R6, R6              // sign-extend low byte -> int32 max
+
+    AND  $15, R3, R4              // tail count
+    CBZ  R4, mm_done
+    // R2 already points at &a[fullBlocks*16] after the loop.
+
+mm_tail:
+    MOVB.P 1(R2), R7              // r (sign-extended)
+    CMPW R5, R7
+    CSEL LT, R7, R5, R5           // R5 = min(r, R5)
+    CMPW R6, R7
+    CSEL GT, R7, R6, R6           // R6 = max(r, R6)
+    SUB  $1, R4
+    CBNZ R4, mm_tail
+
+mm_done:
+    MOVB R5, minVal+24(FP)
+    MOVB R6, maxVal+25(FP)
+    RET

--- a/i8/i8_arm64.s
+++ b/i8/i8_arm64.s
@@ -39,17 +39,17 @@ addsat_loop16:
 addsat_remainder:
     AND  $15, R3
     CBZ  R3, addsat_done
+    MOVD $127, R8                 // clamp constants, hoisted out of the loop
+    MOVD $-128, R9
 
 addsat_scalar:
     MOVB (R1), R5                 // a (sign-extended)
     MOVB (R2), R6                 // b
     ADD  R6, R5, R5               // a + b (exact in 64-bit)
-    MOVD $127, R7
-    CMP  R7, R5
-    CSEL GT, R7, R5, R5           // clamp high
-    MOVD $-128, R7
-    CMP  R7, R5
-    CSEL LT, R7, R5, R5           // clamp low
+    CMP  R8, R5
+    CSEL GT, R8, R5, R5           // clamp high
+    CMP  R9, R5
+    CSEL LT, R9, R5, R5           // clamp low
     MOVB R5, (R0)
     ADD  $1, R1
     ADD  $1, R2
@@ -81,17 +81,17 @@ subsat_loop16:
 subsat_remainder:
     AND  $15, R3
     CBZ  R3, subsat_done
+    MOVD $127, R8                 // clamp constants, hoisted out of the loop
+    MOVD $-128, R9
 
 subsat_scalar:
     MOVB (R1), R5
     MOVB (R2), R6
     SUB  R6, R5, R5               // a - b
-    MOVD $127, R7
-    CMP  R7, R5
-    CSEL GT, R7, R5, R5
-    MOVD $-128, R7
-    CMP  R7, R5
-    CSEL LT, R7, R5, R5
+    CMP  R8, R5
+    CSEL GT, R8, R5, R5           // clamp high
+    CMP  R9, R5
+    CSEL LT, R9, R5, R5           // clamp low
     MOVB R5, (R0)
     ADD  $1, R1
     ADD  $1, R2

--- a/i8/i8_go.go
+++ b/i8/i8_go.go
@@ -1,0 +1,81 @@
+package i8
+
+import "math"
+
+// Pure-Go reference implementations.
+//
+// These are the source of truth for behavior: every SIMD kernel is validated
+// for bit-exact parity against the functions here. They are compiled on every
+// architecture and used directly as the fallback when no SIMD path applies.
+
+// clampI8 saturates a widened sum/difference to the signed 8-bit range.
+func clampI8(v int) int8 {
+	switch {
+	case v > math.MaxInt8:
+		return math.MaxInt8
+	case v < math.MinInt8:
+		return math.MinInt8
+	default:
+		return int8(v)
+	}
+}
+
+func addSatGo(dst, a, b []int8) {
+	for i := range dst {
+		dst[i] = clampI8(int(a[i]) + int(b[i]))
+	}
+}
+
+func subSatGo(dst, a, b []int8) {
+	for i := range dst {
+		dst[i] = clampI8(int(a[i]) - int(b[i]))
+	}
+}
+
+func toI16Go(dst []int16, src []int8) {
+	for i := range dst {
+		dst[i] = int16(src[i])
+	}
+}
+
+func toI32Go(dst []int32, src []int8) {
+	for i := range dst {
+		dst[i] = int32(src[i])
+	}
+}
+
+// sumGo accumulates a into int32 with two's-complement wraparound. It is the
+// bit-exact source of truth the SIMD Sum kernels are validated against.
+func sumGo(a []int8) int32 {
+	var s int32
+	for _, v := range a {
+		s += int32(v)
+	}
+	return s
+}
+
+// dotGo computes the int32-accumulated dot product of a and b (equal length,
+// guaranteed by the public DotProduct clamp) with two's-complement wraparound.
+func dotGo(a, b []int8) int32 {
+	var s int32
+	for i := range a {
+		s += int32(a[i]) * int32(b[i])
+	}
+	return s
+}
+
+// minMaxGo returns the smallest and largest int8 in a via a single signed scan.
+// a must be non-empty (the public MinMax guards the empty case); it is the
+// bit-exact source of truth the SIMD MinMax kernels are validated against.
+func minMaxGo(a []int8) (minVal, maxVal int8) {
+	lo, hi := a[0], a[0]
+	for _, v := range a[1:] {
+		if v < lo {
+			lo = v
+		}
+		if v > hi {
+			hi = v
+		}
+	}
+	return lo, hi
+}

--- a/i8/i8_other.go
+++ b/i8/i8_other.go
@@ -1,0 +1,14 @@
+//go:build !amd64 && !arm64
+
+package i8
+
+// Pure-Go dispatch for architectures without a SIMD backend.
+
+func addSatI8(dst, a, b []int8)   { addSatGo(dst, a, b) }
+func subSatI8(dst, a, b []int8)   { subSatGo(dst, a, b) }
+func toI16(dst []int16, s []int8) { toI16Go(dst, s) }
+func toI32(dst []int32, s []int8) { toI32Go(dst, s) }
+func sumI8(a []int8) int32        { return sumGo(a) }
+func dotI8(a, b []int8) int32     { return dotGo(a, b) }
+
+func minMaxI8(a []int8) (minVal, maxVal int8) { return minMaxGo(a) }

--- a/i8/i8_test.go
+++ b/i8/i8_test.go
@@ -1,0 +1,237 @@
+package i8
+
+import (
+	"testing"
+)
+
+// genI8 produces deterministic pseudo-random int8 data spanning the full range,
+// including the -128/127 extremes, so saturation and sign-extension boundaries
+// are exercised.
+func genI8(n int, seed uint32) []int8 {
+	s := make([]int8, n)
+	x := seed*2654435761 + 1
+	for i := range s {
+		x = x*1664525 + 1013904223
+		s[i] = int8(x >> 17) // spread across the byte range
+	}
+	return s
+}
+
+// lengths sweeps sub-threshold, single-block, multi-block, and ragged-tail sizes
+// for both 16- and 32-byte vector kernels.
+var lengths = []int{0, 1, 2, 3, 7, 8, 15, 16, 17, 31, 32, 33, 63, 64, 65, 100, 255, 256, 257, 1000, 1024, 1031}
+
+func TestAddSaturate(t *testing.T) {
+	// Literal saturation cases validate the reference independently of the SIMD path.
+	cases := []struct{ a, b, want int8 }{
+		{0, 0, 0},
+		{127, 1, 127},   // positive saturation
+		{100, 100, 127}, // positive saturation
+		{-128, -1, -128},
+		{-100, -100, -128}, // negative saturation
+		{50, -60, -10},
+		{127, -128, -1},
+	}
+	for _, c := range cases {
+		dst := make([]int8, 1)
+		AddSaturate(dst, []int8{c.a}, []int8{c.b})
+		if dst[0] != c.want {
+			t.Errorf("AddSaturate(%d, %d) = %d, want %d", c.a, c.b, dst[0], c.want)
+		}
+	}
+	// Parity against the reference across lengths.
+	for _, n := range lengths {
+		a, b := genI8(n, 1), genI8(n, 2)
+		got := make([]int8, n)
+		want := make([]int8, n)
+		AddSaturate(got, a, b)
+		addSatGo(want, a, b)
+		assertI8Eq(t, "AddSaturate", n, got, want)
+	}
+}
+
+func TestSubSaturate(t *testing.T) {
+	cases := []struct{ a, b, want int8 }{
+		{0, 0, 0},
+		{127, -1, 127},   // positive saturation
+		{-128, 1, -128},  // negative saturation
+		{100, -100, 127}, // positive saturation
+		{-100, 100, -128},
+		{10, 30, -20},
+		{-128, -128, 0},  // -128 - (-128) = 0
+		{127, -128, 127}, // 127 - (-128) = 255 -> saturates to 127
+	}
+	for _, c := range cases {
+		dst := make([]int8, 1)
+		SubSaturate(dst, []int8{c.a}, []int8{c.b})
+		if dst[0] != c.want {
+			t.Errorf("SubSaturate(%d, %d) = %d, want %d", c.a, c.b, dst[0], c.want)
+		}
+	}
+	for _, n := range lengths {
+		a, b := genI8(n, 3), genI8(n, 4)
+		got := make([]int8, n)
+		want := make([]int8, n)
+		SubSaturate(got, a, b)
+		subSatGo(want, a, b)
+		assertI8Eq(t, "SubSaturate", n, got, want)
+	}
+}
+
+func TestToInt16(t *testing.T) {
+	for _, n := range lengths {
+		src := genI8(n, 5)
+		got := make([]int16, n)
+		ToInt16(got, src)
+		for i := range src {
+			if got[i] != int16(src[i]) {
+				t.Fatalf("ToInt16 n=%d: got[%d]=%d, want %d", n, i, got[i], int16(src[i]))
+			}
+		}
+	}
+}
+
+func TestToInt32(t *testing.T) {
+	for _, n := range lengths {
+		src := genI8(n, 6)
+		got := make([]int32, n)
+		ToInt32(got, src)
+		for i := range src {
+			if got[i] != int32(src[i]) {
+				t.Fatalf("ToInt32 n=%d: got[%d]=%d, want %d", n, i, got[i], int32(src[i]))
+			}
+		}
+	}
+}
+
+func TestSum(t *testing.T) {
+	// Literal cases.
+	if got := Sum(nil); got != 0 {
+		t.Errorf("Sum(nil) = %d, want 0", got)
+	}
+	if got := Sum([]int8{127, 127, 1, -128}); got != 127 {
+		t.Errorf("Sum([127,127,1,-128]) = %d, want 127", got)
+	}
+	// Parity across lengths.
+	for _, n := range lengths {
+		a := genI8(n, 7)
+		if got, want := Sum(a), sumGo(a); got != want {
+			t.Errorf("Sum n=%d: got %d, want %d", n, got, want)
+		}
+	}
+	// int32 accumulation must not narrow before the total: 300 elements of 127
+	// sum to 38100, which exceeds int16 but fits int32.
+	big := make([]int8, 300)
+	for i := range big {
+		big[i] = 127
+	}
+	if got, want := Sum(big), int32(300*127); got != want {
+		t.Errorf("Sum(300x127) = %d, want %d", got, want)
+	}
+}
+
+func TestDotProduct(t *testing.T) {
+	if got := DotProduct(nil, nil); got != 0 {
+		t.Errorf("DotProduct(nil) = %d, want 0", got)
+	}
+	// (-128)*(-128) = 16384, exceeds int16 but fits int32.
+	if got := DotProduct([]int8{-128, 1}, []int8{-128, 2}); got != 16384+2 {
+		t.Errorf("DotProduct([-128,1],[-128,2]) = %d, want %d", got, 16384+2)
+	}
+	for _, n := range lengths {
+		a, b := genI8(n, 8), genI8(n, 9)
+		if got, want := DotProduct(a, b), dotGo(a, b); got != want {
+			t.Errorf("DotProduct n=%d: got %d, want %d", n, got, want)
+		}
+	}
+	// Mismatched lengths clamp to the shorter operand.
+	if got, want := DotProduct([]int8{1, 2, 3}, []int8{4, 5}), int32(1*4+2*5); got != want {
+		t.Errorf("DotProduct mismatched len = %d, want %d", got, want)
+	}
+	// int32 two's-complement wraparound: 140000 elements of 127*127=16129 sum to
+	// 2_258_060_000, which overflows int32. The result must wrap exactly like the
+	// reference (verified here against an independent int64->int32 truncation).
+	const wn = 140000
+	wa := make([]int8, wn)
+	wb := make([]int8, wn)
+	for i := range wa {
+		wa[i], wb[i] = 127, 127
+	}
+	wantWrap := int32(int64(len(wa)) * 127 * 127) // non-constant: truncates at runtime
+	if got := DotProduct(wa, wb); got != wantWrap {
+		t.Errorf("DotProduct wraparound = %d, want %d", got, wantWrap)
+	}
+	if wantWrap >= 0 {
+		t.Fatalf("test setup: expected wraparound to a negative value, got %d", wantWrap)
+	}
+}
+
+func TestMinMax(t *testing.T) {
+	if lo, hi := MinMax(nil); lo != 0 || hi != 0 {
+		t.Errorf("MinMax(nil) = (%d,%d), want (0,0)", lo, hi)
+	}
+	if lo, hi := MinMax([]int8{5}); lo != 5 || hi != 5 {
+		t.Errorf("MinMax([5]) = (%d,%d), want (5,5)", lo, hi)
+	}
+	if lo, hi := MinMax([]int8{0, -128, 127, 3, -1}); lo != -128 || hi != 127 {
+		t.Errorf("MinMax = (%d,%d), want (-128,127)", lo, hi)
+	}
+	for _, n := range lengths {
+		if n == 0 {
+			continue
+		}
+		a := genI8(n, 10)
+		gotLo, gotHi := MinMax(a)
+		wantLo, wantHi := minMaxGo(a)
+		if gotLo != wantLo || gotHi != wantHi {
+			t.Errorf("MinMax n=%d: got (%d,%d), want (%d,%d)", n, gotLo, gotHi, wantLo, wantHi)
+		}
+	}
+}
+
+func TestZeroAllocations(t *testing.T) {
+	const n = 1024
+	a, b := genI8(n, 11), genI8(n, 12)
+	d8 := make([]int8, n)
+	d16 := make([]int16, n)
+	d32 := make([]int32, n)
+
+	checks := []struct {
+		name string
+		fn   func()
+	}{
+		{"AddSaturate", func() { AddSaturate(d8, a, b) }},
+		{"SubSaturate", func() { SubSaturate(d8, a, b) }},
+		{"ToInt16", func() { ToInt16(d16, a) }},
+		{"ToInt32", func() { ToInt32(d32, a) }},
+		{"Sum", func() { _ = Sum(a) }},
+		{"DotProduct", func() { _ = DotProduct(a, b) }},
+		{"MinMax", func() { _, _ = MinMax(a) }},
+	}
+	for _, c := range checks {
+		if got := testing.AllocsPerRun(10, c.fn); got != 0 {
+			t.Errorf("%s allocated %v times per run, want 0", c.name, got)
+		}
+	}
+}
+
+// TestTrailingCapacityUntouched verifies the binary ops and conversions write
+// exactly n elements and leave trailing dst capacity alone.
+func TestTrailingCapacityUntouched(t *testing.T) {
+	a := []int8{1, 2, 3}
+	b := []int8{4, 5, 6}
+	dst := []int8{-9, -9, -9, 42, 42}
+	AddSaturate(dst, a, b)
+	if dst[3] != 42 || dst[4] != 42 {
+		t.Errorf("AddSaturate clobbered trailing capacity: %v", dst)
+	}
+}
+
+func assertI8Eq(t *testing.T, op string, n int, got, want []int8) {
+	t.Helper()
+	for i := range want {
+		if got[i] != want[i] {
+			t.Fatalf("%s n=%d: got[%d]=%d, want %d", op, n, i, got[i], want[i])
+		}
+	}
+}

--- a/i8/i8_test.go
+++ b/i8/i8_test.go
@@ -220,10 +220,29 @@ func TestZeroAllocations(t *testing.T) {
 func TestTrailingCapacityUntouched(t *testing.T) {
 	a := []int8{1, 2, 3}
 	b := []int8{4, 5, 6}
+
 	dst := []int8{-9, -9, -9, 42, 42}
 	AddSaturate(dst, a, b)
 	if dst[3] != 42 || dst[4] != 42 {
 		t.Errorf("AddSaturate clobbered trailing capacity: %v", dst)
+	}
+
+	dstSub := []int8{-9, -9, -9, 42, 42}
+	SubSaturate(dstSub, a, b)
+	if dstSub[3] != 42 || dstSub[4] != 42 {
+		t.Errorf("SubSaturate clobbered trailing capacity: %v", dstSub)
+	}
+
+	dst16 := []int16{-9, -9, -9, 4242, 4242}
+	ToInt16(dst16, a)
+	if dst16[3] != 4242 || dst16[4] != 4242 {
+		t.Errorf("ToInt16 clobbered trailing capacity: %v", dst16)
+	}
+
+	dst32 := []int32{-9, -9, -9, 424242, 424242}
+	ToInt32(dst32, a)
+	if dst32[3] != 424242 || dst32[4] != 424242 {
+		t.Errorf("ToInt32 clobbered trailing capacity: %v", dst32)
 	}
 }
 

--- a/i8/i8_test.go
+++ b/i8/i8_test.go
@@ -216,34 +216,59 @@ func TestZeroAllocations(t *testing.T) {
 }
 
 // TestTrailingCapacityUntouched verifies the binary ops and conversions write
-// exactly n elements and leave trailing dst capacity alone.
+// exactly n elements and leave trailing dst capacity alone. It runs sizes both
+// below and above the SIMD dispatch thresholds (32/16/8), so the assembly
+// kernels and their scalar tails are covered, not just the pure-Go fallback.
 func TestTrailingCapacityUntouched(t *testing.T) {
-	a := []int8{1, 2, 3}
-	b := []int8{4, 5, 6}
+	for _, n := range []int{3, 35} {
+		a, b := genI8(n, 1), genI8(n, 2)
 
-	dst := []int8{-9, -9, -9, 42, 42}
-	AddSaturate(dst, a, b)
-	if dst[3] != 42 || dst[4] != 42 {
-		t.Errorf("AddSaturate clobbered trailing capacity: %v", dst)
-	}
+		dst := fillI8(n+2, 42)
+		AddSaturate(dst[:n], a, b)
+		if dst[n] != 42 || dst[n+1] != 42 {
+			t.Errorf("AddSaturate (n=%d) clobbered trailing capacity: %v", n, dst[n:])
+		}
 
-	dstSub := []int8{-9, -9, -9, 42, 42}
-	SubSaturate(dstSub, a, b)
-	if dstSub[3] != 42 || dstSub[4] != 42 {
-		t.Errorf("SubSaturate clobbered trailing capacity: %v", dstSub)
-	}
+		dst = fillI8(n+2, 42)
+		SubSaturate(dst[:n], a, b)
+		if dst[n] != 42 || dst[n+1] != 42 {
+			t.Errorf("SubSaturate (n=%d) clobbered trailing capacity: %v", n, dst[n:])
+		}
 
-	dst16 := []int16{-9, -9, -9, 4242, 4242}
-	ToInt16(dst16, a)
-	if dst16[3] != 4242 || dst16[4] != 4242 {
-		t.Errorf("ToInt16 clobbered trailing capacity: %v", dst16)
-	}
+		dst16 := fillI16(n+2, 4242)
+		ToInt16(dst16[:n], a)
+		if dst16[n] != 4242 || dst16[n+1] != 4242 {
+			t.Errorf("ToInt16 (n=%d) clobbered trailing capacity: %v", n, dst16[n:])
+		}
 
-	dst32 := []int32{-9, -9, -9, 424242, 424242}
-	ToInt32(dst32, a)
-	if dst32[3] != 424242 || dst32[4] != 424242 {
-		t.Errorf("ToInt32 clobbered trailing capacity: %v", dst32)
+		dst32 := fillI32(n+2, 424242)
+		ToInt32(dst32[:n], a)
+		if dst32[n] != 424242 || dst32[n+1] != 424242 {
+			t.Errorf("ToInt32 (n=%d) clobbered trailing capacity: %v", n, dst32[n:])
+		}
 	}
+}
+
+func fillI8(n int, v int8) []int8 {
+	s := make([]int8, n)
+	for i := range s {
+		s[i] = v
+	}
+	return s
+}
+func fillI16(n int, v int16) []int16 {
+	s := make([]int16, n)
+	for i := range s {
+		s[i] = v
+	}
+	return s
+}
+func fillI32(n int, v int32) []int32 {
+	s := make([]int32, n)
+	for i := range s {
+		s[i] = v
+	}
+	return s
 }
 
 func assertI8Eq(t *testing.T, op string, n int, got, want []int8) {


### PR DESCRIPTION
## Summary

Adds a new `i8` package with seven high-impact int8 SIMD primitives, mirroring the `i16`/`i32` package structure (pure-Go reference, AVX2 amd64 kernels, NEON arm64 kernels, parity/bit-exact/zero-alloc tests, differential fuzzing).

int8's narrow `-128..127` range makes element-wise arithmetic overflow almost immediately, so this package does not mirror the wrapping arithmetic of `i16`/`i32`. It ships the operations that are genuinely high-impact and well-defined at 8-bit width:

- `AddSaturate`, `SubSaturate`: signed saturating add/sub (`VPADDSB`/`VPSUBSB`, `SQADD`/`SQSUB`), clamping to `[-128,127]` rather than wrapping.
- `ToInt16`, `ToInt32`: sign-extending widen (`VPMOVSXB{W,D}`, `SXTL`/`SXTL2`).
- `Sum`, `DotProduct`: int32-accumulated reductions. `DotProduct` is the quantized matmul inner loop: AVX2 widens with `VPMOVSXBW` and reduces with `VPMADDWD`; ARM64 uses an `SDOT` (FEAT_DotProd) fast path with a `SMULL`/`SADALP` base-NEON fallback for cores without it.
- `MinMax`: signed per-slice min/max (`VPMINSB`/`VPMAXSB`, `SMIN`/`SMAX` + `SMINV`/`SMAXV`).

The int32-accumulated reductions wrap in two's complement exactly like their references; int32 wrapping addition is associative, so the lane-parallel SIMD totals are bit-identical to the scalar reference regardless of summation order, and the int8 products never overflow their lane (`|int8 * int8| <= 16384`).

### Supporting changes

- `cpu`: detect `FEAT_DotProd` (`ARM64.DOTPROD` / `HasDOTPROD()`), wired from `x/sys/cpu.HasASIMDDP` on Linux and unconditionally on Apple Silicon. Adds a `dotprod` `SIMD_DISABLE` token, folded into `clearNEON`.
- `asmcheck`: `arm64asm` cannot decode `SDOT`/`UDOT`, so defer those (alongside the existing FP16 `.8H` case) to the aarch64 objdump cross-check.
- `doc.go` / `README.md`: package listing, op tables, per-arch tiers, and a documented follow-up list.

amd64 gates on AVX2 (pure Go below).

## Test Plan

- [x] amd64: full suite green with AVX2 on and with `SIMD_DISABLE=avx2`/`avx`
- [x] arm64 (Cortex-A76, asimddp): full suite green across the SDOT, base-NEON (`SIMD_DISABLE=dotprod`), and pure-Go (`SIMD_DISABLE=neon`) paths
- [x] Parity sweeps across block/tail boundaries, a 140k-element int32 wraparound case, zero-alloc assertions, and four differential fuzzers (no failures)
- [x] `golangci-lint run ./...` clean (whole tree, `new: false`)
- [x] `go vet ./...` clean; asmcheck passes with `SIMD_REQUIRE_OBJDUMP=1` (SDOT verified via objdump)

## Out of scope (documented follow-ups)

- `float32 <-> int8` affine `Quantize`/`Dequantize` (scale + zero-point)
- AVX-512 VNNI (`VPDPBUSD`) `DotProduct` fast path
- 8-bit channel `Interleave2`/`Deinterleave2`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added i8 package: SIMD‑accelerated int8 primitives — saturating add/sub, sign‑extending conversions, Sum, DotProduct, and MinMax with zero‑allocation and length‑clamping.

* **Documentation**
  * Updated docs and architecture table to describe i8 support, bit‑exactness, and runtime use of AVX2 on amd64 and an SDOT fast path on capable ARM64 cores.

* **Tests**
  * Added benchmarks, examples, fuzz targets, and unit tests validating correctness, zero‑allocation guarantees, and edge cases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->