### PR TITLE
f64/f32: add MaxAbs and fused ConvolveValidMaxAbs[Multi] (peak detection)

### DIFF
--- a/README.md
+++ b/README.md
@@ -175,6 +175,7 @@ live in `f32` instead, so the two float surfaces are intentionally asymmetric.
 |                 | `Sum(a)`                            | Sum of elements               | 8x / 4x / 2x                        |
 |                 | `Min(a)`                            | Minimum value                 | 8x / 4x / 2x                        |
 |                 | `Max(a)`                            | Maximum value                 | 8x / 4x / 2x                        |
+|                 | `MaxAbs(a)`                         | Max absolute value (∞-norm)   | 8x / 4x / 2x                        |
 |                 | `MinIdx(a)`                         | Index of minimum value        | Pure Go                             |
 |                 | `MaxIdx(a)`                         | Index of maximum value        | Pure Go                             |
 | **Statistical** | `Mean(a)`                           | Arithmetic mean               | 8x / 4x / 2x                        |
@@ -196,6 +197,8 @@ live in `f32` instead, so the two float surfaces are intentionally asymmetric.
 | **Batch**       | `DotProductBatch(r, rows, v)`       | Multiple dot products         | 8x / 4x / 2x                        |
 | **Signal**      | `ConvolveValid(dst, sig, k)`        | FIR filter / convolution      | 8x / 4x / 2x                        |
 |                 | `ConvolveValidMulti(dsts, sig, ks)` | Multi-kernel convolution      | 8x / 4x / 2x                        |
+|                 | `ConvolveValidMaxAbs(sig, k)`       | Fused FIR abs-max peak (no scratch) | 8x / 4x / 2x                  |
+|                 | `ConvolveValidMaxAbsMulti(sig, ks)` | Multi-kernel abs-max peak (true-peak) | 8x / 4x / 2x                |
 |                 | `ConvolveDecimate(dst,sig,k,f,p)`   | Strided FIR downsample (decimate) | 8x / 4x / 2x                    |
 |                 | `AccumulateAdd(dst, src, off)`      | Overlap-add: dst[off:] += src | 8x / 4x / 2x                        |
 |                 | `Autocorrelate(autoc, x, maxLag)`   | LPC autocorrelation Σ x[i]·x[i-lag] (bit-exact) | 4x (AVX2) / 2x (NEON)     |
@@ -764,6 +767,21 @@ a Raspberry Pi 5):
 | 241 taps, 2x decimate | **1.6x** | **1.2x** | **1.2x** | **1.1x** |
 | 241 taps, 4x decimate | **1.3x** | **1.2x** | **1.2x** | **1.1x** |
 
+#### ConvolveValidMaxAbs (fused valid convolution + abs-max peak)
+
+`ConvolveValidMaxAbs` returns `max(|valid-convolution output|)` (the infinity
+norm of the FIR output) without materializing the output slice. Each output is
+still a SIMD dot product, but the abs-max reduction is folded into the same pass,
+so it removes both the per-output store to a scratch buffer and the separate
+scalar abs-max scan a consumer writes today. The baseline is `ConvolveValid`
+into a temporary slice followed by a `MaxAbs` over it; both compute the identical
+peak. `ConvolveValidMaxAbsMulti` takes the N phase kernels of a polyphase
+oversampling FIR and returns the single peak of the reconstructed signal in one
+call, which is the canonical true-peak (ITU-R BS.1770 / EBU R 128) primitive.
+The standalone `MaxAbs` reduction (`VANDPD`+`VMAXPD` on AVX2, `ANDPS`+`MAXPS` on
+SSE, `FABS`+`FMAX` on NEON) covers peak metering, clipping detection, and
+normalization headroom on its own.
+
 #### Autocorrelate (lag-vectorized LPC autocorrelation, f64)
 
 `Autocorrelate` is the LPC autocorrelation step in a FLAC-style encoder, the
@@ -869,7 +887,7 @@ All int32 kernels are zero-allocation and bit-exact against the pure-Go referenc
 
 ### Small Slice Fallback for Min/Max (AMD64)
 
-On AMD64, the `Min` and `Max` functions fall back to pure Go for small slices:
+On AMD64, the `Min`, `Max`, and `MaxAbs` functions fall back to pure Go for small slices:
 
 - **float64**: slices with fewer than 4 elements
 - **float32**: slices with fewer than 8 elements

--- a/doc.go
+++ b/doc.go
@@ -72,7 +72,7 @@
 //
 // Core arithmetic: Add, Sub, Mul, Div, Scale, AddScalar, AddScaled, FMA
 //
-// Reductions: Sum, DotProduct, DotProductBatch, DotProductIndexed, DotProductStrided, Min, Max, MinIdx, MaxIdx
+// Reductions: Sum, DotProduct, DotProductBatch, DotProductIndexed, DotProductStrided, Min, Max, MaxAbs, MinIdx, MaxIdx
 //
 // Statistics: Mean, Variance, StdDev, EuclideanDistance, Normalize
 //
@@ -83,7 +83,7 @@
 // Transcendental (f32/f64): Log, Log2, Log10, Pow, PowElem (plus LogInPlace, PowInPlace),
 // SIMD-accelerated on AVX2+FMA and NEON
 //
-// Audio DSP: Interleave2, Deinterleave2, ConvolveValid, ConvolveValidMulti, ConvolveDecimate, AccumulateAdd, CumulativeSum, CubicInterpDot, Int32ToFloat32Scale, Int16ToFloat32Scale, Float32ToInt16Scale
+// Audio DSP: Interleave2, Deinterleave2, ConvolveValid, ConvolveValidMulti, ConvolveValidMaxAbs, ConvolveValidMaxAbsMulti, ConvolveDecimate, AccumulateAdd, CumulativeSum, CubicInterpDot, Int32ToFloat32Scale, Int16ToFloat32Scale, Float32ToInt16Scale
 //
 // Spectral (f64, f32): STFTPlan (NewSTFTPlan, STFT, STFTPower, STFTPowerInto, NumFrames) - fused real-input short-time Fourier transform with optional librosa-style center=true framing (PadMode: NoPad/PadZero/PadReflect)
 //

