### PR TITLE
i8: add MaxAbs and AbsDiff (abs-max + saturating abs-diff)

### DIFF
--- a/README.md
+++ b/README.md
@@ -582,7 +582,7 @@ Like the `i32` interleave kernels, these are pure 16-bit-lane movement (AVX2/SSE
 
 ### `i8` - int8 Operations
 
-SIMD-accelerated int8 operations for quantized numeric pipelines. The narrow `-128..127` range makes element-wise arithmetic overflow almost immediately, so this package does not mirror the wrapping arithmetic of `i16`/`i32`. It ships the operations that are genuinely high-impact and well-defined at 8-bit width: saturating arithmetic, element-wise min/max/clamp and saturating abs/neg, int32-accumulated reductions, signed min/max, and sign-extending widening.
+SIMD-accelerated int8 operations for quantized numeric pipelines. The narrow `-128..127` range makes element-wise arithmetic overflow almost immediately, so this package does not mirror the wrapping arithmetic of `i16`/`i32`. It ships the operations that are genuinely high-impact and well-defined at 8-bit width: saturating arithmetic, element-wise min/max/clamp and saturating abs/neg/abs-diff, int32-accumulated reductions, signed min/max, the per-tensor abs-max for dynamic quantization, and sign-extending widening.
 
 | Category       | Function                   | Description                                                    | SIMD Width             |
 | -------------- | -------------------------- | -------------------------------------------------------------- | ---------------------- |
@@ -593,11 +593,13 @@ SIMD-accelerated int8 operations for quantized numeric pipelines. The narrow `-1
 |                | `Clamp(dst, src, lo, hi)`  | Clamp each element to `[lo, hi]` (activation clipping)         | 32x (AVX2) / 16x (NEON)|
 |                | `Abs(dst, a)`              | Saturating absolute value (`abs(-128) = 127`)                  | 32x (AVX2) / 16x (NEON)|
 |                | `Neg(dst, a)`              | Saturating negation (`neg(-128) = 127`)                        | 32x (AVX2) / 16x (NEON)|
+|                | `AbsDiff(dst, a, b)`       | Saturating `\|a - b\|`, clamped to `[0, 127]`                  | 32x (AVX2) / 16x (NEON)|
 | **Widening**   | `ToInt16(dst, src)`        | Sign-extend `int8` to `int16`                                  | 16x (AVX2) / 16x (NEON)|
 |                | `ToInt32(dst, src)`        | Sign-extend `int8` to `int32`                                  | 8x (AVX2) / 8x (NEON)  |
 | **Reduction**  | `Sum(a) int32`             | int32-accumulated sum                                          | 16x (AVX2) / 16x (NEON)|
 |                | `DotProduct(a, b) int32`   | int32-accumulated dot product (quantized matmul inner loop)    | 16x (AVX2) / 16x (NEON, SDOT)|
 |                | `MinMax(a) (min, max)`     | Signed int8 per-slice minimum and maximum in one pass          | 32x (AVX2) / 16x (NEON)|
+|                | `MaxAbs(a) int`            | Per-tensor abs-max (dynamic-quantization scale), range `[0,128]`| 32x (AVX2) / 16x (NEON)|
 
 ```go
 import "github.com/tphakala/simd/i8"
@@ -614,16 +616,18 @@ i8.Max(dst, a, b)         // element-wise signed max
 i8.Clamp(dst, a, -64, 64) // clamp each element to [-64, 64]
 i8.Abs(dst, a)            // saturating |a|, abs(-128) = 127
 i8.Neg(dst, a)            // saturating -a, neg(-128) = 127
+i8.AbsDiff(dst, a, b)     // saturating |a - b|, clamped to [0, 127]
 
 dot := i8.DotProduct(a, b) // int32-accumulated sum(a[i]*b[i])
 sum := i8.Sum(a)           // int32-accumulated sum
 mn, mx := i8.MinMax(a)     // smallest and largest value in one signed pass
+scale := i8.MaxAbs(a)      // per-tensor abs-max for dynamic quantization
 
 w16 := make([]int16, len(a))
 i8.ToInt16(w16, a) // sign-extend to int16 (exact)
 ```
 
-`AddSaturate`/`SubSaturate` use single saturating instructions (`VPADDSB`/`VPSUBSB` on AVX2, `SQADD`/`SQSUB` on NEON) and clamp instead of wrapping, which is what 8-bit arithmetic almost always wants. The element-wise group is single-instruction too: `Min`/`Max` map to `VPMINSB`/`VPMAXSB` (`SMIN`/`SMAX` on NEON), `Clamp` broadcasts the bounds and applies max-then-min, and `Abs`/`Neg` saturate so `-128` maps to `127` (`SQABS`/`SQNEG` on NEON; `max(a, saturating(0-a))` and `saturating(0-a)` on AVX2). `Sum` and `DotProduct` accumulate in int32 with two's-complement wraparound; since int32 wrapping addition is associative, the lane-parallel SIMD reductions are bit-identical to the scalar reference regardless of summation order, and the int8 products never overflow their lane (`|int8 * int8| <= 16384`). `DotProduct` is the inner loop of quantized matmul/convolution: on AVX2 it widens with `VPMOVSXBW` and reduces with `VPMADDWD`; on ARM64 with `FEAT_DotProd` it uses `SDOT` (16 multiply-accumulates per instruction), falling back to a `SMULL`/`SADALP` base-NEON path on cores without it. All operations are zero-allocation and bit-exact against the pure-Go reference.
+`AddSaturate`/`SubSaturate` use single saturating instructions (`VPADDSB`/`VPSUBSB` on AVX2, `SQADD`/`SQSUB` on NEON) and clamp instead of wrapping, which is what 8-bit arithmetic almost always wants. The element-wise group is single-instruction too: `Min`/`Max` map to `VPMINSB`/`VPMAXSB` (`SMIN`/`SMAX` on NEON), `Clamp` broadcasts the bounds and applies max-then-min, and `Abs`/`Neg` saturate so `-128` maps to `127` (`SQABS`/`SQNEG` on NEON; `max(a, saturating(0-a))` and `saturating(0-a)` on AVX2). `AbsDiff` saturates `|a - b|` to `[0, 127]` (`SABD` then an unsigned min with 127 on NEON; `max(saturating(a-b), saturating(b-a))` on AVX2), and `MaxAbs` returns the per-tensor abs-max as `int` (range `[0, 128]`, since `|-128| = 128` does not fit `int8`) via `PABSB`+unsigned `PMAXUB` on AVX2 and `ABS`+`UMAXV` on NEON, which is the scale a dynamic quantizer needs. `Sum` and `DotProduct` accumulate in int32 with two's-complement wraparound; since int32 wrapping addition is associative, the lane-parallel SIMD reductions are bit-identical to the scalar reference regardless of summation order, and the int8 products never overflow their lane (`|int8 * int8| <= 16384`). `DotProduct` is the inner loop of quantized matmul/convolution: on AVX2 it widens with `VPMOVSXBW` and reduces with `VPMADDWD`; on ARM64 with `FEAT_DotProd` it uses `SDOT` (16 multiply-accumulates per instruction), falling back to a `SMULL`/`SADALP` base-NEON path on cores without it. All operations are zero-allocation and bit-exact against the pure-Go reference.
 
 > **Planned follow-ups:** `float32 <-> int8` affine `Quantize`/`Dequantize` (scale + zero-point), an AVX-512 VNNI (`VPDPBUSD`) `DotProduct` fast path, and 8-bit channel `Interleave2`/`Deinterleave2`.
 

--- a/doc.go
+++ b/doc.go
@@ -89,7 +89,7 @@
 //
 // Integer DSP (i32): Interleave2, Deinterleave2, Add, Sub, MinMax
 //
-// Integer DSP (i8): AddSaturate, SubSaturate, Min, Max, Clamp, Abs, Neg, ToInt16, ToInt32, Sum, MinMax, DotProduct (int32-accumulated; ARM64 SDOT / amd64 VPMADDWD)
+// Integer DSP (i8): AddSaturate, SubSaturate, Min, Max, Clamp, Abs, Neg, AbsDiff, MaxAbs, ToInt16, ToInt32, Sum, MinMax, DotProduct (int32-accumulated; ARM64 SDOT / amd64 VPMADDWD)
 //
 // Complex (c64/c128): Add, Sub, Mul, MulConj, DotProduct, DotProductConj, Conj, Abs, AbsSq, Scale
 //

--- a/docs/superpowers/plans/2026-06-13-i8-maxabs-absdiff.md
+++ b/docs/superpowers/plans/2026-06-13-i8-maxabs-absdiff.md
@@ -1,0 +1,142 @@
+# i8 MaxAbs + AbsDiff Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:executing-plans. Steps use checkbox (`- [ ]`) syntax.
+
+**Goal:** Add two int8 "absolute value" primitives to `i8`: `MaxAbs` (the Tier 1 per-tensor dynamic-quantization scale, a reduction) and `AbsDiff` (the Tier 2/3 saturating absolute difference, element-wise), with AVX2 + NEON kernels, pure-Go references, parity/bit-exact/zero-alloc tests, differential fuzzing, and asmcheck cross-checks.
+
+**Architecture:** Same structure as the existing `i8` package. `MaxAbs` returns `int` because `|-128| = 128` does not fit `int8`; it reduces via unsigned byte max (`VPABSB`+`VPMAXUB`+horizontal `VPMAXUB`; `ABS`+`UMAX`+`UMAXV` on NEON), reading the final byte unsigned. `AbsDiff` saturates `|a-b|` to `[0,127]` consistent with `Abs` (`max(sat(a-b), sat(b-a))` on AVX2; `SABD`+`UMIN`-with-127 on NEON).
+
+**Tech Stack:** Go 1.26, Plan9 assembly (AVX2 mnemonics on amd64; hand-encoded `WORD` NEON cross-checked by `asmcheck`).
+
+---
+
+## Semantics (source of truth)
+
+- `MaxAbs(a []int8) int`: returns `max_i |int(a[i])|`, range `[0,128]`. Empty `a` returns 0. Read-only, zero-alloc.
+- `AbsDiff(dst, a, b []int8)`: `dst[i] = clamp(|int(a[i]) - int(b[i])|, 0, 127)` for `i in [0,n)`, `n = min(len(dst),len(a),len(b))`. Saturates: `|127 - (-128)| = 255 -> 127`. Trailing dst capacity untouched. Zero-alloc.
+
+## Verified instruction encodings (cross-assembler authoritative; agy cross-checked)
+
+x86 AVX2:
+- `MaxAbs`: `VPABSB` (abs; `-128` -> byte `0x80` = 128 unsigned), `VPMAXUB` (unsigned byte max) to fold blocks, horizontal `VPMAXUB`+`VPSRLDQ` cascade + `VEXTRACTI128`; final byte read zero-extended.
+- `AbsDiff`: `VPSUBSB(b,a)` and `VPSUBSB(a,b)` (signed saturating), `VPMAXSB` picks the non-negative capped difference. (`SABD` is not used on x86; no such mnemonic. The max-of-sat-subs already saturates to `[0,127]`.)
+
+NEON .16B (all base ARMv8.0 ASIMD, decodable by arm64asm -> checked directly):
+- `ABS   V2.16B, V0.16B`        = `0x4E20B802`
+- `ABS   V0.16B, V0.16B`        = `0x4E20B800`
+- `UMAXV B3, V2.16B`            = `0x6E30A843`
+- `UMAXV B4, V0.16B`            = `0x6E30A804`
+- `UMAX  V0.16B, V0.16B, V2.16B`= `0x6E226400`
+- `SABD  V2.16B, V0.16B, V1.16B`= `0x4E217402`
+- `UMIN  V2.16B, V2.16B, V3.16B`= `0x6E236C42`
+- `DUP   V3.16B, W5`            = `0x4E010CA3`
+
+---
+
+## Task 1: References + public API + non-arch routing (TDD: tests first)
+
+**Files:** `i8/i8_test.go` (tests first), `i8/i8_go.go` (refs), `i8/i8.go` (API), `i8/i8_other.go` (routing).
+
+- [ ] **Step 1 (RED):** add `TestMaxAbs` and `TestAbsDiff` with literal edge cases (`MaxAbs([-128])==128`, `MaxAbs(nil)==0`, `AbsDiff` `|127-(-128)|==127`, mismatched-length clamp) plus parity across `lengths`. Extend `TestZeroAllocations` (`MaxAbs`, `AbsDiff`) and `TestTrailingCapacityUntouched` (`AbsDiff`). Run; expect compile failure.
+- [ ] **Step 2 (GREEN refs):** add to `i8_go.go`:
+
+```go
+func maxAbsGo(a []int8) int {
+	m := 0
+	for _, v := range a {
+		av := int(v)
+		if av < 0 {
+			av = -av
+		}
+		if av > m {
+			m = av
+		}
+	}
+	return m
+}
+
+func absDiffGo(dst, a, b []int8) {
+	for i := range dst {
+		d := int(a[i]) - int(b[i])
+		if d < 0 {
+			d = -d
+		}
+		if d > 127 {
+			d = 127
+		}
+		dst[i] = int8(d)
+	}
+}
+```
+
+(Check the modernize linter: the `if av < 0` / `if d < 0` are real branches, not min/max-able. `if av > m` may be flagged -> use `m = max(m, av)`.)
+
+- [ ] **Step 3 (GREEN API):** add to `i8.go`:
+
+```go
+// MaxAbs returns max_i |a[i]| accumulated as int (range [0,128], since
+// |-128| = 128 does not fit int8). It is the per-tensor scale for dynamic
+// quantization. Empty a returns 0. a is read-only; allocates nothing.
+func MaxAbs(a []int8) int {
+	if len(a) == 0 {
+		return 0
+	}
+	return maxAbsI8(a)
+}
+
+// AbsDiff writes the saturating absolute difference dst[i] = |a[i] - b[i]|,
+// clamped to [0, 127], for i in [0, n), n = min(len(dst),len(a),len(b)).
+// |127 - (-128)| = 255 saturates to 127. Any trailing capacity in dst is
+// left untouched.
+func AbsDiff(dst, a, b []int8) {
+	n := min(len(dst), len(a), len(b))
+	if n == 0 {
+		return
+	}
+	absDiffI8(dst[:n], a[:n], b[:n])
+}
+```
+
+- [ ] **Step 4:** add to `i8_other.go`:
+
+```go
+func maxAbsI8(a []int8) int        { return maxAbsGo(a) }
+func absDiffI8(dst, a, b []int8)    { absDiffGo(dst, a, b) }
+```
+
+- [ ] **Step 5:** `SIMD_DISABLE=avx go test ./i8/ -run 'MaxAbs|AbsDiff|ZeroAlloc|Trailing' -count=1`. Expect PASS (Go path). Commit `feat(i8): add MaxAbs/AbsDiff references and API`.
+
+## Task 2: AMD64 AVX2 kernels
+
+**Files:** `i8/i8_amd64.go` (dispatch + decls), `i8/i8_amd64.s` (2 kernels).
+
+- [ ] **Step 1:** dispatch `maxAbsI8` (gate `len >= blockMinMax` 32) and `absDiffI8` (gate `len(dst) >= blockSat32` 32), else Go ref; add `//go:noescape func maxAbsAVX2(a []int8) int` and `func absDiffAVX2(dst, a, b []int8)`.
+- [ ] **Step 2:** `maxAbsAVX2`: zero Y0 acc; per 32-byte block `VPABSB (SI),Y1` then `VPMAXUB Y1,Y0,Y0`; reduce with `VEXTRACTI128`+`VPMAXUB`+`VPSRLDQ` cascade to one byte; `MOVD X0,AX; ANDQ $0xFF,AX`; signed scalar tail computes `|v|` (TEST/NEG) and unsigned-compares to update AX; `MOVQ AX,ret+24(FP)`. `absDiffAVX2`: per block `VPSUBSB Y1,Y0,Y2` (a-b) and `VPSUBSB Y0,Y1,Y3` (b-a), `VPMAXSB Y3,Y2,Y4`, store; scalar tail subtract/abs/clamp-127.
+- [ ] **Step 3:** `go vet ./i8/`; `go test ./i8/ -run 'MaxAbs|AbsDiff' -count=1 -v`. Expect PASS.
+- [ ] **Step 4:** commit `feat(i8): AVX2 kernels for MaxAbs/AbsDiff`.
+
+## Task 3: ARM64 NEON kernels
+
+**Files:** `i8/i8_arm64.go` (dispatch + decls), `i8/i8_arm64.s` (2 kernels).
+
+- [ ] **Step 1:** dispatch gating `len >= minNEON16` (16); decls `maxAbsNEON`, `absDiffNEON`.
+- [ ] **Step 2:** `maxAbsNEON`: zero V_acc; per 16-byte block `VLD`, `ABS V1,V0` (`WORD 0x4E20B800`->use V-combo), `UMAX` fold; `UMAXV B,Vacc` reduce; `FMOVS`+`AND $0xFF`; signed scalar tail abs+unsigned-CSEL. `absDiffNEON`: `DUP V3.16B,W` (127), per block `SABD V2,V0,V1` (`0x4E217402`), `UMIN V2,V2,V3` (`0x6E236C42`), store; scalar tail subtract/abs/clamp-127.
+- [ ] **Step 3:** `GOARCH=arm64 go build ./i8/`, `GOARCH=arm64 go vet ./i8/`, `SIMD_REQUIRE_OBJDUMP=1 go test . -run TestArm64WordEncodings`. Expect PASS.
+- [ ] **Step 4:** commit `feat(i8): NEON kernels for MaxAbs/AbsDiff`.
+
+## Task 4: Fuzz + benchmarks + cross-arch + docs
+
+- [ ] **Step 1:** add `FuzzI8AbsOps` (MaxAbs vs ref; AbsDiff vs ref on a/b halves) to `fuzz_test.go`; `BenchmarkMaxAbs`, `BenchmarkAbsDiff` to `benchmark_test.go`.
+- [ ] **Step 2:** amd64: `go test ./i8/ -count=1`, short fuzz, `golangci-lint run ./i8/...`. Expect clean.
+- [ ] **Step 3:** cross-compile + run on rpi5 (native aarch64): full i8 run + fuzz seeds + benchmarks. Expect PASS, 0 allocs.
+- [ ] **Step 4:** docs: add `MaxAbs`/`AbsDiff` to `doc.go` i8 line, README i8 table + example, `i8.go` package doc. Remove the "MaxAbs ... follow-up" note from the README planned-follow-ups line if present.
+- [ ] **Step 5:** `go test ./... -count=1` (full repo), `go test ./i8/ -race`. Commit docs; push; PR (base = feat/i8-elementwise-tier2, stacked), referencing #132.
+
+---
+
+## Self-review notes
+
+- `MaxAbs` returns `int` (not `int8`) precisely because of the `-128` case; literal test `MaxAbs([]int8{-128}) == 128` is the guard.
+- `AbsDiff` saturates to `[0,127]` (not raw `|a-b|` which can be 255) for consistency with `Abs`; the `|127-(-128)|==127` literal test is the guard. On NEON `SABD` gives unsigned `|a-b|` in `[0,255]`, then `UMIN` with 127 saturates.
+- Unsigned reductions: `VPMAXUB`/`UMAXV` are unsigned, so `VPABSB`/`ABS` producing `0x80` for `-128` is correctly treated as 128 (the largest), not as a negative.
+</content>

--- a/i8/benchmark_test.go
+++ b/i8/benchmark_test.go
@@ -120,3 +120,22 @@ func BenchmarkNeg(b *testing.B) {
 		Neg(dst, a)
 	}
 }