--- a/docs/superpowers/plans/2026-06-14-maxabs-convolvevalidmaxabs.md
+++ b/docs/superpowers/plans/2026-06-14-maxabs-convolvevalidmaxabs.md
@@ -1,0 +1,635 @@
+# MaxAbs + fused ConvolveValid+MaxAbs Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add `MaxAbs`, `ConvolveValidMaxAbs`, and `ConvolveValidMaxAbsMulti` to the `f64` and `f32` packages (tphakala/simd#138).
+
+**Architecture:** `MaxAbs` is a vectorized infinity-norm reduction reusing the `Sum`/`Min`/`Max` dispatch machinery (Go + AVX2 + SSE2 + NEON kernels; AVX-512 routes to AVX2). `ConvolveValidMaxAbs[Multi]` are Go-level fusions over the already-dispatched SIMD `dotProduct`: no scratch buffer, no second pass, no new assembly.
+
+**Tech Stack:** Pure Go + hand-written Plan 9 assembly (amd64 AVX/SSE2, arm64 NEON as hand-encoded `WORD`s). Tests with `testing`, fuzzing, asmcheck.
+
+**Verification commands** (run from repo root):
+- amd64: `go test ./f64/ ./f32/` and `go vet ./f64/ ./f32/`
+- lint: `golangci-lint run ./f64/... ./f32/...`
+- arm64 (NEON): cross-compile test binary, copy to `thakala@rpi5.local`, run there.
+  `GOOS=linux GOARCH=arm64 go test -c -o /tmp/f64.arm64.test ./f64/` then
+  `scp /tmp/f64.arm64.test rpi5.local:/tmp/ && ssh rpi5.local /tmp/f64.arm64.test`
+- asmcheck: `go test ./ -run TestAsm` (validates NEON WORD encodings).
+
+---
+
+## Phase 1: f64 MaxAbs
+
+### Task 1: f64 maxAbsGo reference + public API + dispatch (Go fallback only)
+
+**Files:**
+- Modify: `f64/f64_go.go` (add `maxAbsGo` after `maxGo`)
+- Modify: `f64/f64.go` (add `MaxAbs` public func after `Max`)
+- Modify: `f64/f64_amd64.go` (add `maxAbsImpl` var, `maxAbs64` dispatcher, wire all 5 init funcs to a temporary Go impl until kernels land)
+- Modify: `f64/f64_arm64.go` (add `maxAbs64` dispatcher -> Go for now)
+- Modify: `f64/f64_other.go` (add `maxAbs64` -> `maxAbsGo`)
+- Test: `f64/f64_test.go` (or a new `f64/maxabs_test.go`)
+
+- [ ] **Step 1: Write the failing test** in `f64/maxabs_test.go`:
+
+```go
+package f64
+
+import (
+	"math"
+	"testing"
+)
+
+// scalarMaxAbs is the independent reference: max(|a[i]|), 0 for empty.
+func scalarMaxAbs(a []float64) float64 {
+	m := 0.0
+	for _, v := range a {
+		av := math.Abs(v)
+		if av > m {
+			m = av
+		}
+	}
+	return m
+}
+
+func TestMaxAbs(t *testing.T) {
+	cases := [][]float64{
+		nil,
+		{},
+		{0},
+		{-0.0},
+		{3, -7, 2},
+		{-1, -2, -3, -4, -5, -6, -7, -8, -9},
+		{1.5, -1.5, 0.25, -0.25, 100, -99.9, 0, 42},
+		{math.Inf(1), -3},
+		{math.Inf(-1), 3},
+	}
+	for i, a := range cases {
+		got := MaxAbs(a)
+		want := scalarMaxAbs(a)
+		if got != want {
+			t.Errorf("case %d: MaxAbs(%v) = %v, want %v", i, a, got, want)
+		}
+	}
+}
+
+func TestMaxAbsParity(t *testing.T) {
+	// Lengths spanning the SIMD body, the scalar tail, and the small fallback.
+	for _, n := range []int{0, 1, 2, 3, 4, 5, 7, 8, 9, 15, 16, 17, 31, 33, 64, 127, 256} {
+		a := make([]float64, n)
+		for i := range a {
+			a[i] = math.Sin(float64(i)*0.7) * float64((i%5)-2) * 13.3
+		}
+		if got, want := MaxAbs(a), scalarMaxAbs(a); got != want {
+			t.Errorf("n=%d: MaxAbs=%v want %v", n, got, want)
+		}
+	}
+}
+
+func TestMaxAbsNoAlloc(t *testing.T) {
+	a := make([]float64, 1024)
+	for i := range a {
+		a[i] = float64(i%7) - 3
+	}
+	if n := testing.AllocsPerRun(100, func() { _ = MaxAbs(a) }); n != 0 {
+		t.Errorf("MaxAbs allocated %v times, want 0", n)
+	}
+}
+```
+
+- [ ] **Step 2: Run, verify it fails to compile** (`MaxAbs` undefined): `go test ./f64/ -run TestMaxAbs`
+
+- [ ] **Step 3: Add `maxAbsGo`** to `f64/f64_go.go` (right after `maxGo`):
+
+```go
+// maxAbsGo returns max_i |a[i]| (the infinity norm), 0 for an empty slice.
+// It is the bit-exact source of truth for the MaxAbs kernels.
+func maxAbsGo(a []float64) float64 {
+	m := 0.0
+	for _, v := range a {
+		av := math.Abs(v)
+		if av > m {
+			m = av
+		}
+	}
+	return m
+}
+```
+
+- [ ] **Step 4: Add `MaxAbs`** to `f64/f64.go` (right after `Max`):
+
+```go
+// MaxAbs returns the maximum absolute value in the slice (the infinity norm),
+// max_i |a[i]|. Returns 0 for an empty slice.
+//
+// Uses AVX2/SSE2 on AMD64 (AVX-512 CPUs reuse the AVX2 kernel), NEON on ARM64,
+// with a pure Go fallback. a is read-only; the call allocates nothing.
+//
+// NaN handling: |NaN| is NaN and compares false, so the Go path skips NaN. On the
+// SIMD paths NaN handling is architecture-dependent, matching [Min] and [Max].
+// Callers needing strict NaN semantics should filter NaN first.
+func MaxAbs(a []float64) float64 {
+	if len(a) == 0 {
+		return 0
+	}
+	return maxAbs64(a)
+}
+```
+
+- [ ] **Step 5: Wire dispatch.** In `f64/f64_amd64.go`: add `maxAbsImpl reduceFunc` to the `var (...)` block (next to `maxImpl`); add `maxAbsImpl = maxAbsGo` to **all five** init funcs for now (initAVX512, initAVX, initAVXNoFMA, initSSE2, initGo); add the dispatcher:
+
+```go
+func maxAbs64(a []float64) float64 {
+	if len(a) < minSIMDElements {
+		return maxAbsGo(a)
+	}
+	return maxAbsImpl(a)
+}
+```
+
+In `f64/f64_arm64.go` add a temporary dispatcher (replaced in Task 3):
+
+```go
+func maxAbs64(a []float64) float64 {
+	return maxAbsGo(a)
+}
+```
+
+In `f64/f64_other.go` add: `func maxAbs64(a []float64) float64 { return maxAbsGo(a) }`
+
+- [ ] **Step 6: Run tests, verify pass:** `go test ./f64/ -run TestMaxAbs` -> PASS.
+
+- [ ] **Step 7: Commit:**
+
+```bash
+git add f64/
+git commit -m "f64: add MaxAbs infinity-norm reduction (Go path)"
+```
+
+### Task 2: f64 maxAbsAVX + maxAbsSSE2 kernels
+
+**Files:**
+- Modify: `f64/f64_amd64.s` (add two kernels)
+- Modify: `f64/f64_amd64.go` (replace temporary Go wiring; add `//go:noescape` decls)
+- Test: extend `f64/maxabs_test.go` (parity already covers it once kernels are active)
+
+- [ ] **Step 1: Add `maxAbsAVX`** to `f64/f64_amd64.s` (mirror `maxAVX` at line ~536 with the abs mask folded in):
+
+```
+// func maxAbsAVX(a []float64) float64
+TEXT ·maxAbsAVX(SB), NOSPLIT, $0-32
+    MOVQ a_base+0(FP), SI
+    MOVQ a_len+8(FP), CX
+
+    VMOVUPD absf64mask<>(SB), Y2   // Y2 = abs mask (X2 = low 128 for the tail)
+    VMOVUPD (SI), Y0
+    VANDPD Y0, Y2, Y0             // Y0 = |a[0:4]|
+    ADDQ $32, SI
+    SUBQ $4, CX
+
+    MOVQ CX, AX
+    SHRQ $2, AX
+    JZ   maxabs_avx_reduce
+
+maxabs_avx_loop4:
+    VMOVUPD (SI), Y1
+    VANDPD Y1, Y2, Y1
+    VMAXPD Y0, Y1, Y0
+    ADDQ $32, SI
+    DECQ AX
+    JNZ  maxabs_avx_loop4
+
+maxabs_avx_reduce:
+    VEXTRACTF128 $1, Y0, X1
+    VMAXPD X0, X1, X0
+    VPERMILPD $1, X0, X1
+    VMAXSD X0, X1, X0
+
+    ANDQ $3, CX
+    JZ   maxabs_avx_done
+
+maxabs_avx_scalar:
+    VMOVSD (SI), X1
+    VANDPD X1, X2, X1
+    VMAXSD X0, X1, X0
+    ADDQ $8, SI
+    DECQ CX
+    JNZ  maxabs_avx_scalar
+
+maxabs_avx_done:
+    VMOVSD X0, ret+24(FP)
+    VZEROUPPER
+    RET
+```
+
+- [ ] **Step 2: Add `maxAbsSSE2`** to `f64/f64_amd64.s` (mirror `maxSSE2` at line ~2746 with `ANDPD`):
+
+```
+// func maxAbsSSE2(a []float64) float64
+TEXT ·maxAbsSSE2(SB), NOSPLIT, $0-32
+    MOVQ a_base+0(FP), SI
+    MOVQ a_len+8(FP), CX
+
+    MOVUPD absf64mask<>(SB), X2
+    MOVUPD (SI), X0
+    ANDPD X2, X0                 // X0 = |a[0:2]|
+    ADDQ $16, SI
+    SUBQ $2, CX
+
+    MOVQ CX, AX
+    SHRQ $1, AX
+    JZ   maxabs_sse2_reduce
+
+maxabs_sse2_loop2:
+    MOVUPD (SI), X1
+    ANDPD X2, X1
+    MAXPD X1, X0
+    ADDQ $16, SI
+    DECQ AX
+    JNZ  maxabs_sse2_loop2
+
+maxabs_sse2_reduce:
+    MOVAPD X0, X1
+    SHUFPD $1, X1, X1
+    MAXSD X1, X0
+
+    ANDQ $1, CX
+    JZ   maxabs_sse2_done
+
+    MOVSD (SI), X1
+    ANDPD X2, X1
+    MAXSD X1, X0
+
+maxabs_sse2_done:
+    MOVSD X0, ret+24(FP)
+    RET
+```
+
+- [ ] **Step 3: Declare + wire.** In `f64/f64_amd64.go`: add near the other reduction decls:
+
+```go
+//go:noescape
+func maxAbsAVX(a []float64) float64
+
+//go:noescape
+func maxAbsSSE2(a []float64) float64
+```
+
+Then set the impls: `initAVX512`, `initAVX`, `initAVXNoFMA` -> `maxAbsImpl = maxAbsAVX`; `initSSE2` -> `maxAbsImpl = maxAbsSSE2`; `initGo` stays `maxAbsGo`.
+
+- [ ] **Step 4: Run, verify pass:** `go test ./f64/ -run TestMaxAbs` -> PASS. Also force SSE2 via the existing vector-path test mechanism if present (`vector_path_test.go`); otherwise the parity test on this AVX2 host covers AVX.
+
+- [ ] **Step 5: Vet + lint:** `go vet ./f64/` and `golangci-lint run ./f64/...`.
+
+- [ ] **Step 6: Commit:**
+
+```bash
+git add f64/
+git commit -m "f64: add AVX2 + SSE2 MaxAbs kernels"
+```
+
+### Task 3: f64 maxAbsNEON kernel
+
+**Files:**
+- Modify: `f64/f64_arm64.s` (add kernel)
+- Modify: `f64/f64_arm64.go` (replace temporary dispatcher; add `//go:noescape` decl)
+
+- [ ] **Step 1: Add `maxAbsNEON`** to `f64/f64_arm64.s` (mirror `maxNEON` at line ~330 with `FABS V*.2D`). Encodings: `FABS V0.2D = 0x4EE0F800`, `FABS V1.2D = 0x4EE0F821` (`0x4EE0F800 | (Vn=1<<5) | Vd=1`):
+
+```
+// func maxAbsNEON(a []float64) float64
+TEXT ·maxAbsNEON(SB), NOSPLIT, $0-32
+    MOVD a_base+0(FP), R0
+    MOVD a_len+8(FP), R1
+
+    VLD1.P 16(R0), [V0.D2]
+    WORD $0x4EE0F800           // FABS V0.2D, V0.2D
+    SUB $2, R1
+
+    LSR $1, R1, R2
+    CBZ R2, maxabs_scalar
+
+maxabs_loop2:
+    VLD1.P 16(R0), [V1.D2]
+    WORD $0x4EE0F821           // FABS V1.2D, V1.2D
+    WORD $0x4E61F400           // FMAX V0.2D, V0.2D, V1.2D
+    SUB $1, R2
+    CBNZ R2, maxabs_loop2
+
+maxabs_scalar:
+    AND $1, R1
+    CBZ R1, maxabs_reduce
+
+    VDUP V0.D[1], V1.D2
+    FMAXD F0, F1, F0
+    FMOVD (R0), F1
+    FABSD F1, F1
+    FMAXD F0, F1, F0
+    FMOVD F0, ret+24(FP)
+    RET
+
+maxabs_reduce:
+    VDUP V0.D[1], V1.D2
+    FMAXD F0, F1, F0
+    FMOVD F0, ret+24(FP)
+    RET
+```
+
+(`FABSD` is a Go-assembler scalar mnemonic; if the assembler rejects it, hand-encode scalar `FABS D1,D1 = 0x1E60C021`. Verify during build.)
+
+- [ ] **Step 2: Declare + wire.** In `f64/f64_arm64.go`: replace the temporary `maxAbs64` with:
+
+```go
+func maxAbs64(a []float64) float64 {
+	if hasNEON && len(a) >= 2 {
+		return maxAbsNEON(a)
+	}
+	return maxAbsGo(a)
+}
+```
+
+Add with the other NEON decls:
+
+```go
+//go:noescape
+func maxAbsNEON(a []float64) float64
+```
+
+- [ ] **Step 3: Build arm64 + asmcheck on host:** `GOOS=linux GOARCH=arm64 go build ./f64/` and `go test ./ -run TestAsm` (asmcheck validates the new WORDs).
+
+- [ ] **Step 4: Run on rpi5:**
+
+```bash
+GOOS=linux GOARCH=arm64 go test -c -o /tmp/f64.arm64.test ./f64/
+scp /tmp/f64.arm64.test rpi5.local:/tmp/
+ssh rpi5.local /tmp/f64.arm64.test -test.run 'TestMaxAbs|TestAsm'
+```
+Expected: PASS.
+
+- [ ] **Step 5: Commit:**
+
+```bash
+git add f64/
+git commit -m "f64: add NEON MaxAbs kernel"
+```
+
+---
+
+## Phase 2: f32 MaxAbs
+
+### Task 4: f32 MaxAbs (Go + AVX + SSE + NEON), mirroring Phase 1
+
+**Files:** the `f32/` analogues of every file in Phase 1, plus `f32/maxabs_test.go`.
+
+- [ ] **Step 1:** Write `f32/maxabs_test.go` identical to `f64/maxabs_test.go` but with `float32`, `package f32`, and `float32(math.Abs(float64(v)))` in the reference (or a `float32`-native abs helper). Use `float32` literals.
+
+- [ ] **Step 2:** Add `maxAbsGo` to `f32/f32_go.go`, `MaxAbs` to `f32/f32.go`, `maxAbsImpl`/`maxAbs64`/init wiring to `f32/f32_amd64.go`, dispatcher to `f32/f32_arm64.go`, fallback to `f32/f32_other.go` — same shapes as Phase 1.
+
+- [ ] **Step 3:** Add `maxAbsAVX` to `f32/f32_amd64.s` mirroring f32 `maxAVX` (line ~539, 8-wide): load `VMOVUPS absf32mask<>(SB), Y2`; `VANDPS` each loaded vector; `SHRQ $3` / `ANDQ $7` tail; scalar uses `VMOVSS`+`VANDPS X1,X2,X1`+`VMAXSS`. Add `maxAbsSSE` mirroring f32 `maxSSE` (line ~1812) with `MOVUPS absf32mask<>(SB), X2` + `ANDPS X2, X*`.
+
+- [ ] **Step 4:** Add `maxAbsNEON` to `f32/f32_arm64.s` mirroring f32 `maxNEON` (4S, 4 lanes/vector) with `FABS V*.4S`. Encodings: `FABS V0.4S = 0x4EA0F800`, `FABS V1.4S = 0x4EA0F821`. Reduce path matches f32 `maxNEON` (uses `FMAXP`/`VDUP` lane reduction as in the existing kernel — copy its reduce sequence verbatim, prepend FABS to each load, and FABS the scalar tail element).
+
+- [ ] **Step 5:** Wire `//go:noescape` decls and init funcs in `f32/f32_amd64.go` (AVX512/AVX/AVXNoFMA -> `maxAbsAVX`, SSE2 -> `maxAbsSSE`, Go -> `maxAbsGo`) and `f32/f32_arm64.go` (`hasNEON && len>=4` -> `maxAbsNEON` else Go; note f32 NEON threshold is 4, matching f32 `max32`).
+
+- [ ] **Step 6:** `go test ./f32/`, `go vet ./f32/`, `golangci-lint run ./f32/...`, arm64 build + asmcheck, run on rpi5.
+
+- [ ] **Step 7: Commit:** `git commit -am "f32: add MaxAbs (Go + AVX + SSE + NEON)"`
+
+---
+
+## Phase 3: f64 + f32 ConvolveValidMaxAbs / ConvolveValidMaxAbsMulti
+
+### Task 5: f64 ConvolveValidMaxAbs + Multi (Go-level fusion)
+
+**Files:**
+- Modify: `f64/f64.go` (public funcs + fusion helpers)
+- Test: `f64/convolve_maxabs_test.go`
+
+- [ ] **Step 1: Write failing test** `f64/convolve_maxabs_test.go`:
+
+```go
+package f64
+
+import (
+	"math"
+	"testing"
+)
+
+// reference: full valid convolution then scalar abs-max.
+func refConvolveValidMaxAbs(signal, kernel []float64) float64 {
+	if len(kernel) == 0 || len(signal) < len(kernel) {
+		return 0
+	}
+	out := make([]float64, len(signal)-len(kernel)+1)
+	ConvolveValid(out, signal, kernel)
+	return scalarMaxAbs(out)
+}
+
+func TestConvolveValidMaxAbs(t *testing.T) {
+	for _, sl := range []int{1, 4, 7, 16, 33, 128} {
+		for _, kl := range []int{1, 2, 3, 5, 8} {
+			if sl < kl {
+				continue
+			}
+			signal := make([]float64, sl)
+			kernel := make([]float64, kl)
+			for i := range signal {
+				signal[i] = math.Sin(float64(i)*0.3) - 0.4*float64(i%3)
+			}
+			for i := range kernel {
+				kernel[i] = 0.5 - float64(i)*0.1
+			}
+			got := ConvolveValidMaxAbs(signal, kernel)
+			want := refConvolveValidMaxAbs(signal, kernel)
+			if math.Abs(got-want) > 1e-12*(1+math.Abs(want)) {
+				t.Errorf("sl=%d kl=%d: got %v want %v", sl, kl, got, want)
+			}
+		}
+	}
+}
+
+func TestConvolveValidMaxAbsEdge(t *testing.T) {
+	if got := ConvolveValidMaxAbs(nil, nil); got != 0 {
+		t.Errorf("nil/nil = %v want 0", got)
+	}
+	if got := ConvolveValidMaxAbs([]float64{1, 2}, []float64{1, 2, 3}); got != 0 {
+		t.Errorf("short signal = %v want 0", got)
+	}
+}
+
+func TestConvolveValidMaxAbsMulti(t *testing.T) {
+	signal := make([]float64, 64)
+	for i := range signal {
+		signal[i] = math.Cos(float64(i) * 0.21)
+	}
+	kernels := [][]float64{
+		{0.2, -0.1, 0.05, 0.3},
+		{-0.4, 0.4, -0.2, 0.1},
+		{0.9, 0.0, -0.9, 0.5},
+		{0.1, 0.1, 0.1, 0.1},
+	}
+	got := ConvolveValidMaxAbsMulti(signal, kernels)
+	want := 0.0
+	for _, k := range kernels {
+		if v := refConvolveValidMaxAbs(signal, k); v > want {
+			want = v
+		}
+	}
+	if math.Abs(got-want) > 1e-12*(1+math.Abs(want)) {
+		t.Errorf("Multi got %v want %v", got, want)
+	}
+}
+
+func TestConvolveValidMaxAbsMultiPanic(t *testing.T) {
+	defer func() {
+		if recover() == nil {
+			t.Error("expected panic on mismatched kernel lengths")
+		}
+	}()
+	ConvolveValidMaxAbsMulti([]float64{1, 2, 3, 4}, [][]float64{{1, 2}, {1, 2, 3}})
+}
+
+func TestConvolveValidMaxAbsNoAlloc(t *testing.T) {
+	signal := make([]float64, 256)
+	for i := range signal {
+		signal[i] = float64(i%9) - 4
+	}
+	kernel := []float64{0.1, -0.2, 0.3, -0.4}
+	if n := testing.AllocsPerRun(100, func() { _ = ConvolveValidMaxAbs(signal, kernel) }); n != 0 {
+		t.Errorf("ConvolveValidMaxAbs allocated %v, want 0", n)
+	}
+	kernels := [][]float64{{0.1, -0.2, 0.3, -0.4}, {0.2, 0.2, 0.2, 0.2}}
+	if n := testing.AllocsPerRun(100, func() { _ = ConvolveValidMaxAbsMulti(signal, kernels) }); n != 0 {
+		t.Errorf("ConvolveValidMaxAbsMulti allocated %v, want 0", n)
+	}
+}
+```
+
+- [ ] **Step 2: Run, verify fail (undefined):** `go test ./f64/ -run TestConvolveValidMaxAbs`
+
+- [ ] **Step 3: Implement** in `f64/f64.go` (after `ConvolveValidMulti`):
+
+```go
+// ConvolveValidMaxAbs returns max(|valid-convolution output|) without
+// materializing the output slice: the peak (infinity norm) of the FIR applied to
+// signal with no zero-padding. Returns 0 when len(kernel) == 0 or
+// len(signal) < len(kernel). Each output is a SIMD dot product; the abs-max is
+// fused in, so there is no scratch buffer and no second pass. Allocates nothing.
+func ConvolveValidMaxAbs(signal, kernel []float64) float64 {
+	if len(kernel) == 0 || len(signal) < len(kernel) {
+		return 0
+	}
+	return convolveValidMaxAbs64(signal, kernel)
+}
+
+func convolveValidMaxAbs64(signal, kernel []float64) float64 {
+	kLen := len(kernel)
+	validLen := len(signal) - kLen + 1
+	var m float64 // abs values are >= 0, so 0 is the correct identity
+	for i := 0; i < validLen; i++ {
+		if v := math.Abs(dotProduct(signal[i:i+kLen], kernel)); v > m {
+			m = v
+		}
+	}
+	return m
+}
+
+// ConvolveValidMaxAbsMulti returns the single maximum of |valid-convolution
+// output| across every kernel applied to signal, without materializing any
+// output. This is the polyphase true-peak primitive: pass the N phase kernels,
+// get back the peak of the reconstructed signal in one call. Returns 0 when
+// kernels is empty, the first kernel is empty, or len(signal) < kernel length.
+// Allocates nothing.
+//
+// Panics if the kernels do not all share one length, matching [ConvolveValidMulti].
+func ConvolveValidMaxAbsMulti(signal []float64, kernels [][]float64) float64 {
+	numKernels := len(kernels)
+	if numKernels == 0 {
+		return 0
+	}
+	kLen := len(kernels[0])
+	if kLen == 0 || len(signal) < kLen {
+		return 0
+	}
+	for i := 1; i < numKernels; i++ {
+		if len(kernels[i]) != kLen {
+			panic("simd: all kernels must have the same length")
+		}
+	}
+	var m float64
+	for _, kernel := range kernels {
+		if km := convolveValidMaxAbs64(signal, kernel); km > m {
+			m = km
+		}
+	}
+	return m
+}
+```
+
+Confirm `math` is imported in `f64/f64.go` (it is, used elsewhere).
+
+- [ ] **Step 4: Run, verify pass:** `go test ./f64/ -run TestConvolveValidMaxAbs` -> PASS.
+
+- [ ] **Step 5: Vet + lint:** `go vet ./f64/`; `golangci-lint run ./f64/...`.
+
+- [ ] **Step 6: Commit:** `git commit -am "f64: add ConvolveValidMaxAbs + ConvolveValidMaxAbsMulti"`
+
+### Task 6: f32 ConvolveValidMaxAbs + Multi
+
+**Files:**
+- Modify: `f32/f32.go`
+- Test: `f32/convolve_maxabs_test.go`
+
+- [ ] **Step 1:** Write `f32/convolve_maxabs_test.go` mirroring Task 5 with `float32` (tolerance `1e-4` relative, since f32). Reference uses `ConvolveValid` (f32) + `scalarMaxAbs` (f32 version).
+
+- [ ] **Step 2:** Implement `ConvolveValidMaxAbs`, `convolveValidMaxAbsF32`, `ConvolveValidMaxAbsMulti` in `f32/f32.go`, identical shape to f64 with `float32`. Abs via `float32(math.Abs(float64(v)))` or a local `absF32`.
+
+- [ ] **Step 3:** `go test ./f32/ -run TestConvolveValidMaxAbs` -> PASS; vet; lint.
+
+- [ ] **Step 4: Commit:** `git commit -am "f32: add ConvolveValidMaxAbs + ConvolveValidMaxAbsMulti"`
+
+---
+
+## Phase 4: Examples + Docs
+
+### Task 7: Example tests
+
+**Files:** `f64/example_test.go`, `f32/example_test.go`
+
+- [ ] **Step 1:** Add `ExampleMaxAbs`, `ExampleConvolveValidMaxAbs`, `ExampleConvolveValidMaxAbsMulti` to each package's `example_test.go`, each with `// Output:` blocks. Run `go test ./f64/ ./f32/ -run Example` -> PASS.
+
+- [ ] **Step 2: Commit:** `git commit -am "f64,f32: add MaxAbs/ConvolveValidMaxAbs examples"`
+
+### Task 8: doc.go + README
+
+**Files:** `doc.go`, `README.md`
+
+- [ ] **Step 1:** Add the three new functions (f64 + f32) to the function index in `doc.go`, in the reductions / convolution sections, matching the existing format.
+
+- [ ] **Step 2:** Add README entries: a `MaxAbs` row/section under the reduction ops and a `ConvolveValidMaxAbs`/`ConvolveValidMaxAbsMulti` section under convolution, describing the peak-detection use case and the empty/panic behavior. Mirror the format of neighboring entries (e.g. `Max`, `ConvolveValidMulti`).
+
+- [ ] **Step 3:** `go test ./...` (whole tree) and `golangci-lint run ./...` -> PASS.
+
+- [ ] **Step 4: Commit:** `git commit -am "docs: document MaxAbs and ConvolveValidMaxAbs[Multi]"`
+
+---
+
+## Phase 5: Final verification + PR
+
+### Task 9: Cross-arch verification and push
+
+- [ ] **Step 1:** Full amd64 suite: `go test ./...` -> PASS.
+- [ ] **Step 2:** Cross-compile + run full f64/f32 suites on rpi5 (arm64 NEON), confirm PASS.
+- [ ] **Step 3:** `golangci-lint run ./...` clean.
+- [ ] **Step 4:** Run `/gate` (or equivalent review) over the diff; address findings.
+- [ ] **Step 5:** Push branch, open PR referencing #138, run watch-pr loop to green + merge.
+
+---
+
+## Self-Review notes
+
+- Spec coverage: `MaxAbs` (Tasks 1-4), `ConvolveValidMaxAbs[Multi]` (Tasks 5-6), tests (each task), examples (Task 7), docs (Task 8), cross-arch (Task 9). All spec sections mapped.
+- AVX-512 routing: handled in Task 2/4 init wiring (AVX512 init -> `maxAbsAVX`).
+- Naming consistency: `maxAbs64`/`maxAbsImpl`/`maxAbsGo`/`maxAbsAVX`/`maxAbsSSE2`/`maxAbsNEON` (f64); `maxAbsF32`?? — f32 dispatcher is `maxAbs64`'s analogue. Match the f32 repo convention: f32 uses `max32` for the dispatcher, `maxGo`/`maxAVX`/`maxSSE`/`maxNEON` for kernels. So f32 names: dispatcher `maxAbs32`, kernels `maxAbsGo`/`maxAbsAVX`/`maxAbsSSE`/`maxAbsNEON`. Confirm against `f32/f32_amd64.go` `max32` at implementation time.
+- Convolve helpers call the dispatched `dotProduct`, so they are SIMD on every backend with no new asm.
+```

--- a/docs/superpowers/specs/2026-06-14-maxabs-convolvevalidmaxabs-design.md
+++ b/docs/superpowers/specs/2026-06-14-maxabs-convolvevalidmaxabs-design.md
@@ -1,0 +1,172 @@
+# MaxAbs reduction + fused ConvolveValid+MaxAbs for f64/f32
+
+GitHub issue: tphakala/simd#138
+
+## Problem
+
+A downstream EBU R 128 / ITU-R BS.1770-4 true-peak path runs a 4x polyphase
+oversampling FIR and needs the peak (max absolute value) of the oversampled
+signal. The convolution already runs through the SIMD dot-product path via
+`ConvolveValid`, but two costs remain:
+
+1. The abs-max reduction over each convolution output is a scalar loop that does
+   not vectorize (~7.5% of CPU in the caller's profile).
+2. A per-call scratch buffer holds the convolution outputs only so the caller can
+   scan them for the peak.
+
+## Goals
+
+Add to both the `f64` and `f32` packages (identical API shapes, `float32`
+substituted):
+
+```go
+// Vectorized infinity-norm reduction. Returns 0 for an empty slice.
+func MaxAbs(a []float64) float64
+
+// max(|valid-convolution output|) without materializing the output slice.
+func ConvolveValidMaxAbs(signal, kernel []float64) float64
+
+// Single maximum across all kernels' valid-convolution outputs.
+func ConvolveValidMaxAbsMulti(signal []float64, kernels [][]float64) float64
+```
+
+Non-goals: a dedicated AVX-512 kernel (no hardware here to validate it; AVX-512
+machines reuse the AVX2 kernel), and a fully fused single-pass convolution+max
+assembly kernel (the dot product already dominates; Go-level fusion captures the
+stated wins).
+
+## Design
+
+### 1. `MaxAbs` — vectorized reduction
+
+`MaxAbs` is a pure reduction in the same family as `Sum`/`Min`/`Max`, so it reuses
+that infrastructure.
+
+- **Public wrapper** (`f64.go` / `f32.go`): `len(a)==0` returns 0; otherwise call
+  the dispatched `maxAbs64` / `maxAbsF32`.
+- **Dispatch** (`f64_amd64.go` / `f32_amd64.go`): a new `maxAbsImpl reduceFunc`
+  function pointer, assigned in every `init*` path:
+  - `initAVX512` -> `maxAbsAVX` (reuse the tested AVX2 kernel)
+  - `initAVX` / `initAVXNoFMA` -> `maxAbsAVX`
+  - `initSSE2` -> `maxAbsSSE2` (f64) / `maxAbsSSE` (f32)
+  - `initGo` -> `maxAbsGo`
+  - The dispatcher `maxAbs64` falls back to `maxAbsGo` when
+    `len(a) < minSIMDElements`, mirroring `min64`/`max64` (the SIMD kernels do an
+    initial full-width vector load and must not read past the slice).
+- **Kernels** (each mirrors the existing `max*` reduction with abs folded into the
+  per-element load):
+  - `maxAbsGo` (`f64_go.go` / `f32_go.go`): bit-exact oracle.
+    `m := 0; for _, v := range a { av := abs(v); if av > m { m = av } }`.
+  - `maxAbsAVX` (`f64_amd64.s` / `f32_amd64.s`): the `maxAVX` body with
+    `VANDPD`/`VANDPS` against the existing `absf64mask<>` / `absf32mask<>` constant
+    applied to each loaded vector and to the scalar tail. 4-wide f64 / 8-wide f32.
+  - `maxAbsSSE2` (f64) / `maxAbsSSE` (f32): the `maxSSE2`/`maxSSE` body with
+    `ANDPD`/`ANDPS` masking.
+  - `maxAbsNEON` (`f64_arm64.s` / `f32_arm64.s`): the `maxNEON` body with `FABS`
+    (`0x4EE0F800` family for 2D, `0x4EA0F800` family for 4S) applied to each
+    loaded vector and the scalar tail. Hand-encoded `WORD`s with decoded-mnemonic
+    comments, cross-checked by the asmcheck suite.
+- **`_other.go`**: `func maxAbs64(a []float64) float64 { return maxAbsGo(a) }`.
+- **NaN**: `|NaN| = NaN`; comparisons against NaN are false, so the Go oracle
+  skips NaN. The SIMD `MAX` instructions make NaN handling architecture-dependent,
+  identical to the existing `Min`/`Max`. Documented with the same caveat; bit-exact
+  tests use non-NaN inputs.
+- **Empty**: returns 0.
+
+### 2. `ConvolveValidMaxAbs` / `ConvolveValidMaxAbsMulti` — Go-level fusion
+
+These reuse the already-dispatched SIMD `dotProduct`; no new assembly. Defined in
+`f64.go` / `f32.go` (which already call the arch-dispatched `dotProduct`), so the
+same source serves every backend.
+
+```go
+func ConvolveValidMaxAbs(signal, kernel []float64) float64 {
+    if len(kernel) == 0 || len(signal) < len(kernel) {
+        return 0
+    }
+    return convolveValidMaxAbs64(signal, kernel)
+}
+
+func convolveValidMaxAbs64(signal, kernel []float64) float64 {
+    kLen := len(kernel)
+    validLen := len(signal) - kLen + 1
+    var m float64 // abs values are >= 0, so 0 is the correct identity
+    for i := 0; i < validLen; i++ {
+        v := math.Abs(dotProduct(signal[i:i+kLen], kernel))
+        if v > m {
+            m = v
+        }
+    }
+    return m
+}
+```
+
+This removes the scratch buffer and the second abs-max scan; each output is still
+a SIMD dot product.
+
+`ConvolveValidMaxAbsMulti` mirrors `ConvolveValidMulti`'s validation contract:
+
+```go
+func ConvolveValidMaxAbsMulti(signal []float64, kernels [][]float64) float64 {
+    numKernels := len(kernels)
+    if numKernels == 0 {
+        return 0
+    }
+    kLen := len(kernels[0])
+    if kLen == 0 || len(signal) < kLen {
+        return 0
+    }
+    for i := 1; i < numKernels; i++ {
+        if len(kernels[i]) != kLen {
+            panic("simd: all kernels must have the same length")
+        }
+    }
+    var m float64
+    for _, kernel := range kernels {
+        if km := convolveValidMaxAbs64(signal, kernel); km > m {
+            m = km
+        }
+    }
+    return m
+}
+```
+
+Empty `kernels`, an empty first kernel, or a signal shorter than the kernel return
+0. Unequal kernel lengths panic, matching `ConvolveValidMulti` and the polyphase
+use case (all phase kernels share a length).
+
+## Testing
+
+Following the repo conventions (one Go reference, parity vs the active SIMD path,
+bit-exactness vs the per-element scalar path, allocation-free assertion):
+
+- `maxAbsGo` parity against the SIMD path on randomized data spanning lengths that
+  exercise the full-width body, the scalar tail, and the sub-`minSIMDElements`
+  fallback; include negatives, zeros, +/-Inf, and the empty slice.
+- Bit-exactness: `MaxAbs(a)` equals the scalar `max(|a[i]|)` reference.
+- `ConvolveValidMaxAbs` parity against `ConvolveValid` followed by a scalar
+  abs-max over the output; same for `Multi` across multiple kernels. Cover
+  `validLen == 0`, empty kernel, short signal, and the panic on mismatched kernel
+  lengths.
+- `testing.AllocsPerRun(... ) == 0` for `MaxAbs`, `ConvolveValidMaxAbs`, and
+  `ConvolveValidMaxAbsMulti` (the caller passes the kernels slice; no internal
+  allocation).
+- Fuzz tests for `MaxAbs` and `ConvolveValidMaxAbs` (parity oracle).
+- Runnable `Example` functions.
+- asmcheck validates every new NEON `WORD` against `golang.org/x/arch/arm64asm`.
+- amd64 paths (SSE2, AVX2, Go) run natively here; NEON runs on the rpi5 aarch64
+  host.
+
+## Files touched
+
+Per package (`f64`, `f32`):
+- `*.go`: public API + `ConvolveValidMaxAbs[Multi]` fusion helpers.
+- `*_amd64.go`: `maxAbsImpl` var, `init*` wiring, `maxAbs64` dispatcher, `//go:noescape` decls.
+- `*_amd64.s`: `maxAbsAVX`, `maxAbsSSE2`/`maxAbsSSE`.
+- `*_go.go`: `maxAbsGo`.
+- `*_arm64.go`: `maxAbs64` dispatcher, `//go:noescape` decl.
+- `*_arm64.s`: `maxAbsNEON`.
+- `*_other.go`: `maxAbs64` Go fallback.
+- new `*_test.go` coverage.
+
+Repo-level: `doc.go` function index, `README.md` sections.

--- a/f32/convolve_maxabs_test.go
+++ b/f32/convolve_maxabs_test.go
@@ -1,0 +1,113 @@
+package f32
+
+import (
+	"math"
+	"testing"
+)
+
+// refConvolveValidMaxAbs is the reference: a full valid convolution into a
+// materialized output, then a scalar abs-max over it.
+func refConvolveValidMaxAbs(signal, kernel []float32) float32 {
+	if len(kernel) == 0 || len(signal) < len(kernel) {
+		return 0
+	}
+	out := make([]float32, len(signal)-len(kernel)+1)
+	ConvolveValid(out, signal, kernel)
+	return scalarMaxAbs(out)
+}
+
+func TestConvolveValidMaxAbs(t *testing.T) {
+	for _, sl := range []int{1, 4, 7, 16, 33, 128} {
+		for _, kl := range []int{1, 2, 3, 5, 8} {
+			if sl < kl {
+				continue
+			}
+			signal := make([]float32, sl)
+			kernel := make([]float32, kl)
+			for i := range signal {
+				signal[i] = float32(math.Sin(float64(i)*0.3)) - 0.4*float32(i%3)
+			}
+			for i := range kernel {
+				kernel[i] = 0.5 - float32(i)*0.1
+			}
+			got := ConvolveValidMaxAbs(signal, kernel)
+			want := refConvolveValidMaxAbs(signal, kernel)
+			// Both paths run the same dispatched dotProduct, so they match exactly.
+			if got != want {
+				t.Errorf("sl=%d kl=%d: got %v want %v", sl, kl, got, want)
+			}
+		}
+	}
+}
+
+func TestConvolveValidMaxAbsEdge(t *testing.T) {
+	if got := ConvolveValidMaxAbs(nil, nil); got != 0 {
+		t.Errorf("nil/nil = %v want 0", got)
+	}
+	if got := ConvolveValidMaxAbs([]float32{1, 2}, []float32{1, 2, 3}); got != 0 {
+		t.Errorf("short signal = %v want 0", got)
+	}
+	if got := ConvolveValidMaxAbs([]float32{1, 2, 3}, nil); got != 0 {
+		t.Errorf("empty kernel = %v want 0", got)
+	}
+}
+
+func TestConvolveValidMaxAbsMulti(t *testing.T) {
+	signal := make([]float32, 64)
+	for i := range signal {
+		signal[i] = float32(math.Cos(float64(i) * 0.21))
+	}
+	kernels := [][]float32{
+		{0.2, -0.1, 0.05, 0.3},
+		{-0.4, 0.4, -0.2, 0.1},
+		{0.9, 0.0, -0.9, 0.5},
+		{0.1, 0.1, 0.1, 0.1},
+	}
+	got := ConvolveValidMaxAbsMulti(signal, kernels)
+	var want float32
+	for _, k := range kernels {
+		if v := refConvolveValidMaxAbs(signal, k); v > want {
+			want = v
+		}
+	}
+	if got != want {
+		t.Errorf("Multi got %v want %v", got, want)
+	}
+}
+
+func TestConvolveValidMaxAbsMultiEdge(t *testing.T) {
+	signal := []float32{1, 2, 3, 4}
+	if got := ConvolveValidMaxAbsMulti(signal, nil); got != 0 {
+		t.Errorf("no kernels = %v want 0", got)
+	}
+	if got := ConvolveValidMaxAbsMulti(signal, [][]float32{{}}); got != 0 {
+		t.Errorf("empty first kernel = %v want 0", got)
+	}
+	if got := ConvolveValidMaxAbsMulti([]float32{1}, [][]float32{{1, 2, 3}}); got != 0 {
+		t.Errorf("signal shorter than kernel = %v want 0", got)
+	}
+}
+
+func TestConvolveValidMaxAbsMultiPanic(t *testing.T) {
+	defer func() {
+		if recover() == nil {
+			t.Error("expected panic on mismatched kernel lengths")
+		}
+	}()
+	ConvolveValidMaxAbsMulti([]float32{1, 2, 3, 4}, [][]float32{{1, 2}, {1, 2, 3}})
+}
+
+func TestConvolveValidMaxAbsNoAlloc(t *testing.T) {
+	signal := make([]float32, 256)
+	for i := range signal {
+		signal[i] = float32(i%9) - 4
+	}
+	kernel := []float32{0.1, -0.2, 0.3, -0.4}
+	if n := testing.AllocsPerRun(100, func() { _ = ConvolveValidMaxAbs(signal, kernel) }); n != 0 {
+		t.Errorf("ConvolveValidMaxAbs allocated %v, want 0", n)
+	}
+	kernels := [][]float32{{0.1, -0.2, 0.3, -0.4}, {0.2, 0.2, 0.2, 0.2}}
+	if n := testing.AllocsPerRun(100, func() { _ = ConvolveValidMaxAbsMulti(signal, kernels) }); n != 0 {
+		t.Errorf("ConvolveValidMaxAbsMulti allocated %v, want 0", n)
+	}
+}