+
+func BenchmarkMaxAbs(b *testing.B) {
+	a := genI8(benchN, 1)
+	b.SetBytes(benchN)
+	b.ResetTimer()
+	for b.Loop() {
+		_ = MaxAbs(a)
+	}
+}
+
+func BenchmarkAbsDiff(b *testing.B) {
+	a, c := genI8(benchN, 1), genI8(benchN, 2)
+	dst := make([]int8, benchN)
+	b.SetBytes(benchN)
+	b.ResetTimer()
+	for b.Loop() {
+		AbsDiff(dst, a, c)
+	}
+}

--- a/i8/fuzz_test.go
+++ b/i8/fuzz_test.go
@@ -130,6 +130,25 @@ func FuzzI8Elementwise(f *testing.F) {
 	})
 }
 
+func FuzzI8AbsOps(f *testing.F) {
+	lenSeeds(f)
+	f.Fuzz(func(t *testing.T, raw []byte) {
+		v := i8FromBytes(raw)
+
+		if got, want := MaxAbs(v), maxAbsGo(v); got != want {
+			t.Fatalf("MaxAbs: got %d want %d (len=%d)", got, want, len(v))
+		}
+
+		h := len(v) / 2
+		a, b := v[:h], v[h:2*h]
+		got := make([]int8, h)
+		want := make([]int8, h)
+		AbsDiff(got, a, b)
+		absDiffGo(want, a, b)
+		assertI8Eq(t, "AbsDiff", h, got, want)
+	})
+}
+
 func FuzzI8Convert(f *testing.F) {
 	lenSeeds(f)
 	f.Fuzz(func(t *testing.T, raw []byte) {

--- a/i8/i8.go
+++ b/i8/i8.go
@@ -16,6 +16,8 @@
 //   - Signed min/max (MinMax reduction; element-wise two-slice Min/Max).
 //   - Element-wise Clamp (activation clipping) and saturating Abs/Neg, where
 //     -128 maps to 127 (SQABS/SQNEG on NEON; saturating constructions on AVX2).
+//   - Saturating AbsDiff (|a-b| clamped to [0,127]) and MaxAbs (the per-tensor
+//     abs-max for dynamic quantization, returned as int because |-128| = 128).
 //   - Sign-extending widening (ToInt16, ToInt32) to hand off to the wider
 //     integer or float packages.
 //

--- a/i8/i8.go
+++ b/i8/i8.go
@@ -176,3 +176,27 @@ func Neg(dst, a []int8) {
 	}
 	negI8(dst[:n], a[:n])
 }
+
+// MaxAbs returns max_i |a[i]| accumulated as int (range [0, 128], since
+// |-128| = 128 does not fit int8). It is the per-tensor scale for dynamic
+// quantization (PABSB+PMAXUB on AVX2; ABS+UMAXV on NEON). An empty a returns 0.
+// a is read-only; the call allocates nothing.
+func MaxAbs(a []int8) int {
+	if len(a) == 0 {
+		return 0
+	}
+	return maxAbsI8(a)
+}
+
+// AbsDiff writes the saturating absolute difference dst[i] = |a[i] - b[i]|,
+// clamped to [0, 127], for i in [0, n), n = min(len(dst), len(a), len(b)).
+// |127 - (-128)| = 255 saturates to 127, consistent with Abs. It uses
+// max(saturating(a-b), saturating(b-a)) on AVX2 and SABD then an unsigned min
+// with 127 on NEON. Any trailing capacity in dst is left untouched.
+func AbsDiff(dst, a, b []int8) {
+	n := min(len(dst), len(a), len(b))
+	if n == 0 {
+		return
+	}
+	absDiffI8(dst[:n], a[:n], b[:n])
+}

--- a/i8/i8_amd64.go
+++ b/i8/i8_amd64.go
@@ -113,6 +113,21 @@ func negI8(dst, a []int8) {
 	negGo(dst, a)
 }
 
+func maxAbsI8(a []int8) int {
+	if hasAVX2 && len(a) >= blockMinMax {
+		return maxAbsAVX2(a)
+	}
+	return maxAbsGo(a)
+}
+
+func absDiffI8(dst, a, b []int8) {
+	if hasAVX2 && len(dst) >= blockSat32 {
+		absDiffAVX2(dst, a, b)
+		return
+	}
+	absDiffGo(dst, a, b)
+}
+
 //go:noescape
 func addSatAVX2(dst, a, b []int8)
 
@@ -148,3 +163,9 @@ func absAVX2(dst, a []int8)
 
 //go:noescape
 func negAVX2(dst, a []int8)
+
+//go:noescape
+func maxAbsAVX2(a []int8) int
+
+//go:noescape
+func absDiffAVX2(dst, a, b []int8)

--- a/i8/i8_amd64.s
+++ b/i8/i8_amd64.s
@@ -607,3 +607,117 @@ neg_store:
 neg_done:
     VZEROUPPER
     RET
+
+// func maxAbsAVX2(a []int8) int
+// Per-tensor abs-max for dynamic quantization: VPABSB maps each byte to its
+// magnitude (abs(-128) -> 0x80, i.e. 128 read unsigned), VPMAXUB folds 32-byte
+// blocks into an unsigned-max accumulator, a VPMAXUB/VPSRLDQ cascade reduces a
+// 128-bit lane to one byte, and a scalar tail folds the (n mod 32) remainder.
+// The result is read zero-extended, so it lands in [0, 128].
+TEXT ·maxAbsAVX2(SB), NOSPLIT, $0-32
+    MOVQ a_base+0(FP), SI
+    MOVQ a_len+8(FP), CX
+
+    VPXOR Y0, Y0, Y0           // unsigned-max accumulator = 0
+
+    MOVQ CX, AX
+    SHRQ $5, AX                // AX = n / 32
+    JZ   maxabs_reduce
+
+maxabs_loop32:
+    VPABSB (SI), Y1            // |a| as unsigned bytes
+    VPMAXUB Y1, Y0, Y0         // unsigned max accumulate
+    ADDQ $32, SI
+    DECQ AX
+    JNZ  maxabs_loop32
+
+maxabs_reduce:
+    VEXTRACTI128 $1, Y0, X1
+    VPMAXUB X1, X0, X0         // fold 32 -> 16 bytes
+    VPSRLDQ $8, X0, X1
+    VPMAXUB X1, X0, X0         // 8 bytes
+    VPSRLDQ $4, X0, X1
+    VPMAXUB X1, X0, X0         // 4 bytes
+    VPSRLDQ $2, X0, X1
+    VPMAXUB X1, X0, X0         // 2 bytes
+    VPSRLDQ $1, X0, X1
+    VPMAXUB X1, X0, X0         // 1 byte
+    MOVD X0, AX
+    ANDQ $0xFF, AX             // running abs-max (unsigned byte) in [0, 128]
+
+    ANDQ $31, CX
+    JZ   maxabs_done
+
+maxabs_scalar:
+    MOVBLSX (SI), BX           // v (sign-extended)
+    TESTL BX, BX
+    JGE  maxabs_cmp
+    NEGL BX                    // |v|; -(-128) = 128
+maxabs_cmp:
+    CMPL BX, AX                // both in [0, 128], unsigned == signed here
+    JLE  maxabs_next
+    MOVL BX, AX                // new running max
+maxabs_next:
+    INCQ SI
+    DECQ CX
+    JNZ  maxabs_scalar
+
+maxabs_done:
+    MOVQ AX, ret+24(FP)
+    VZEROUPPER
+    RET
+
+// func absDiffAVX2(dst, a, b []int8)
+// Saturating absolute difference clamped to [0, 127]: |a-b| = max(saturating
+// (a-b), saturating(b-a)); the VPMAXSB picks the non-negative capped difference,
+// so |127 - (-128)| = 255 saturates to 127. A scalar tail subtracts, negates if
+// negative, and clamps high on the (n mod 32) remainder.
+TEXT ·absDiffAVX2(SB), NOSPLIT, $0-72
+    MOVQ dst_base+0(FP), DX
+    MOVQ dst_len+8(FP), CX
+    MOVQ a_base+24(FP), SI
+    MOVQ b_base+48(FP), DI
+
+    MOVQ CX, AX
+    SHRQ $5, AX
+    JZ   absdiff_remainder
+
+absdiff_loop32:
+    VMOVDQU (SI), Y0           // a
+    VMOVDQU (DI), Y1           // b
+    VPSUBSB Y1, Y0, Y2         // Y2 = saturating(a - b)
+    VPSUBSB Y0, Y1, Y3         // Y3 = saturating(b - a)
+    VPMAXSB Y3, Y2, Y4         // Y4 = |a - b| clamped to [0, 127]
+    VMOVDQU Y4, (DX)
+    ADDQ $32, SI
+    ADDQ $32, DI
+    ADDQ $32, DX
+    DECQ AX
+    JNZ  absdiff_loop32
+
+absdiff_remainder:
+    ANDQ $31, CX
+    JZ   absdiff_done
+
+absdiff_scalar:
+    MOVBLSX (SI), AX
+    MOVBLSX (DI), BX
+    SUBL BX, AX                // a - b in int32 (|.| <= 255)
+    TESTL AX, AX
+    JGE  absdiff_clamp
+    NEGL AX                    // |a - b|
+absdiff_clamp:
+    CMPL AX, $127
+    JLE  absdiff_store
+    MOVL $127, AX              // saturate to 127
+absdiff_store:
+    MOVB AX, (DX)
+    INCQ SI
+    INCQ DI
+    INCQ DX
+    DECQ CX
+    JNZ  absdiff_scalar
+
+absdiff_done:
+    VZEROUPPER
+    RET

--- a/i8/i8_arm64.go
+++ b/i8/i8_arm64.go
@@ -113,6 +113,21 @@ func negI8(dst, a []int8) {
 	negGo(dst, a)
 }
 
+func maxAbsI8(a []int8) int {
+	if hasNEON && len(a) >= minNEON16 {
+		return maxAbsNEON(a)
+	}
+	return maxAbsGo(a)
+}
+
+func absDiffI8(dst, a, b []int8) {
+	if hasNEON && len(dst) >= minNEON16 {
+		absDiffNEON(dst, a, b)
+		return
+	}
+	absDiffGo(dst, a, b)
+}
+
 //go:noescape
 func addSatNEON(dst, a, b []int8)
 
@@ -151,3 +166,9 @@ func absNEON(dst, a []int8)
 
 //go:noescape
 func negNEON(dst, a []int8)
+
+//go:noescape
+func maxAbsNEON(a []int8) int
+
+//go:noescape
+func absDiffNEON(dst, a, b []int8)

--- a/i8/i8_arm64.s
+++ b/i8/i8_arm64.s
@@ -537,3 +537,96 @@ neg_scalar:
 
 neg_done:
     RET
+
+// func maxAbsNEON(a []int8) int
+// Per-tensor abs-max for dynamic quantization: ABS maps each byte to its
+// magnitude (abs(-128) -> 0x80, i.e. 128 read unsigned), UMAX folds 16-byte
+// blocks into an unsigned-max accumulator, UMAXV reduces it to a byte, and a
+// scalar tail folds the (n mod 16) remainder. The byte is read zero-extended,
+// so the result lands in [0, 128].
+TEXT ·maxAbsNEON(SB), NOSPLIT, $0-32
+    MOVD a_base+0(FP), R1
+    MOVD a_len+8(FP), R3
+
+    VEOR V2.B16, V2.B16, V2.B16   // unsigned-max accumulator = 0
+    LSR  $4, R3, R4               // R4 = n / 16
+    CBZ  R4, maxabs_reduce
+
+maxabs_loop16:
+    VLD1.P 16(R1), [V0.B16]
+    WORD $0x4E20B800             // ABS  V0.16B, V0.16B   (|a|; abs(-128)=0x80)
+    WORD $0x6E206442             // UMAX V2.16B, V2.16B, V0.16B
+    SUB  $1, R4
+    CBNZ R4, maxabs_loop16
+
+maxabs_reduce:
+    WORD $0x6E30A843             // UMAXV B3, V2.16B
+    FMOVS F3, R5                  // R5 = abs-max byte (zero-extended)
+    AND  $0xFF, R5, R5            // defensively keep only the byte, [0, 128]
+
+    AND  $15, R3
+    CBZ  R3, maxabs_done
+
+maxabs_scalar:
+    MOVB (R1), R6                 // v (sign-extended)
+    NEG  R6, R7                   // -v
+    CMP  $0, R6
+    CSEL LT, R7, R6, R6           // |v| = v < 0 ? -v : v   (can be 128)
+    CMP  R5, R6
+    CSEL HI, R6, R5, R5           // unsigned: |v| > max ? |v| : max
+    ADD  $1, R1
+    SUB  $1, R3
+    CBNZ R3, maxabs_scalar
+
+maxabs_done:
+    MOVD R5, ret+24(FP)
+    RET
+
+// func absDiffNEON(dst, a, b []int8)
+// Saturating absolute difference clamped to [0, 127]: SABD computes |a-b| as an
+// unsigned byte in [0, 255], and an unsigned min with a broadcast 127 saturates
+// it, so |127 - (-128)| = 255 maps to 127. A scalar tail subtracts, negates if
+// negative, and clamps high on the (n mod 16) remainder.
+TEXT ·absDiffNEON(SB), NOSPLIT, $0-72
+    MOVD dst_base+0(FP), R0
+    MOVD dst_len+8(FP), R3
+    MOVD a_base+24(FP), R1
+    MOVD b_base+48(FP), R2
+
+    MOVD $127, R5                 // clamp constant, also the SABD-min broadcast
+    WORD $0x4E010CA3             // DUP V3.16B, W5   (127 in all 16 lanes)
+
+    LSR  $4, R3, R4
+    CBZ  R4, absdiff_remainder
+
+absdiff_loop16:
+    VLD1.P 16(R1), [V0.B16]
+    VLD1.P 16(R2), [V1.B16]
+    WORD $0x4E217402             // SABD V2.16B, V0.16B, V1.16B   (|a-b|, 0..255)
+    WORD $0x6E236C42             // UMIN V2.16B, V2.16B, V3.16B   (clamp to <= 127)
+    VST1.P [V2.B16], 16(R0)
+    SUB  $1, R4
+    CBNZ R4, absdiff_loop16
+
+absdiff_remainder:
+    AND  $15, R3
+    CBZ  R3, absdiff_done
+
+absdiff_scalar:
+    MOVB (R1), R6                 // a (sign-extended)
+    MOVB (R2), R7                 // b
+    SUB  R7, R6, R6               // a - b
+    NEG  R6, R9                   // -(a - b)
+    CMP  $0, R6
+    CSEL LT, R9, R6, R6           // |a - b|  (0..255)
+    CMP  R5, R6
+    CSEL GT, R5, R6, R6           // |a - b| > 127 ? 127 : |a - b|
+    MOVB R6, (R0)
+    ADD  $1, R1
+    ADD  $1, R2
+    ADD  $1, R0
+    SUB  $1, R3
+    CBNZ R3, absdiff_scalar
+
+absdiff_done:
+    RET

--- a/i8/i8_go.go
+++ b/i8/i8_go.go
@@ -73,6 +73,24 @@ func absInt(v int) int {
 	return v
 }
 
+// maxAbsGo returns max_i |a[i]| as int. |-128| = 128 does not fit int8, hence
+// the int return. It is the bit-exact source of truth for the MaxAbs kernels.
+func maxAbsGo(a []int8) int {
+	m := 0
+	for _, v := range a {
+		m = max(m, absInt(int(v)))
+	}
+	return m
+}
+
+// absDiffGo writes the saturating absolute difference clamped to [0, 127], so
+// |127 - (-128)| = 255 maps to 127.
+func absDiffGo(dst, a, b []int8) {
+	for i := range dst {
+		dst[i] = int8(min(absInt(int(a[i])-int(b[i])), math.MaxInt8))
+	}
+}
+
 func toI16Go(dst []int16, src []int8) {
 	for i := range dst {
 		dst[i] = int16(src[i])

--- a/i8/i8_other.go
+++ b/i8/i8_other.go
@@ -13,8 +13,10 @@ func dotI8(a, b []int8) int32     { return dotGo(a, b) }
 
 func minMaxI8(a []int8) (minVal, maxVal int8) { return minMaxGo(a) }
 
-func minI8(dst, a, b []int8)                  { minGo(dst, a, b) }
-func maxI8(dst, a, b []int8)                  { maxGo(dst, a, b) }
-func clampElemI8(dst, s []int8, lo, hi int8)  { clampGo(dst, s, lo, hi) }
-func absI8(dst, a []int8)                      { absGo(dst, a) }
-func negI8(dst, a []int8)                      { negGo(dst, a) }
+func minI8(dst, a, b []int8)                 { minGo(dst, a, b) }
+func maxI8(dst, a, b []int8)                 { maxGo(dst, a, b) }
+func clampElemI8(dst, s []int8, lo, hi int8) { clampGo(dst, s, lo, hi) }
+func absI8(dst, a []int8)                    { absGo(dst, a) }
+func negI8(dst, a []int8)                    { negGo(dst, a) }
+func maxAbsI8(a []int8) int                  { return maxAbsGo(a) }
+func absDiffI8(dst, a, b []int8)             { absDiffGo(dst, a, b) }

--- a/i8/i8_test.go
+++ b/i8/i8_test.go
@@ -256,7 +256,7 @@ func TestClamp(t *testing.T) {
 		{50, -10, 10, 10},
 		{-128, -128, 127, -128},
 		{127, -128, 127, 127},
-		{5, 5, 5, 5},     // lo == hi
+		{5, 5, 5, 5},      // lo == hi
 		{5, 10, -10, -10}, // lo > hi: every element maps to hi
 		{-5, 10, -10, -10},
 	}
@@ -329,6 +329,71 @@ func TestNeg(t *testing.T) {
 	}
 }
 
+func TestMaxAbs(t *testing.T) {
+	if got := MaxAbs(nil); got != 0 {
+		t.Errorf("MaxAbs(nil) = %d, want 0", got)
+	}
+	cases := []struct {
+		a    []int8
+		want int
+	}{
+		{[]int8{0}, 0},
+		{[]int8{5, -3, 2}, 5},
+		{[]int8{-3, 5, -2}, 5},
+		{[]int8{-128}, 128}, // |−128| = 128 does not fit int8
+		{[]int8{127, -128, 1}, 128},
+		{[]int8{-1, -2, -127}, 127},
+	}
+	for _, c := range cases {
+		if got := MaxAbs(c.a); got != c.want {
+			t.Errorf("MaxAbs(%v) = %d, want %d", c.a, got, c.want)
+		}
+	}
+	for _, n := range lengths {
+		if n == 0 {
+			continue
+		}
+		a := genI8(n, 20)
+		if got, want := MaxAbs(a), maxAbsGo(a); got != want {
+			t.Errorf("MaxAbs n=%d: got %d, want %d", n, got, want)
+		}
+	}
+}
+
+func TestAbsDiff(t *testing.T) {
+	cases := []struct{ a, b, want int8 }{
+		{0, 0, 0},
+		{5, 3, 2},
+		{3, 5, 2},
+		{-5, 5, 10},
+		{127, -128, 127}, // |255| saturates to 127
+		{-128, 127, 127}, // |−255| saturates to 127
+		{-128, -128, 0},
+		{100, -100, 127}, // |200| saturates to 127
+	}
+	for _, c := range cases {
+		dst := make([]int8, 1)
+		AbsDiff(dst, []int8{c.a}, []int8{c.b})
+		if dst[0] != c.want {
+			t.Errorf("AbsDiff(%d, %d) = %d, want %d", c.a, c.b, dst[0], c.want)
+		}
+	}
+	for _, n := range lengths {
+		a, b := genI8(n, 21), genI8(n, 22)
+		got := make([]int8, n)
+		want := make([]int8, n)
+		AbsDiff(got, a, b)
+		absDiffGo(want, a, b)
+		assertI8Eq(t, "AbsDiff", n, got, want)
+	}
+	// Mismatched lengths clamp to the shortest operand.
+	got := make([]int8, 3)
+	AbsDiff(got, []int8{10, 20, 30}, []int8{1, 2})
+	if got[0] != 9 || got[1] != 18 || got[2] != 0 {
+		t.Errorf("AbsDiff mismatched len = %v, want [9 18 0]", got)
+	}
+}
+
 func TestZeroAllocations(t *testing.T) {
 	const n = 1024
 	a, b := genI8(n, 11), genI8(n, 12)
@@ -352,6 +417,8 @@ func TestZeroAllocations(t *testing.T) {
 		{"Clamp", func() { Clamp(d8, a, -20, 20) }},
 		{"Abs", func() { Abs(d8, a) }},
 		{"Neg", func() { Neg(d8, a) }},
+		{"MaxAbs", func() { _ = MaxAbs(a) }},
+		{"AbsDiff", func() { AbsDiff(d8, a, b) }},
 	}
 	for _, c := range checks {
 		if got := testing.AllocsPerRun(10, c.fn); got != 0 {
@@ -420,6 +487,12 @@ func TestTrailingCapacityUntouched(t *testing.T) {
 		Neg(dst[:n], a)
 		if dst[n] != 42 || dst[n+1] != 42 {
 			t.Errorf("Neg (n=%d) clobbered trailing capacity: %v", n, dst[n:])
+		}
+
+		dst = fillI8(n+2, 42)
+		AbsDiff(dst[:n], a, b)
+		if dst[n] != 42 || dst[n+1] != 42 {
+			t.Errorf("AbsDiff (n=%d) clobbered trailing capacity: %v", n, dst[n:])
 		}
 	}
 }


### PR DESCRIPTION
## Summary

Adds the "absolute value" primitives from the int8/byte tracking issue (#132): the Tier 1 `MaxAbs` dynamic-quantization scale and the Tier 2/3 saturating `AbsDiff`.

- `MaxAbs(a []int8) int`: returns `max_i |a[i]|`, the per-tensor scale a dynamic quantizer needs. Returned as `int` because `|-128| = 128` does not fit `int8` (range `[0, 128]`). On AVX2 it maps each byte to its magnitude with `VPABSB` (so `-128` becomes byte `0x80`) and reduces with the **unsigned** `VPMAXUB` (which reads `0x80` as 128, correctly the largest), then a horizontal `VPMAXUB` cascade; on NEON it is `ABS` + `UMAX` + `UMAXV`, reading the result byte zero-extended.
- `AbsDiff(dst, a, b []int8)`: saturating `|a - b|` clamped to `[0, 127]` (consistent with `Abs`), so `|127 - (-128)| = 255` maps to `127`. On AVX2 it is `max(saturating(a-b), saturating(b-a))` (the `VPMAXSB` picks the non-negative capped difference); on NEON it is `SABD` (which yields the unsigned `|a-b|` in `[0, 255]`) followed by an unsigned `UMIN` with a broadcast `127`.

Both ship the established discipline: pure-Go references as the source of truth, AVX2 + NEON kernels validated against them, parity across a length sweep, literal saturation edge cases (`MaxAbs([-128]) == 128`, `AbsDiff(127, -128) == 127`), zero-allocation and trailing-capacity assertions, a differential fuzz target, and benchmarks. The new NEON `WORD` encodings (`ABS`, `UMAX`, `UMAXV`, `SABD`, `UMIN`) were verified with `aarch64-linux-gnu-as`/`objdump`, cross-checked against `arm64asm` by the repo's `asmcheck` harness, and independently confirmed against the Arm ARM. New AVX2 kernels use only mnemonics the Go assembler emits directly.

Zero allocations and bit-exact parity with the references on both architectures.

## Related Issues

Relates to #132 (implements the Tier 1 `MaxAbs` and Tier 2/3 `AbsDiff` items).

## Notes for reviewers

This PR is **stacked on #133** (Min/Max/Clamp/Abs/Neg); its base branch is `feat/i8-elementwise-tier2`, so the diff shown here is only the MaxAbs/AbsDiff changes. GitHub will retarget this PR to `main` automatically once #133 merges.

## Test Plan

- [x] `go test ./i8/ -count=1` passes on amd64 (AVX2 path and the `< 32`-byte Go-reference tail).
- [x] `SIMD_DISABLE=avx go test ./i8/` passes (pure-Go reference path validated independently).
- [x] Cross-compiled and run natively on aarch64 (Raspberry Pi 5): parity, zero-alloc, trailing-capacity, and fuzz-seed tests pass on the NEON path.
- [x] `SIMD_REQUIRE_OBJDUMP=1 go test . -run TestArm64WordEncodings` cross-checks every new `WORD` against `arm64asm`/objdump.
- [x] `go vet ./i8/` and `GOARCH=arm64 go vet ./i8/` clean.
- [x] `go test ./i8/ -fuzz FuzzI8AbsOps` ran ~6.5M executions with no failures.
- [x] `golangci-lint run ./i8/...` clean; `go test ./... -count=1` (full repo) and `go test ./i8/ -race` pass.
- [x] Benchmarks confirm 0 B/op: AVX2 MaxAbs ~94 GB/s (~49x vs scalar), AbsDiff ~46 GB/s (~36x vs scalar); NEON (rpi5) ~15-19 GB/s.