--- a/f32/example_test.go
+++ b/f32/example_test.go
@@ -72,3 +72,34 @@ func ExampleFMA() {
 	fmt.Println(dst)
 	// Output: [3 5 7]
 }
+
+func ExampleMaxAbs() {
+	a := []float32{1, -7, 3, -2}
+
+	result := f32.MaxAbs(a)
+	fmt.Printf("%.0f\n", result)
+	// Output: 7
+}
+
+func ExampleConvolveValidMaxAbs() {
+	signal := []float32{1, -2, 3, -4, 5}
+	kernel := []float32{1, -1}
+
+	// Peak of the valid-correlation output, no scratch buffer.
+	peak := f32.ConvolveValidMaxAbs(signal, kernel)
+	fmt.Printf("%.0f\n", peak)
+	// Output: 9
+}
+
+func ExampleConvolveValidMaxAbsMulti() {
+	signal := []float32{1, -2, 3, -4, 5}
+	kernels := [][]float32{
+		{1, 1},
+		{1, -1},
+	}
+
+	// Single peak across every kernel's output (polyphase true-peak).
+	peak := f32.ConvolveValidMaxAbsMulti(signal, kernels)
+	fmt.Printf("%.0f\n", peak)
+	// Output: 9
+}

--- a/f32/f32.go
+++ b/f32/f32.go
@@ -155,6 +155,22 @@ func Max(a []float32) float32 {
 	return max32(a)
 }
 
+// MaxAbs returns the maximum absolute value in the slice (the infinity norm),
+// max_i |a[i]|. Returns 0 for an empty slice.
+//
+// Uses AVX2/SSE on AMD64 (AVX-512 CPUs reuse the AVX2 kernel), NEON on ARM64,
+// with a pure Go fallback. a is read-only; the call allocates nothing.
+//
+// NaN handling: |NaN| is NaN and compares false, so the Go path skips NaN. On the
+// SIMD paths NaN handling is architecture-dependent, matching [Min] and [Max].
+// Callers needing strict NaN semantics should filter NaN first.
+func MaxAbs(a []float32) float32 {
+	if len(a) == 0 {
+		return 0
+	}
+	return maxAbs32(a)
+}
+
 // Abs computes element-wise absolute value: dst[i] = |a[i]|.
 func Abs(dst, a []float32) {
 	n := min(len(a), len(dst))

--- a/f32/f32.go
+++ b/f32/f32.go
@@ -634,6 +634,72 @@ func ConvolveValidMulti(dsts [][]float32, signal []float32, kernels [][]float32)
 	convolveValidMulti32(dsts, signal, kernels, n, kLen)
 }
 
+// ConvolveValidMaxAbs returns max(|valid-convolution output|) without
+// materializing the output slice: the peak (infinity norm) of the FIR applied to
+// signal with no zero-padding. Returns 0 when len(kernel) == 0 or
+// len(signal) < len(kernel).
+//
+// Each output element is a SIMD dot product; the abs-max is fused into the pass,
+// so there is no scratch buffer and no second scan over an output array. This is
+// the peak-detection / true-peak primitive. a is read-only; the call allocates
+// nothing.
+func ConvolveValidMaxAbs(signal, kernel []float32) float32 {
+	if len(kernel) == 0 || len(signal) < len(kernel) {
+		return 0
+	}
+	return convolveValidMaxAbs32(signal, kernel)
+}
+
+// convolveValidMaxAbs32 fuses the valid convolution with the abs-max reduction.
+// It calls the dispatched SIMD dotProduct per output position, so it is
+// vectorized on every backend without a dedicated kernel.
+func convolveValidMaxAbs32(signal, kernel []float32) float32 {
+	kLen := len(kernel)
+	validLen := len(signal) - kLen + 1
+	var m float32 // abs values are >= 0, so 0 is the correct identity
+	for i := range validLen {
+		v := dotProduct(signal[i:i+kLen], kernel)
+		if v < 0 {
+			v = -v
+		}
+		if v > m {
+			m = v
+		}
+	}
+	return m
+}
+
+// ConvolveValidMaxAbsMulti returns the single maximum of |valid-convolution
+// output| across every kernel applied to signal, without materializing any
+// output. This is the polyphase true-peak primitive: pass the N phase kernels and
+// get back the peak of the reconstructed signal in one call. Returns 0 when
+// kernels is empty, the first kernel is empty, or len(signal) is shorter than the
+// kernel length. The call allocates nothing.
+//
+// Panics if the kernels do not all share one length, matching [ConvolveValidMulti].
+func ConvolveValidMaxAbsMulti(signal []float32, kernels [][]float32) float32 {
+	numKernels := len(kernels)
+	if numKernels == 0 {
+		return 0
+	}
+	kLen := len(kernels[0])
+	if kLen == 0 || len(signal) < kLen {
+		return 0
+	}
+	for i := 1; i < numKernels; i++ {
+		if len(kernels[i]) != kLen {
+			panic("simd: all kernels must have the same length")
+		}
+	}
+	var m float32
+	for _, kernel := range kernels {
+		if km := convolveValidMaxAbs32(signal, kernel); km > m {
+			m = km
+		}
+	}
+	return m
+}
+
 // Sigmoid computes the sigmoid activation function: dst[i] = 1 / (1 + e^(-src[i])).
 // This is commonly used as an activation function in neural networks.
 // Processes min(len(dst), len(src)) elements.

--- a/f32/f32_amd64.go
+++ b/f32/f32_amd64.go
@@ -51,6 +51,7 @@ var (
 	sumImpl               reduceFunc
 	minImpl               reduceFunc
 	maxImpl               reduceFunc
+	maxAbsImpl            reduceFunc
 	absImpl               unaryOpFunc
 	negImpl               unaryOpFunc
 	sqrtImpl              unaryOpFunc
@@ -95,6 +96,9 @@ func initAVX512() {
 	sumImpl = sumAVX512
 	minImpl = minAVX512
 	maxImpl = maxAVX512
+	// AVX-512 reuses the AVX2 MaxAbs kernel (no AVX-512 hardware to verify a
+	// dedicated VL kernel; see #138), mirroring variance/euclidean above.
+	maxAbsImpl = maxAbsAVX
 	absImpl = absAVX512
 	negImpl = negAVX512
 	sqrtImpl = sqrtAVX512
@@ -125,6 +129,7 @@ func initAVX() {
 	sumImpl = sumAVX
 	minImpl = minAVX
 	maxImpl = maxAVX
+	maxAbsImpl = maxAbsAVX
 	absImpl = absAVX
 	negImpl = negAVX
 	sqrtImpl = sqrtAVX
@@ -152,6 +157,7 @@ func initSSE() {
 	sumImpl = sumSSE
 	minImpl = minSSE
 	maxImpl = maxSSE
+	maxAbsImpl = maxAbsSSE
 	absImpl = absSSE
 	negImpl = negSSE
 	sqrtImpl = sqrtSSE
@@ -181,6 +187,7 @@ func initGo() {
 	sumImpl = sumGo
 	minImpl = minGo
 	maxImpl = maxGo
+	maxAbsImpl = maxAbsGo
 	absImpl = absGo
 	negImpl = negGo
 	sqrtImpl = sqrt32Go
@@ -247,6 +254,15 @@ func max32(a []float32) float32 {
 		return maxGo(a)
 	}
 	return maxImpl(a)
+}
+
+func maxAbs32(a []float32) float32 {
+	// The SIMD kernels do a full-width initial vector load; fall back to Go for
+	// small slices to avoid reading beyond bounds (mirrors min32/max32).
+	if len(a) < minSIMDElements {
+		return maxAbsGo(a)
+	}
+	return maxAbsImpl(a)
 }
 
 func abs32(dst, a []float32) {
@@ -712,6 +728,9 @@ func minAVX(a []float32) float32
 func maxAVX(a []float32) float32
 
 //go:noescape
+func maxAbsAVX(a []float32) float32
+
+//go:noescape
 func absAVX(dst, a []float32)
 
 //go:noescape
@@ -840,6 +859,9 @@ func minSSE(a []float32) float32
 
 //go:noescape
 func maxSSE(a []float32) float32
+
+//go:noescape
+func maxAbsSSE(a []float32) float32
 
 //go:noescape
 func absSSE(dst, a []float32)

--- a/f32/f32_amd64.s
+++ b/f32/f32_amd64.s
@@ -579,6 +579,55 @@ max32_done:
     VZEROUPPER
     RET
 
+// func maxAbsAVX(a []float32) float32
+// max_i |a[i]|. Mirrors maxAVX with the sign bit cleared (VANDPS absf32mask)
+// on each loaded vector and the scalar tail before the running max.
+TEXT ·maxAbsAVX(SB), NOSPLIT, $0-28
+    MOVQ a_base+0(FP), SI
+    MOVQ a_len+8(FP), CX
+
+    VMOVUPS absf32mask<>(SB), Y2   // Y2 = abs mask (X2 = low 128 for the tail)
+    VMOVUPS (SI), Y0
+    VANDPS Y0, Y2, Y0             // Y0 = |a[0:8]|
+    ADDQ $32, SI
+    SUBQ $8, CX
+
+    MOVQ CX, AX
+    SHRQ $3, AX
+    JZ   maxabs32_avx_reduce
+
+maxabs32_avx_loop8:
+    VMOVUPS (SI), Y1
+    VANDPS Y1, Y2, Y1
+    VMAXPS Y0, Y1, Y0
+    ADDQ $32, SI
+    DECQ AX
+    JNZ  maxabs32_avx_loop8
+
+maxabs32_avx_reduce:
+    VEXTRACTF128 $1, Y0, X1
+    VMAXPS X0, X1, X0
+    VPERMILPS $0x0E, X0, X1
+    VMAXPS X0, X1, X0
+    VPERMILPS $0x01, X0, X1
+    VMAXSS X0, X1, X0
+
+    ANDQ $7, CX
+    JZ   maxabs32_avx_done
+
+maxabs32_avx_scalar:
+    VMOVSS (SI), X1
+    VANDPS X1, X2, X1
+    VMAXSS X0, X1, X0
+    ADDQ $4, SI
+    DECQ CX
+    JNZ  maxabs32_avx_scalar
+
+maxabs32_avx_done:
+    VMOVSS X0, ret+24(FP)
+    VZEROUPPER
+    RET
+
 // func absAVX(dst, a []float32)
 TEXT ·absAVX(SB), NOSPLIT, $0-48
     MOVQ dst_base+0(FP), DX
@@ -1847,6 +1896,53 @@ max32_sse_scalar:
     JNZ  max32_sse_scalar
 
 max32_sse_done:
+    MOVSS X0, ret+24(FP)
+    RET
+
+// func maxAbsSSE(a []float32) float32
+// max_i |a[i]|. Mirrors maxSSE with ANDPS absf32mask folded into each load.
+TEXT ·maxAbsSSE(SB), NOSPLIT, $0-28
+    MOVQ a_base+0(FP), SI
+    MOVQ a_len+8(FP), CX
+
+    MOVUPS absf32mask<>(SB), X2
+    MOVUPS (SI), X0
+    ANDPS X2, X0                 // X0 = |a[0:4]|
+    ADDQ $16, SI
+    SUBQ $4, CX
+
+    MOVQ CX, AX
+    SHRQ $2, AX
+    JZ   maxabs32_sse_reduce
+
+maxabs32_sse_loop4:
+    MOVUPS (SI), X1
+    ANDPS X2, X1
+    MAXPS X1, X0
+    ADDQ $16, SI
+    DECQ AX
+    JNZ  maxabs32_sse_loop4
+
+maxabs32_sse_reduce:
+    MOVAPS X0, X1
+    SHUFPS $0x0E, X1, X1
+    MAXPS X1, X0
+    MOVAPS X0, X1
+    SHUFPS $0x01, X1, X1
+    MAXSS X1, X0
+
+    ANDQ $3, CX
+    JZ   maxabs32_sse_done
+
+maxabs32_sse_scalar:
+    MOVSS (SI), X1
+    ANDPS X2, X1
+    MAXSS X1, X0
+    ADDQ $4, SI
+    DECQ CX
+    JNZ  maxabs32_sse_scalar
+
+maxabs32_sse_done:
     MOVSS X0, ret+24(FP)
     RET
 

--- a/f32/f32_arm64.go
+++ b/f32/f32_arm64.go
@@ -89,6 +89,13 @@ func max32(a []float32) float32 {
 	return maxGo(a)
 }
 
+func maxAbs32(a []float32) float32 {
+	if hasNEON && len(a) >= 4 {
+		return maxAbsNEON(a)
+	}
+	return maxAbsGo(a)
+}
+
 func abs32(dst, a []float32) {
 	if hasNEON && len(dst) >= 4 {
 		absNEON(dst, a)
@@ -347,6 +354,9 @@ func minNEON(a []float32) float32
 
 //go:noescape
 func maxNEON(a []float32) float32
+
+//go:noescape
+func maxAbsNEON(a []float32) float32
 
 //go:noescape
 func absNEON(dst, a []float32)

--- a/f32/f32_arm64.s
+++ b/f32/f32_arm64.s
@@ -535,6 +535,53 @@ max32_reduce:
     FMOVS F0, ret+24(FP)
     RET
 
+// func maxAbsNEON(a []float32) float32
+// max_i |a[i]|. Mirrors maxNEON with FABS folded into each loaded vector and the
+// scalar tail (4 x float32 per 128-bit register).
+TEXT ·maxAbsNEON(SB), NOSPLIT, $0-28
+    MOVD a_base+0(FP), R0
+    MOVD a_len+8(FP), R1
+
+    VLD1.P 16(R0), [V0.S4]
+    WORD $0x4EA0F800           // FABS V0.4S, V0.4S
+    SUB $4, R1
+
+    LSR $2, R1, R2
+    CBZ R2, maxabs32_scalar
+
+maxabs32_loop4:
+    VLD1.P 16(R0), [V1.S4]
+    WORD $0x4EA0F821           // FABS V1.4S, V1.4S
+    WORD $0x4E21F400           // FMAX V0.4S, V0.4S, V1.4S
+    SUB $1, R2
+    CBNZ R2, maxabs32_loop4
+
+maxabs32_scalar:
+    AND $3, R1
+    CBZ R1, maxabs32_reduce
+
+    // Reduce vector FIRST before scalar ops
+    WORD $0x6E20F400           // FMAXP V0.4S, V0.4S, V0.4S
+    WORD $0x7E30F800           // FMAXP S0, V0.2S
+
+maxabs32_loop1:
+    FMOVS (R0), F1
+    FABSS F1, F1
+    FMAXS F0, F1, F0
+    ADD $4, R0
+    SUB $1, R1
+    CBNZ R1, maxabs32_loop1
+
+    FMOVS F0, ret+24(FP)
+    RET
+
+maxabs32_reduce:
+    // Horizontal max when no scalar remainder
+    WORD $0x6E20F400           // FMAXP V0.4S, V0.4S, V0.4S
+    WORD $0x7E30F800           // FMAXP S0, V0.2S
+    FMOVS F0, ret+24(FP)
+    RET
+
 // func absNEON(dst, a []float32)
 TEXT ·absNEON(SB), NOSPLIT, $0-48
     MOVD dst_base+0(FP), R0

--- a/f32/f32_go.go
+++ b/f32/f32_go.go
@@ -148,6 +148,21 @@ func maxGo(a []float32) float32 {
 	return m
 }
 
+// maxAbsGo returns max_i |a[i]| (the infinity norm), 0 for an empty slice.
+// It is the bit-exact source of truth for the MaxAbs kernels.
+func maxAbsGo(a []float32) float32 {
+	var m float32
+	for _, v := range a {
+		if v < 0 {
+			v = -v
+		}
+		if v > m {
+			m = v
+		}
+	}
+	return m
+}
+
 func absGo(dst, a []float32) {
 	if len(dst) == 0 {
 		return

--- a/f32/f32_other.go
+++ b/f32/f32_other.go
@@ -13,6 +13,7 @@ func subFromScalar32(dst, a []float32, s float32)      { subFromScalarGo(dst, a,
 func sum(a []float32) float32                          { return sumGo(a) }
 func min32(a []float32) float32                        { return minGo(a) }
 func max32(a []float32) float32                        { return maxGo(a) }
+func maxAbs32(a []float32) float32                     { return maxAbsGo(a) }
 func abs32(dst, a []float32)                           { absGo(dst, a) }
 func neg32(dst, a []float32)                           { negGo(dst, a) }
 func fma32(dst, a, b, c []float32)                     { fmaGo(dst, a, b, c) }

--- a/f32/fuzz_test.go
+++ b/f32/fuzz_test.go
@@ -293,6 +293,58 @@ func FuzzF32Convolve(f *testing.F) {
 	})
 }
 
+func FuzzF32MaxAbs(f *testing.F) {
+	addByteLenSeeds(f)
+	f.Fuzz(func(t *testing.T, raw []byte) {
+		v := f32sUnit(raw)
+		// abs and max are exact and order-independent, so the SIMD path matches
+		// the Go reference bit-for-bit.
+		if got, want := MaxAbs(v), maxAbsGo(v); got != want {
+			t.Fatalf("MaxAbs got %v want %v", got, want)
+		}
+	})
+}
+
+func FuzzF32ConvolveMaxAbs(f *testing.F) {
+	addByteLenSeeds(f)
+	f.Fuzz(func(t *testing.T, raw []byte) {
+		v := f32sUnit(raw)
+		if len(v) < 4 {
+			return
+		}
+		kLen := 1 + int(raw[0])%min(len(v)-1, 16)
+		kernel := v[:kLen]
+		signal := v[kLen:]
+		if len(signal) < kLen {
+			return
+		}
+		// ConvolveValid and ConvolveValidMaxAbs share the dispatched dotProduct,
+		// so the fused peak equals max|ConvolveValid output| exactly.
+		out := make([]float32, len(signal)-kLen+1)
+		ConvolveValid(out, signal, kernel)
+		want := maxAbsGo(out)
+		if got := ConvolveValidMaxAbs(signal, kernel); got != want {
+			t.Fatalf("ConvolveValidMaxAbs got %v want %v", got, want)
+		}
+
+		if kLen >= 2 {
+			half := kLen / 2
+			kernels := [][]float32{kernel[:half], kernel[half : half*2]}
+			var wantMulti float32
+			for _, k := range kernels {
+				o := make([]float32, len(signal)-len(k)+1)
+				ConvolveValid(o, signal, k)
+				if m := maxAbsGo(o); m > wantMulti {
+					wantMulti = m
+				}
+			}
+			if got := ConvolveValidMaxAbsMulti(signal, kernels); got != wantMulti {
+				t.Fatalf("ConvolveValidMaxAbsMulti got %v want %v", got, wantMulti)
+			}
+		}
+	})
+}
+
 func FuzzF32InterleaveN(f *testing.F) {
 	addByteLenSeeds(f)
 	f.Fuzz(func(t *testing.T, raw []byte) {

--- a/f32/maxabs_amd64_test.go
+++ b/f32/maxabs_amd64_test.go
@@ -1,0 +1,45 @@
+//go:build amd64
+
+package f32
+
+import (
+	"math"
+	"testing"
+
+	"github.com/tphakala/simd/cpu"
+)
+
+// TestMaxAbsKernelsAMD64 exercises each amd64 MaxAbs kernel directly (bypassing
+// dispatch), so SSE is covered even on an AVX2 host. Each kernel does a
+// full-width initial load, so only lengths >= the kernel stride are passed
+// (SSE: 4 lanes, AVX: 8 lanes).
+func TestMaxAbsKernelsAMD64(t *testing.T) {
+	mk := func(n int) []float32 {
+		a := make([]float32, n)
+		for i := range a {
+			a[i] = float32(math.Cos(float64(i)*0.37)) * float32((i%7)-3) * 9.5
+		}
+		return a
+	}
+
+	t.Run("SSE", func(t *testing.T) {
+		for _, n := range []int{4, 5, 6, 7, 8, 9, 16, 17, 31, 64, 127} {
+			a := mk(n)
+			if got, want := maxAbsSSE(a), maxAbsGo(a); got != want {
+				t.Errorf("n=%d: maxAbsSSE=%v want %v", n, got, want)
+			}
+		}
+	})
+
+	t.Run("AVX", func(t *testing.T) {
+		if !cpu.X86.AVX {
+			t.Skip("AVX not supported on this CPU")
+		}
+		for _, n := range []int{8, 9, 10, 15, 16, 17, 31, 33, 64, 127, 256} {
+			a := mk(n)
+			if got, want := maxAbsAVX(a), maxAbsGo(a); got != want {
+				t.Errorf("n=%d: maxAbsAVX=%v want %v", n, got, want)
+			}
+		}
+	})
+}

--- a/f32/maxabs_test.go
+++ b/f32/maxabs_test.go
@@ -1,0 +1,64 @@
+package f32
+
+import (
+	"math"
+	"testing"
+)
+
+// scalarMaxAbs is the independent reference: max(|a[i]|), 0 for empty.
+func scalarMaxAbs(a []float32) float32 {
+	var m float32
+	for _, v := range a {
+		if v < 0 {
+			v = -v
+		}
+		if v > m {
+			m = v
+		}
+	}
+	return m
+}
+
+func TestMaxAbs(t *testing.T) {
+	cases := [][]float32{
+		nil,
+		{},
+		{0},
+		{float32(math.Copysign(0, -1))},
+		{3, -7, 2},
+		{-1, -2, -3, -4, -5, -6, -7, -8, -9},
+		{1.5, -1.5, 0.25, -0.25, 100, -99.9, 0, 42},
+		{float32(math.Inf(1)), -3},
+		{float32(math.Inf(-1)), 3},
+	}
+	for i, a := range cases {
+		got := MaxAbs(a)
+		want := scalarMaxAbs(a)
+		if got != want {
+			t.Errorf("case %d: MaxAbs(%v) = %v, want %v", i, a, got, want)
+		}
+	}
+}
+
+func TestMaxAbsParity(t *testing.T) {
+	// Lengths spanning the SIMD body, the scalar tail, and the small fallback.
+	for _, n := range []int{0, 1, 2, 3, 4, 5, 7, 8, 9, 15, 16, 17, 31, 33, 64, 127, 256} {
+		a := make([]float32, n)
+		for i := range a {
+			a[i] = float32(math.Sin(float64(i)*0.7)) * float32((i%5)-2) * 13.3
+		}
+		if got, want := MaxAbs(a), scalarMaxAbs(a); got != want {
+			t.Errorf("n=%d: MaxAbs=%v want %v", n, got, want)
+		}
+	}
+}
+
+func TestMaxAbsNoAlloc(t *testing.T) {
+	a := make([]float32, 1024)
+	for i := range a {
+		a[i] = float32(i%7) - 3
+	}
+	if n := testing.AllocsPerRun(100, func() { _ = MaxAbs(a) }); n != 0 {
+		t.Errorf("MaxAbs allocated %v times, want 0", n)
+	}
+}

--- a/f64/convolve_maxabs_test.go
+++ b/f64/convolve_maxabs_test.go
@@ -32,7 +32,8 @@ func TestConvolveValidMaxAbs(t *testing.T) {
 			}
 			got := ConvolveValidMaxAbs(signal, kernel)
 			want := refConvolveValidMaxAbs(signal, kernel)
-			if math.Abs(got-want) > 1e-12*(1+math.Abs(want)) {
+			// Both paths run the same dispatched dotProduct, so they match exactly.
+			if got != want {
 				t.Errorf("sl=%d kl=%d: got %v want %v", sl, kl, got, want)
 			}
 		}
@@ -69,7 +70,8 @@ func TestConvolveValidMaxAbsMulti(t *testing.T) {
 			want = v
 		}
 	}
-	if math.Abs(got-want) > 1e-12*(1+math.Abs(want)) {
+	// Both paths run the same dispatched dotProduct, so they match exactly.
+	if got != want {
 		t.Errorf("Multi got %v want %v", got, want)
 	}
 }

--- a/f64/convolve_maxabs_test.go
+++ b/f64/convolve_maxabs_test.go
@@ -1,0 +1,112 @@
+package f64
+
+import (
+	"math"
+	"testing"
+)
+
+// refConvolveValidMaxAbs is the reference: a full valid convolution into a
+// materialized output, then a scalar abs-max over it.
+func refConvolveValidMaxAbs(signal, kernel []float64) float64 {
+	if len(kernel) == 0 || len(signal) < len(kernel) {
+		return 0
+	}
+	out := make([]float64, len(signal)-len(kernel)+1)
+	ConvolveValid(out, signal, kernel)
+	return scalarMaxAbs(out)
+}
+
+func TestConvolveValidMaxAbs(t *testing.T) {
+	for _, sl := range []int{1, 4, 7, 16, 33, 128} {
+		for _, kl := range []int{1, 2, 3, 5, 8} {
+			if sl < kl {
+				continue
+			}
+			signal := make([]float64, sl)
+			kernel := make([]float64, kl)
+			for i := range signal {
+				signal[i] = math.Sin(float64(i)*0.3) - 0.4*float64(i%3)
+			}
+			for i := range kernel {
+				kernel[i] = 0.5 - float64(i)*0.1
+			}
+			got := ConvolveValidMaxAbs(signal, kernel)
+			want := refConvolveValidMaxAbs(signal, kernel)
+			if math.Abs(got-want) > 1e-12*(1+math.Abs(want)) {
+				t.Errorf("sl=%d kl=%d: got %v want %v", sl, kl, got, want)
+			}
+		}
+	}
+}
+
+func TestConvolveValidMaxAbsEdge(t *testing.T) {
+	if got := ConvolveValidMaxAbs(nil, nil); got != 0 {
+		t.Errorf("nil/nil = %v want 0", got)
+	}
+	if got := ConvolveValidMaxAbs([]float64{1, 2}, []float64{1, 2, 3}); got != 0 {
+		t.Errorf("short signal = %v want 0", got)
+	}
+	if got := ConvolveValidMaxAbs([]float64{1, 2, 3}, nil); got != 0 {
+		t.Errorf("empty kernel = %v want 0", got)
+	}
+}
+
+func TestConvolveValidMaxAbsMulti(t *testing.T) {
+	signal := make([]float64, 64)
+	for i := range signal {
+		signal[i] = math.Cos(float64(i) * 0.21)
+	}
+	kernels := [][]float64{
+		{0.2, -0.1, 0.05, 0.3},
+		{-0.4, 0.4, -0.2, 0.1},
+		{0.9, 0.0, -0.9, 0.5},
+		{0.1, 0.1, 0.1, 0.1},
+	}
+	got := ConvolveValidMaxAbsMulti(signal, kernels)
+	want := 0.0
+	for _, k := range kernels {
+		if v := refConvolveValidMaxAbs(signal, k); v > want {
+			want = v
+		}
+	}
+	if math.Abs(got-want) > 1e-12*(1+math.Abs(want)) {
+		t.Errorf("Multi got %v want %v", got, want)
+	}
+}
+
+func TestConvolveValidMaxAbsMultiEdge(t *testing.T) {
+	signal := []float64{1, 2, 3, 4}
+	if got := ConvolveValidMaxAbsMulti(signal, nil); got != 0 {
+		t.Errorf("no kernels = %v want 0", got)
+	}
+	if got := ConvolveValidMaxAbsMulti(signal, [][]float64{{}}); got != 0 {
+		t.Errorf("empty first kernel = %v want 0", got)
+	}
+	if got := ConvolveValidMaxAbsMulti([]float64{1}, [][]float64{{1, 2, 3}}); got != 0 {
+		t.Errorf("signal shorter than kernel = %v want 0", got)
+	}
+}
+
+func TestConvolveValidMaxAbsMultiPanic(t *testing.T) {
+	defer func() {
+		if recover() == nil {
+			t.Error("expected panic on mismatched kernel lengths")
+		}
+	}()
+	ConvolveValidMaxAbsMulti([]float64{1, 2, 3, 4}, [][]float64{{1, 2}, {1, 2, 3}})
+}
+
+func TestConvolveValidMaxAbsNoAlloc(t *testing.T) {
+	signal := make([]float64, 256)
+	for i := range signal {
+		signal[i] = float64(i%9) - 4
+	}
+	kernel := []float64{0.1, -0.2, 0.3, -0.4}
+	if n := testing.AllocsPerRun(100, func() { _ = ConvolveValidMaxAbs(signal, kernel) }); n != 0 {
+		t.Errorf("ConvolveValidMaxAbs allocated %v, want 0", n)
+	}
+	kernels := [][]float64{{0.1, -0.2, 0.3, -0.4}, {0.2, 0.2, 0.2, 0.2}}
+	if n := testing.AllocsPerRun(100, func() { _ = ConvolveValidMaxAbsMulti(signal, kernels) }); n != 0 {
+		t.Errorf("ConvolveValidMaxAbsMulti allocated %v, want 0", n)
+	}
+}

--- a/f64/example_test.go
+++ b/f64/example_test.go
@@ -98,3 +98,34 @@ func ExampleFMA() {
 	fmt.Println(dst)
 	// Output: [3 5 7]
 }
+
+func ExampleMaxAbs() {
+	a := []float64{1, -7, 3, -2}
+
+	result := f64.MaxAbs(a)
+	fmt.Printf("%.0f\n", result)
+	// Output: 7
+}
+
+func ExampleConvolveValidMaxAbs() {
+	signal := []float64{1, -2, 3, -4, 5}
+	kernel := []float64{1, -1}
+
+	// Peak of the valid-correlation output, no scratch buffer.
+	peak := f64.ConvolveValidMaxAbs(signal, kernel)
+	fmt.Printf("%.0f\n", peak)
+	// Output: 9
+}
+
+func ExampleConvolveValidMaxAbsMulti() {
+	signal := []float64{1, -2, 3, -4, 5}
+	kernels := [][]float64{
+		{1, 1},
+		{1, -1},
+	}
+
+	// Single peak across every kernel's output (polyphase true-peak).
+	peak := f64.ConvolveValidMaxAbsMulti(signal, kernels)
+	fmt.Printf("%.0f\n", peak)
+	// Output: 9
+}

--- a/f64/f64.go
+++ b/f64/f64.go
@@ -155,6 +155,22 @@ func Max(a []float64) float64 {
 	return max64(a)
 }
 
+// MaxAbs returns the maximum absolute value in the slice (the infinity norm),
+// max_i |a[i]|. Returns 0 for an empty slice.
+//
+// Uses AVX2/SSE2 on AMD64 (AVX-512 CPUs reuse the AVX2 kernel), NEON on ARM64,
+// with a pure Go fallback. a is read-only; the call allocates nothing.
+//
+// NaN handling: |NaN| is NaN and compares false, so the Go path skips NaN. On the
+// SIMD paths NaN handling is architecture-dependent, matching [Min] and [Max].
+// Callers needing strict NaN semantics should filter NaN first.
+func MaxAbs(a []float64) float64 {
+	if len(a) == 0 {
+		return 0
+	}
+	return maxAbs64(a)
+}
+
 // Abs computes element-wise absolute value: dst[i] = |a[i]|.
 // Processes min(len(dst), len(a)) elements.
 func Abs(dst, a []float64) {

--- a/f64/f64.go
+++ b/f64/f64.go
@@ -634,6 +634,68 @@ func ConvolveValidMulti(dsts [][]float64, signal []float64, kernels [][]float64)
 	convolveValidMulti64(dsts, signal, kernels, n, kLen)
 }
 
+// ConvolveValidMaxAbs returns max(|valid-convolution output|) without
+// materializing the output slice: the peak (infinity norm) of the FIR applied to
+// signal with no zero-padding. Returns 0 when len(kernel) == 0 or
+// len(signal) < len(kernel).
+//
+// Each output element is a SIMD dot product; the abs-max is fused into the pass,
+// so there is no scratch buffer and no second scan over an output array. This is
+// the peak-detection / true-peak primitive. a is read-only; the call allocates
+// nothing.
+func ConvolveValidMaxAbs(signal, kernel []float64) float64 {
+	if len(kernel) == 0 || len(signal) < len(kernel) {
+		return 0
+	}
+	return convolveValidMaxAbs64(signal, kernel)
+}
+
+// convolveValidMaxAbs64 fuses the valid convolution with the abs-max reduction.
+// It calls the dispatched SIMD dotProduct per output position, so it is
+// vectorized on every backend without a dedicated kernel.
+func convolveValidMaxAbs64(signal, kernel []float64) float64 {
+	kLen := len(kernel)
+	validLen := len(signal) - kLen + 1
+	var m float64 // abs values are >= 0, so 0 is the correct identity
+	for i := range validLen {
+		if v := math.Abs(dotProduct(signal[i:i+kLen], kernel)); v > m {
+			m = v
+		}
+	}
+	return m
+}
+
+// ConvolveValidMaxAbsMulti returns the single maximum of |valid-convolution
+// output| across every kernel applied to signal, without materializing any
+// output. This is the polyphase true-peak primitive: pass the N phase kernels and
+// get back the peak of the reconstructed signal in one call. Returns 0 when
+// kernels is empty, the first kernel is empty, or len(signal) is shorter than the
+// kernel length. The call allocates nothing.
+//
+// Panics if the kernels do not all share one length, matching [ConvolveValidMulti].
+func ConvolveValidMaxAbsMulti(signal []float64, kernels [][]float64) float64 {
+	numKernels := len(kernels)
+	if numKernels == 0 {
+		return 0
+	}
+	kLen := len(kernels[0])
+	if kLen == 0 || len(signal) < kLen {
+		return 0
+	}
+	for i := 1; i < numKernels; i++ {
+		if len(kernels[i]) != kLen {
+			panic("simd: all kernels must have the same length")
+		}
+	}
+	var m float64
+	for _, kernel := range kernels {
+		if km := convolveValidMaxAbs64(signal, kernel); km > m {
+			m = km
+		}
+	}
+	return m
+}
+
 // Sigmoid computes the sigmoid activation function: dst[i] = 1 / (1 + e^(-src[i])).
 // This is commonly used as an activation function in neural networks.
 // Processes min(len(dst), len(src)) elements.

--- a/f64/f64_amd64.go
+++ b/f64/f64_amd64.go
@@ -54,6 +54,7 @@ var (
 	sumImpl               reduceFunc
 	minImpl               reduceFunc
 	maxImpl               reduceFunc
+	maxAbsImpl            reduceFunc
 	absImpl               unaryOpFunc
 	negImpl               unaryOpFunc
 	sqrtImpl              unaryOpFunc
@@ -98,6 +99,7 @@ func initAVX512() {
 	sumImpl = sumAVX512
 	minImpl = minAVX512
 	maxImpl = maxAVX512
+	maxAbsImpl = maxAbsGo
 	absImpl = absAVX512
 	negImpl = negAVX512
 	sqrtImpl = sqrtAVX512
@@ -125,6 +127,7 @@ func initAVX() {
 	sumImpl = sumAVX
 	minImpl = minAVX
 	maxImpl = maxAVX
+	maxAbsImpl = maxAbsGo
 	absImpl = absAVX
 	negImpl = negAVX
 	sqrtImpl = sqrtAVX
@@ -156,6 +159,7 @@ func initAVXNoFMA() {
 	sumImpl = sumAVX
 	minImpl = minAVX
 	maxImpl = maxAVX
+	maxAbsImpl = maxAbsGo
 	absImpl = absAVX
 	negImpl = negAVX
 	sqrtImpl = sqrtAVX
@@ -182,6 +186,7 @@ func initSSE2() {
 	sumImpl = sumSSE2
 	minImpl = minSSE2
 	maxImpl = maxSSE2
+	maxAbsImpl = maxAbsGo
 	absImpl = absSSE2
 	negImpl = negSSE2
 	sqrtImpl = sqrtSSE2
@@ -208,6 +213,7 @@ func initGo() {
 	sumImpl = sumGo
 	minImpl = minGo
 	maxImpl = maxGo
+	maxAbsImpl = maxAbsGo
 	absImpl = absGo
 	negImpl = negGo
 	sqrtImpl = sqrt64Go
@@ -281,6 +287,15 @@ func max64(a []float64) float64 {
 		return maxGo(a)
 	}
 	return maxImpl(a)
+}
+
+func maxAbs64(a []float64) float64 {
+	// The SIMD kernels do a full-width initial vector load; fall back to Go for
+	// small slices to avoid reading beyond bounds (mirrors min64/max64).
+	if len(a) < minSIMDElements {
+		return maxAbsGo(a)
+	}
+	return maxAbsImpl(a)
 }
 
 func abs64(dst, a []float64) {

--- a/f64/f64_amd64.go
+++ b/f64/f64_amd64.go
@@ -99,7 +99,7 @@ func initAVX512() {
 	sumImpl = sumAVX512
 	minImpl = minAVX512
 	maxImpl = maxAVX512
-	maxAbsImpl = maxAbsGo
+	maxAbsImpl = maxAbsAVX
 	absImpl = absAVX512
 	negImpl = negAVX512
 	sqrtImpl = sqrtAVX512
@@ -127,7 +127,7 @@ func initAVX() {
 	sumImpl = sumAVX
 	minImpl = minAVX
 	maxImpl = maxAVX
-	maxAbsImpl = maxAbsGo
+	maxAbsImpl = maxAbsAVX
 	absImpl = absAVX
 	negImpl = negAVX
 	sqrtImpl = sqrtAVX
@@ -159,7 +159,7 @@ func initAVXNoFMA() {
 	sumImpl = sumAVX
 	minImpl = minAVX
 	maxImpl = maxAVX
-	maxAbsImpl = maxAbsGo
+	maxAbsImpl = maxAbsAVX
 	absImpl = absAVX
 	negImpl = negAVX
 	sqrtImpl = sqrtAVX
@@ -186,7 +186,7 @@ func initSSE2() {
 	sumImpl = sumSSE2
 	minImpl = minSSE2
 	maxImpl = maxSSE2
-	maxAbsImpl = maxAbsGo
+	maxAbsImpl = maxAbsSSE2
 	absImpl = absSSE2
 	negImpl = negSSE2
 	sqrtImpl = sqrtSSE2
@@ -822,6 +822,9 @@ func minAVX(a []float64) float64
 func maxAVX(a []float64) float64
 
 //go:noescape
+func maxAbsAVX(a []float64) float64
+
+//go:noescape
 func absAVX(dst, a []float64)
 
 //go:noescape
@@ -947,6 +950,9 @@ func minSSE2(a []float64) float64
 
 //go:noescape
 func maxSSE2(a []float64) float64
+
+//go:noescape
+func maxAbsSSE2(a []float64) float64
 
 //go:noescape
 func absSSE2(dst, a []float64)

--- a/f64/f64_amd64.s
+++ b/f64/f64_amd64.s
@@ -573,6 +573,53 @@ max_avx_done:
     VZEROUPPER
     RET
 
+// func maxAbsAVX(a []float64) float64
+// max_i |a[i]|. Mirrors maxAVX with the sign bit cleared (VANDPD absf64mask)
+// on each loaded vector and the scalar tail before the running max.
+TEXT ·maxAbsAVX(SB), NOSPLIT, $0-32
+    MOVQ a_base+0(FP), SI
+    MOVQ a_len+8(FP), CX
+
+    VMOVUPD absf64mask<>(SB), Y2   // Y2 = abs mask (X2 = low 128 for the tail)
+    VMOVUPD (SI), Y0
+    VANDPD Y0, Y2, Y0             // Y0 = |a[0:4]|
+    ADDQ $32, SI
+    SUBQ $4, CX
+
+    MOVQ CX, AX
+    SHRQ $2, AX
+    JZ   maxabs_avx_reduce
+
+maxabs_avx_loop4:
+    VMOVUPD (SI), Y1
+    VANDPD Y1, Y2, Y1
+    VMAXPD Y0, Y1, Y0
+    ADDQ $32, SI
+    DECQ AX
+    JNZ  maxabs_avx_loop4
+
+maxabs_avx_reduce:
+    VEXTRACTF128 $1, Y0, X1
+    VMAXPD X0, X1, X0
+    VPERMILPD $1, X0, X1
+    VMAXSD X0, X1, X0
+
+    ANDQ $3, CX
+    JZ   maxabs_avx_done
+
+maxabs_avx_scalar:
+    VMOVSD (SI), X1
+    VANDPD X1, X2, X1
+    VMAXSD X0, X1, X0
+    ADDQ $8, SI
+    DECQ CX
+    JNZ  maxabs_avx_scalar
+
+maxabs_avx_done:
+    VMOVSD X0, ret+24(FP)
+    VZEROUPPER
+    RET
+
 // func absAVX(dst, a []float64)
 TEXT ·absAVX(SB), NOSPLIT, $0-48
     MOVQ dst_base+0(FP), DX
@@ -2774,6 +2821,46 @@ max_sse2_reduce:
     MAXSD X1, X0
 
 max_sse2_done:
+    MOVSD X0, ret+24(FP)
+    RET
+
+// func maxAbsSSE2(a []float64) float64
+// max_i |a[i]|. Mirrors maxSSE2 with ANDPD absf64mask folded into each load.
+TEXT ·maxAbsSSE2(SB), NOSPLIT, $0-32
+    MOVQ a_base+0(FP), SI
+    MOVQ a_len+8(FP), CX
+
+    MOVUPD absf64mask<>(SB), X2
+    MOVUPD (SI), X0
+    ANDPD X2, X0                 // X0 = |a[0:2]|
+    ADDQ $16, SI
+    SUBQ $2, CX
+
+    MOVQ CX, AX
+    SHRQ $1, AX
+    JZ   maxabs_sse2_reduce
+
+maxabs_sse2_loop2:
+    MOVUPD (SI), X1
+    ANDPD X2, X1
+    MAXPD X1, X0
+    ADDQ $16, SI
+    DECQ AX
+    JNZ  maxabs_sse2_loop2
+
+maxabs_sse2_reduce:
+    MOVAPD X0, X1
+    SHUFPD $1, X1, X1
+    MAXSD X1, X0
+
+    ANDQ $1, CX
+    JZ   maxabs_sse2_done
+
+    MOVSD (SI), X1
+    ANDPD X2, X1
+    MAXSD X1, X0
+
+maxabs_sse2_done:
     MOVSD X0, ret+24(FP)
     RET
 

--- a/f64/f64_arm64.go
+++ b/f64/f64_arm64.go
@@ -97,6 +97,10 @@ func max64(a []float64) float64 {
 	return maxGo(a)
 }
 
+func maxAbs64(a []float64) float64 {
+	return maxAbsGo(a)
+}
+
 func abs64(dst, a []float64) {
 	if hasNEON && len(dst) >= 2 {
 		absNEON(dst, a)

--- a/f64/f64_arm64.go
+++ b/f64/f64_arm64.go
@@ -98,6 +98,9 @@ func max64(a []float64) float64 {
 }
 
 func maxAbs64(a []float64) float64 {
+	if hasNEON && len(a) >= 2 {
+		return maxAbsNEON(a)
+	}
 	return maxAbsGo(a)
 }
 
@@ -326,6 +329,9 @@ func minNEON(a []float64) float64
 
 //go:noescape
 func maxNEON(a []float64) float64
+
+//go:noescape
+func maxAbsNEON(a []float64) float64
 
 //go:noescape
 func absNEON(dst, a []float64)

--- a/f64/f64_arm64.s
+++ b/f64/f64_arm64.s
@@ -362,6 +362,47 @@ max_reduce:
     FMOVD F0, ret+24(FP)
     RET
 
+// func maxAbsNEON(a []float64) float64
+// max_i |a[i]|. Mirrors maxNEON with FABS folded into each loaded vector and the
+// scalar tail (2 x float64 per 128-bit register).
+TEXT ·maxAbsNEON(SB), NOSPLIT, $0-32
+    MOVD a_base+0(FP), R0
+    MOVD a_len+8(FP), R1
+
+    VLD1.P 16(R0), [V0.D2]
+    WORD $0x4EE0F800           // FABS V0.2D, V0.2D
+    SUB $2, R1
+
+    LSR $1, R1, R2
+    CBZ R2, maxabs_scalar
+
+maxabs_loop2:
+    VLD1.P 16(R0), [V1.D2]
+    WORD $0x4EE0F821           // FABS V1.2D, V1.2D
+    WORD $0x4E61F400           // FMAX V0.2D, V0.2D, V1.2D
+    SUB $1, R2
+    CBNZ R2, maxabs_loop2
+
+maxabs_scalar:
+    AND $1, R1
+    CBZ R1, maxabs_reduce
+
+    // Reduce vector FIRST before scalar ops
+    VDUP V0.D[1], V1.D2
+    FMAXD F0, F1, F0
+    FMOVD (R0), F1
+    FABSD F1, F1
+    FMAXD F0, F1, F0
+    FMOVD F0, ret+24(FP)
+    RET
+
+maxabs_reduce:
+    // No scalar remainder
+    VDUP V0.D[1], V1.D2
+    FMAXD F0, F1, F0
+    FMOVD F0, ret+24(FP)
+    RET
+
 // func absNEON(dst, a []float64)
 TEXT ·absNEON(SB), NOSPLIT, $0-48
     MOVD dst_base+0(FP), R0

--- a/f64/f64_go.go
+++ b/f64/f64_go.go
@@ -134,6 +134,19 @@ func maxGo(a []float64) float64 {
 	return m
 }
 
+// maxAbsGo returns max_i |a[i]| (the infinity norm), 0 for an empty slice.
+// It is the bit-exact source of truth for the MaxAbs kernels.
+func maxAbsGo(a []float64) float64 {
+	m := 0.0
+	for _, v := range a {
+		av := math.Abs(v)
+		if av > m {
+			m = av
+		}
+	}
+	return m
+}
+
 func absGo(dst, a []float64) {
 	if len(dst) == 0 {
 		return

--- a/f64/f64_other.go
+++ b/f64/f64_other.go
@@ -15,6 +15,7 @@ func subFromScalar64(dst, a []float64, s float64)      { subFromScalarGo(dst, a,
 func sum(a []float64) float64                          { return sumGo(a) }
 func min64(a []float64) float64                        { return minGo(a) }
 func max64(a []float64) float64                        { return maxGo(a) }
+func maxAbs64(a []float64) float64                     { return maxAbsGo(a) }
 func abs64(dst, a []float64)                           { absGo(dst, a) }
 func neg64(dst, a []float64)                           { negGo(dst, a) }
 func fma64(dst, a, b, c []float64)                     { fmaGo(dst, a, b, c) }

--- a/f64/fuzz_test.go
+++ b/f64/fuzz_test.go
@@ -255,6 +255,58 @@ func FuzzF64Convolve(f *testing.F) {
 	})
 }
 
+func FuzzF64MaxAbs(f *testing.F) {
+	addByteLenSeeds(f)
+	f.Fuzz(func(t *testing.T, raw []byte) {
+		v := f64sUnit(raw)
+		// abs and max are exact and order-independent, so the SIMD path matches
+		// the Go reference bit-for-bit.
+		if got, want := MaxAbs(v), maxAbsGo(v); got != want {
+			t.Fatalf("MaxAbs got %v want %v", got, want)
+		}
+	})
+}
+
+func FuzzF64ConvolveMaxAbs(f *testing.F) {
+	addByteLenSeeds(f)
+	f.Fuzz(func(t *testing.T, raw []byte) {
+		v := f64sUnit(raw)
+		if len(v) < 4 {
+			return
+		}
+		kLen := 1 + int(raw[0])%min(len(v)-1, 16)
+		kernel := v[:kLen]
+		signal := v[kLen:]
+		if len(signal) < kLen {
+			return
+		}
+		// ConvolveValid and ConvolveValidMaxAbs share the dispatched dotProduct,
+		// so the fused peak equals max|ConvolveValid output| exactly.
+		out := make([]float64, len(signal)-kLen+1)
+		ConvolveValid(out, signal, kernel)
+		want := maxAbsGo(out)
+		if got := ConvolveValidMaxAbs(signal, kernel); got != want {
+			t.Fatalf("ConvolveValidMaxAbs got %v want %v", got, want)
+		}
+
+		if kLen >= 2 {
+			half := kLen / 2
+			kernels := [][]float64{kernel[:half], kernel[half : half*2]}
+			var wantMulti float64
+			for _, k := range kernels {
+				o := make([]float64, len(signal)-len(k)+1)
+				ConvolveValid(o, signal, k)
+				if m := maxAbsGo(o); m > wantMulti {
+					wantMulti = m
+				}
+			}
+			if got := ConvolveValidMaxAbsMulti(signal, kernels); got != wantMulti {
+				t.Fatalf("ConvolveValidMaxAbsMulti got %v want %v", got, wantMulti)
+			}
+		}
+	})
+}
+
 func FuzzF64InterleaveN(f *testing.F) {
 	addByteLenSeeds(f)
 	f.Fuzz(func(t *testing.T, raw []byte) {

--- a/f64/go_impl_amd64_test.go
+++ b/f64/go_impl_amd64_test.go
@@ -22,6 +22,7 @@ type implSnapshot struct {
 	sum               reduceFunc
 	min               reduceFunc
 	max               reduceFunc
+	maxAbs            reduceFunc
 	abs               unaryOpFunc
 	neg               unaryOpFunc
 	sqrt              unaryOpFunc
@@ -49,6 +50,7 @@ func snapshotDispatch() implSnapshot {
 		sum:               sumImpl,
 		min:               minImpl,
 		max:               maxImpl,
+		maxAbs:            maxAbsImpl,
 		abs:               absImpl,
 		neg:               negImpl,
 		sqrt:              sqrtImpl,
@@ -76,6 +78,7 @@ func restoreDispatch(s *implSnapshot) {
 	sumImpl = s.sum
 	minImpl = s.min
 	maxImpl = s.max
+	maxAbsImpl = s.maxAbs
 	absImpl = s.abs
 	negImpl = s.neg
 	sqrtImpl = s.sqrt

--- a/f64/maxabs_amd64_test.go
+++ b/f64/maxabs_amd64_test.go
@@ -1,0 +1,44 @@
+//go:build amd64
+
+package f64
+
+import (
+	"math"
+	"testing"
+
+	"github.com/tphakala/simd/cpu"
+)
+
+// TestMaxAbsKernelsAMD64 exercises each amd64 MaxAbs kernel directly (bypassing
+// dispatch), so SSE2 is covered even on an AVX2 host. Each kernel does a
+// full-width initial load, so only lengths >= the kernel stride are passed.
+func TestMaxAbsKernelsAMD64(t *testing.T) {
+	mk := func(n int) []float64 {
+		a := make([]float64, n)
+		for i := range a {
+			a[i] = math.Cos(float64(i)*0.37) * float64((i%7)-3) * 9.5
+		}
+		return a
+	}
+
+	t.Run("SSE2", func(t *testing.T) {
+		for _, n := range []int{2, 3, 4, 5, 8, 9, 16, 17, 31, 64, 127} {
+			a := mk(n)
+			if got, want := maxAbsSSE2(a), maxAbsGo(a); got != want {
+				t.Errorf("n=%d: maxAbsSSE2=%v want %v", n, got, want)
+			}
+		}
+	})
+
+	t.Run("AVX", func(t *testing.T) {
+		if !cpu.X86.AVX {
+			t.Skip("AVX not supported on this CPU")
+		}
+		for _, n := range []int{4, 5, 6, 7, 8, 9, 15, 16, 17, 31, 33, 64, 127} {
+			a := mk(n)
+			if got, want := maxAbsAVX(a), maxAbsGo(a); got != want {
+				t.Errorf("n=%d: maxAbsAVX=%v want %v", n, got, want)
+			}
+		}
+	})
+}

--- a/f64/maxabs_test.go
+++ b/f64/maxabs_test.go
@@ -1,0 +1,62 @@
+package f64
+
+import (
+	"math"
+	"testing"
+)
+
+// scalarMaxAbs is the independent reference: max(|a[i]|), 0 for empty.
+func scalarMaxAbs(a []float64) float64 {
+	m := 0.0
+	for _, v := range a {
+		av := math.Abs(v)
+		if av > m {
+			m = av
+		}
+	}
+	return m
+}
+
+func TestMaxAbs(t *testing.T) {
+	cases := [][]float64{
+		nil,
+		{},
+		{0},
+		{math.Copysign(0, -1)},
+		{3, -7, 2},
+		{-1, -2, -3, -4, -5, -6, -7, -8, -9},
+		{1.5, -1.5, 0.25, -0.25, 100, -99.9, 0, 42},
+		{math.Inf(1), -3},
+		{math.Inf(-1), 3},
+	}
+	for i, a := range cases {
+		got := MaxAbs(a)
+		want := scalarMaxAbs(a)
+		if got != want {
+			t.Errorf("case %d: MaxAbs(%v) = %v, want %v", i, a, got, want)
+		}
+	}
+}
+
+func TestMaxAbsParity(t *testing.T) {
+	// Lengths spanning the SIMD body, the scalar tail, and the small fallback.
+	for _, n := range []int{0, 1, 2, 3, 4, 5, 7, 8, 9, 15, 16, 17, 31, 33, 64, 127, 256} {
+		a := make([]float64, n)
+		for i := range a {
+			a[i] = math.Sin(float64(i)*0.7) * float64((i%5)-2) * 13.3
+		}
+		if got, want := MaxAbs(a), scalarMaxAbs(a); got != want {
+			t.Errorf("n=%d: MaxAbs=%v want %v", n, got, want)
+		}
+	}
+}
+
+func TestMaxAbsNoAlloc(t *testing.T) {
+	a := make([]float64, 1024)
+	for i := range a {
+		a[i] = float64(i%7) - 3
+	}
+	if n := testing.AllocsPerRun(100, func() { _ = MaxAbs(a) }); n != 0 {
+		t.Errorf("MaxAbs allocated %v times, want 0", n)
+	}
+}


### PR DESCRIPTION
## Summary

Adds three primitives to both the `f64` and `f32` packages, as requested in #138 for a true-peak / peak-detection hot path:

- **`MaxAbs(a) T`** - the infinity norm `max_i |a[i]|`, 0 for an empty slice. A real vectorized reduction: AVX2 (`VANDPD`/`VANDPS` + `VMAXPD`/`VMAXPS`), SSE2/SSE (`ANDPD`/`ANDPS` + `MAXPD`/`MAXPS`), NEON (`FABS` + `FMAX`), with a pure-Go fallback. Mirrors the existing `Min`/`Max` kernels with the abs folded into each load. AVX-512 CPUs reuse the AVX2 kernel (no AVX-512 hardware here to validate a dedicated VL kernel; consistent with the existing variance/euclidean handling in `f32`).
- **`ConvolveValidMaxAbs(signal, kernel) T`** - `max(|valid-convolution output|)` without materializing the output slice. The abs-max is fused into the convolution pass over the already-dispatched SIMD `dotProduct`, so it drops both the per-output scratch store and the separate scalar abs-max scan a consumer writes today.
- **`ConvolveValidMaxAbsMulti(signal, kernels) T`** - the single peak across all kernels' outputs, the polyphase true-peak primitive. Mirrors `ConvolveValidMulti`'s equal-kernel-length contract (panics on mismatch).

Per the issue author's follow-up, the convolution speedup lever is the fusion (removing the output store + the ~9% scalar abs-max scan), not lane width, so `ConvolveValidMaxAbs[Multi]` is implemented as a Go-level fusion that keeps each per-output dot product on the SIMD path on every backend; no new convolution assembly. The standalone `MaxAbs` reduction is independently useful (peak metering, clipping detection, normalization headroom) and is the part that gets dedicated kernels.

Empty-input behavior: `MaxAbs` and both convolution helpers return 0 (no panic), as suggested in the issue.

## Related Issues

Fixes #138

## Test Plan

- [x] Go-reference parity + bit-exactness vs the per-element scalar path (`MaxAbs`)
- [x] Direct per-kernel parity tests so SSE/SSE2 is exercised on an AVX2 host
- [x] `ConvolveValidMaxAbs[Multi]` parity vs `ConvolveValid` + scalar abs-max (exact equality: both share the dispatched dot product)
- [x] Edge cases: empty/short signal, empty kernel, mismatched-kernel-length panic
- [x] `testing.AllocsPerRun == 0` for all three
- [x] Fuzz harnesses (SIMD vs Go reference, bit-exact)
- [x] Runnable examples
- [x] asmcheck validates every new NEON `WORD` against `golang.org/x/arch/arm64asm`
- [x] Full suite green on amd64 (SSE2/AVX2/Go) and on a Raspberry Pi 5 (NEON)
- [x] `golangci-lint run ./...` clean

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added `MaxAbs()` to compute the maximum absolute value of floating-point slices.
  * Added `ConvolveValidMaxAbs()` and `ConvolveValidMaxAbsMulti()` for efficient convolution true-peak detection without materializing intermediate outputs.
  * Available for both 32-bit and 64-bit floating-point types.
* **Documentation**
  * Extended operation tables, examples, and known limitations (including AMD64 small-slice fallback coverage).
* **Tests**
  * Added unit tests, fuzz coverage, and new Go examples to validate correctness and allocation-free behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->