### PR TITLE
f64/f32: dedicated fused ConvolveValidMaxAbs kernels (peak-detection speedup)

### DIFF
--- a/README.md
+++ b/README.md
@@ -770,17 +770,23 @@ a Raspberry Pi 5):
 #### ConvolveValidMaxAbs (fused valid convolution + abs-max peak)
 
 `ConvolveValidMaxAbs` returns `max(|valid-convolution output|)` (the infinity
-norm of the FIR output) without materializing the output slice. Each output is
-still a SIMD dot product, but the abs-max reduction is folded into the same pass,
-so it removes both the per-output store to a scratch buffer and the separate
-scalar abs-max scan a consumer writes today. The baseline is `ConvolveValid`
-into a temporary slice followed by a `MaxAbs` over it; both compute the identical
-peak. `ConvolveValidMaxAbsMulti` takes the N phase kernels of a polyphase
-oversampling FIR and returns the single peak of the reconstructed signal in one
-call, which is the canonical true-peak (ITU-R BS.1770 / EBU R 128) primitive.
-The standalone `MaxAbs` reduction (`VANDPD`+`VMAXPD` on AVX2, `ANDPS`+`MAXPS` on
-SSE, `FABS`+`FMAX` on NEON) covers peak metering, clipping detection, and
-normalization headroom on its own.
+norm of the FIR output) without materializing the output slice. It is a single
+fused kernel (modeled on `ConvolveDecimate` with a stride of one): the kernel
+coefficients stay resident across output positions and the abs-max is folded into
+each window's reduce, so it removes the per-output dispatch and slice-header
+overhead, the per-output store to a scratch buffer, and the separate scalar
+abs-max scan a consumer writes today. The inner dot replicates `dotProduct`
+exactly, so the peak is bit-identical to `ConvolveValid` into a temporary slice
+followed by a `MaxAbs` over it. Versus that materialized baseline (and the
+Go-level fusion that just loops over `dotProduct`), the fused kernel runs roughly
+1.4x-2.2x faster for 16-64 tap kernels, the largest win at short kernels where
+the per-output overhead dominates the MAC work (AVX2; FMA-less CPUs use the SSE
+kernel, ARM64 uses NEON). `ConvolveValidMaxAbsMulti` takes the N phase kernels of
+a polyphase oversampling FIR and returns the single peak of the reconstructed
+signal in one call, which is the canonical true-peak (ITU-R BS.1770 / EBU R 128)
+primitive. The standalone `MaxAbs` reduction (`VANDPD`+`VMAXPD` on AVX2,
+`ANDPS`+`MAXPS` on SSE, `FABS`+`FMAX` on NEON) covers peak metering, clipping
+detection, and normalization headroom on its own.
 
 #### Autocorrelate (lag-vectorized LPC autocorrelation, f64)
 

--- a/f32/benchmark_test.go
+++ b/f32/benchmark_test.go
@@ -540,6 +540,44 @@ func BenchmarkConvolveValid(b *testing.B) {
 	}
 }
 
+// BenchmarkConvolveValidMaxAbs compares the fused kernel against the Go-level
+// fusion it replaces (rc.1 behavior: a loop over the dispatched dotProduct). The
+// fused kernel keeps the kernel resident and folds the abs-max in, removing the
+// per-output dispatch overhead; the win is largest for short kernels.
+func BenchmarkConvolveValidMaxAbs(b *testing.B) {
+	signalSizes := []int{4096, 48000}
+	kernelSizes := []int{16, 32, 64}
+
+	for _, sigSize := range signalSizes {
+		for _, kerSize := range kernelSizes {
+			signal := make([]float32, sigSize)
+			kernel := make([]float32, kerSize)
+			for i := range signal {
+				signal[i] = float32(i%100) - 50
+			}
+			for i := range kernel {
+				kernel[i] = float32(i%10) - 5
+			}
+
+			name := fmt.Sprintf("sig%d_ker%d", sigSize, kerSize)
+			b.Run(fmt.Sprintf("Fused_%s", name), func(b *testing.B) {
+				var sink float32
+				for i := 0; i < b.N; i++ {
+					sink = ConvolveValidMaxAbs(signal, kernel)
+				}
+				_ = sink
+			})
+			b.Run(fmt.Sprintf("GoFusion_%s", name), func(b *testing.B) {
+				var sink float32
+				for i := 0; i < b.N; i++ {
+					sink = convolveValidMaxAbsGo(signal, kernel)
+				}
+				_ = sink
+			})
+		}
+	}
+}
+
 // =============================================================================
 // Quick Summary Benchmark (run with -bench=Summary)
 // =============================================================================

--- a/f32/convolve_maxabs_amd64_test.go
+++ b/f32/convolve_maxabs_amd64_test.go
@@ -70,4 +70,16 @@ func TestConvolveValidMaxAbsKernelsAMD64(t *testing.T) {
 			}
 		}
 	})
+
+	t.Run("NoAlloc", func(t *testing.T) {
+		s, k := mkPair(256, 32)
+		if n := testing.AllocsPerRun(50, func() { _ = convolveValidMaxAbsSSE(s, k) }); n != 0 {
+			t.Errorf("convolveValidMaxAbsSSE allocated %v, want 0", n)
+		}
+		if cpu.X86.AVX && cpu.X86.FMA {
+			if n := testing.AllocsPerRun(50, func() { _ = convolveValidMaxAbsAVX(s, k) }); n != 0 {
+				t.Errorf("convolveValidMaxAbsAVX allocated %v, want 0", n)
+			}
+		}
+	})
 }

--- a/f32/convolve_maxabs_amd64_test.go
+++ b/f32/convolve_maxabs_amd64_test.go
@@ -1,0 +1,73 @@
+//go:build amd64
+
+package f32
+
+import (
+	"math"
+	"testing"
+
+	"github.com/tphakala/simd/cpu"
+)
+
+// refConvMaxAbsDot computes max|valid-conv output| using the given per-window dot
+// product, so each amd64 fused kernel can be checked for bit-exactness against the
+// exact dotProduct kernel whose accumulation it replicates.
+func refConvMaxAbsDot(signal, kernel []float32, dot func(a, b []float32) float32) float32 {
+	kLen := len(kernel)
+	validLen := len(signal) - kLen + 1
+	var m float32
+	for i := range validLen {
+		v := dot(signal[i:i+kLen], kernel)
+		if v < 0 {
+			v = -v
+		}
+		if v > m {
+			m = v
+		}
+	}
+	return m
+}
+
+// TestConvolveValidMaxAbsKernelsAMD64 exercises each fused kernel directly
+// (bypassing dispatch) so SSE is covered even on an AVX2 host, and asserts each
+// is bit-identical to max|its matching per-window dotProduct|.
+func TestConvolveValidMaxAbsKernelsAMD64(t *testing.T) {
+	mkPair := func(sl, kl int) ([]float32, []float32) {
+		s := make([]float32, sl)
+		k := make([]float32, kl)
+		for i := range s {
+			s[i] = float32(math.Sin(float64(i)*0.31)) - 0.3*float32(i%4)
+		}
+		for i := range k {
+			k[i] = 0.4 - float32(i)*0.07
+		}
+		return s, k
+	}
+	type cfg struct{ sl, kl int }
+	cfgs := []cfg{{4, 1}, {8, 2}, {16, 3}, {17, 4}, {33, 5}, {64, 8}, {128, 16}, {200, 17}, {256, 32}}
+
+	t.Run("SSE", func(t *testing.T) {
+		for _, c := range cfgs {
+			s, k := mkPair(c.sl, c.kl)
+			got := convolveValidMaxAbsSSE(s, k)
+			want := refConvMaxAbsDot(s, k, dotProductSSE)
+			if got != want {
+				t.Errorf("sl=%d kl=%d: SSE=%v want %v", c.sl, c.kl, got, want)
+			}
+		}
+	})
+
+	t.Run("AVX", func(t *testing.T) {
+		if !cpu.X86.AVX || !cpu.X86.FMA {
+			t.Skip("AVX+FMA not supported on this CPU")
+		}
+		for _, c := range cfgs {
+			s, k := mkPair(c.sl, c.kl)
+			got := convolveValidMaxAbsAVX(s, k)
+			want := refConvMaxAbsDot(s, k, dotProductAVX)
+			if got != want {
+				t.Errorf("sl=%d kl=%d: AVX=%v want %v", c.sl, c.kl, got, want)
+			}
+		}
+	})
+}

--- a/f32/convolve_maxabs_test.go
+++ b/f32/convolve_maxabs_test.go
@@ -111,3 +111,42 @@ func TestConvolveValidMaxAbsNoAlloc(t *testing.T) {
 		t.Errorf("ConvolveValidMaxAbsMulti allocated %v, want 0", n)
 	}
 }
+
+// TestConvolveValidMaxAbsScalarOracle checks the dispatched (SIMD) path against an
+// independent pure-Go oracle rather than ConvolveValid, so a bug shared by the
+// fused convolution and the dot-product path is still caught. Tolerance, since the
+// SIMD lane-parallel summation order differs from the sequential float32 oracle.
+func TestConvolveValidMaxAbsScalarOracle(t *testing.T) {
+	for _, kl := range []int{1, 2, 3, 4, 5, 8, 13, 16, 17, 31, 32, 33, 64} {
+		for _, sl := range []int{kl, kl + 1, 65, 128, 257} {
+			if sl < kl {
+				continue
+			}
+			signal := make([]float32, sl)
+			kernel := make([]float32, kl)
+			for i := range signal {
+				signal[i] = float32(math.Sin(float64(i)*0.17)) - 0.25*float32(i%5)
+			}
+			for i := range kernel {
+				kernel[i] = float32(math.Cos(float64(i)*0.23)) * 0.6
+			}
+			got := ConvolveValidMaxAbs(signal, kernel)
+			var want float32
+			for i := range sl - kl + 1 {
+				var s float32
+				for j := range kl {
+					s += signal[i+j] * kernel[j]
+				}
+				if s < 0 {
+					s = -s
+				}
+				if s > want {
+					want = s
+				}
+			}
+			if d := math.Abs(float64(got - want)); d > 1e-4*(1+float64(want)) {
+				t.Errorf("sl=%d kl=%d: got %v want(scalar) %v diff=%g", sl, kl, got, want, d)
+			}
+		}
+	}
+}

--- a/f32/f32.go
+++ b/f32/f32.go
@@ -650,25 +650,6 @@ func ConvolveValidMaxAbs(signal, kernel []float32) float32 {
 	return convolveValidMaxAbs32(signal, kernel)
 }
 
-// convolveValidMaxAbs32 fuses the valid convolution with the abs-max reduction.
-// It calls the dispatched SIMD dotProduct per output position, so it is
-// vectorized on every backend without a dedicated kernel.
-func convolveValidMaxAbs32(signal, kernel []float32) float32 {
-	kLen := len(kernel)
-	validLen := len(signal) - kLen + 1
-	var m float32 // abs values are >= 0, so 0 is the correct identity
-	for i := range validLen {
-		v := dotProduct(signal[i:i+kLen], kernel)
-		if v < 0 {
-			v = -v
-		}
-		if v > m {
-			m = v
-		}
-	}
-	return m
-}
-
 // ConvolveValidMaxAbsMulti returns the single maximum of |valid-convolution
 // output| across every kernel applied to signal, without materializing any
 // output. This is the polyphase true-peak primitive: pass the N phase kernels and

--- a/f32/f32_amd64.go
+++ b/f32/f32_amd64.go
@@ -23,50 +23,52 @@ var minSIMDElements = minAVXElements
 
 // Function pointer types for SIMD operations
 type (
-	dotProductFunc        func(a, b []float32) float32
-	binaryOpFunc          func(dst, a, b []float32)
-	scaleFunc             func(dst, a []float32, s float32)
-	unaryOpFunc           func(dst, a []float32)
-	reduceFunc            func(a []float32) float32
-	reduceIdxFunc         func(a []float32) int
-	fmaFunc               func(dst, a, b, c []float32)
-	clampFunc             func(dst, a []float32, minVal, maxVal float32)
-	varianceFunc          func(a []float32, mean float32) float32
-	euclideanDistanceFunc func(a, b []float32) float32
-	addScaledFunc         func(dst []float32, alpha float32, s []float32)
-	convolveDecimateFunc  func(dst, signal, kernel []float32, factor, phase int)
-	interleave2Func       func(dst, a, b []float32)
-	deinterleave2Func     func(a, b, src []float32)
+	dotProductFunc          func(a, b []float32) float32
+	binaryOpFunc            func(dst, a, b []float32)
+	scaleFunc               func(dst, a []float32, s float32)
+	unaryOpFunc             func(dst, a []float32)
+	reduceFunc              func(a []float32) float32
+	reduceIdxFunc           func(a []float32) int
+	fmaFunc                 func(dst, a, b, c []float32)
+	clampFunc               func(dst, a []float32, minVal, maxVal float32)
+	varianceFunc            func(a []float32, mean float32) float32
+	euclideanDistanceFunc   func(a, b []float32) float32
+	addScaledFunc           func(dst []float32, alpha float32, s []float32)
+	convolveDecimateFunc    func(dst, signal, kernel []float32, factor, phase int)
+	convolveValidMaxAbsFunc func(signal, kernel []float32) float32
+	interleave2Func         func(dst, a, b []float32)
+	deinterleave2Func       func(a, b, src []float32)
 )
 
 // Function pointers - assigned at init time based on CPU features
 var (
-	dotProductImpl        dotProductFunc
-	addImpl               binaryOpFunc
-	subImpl               binaryOpFunc
-	mulImpl               binaryOpFunc
-	divImpl               binaryOpFunc
-	scaleImpl             scaleFunc
-	addScalarImpl         scaleFunc
-	sumImpl               reduceFunc
-	minImpl               reduceFunc
-	maxImpl               reduceFunc
-	maxAbsImpl            reduceFunc
-	absImpl               unaryOpFunc
-	negImpl               unaryOpFunc
-	sqrtImpl              unaryOpFunc
-	reciprocalImpl        unaryOpFunc
-	roundImpl             unaryOpFunc
-	fmaImpl               fmaFunc
-	clampImpl             clampFunc
-	varianceImpl          varianceFunc
-	euclideanDistanceImpl euclideanDistanceFunc
-	minIdxImpl            reduceIdxFunc
-	maxIdxImpl            reduceIdxFunc
-	addScaledImpl         addScaledFunc
-	convolveDecimateImpl  convolveDecimateFunc
-	interleave2Impl       interleave2Func
-	deinterleave2Impl     deinterleave2Func
+	dotProductImpl          dotProductFunc
+	addImpl                 binaryOpFunc
+	subImpl                 binaryOpFunc
+	mulImpl                 binaryOpFunc
+	divImpl                 binaryOpFunc
+	scaleImpl               scaleFunc
+	addScalarImpl           scaleFunc
+	sumImpl                 reduceFunc
+	minImpl                 reduceFunc
+	maxImpl                 reduceFunc
+	maxAbsImpl              reduceFunc
+	absImpl                 unaryOpFunc
+	negImpl                 unaryOpFunc
+	sqrtImpl                unaryOpFunc
+	reciprocalImpl          unaryOpFunc
+	roundImpl               unaryOpFunc
+	fmaImpl                 fmaFunc
+	clampImpl               clampFunc
+	varianceImpl            varianceFunc
+	euclideanDistanceImpl   euclideanDistanceFunc
+	minIdxImpl              reduceIdxFunc
+	maxIdxImpl              reduceIdxFunc
+	addScaledImpl           addScaledFunc
+	convolveDecimateImpl    convolveDecimateFunc
+	convolveValidMaxAbsImpl convolveValidMaxAbsFunc
+	interleave2Impl         interleave2Func
+	deinterleave2Impl       deinterleave2Func
 )
 
 func init() {
@@ -114,6 +116,7 @@ func initAVX512() {
 	maxIdxImpl = maxIdxGo
 	addScaledImpl = addScaledAVX512
 	convolveDecimateImpl = convolveDecimateAVX512
+	convolveValidMaxAbsImpl = convolveValidMaxAbsAVX
 	// AVX-512 CPUs also support AVX, so the AVX1 interleave kernels are safe.
 	interleave2Impl, deinterleave2Impl = interleave2Kernels(true)
 }
@@ -143,6 +146,7 @@ func initAVX() {
 	maxIdxImpl = maxIdxGo
 	addScaledImpl = addScaledAVX
 	convolveDecimateImpl = convolveDecimateAVX
+	convolveValidMaxAbsImpl = convolveValidMaxAbsAVX
 	interleave2Impl, deinterleave2Impl = interleave2Kernels(true)
 }
 
@@ -171,6 +175,7 @@ func initSSE() {
 	maxIdxImpl = maxIdxGo
 	addScaledImpl = addScaledSSE
 	convolveDecimateImpl = convolveDecimateSSE
+	convolveValidMaxAbsImpl = convolveValidMaxAbsSSE
 	// No SSE2 interleave2 kernel exists; the AVX kernel would SIGILL here, so
 	// fall back to the scalar Go path on AVX-less CPUs (birdnet-go issue #3353).
 	interleave2Impl, deinterleave2Impl = interleave2Kernels(false)
@@ -201,6 +206,7 @@ func initGo() {
 	maxIdxImpl = maxIdxGo
 	addScaledImpl = addScaledGo
 	convolveDecimateImpl = convolveDecimate32Go
+	convolveValidMaxAbsImpl = convolveValidMaxAbsGo
 	interleave2Impl, deinterleave2Impl = interleave2Kernels(false)
 }
 
@@ -510,6 +516,10 @@ func convolveDecimate32(dst, signal, kernel []float32, factor, phase int) {
 	convolveDecimateImpl(dst, signal, kernel, factor, phase)
 }
 
+func convolveValidMaxAbs32(signal, kernel []float32) float32 {
+	return convolveValidMaxAbsImpl(signal, kernel)
+}
+
 func accumulateAdd32(dst, src []float32) {
 	// AccumulateAdd is dst += src, which is the same as add(dst, dst, src)
 	addImpl(dst, dst, src)
@@ -696,6 +706,12 @@ func convolveDecimateAVX512(dst, signal, kernel []float32, factor, phase int)
 
 //go:noescape
 func convolveDecimateSSE(dst, signal, kernel []float32, factor, phase int)
+
+//go:noescape
+func convolveValidMaxAbsAVX(signal, kernel []float32) float32
+
+//go:noescape
+func convolveValidMaxAbsSSE(signal, kernel []float32) float32
 
 //go:noescape
 func dotProduct4AVX(results, row0, row1, row2, row3, vec *float32, n int)

--- a/f32/f32_amd64.go
+++ b/f32/f32_amd64.go
@@ -116,7 +116,12 @@ func initAVX512() {
 	maxIdxImpl = maxIdxGo
 	addScaledImpl = addScaledAVX512
 	convolveDecimateImpl = convolveDecimateAVX512
-	convolveValidMaxAbsImpl = convolveValidMaxAbsAVX
+	// AVX-512 keeps the Go-level fusion over the 16-wide dotProductAVX512: the
+	// fused kernel is 8-wide (AVX2) and its dot summation order would diverge from
+	// ConvolveValid here. A dedicated 16-wide fused kernel needs AVX-512 hardware to
+	// validate (none available; see #138), so the AVX-512 tier forgoes the fused
+	// speedup but stays bit-identical to ConvolveValid.
+	convolveValidMaxAbsImpl = convolveValidMaxAbsGo
 	// AVX-512 CPUs also support AVX, so the AVX1 interleave kernels are safe.
 	interleave2Impl, deinterleave2Impl = interleave2Kernels(true)
 }

--- a/f32/f32_amd64.s
+++ b/f32/f32_amd64.s
@@ -5451,6 +5451,108 @@ cd_avx_ret:
     VZEROUPPER
     RET
 
+// func convolveValidMaxAbsAVX(signal, kernel []float32) float32
+//
+// Fused valid convolution + abs-max: returns max_i |dot(signal[i:i+kLen], kernel)|
+// over the n = len(signal)-kLen+1 windows without materializing the output. The
+// inner dot replicates convolveDecimateAVX / dotProductAVX (4 Y accumulators,
+// 32/8/scalar reduction), so each window is bit-identical to ConvolveValid; the
+// per-window store is replaced by an abs (VANDPS) into a running max (X7).
+// Caller guarantees kLen >= 1 and len(signal) >= kLen, so n >= 1.
+TEXT ·convolveValidMaxAbsAVX(SB), NOSPLIT, $0-52
+    MOVQ signal_base+0(FP), R10    // R10 = &signal[pos], advances 4 bytes/output
+    MOVQ signal_len+8(FP), R9
+    MOVQ kernel_base+24(FP), R11
+    MOVQ kernel_len+32(FP), R12    // R12 = kLen
+
+    SUBQ R12, R9
+    INCQ R9                        // R9 = n
+
+    VMOVUPS absf32mask<>(SB), X6   // abs mask
+    VXORPS X7, X7, X7              // running max = 0
+
+cvma_avx_outer:
+    MOVQ R10, SI
+    MOVQ R11, DI
+
+    VXORPS Y0, Y0, Y0
+    VXORPS Y3, Y3, Y3
+    VXORPS Y4, Y4, Y4
+    VXORPS Y5, Y5, Y5
+
+    MOVQ R12, CX
+    MOVQ CX, AX
+    SHRQ $5, AX                    // kLen / 32
+    JZ   cvma_avx_loop8_check
+
+cvma_avx_loop32:
+    VMOVUPS (SI), Y1
+    VMOVUPS (DI), Y2
+    VFMADD231PS Y1, Y2, Y0
+    VMOVUPS 32(SI), Y1
+    VMOVUPS 32(DI), Y2
+    VFMADD231PS Y1, Y2, Y3
+    VMOVUPS 64(SI), Y1
+    VMOVUPS 64(DI), Y2
+    VFMADD231PS Y1, Y2, Y4
+    VMOVUPS 96(SI), Y1
+    VMOVUPS 96(DI), Y2
+    VFMADD231PS Y1, Y2, Y5
+    ADDQ $128, SI
+    ADDQ $128, DI
+    DECQ AX
+    JNZ  cvma_avx_loop32
+
+    VADDPS Y3, Y0, Y0
+    VADDPS Y4, Y0, Y0
+    VADDPS Y5, Y0, Y0
+
+cvma_avx_loop8_check:
+    MOVQ R12, CX
+    ANDQ $31, CX
+    MOVQ CX, AX
+    SHRQ $3, AX
+    JZ   cvma_avx_reduce
+
+cvma_avx_loop8:
+    VMOVUPS (SI), Y1
+    VMOVUPS (DI), Y2
+    VFMADD231PS Y1, Y2, Y0
+    ADDQ $32, SI
+    ADDQ $32, DI
+    DECQ AX
+    JNZ  cvma_avx_loop8
+
+cvma_avx_reduce:
+    VEXTRACTF128 $1, Y0, X1
+    VADDPS X1, X0, X0
+    VHADDPS X0, X0, X0
+    VHADDPS X0, X0, X0
+
+    MOVQ R12, CX
+    ANDQ $7, CX
+    JZ   cvma_avx_absmax
+
+cvma_avx_scalar:
+    VMOVSS (SI), X1
+    VMOVSS (DI), X2
+    VFMADD231SS X1, X2, X0
+    ADDQ $4, SI
+    ADDQ $4, DI
+    DECQ CX
+    JNZ  cvma_avx_scalar
+
+cvma_avx_absmax:
+    VANDPS X0, X6, X0             // |dot|
+    VMAXSS X0, X7, X7            // running max = max(running, |dot|)
+    ADDQ $4, R10                  // pos += 1
+    DECQ R9
+    JNZ  cvma_avx_outer
+
+    VMOVSS X7, ret+48(FP)
+    VZEROUPPER
+    RET
+
 // func convolveDecimateAVX512(dst, signal, kernel []float32, factor, phase int)
 //
 // AVX-512 fused decimating valid convolution. Inner dot replicates
@@ -5620,6 +5722,76 @@ cd_sse_store:
     JNZ  cd_sse_outer
 
 cd_sse_ret:
+    RET
+
+// func convolveValidMaxAbsSSE(signal, kernel []float32) float32
+//
+// SSE fused valid convolution + abs-max. Inner dot replicates convolveDecimateSSE
+// / dotProductSSE (single accumulator, MULPS+ADDPS, 4/scalar reduction); the
+// per-window store is replaced by an abs (ANDPS) into a running max (X7). Caller
+// guarantees kLen >= 1 and len(signal) >= kLen, so n >= 1.
+TEXT ·convolveValidMaxAbsSSE(SB), NOSPLIT, $0-52
+    MOVQ signal_base+0(FP), R10
+    MOVQ signal_len+8(FP), R9
+    MOVQ kernel_base+24(FP), R11
+    MOVQ kernel_len+32(FP), R12
+
+    SUBQ R12, R9
+    INCQ R9                        // n
+
+    MOVUPS absf32mask<>(SB), X6
+    XORPS X7, X7                   // running max = 0
+
+cvma_sse_outer:
+    MOVQ R10, SI
+    MOVQ R11, DI
+    XORPS X0, X0
+
+    MOVQ R12, CX
+    MOVQ CX, AX
+    SHRQ $2, AX                    // kLen / 4
+    JZ   cvma_sse_reduce
+
+cvma_sse_loop4:
+    MOVUPS (SI), X1
+    MOVUPS (DI), X2
+    MULPS X2, X1
+    ADDPS X1, X0
+    ADDQ $16, SI
+    ADDQ $16, DI
+    DECQ AX
+    JNZ  cvma_sse_loop4
+
+cvma_sse_reduce:
+    MOVAPS X0, X1
+    SHUFPS $0x0E, X1, X1
+    ADDPS X1, X0
+    MOVAPS X0, X1
+    SHUFPS $0x01, X1, X1
+    ADDSS X1, X0
+
+    MOVQ R12, CX
+    ANDQ $3, CX
+    JZ   cvma_sse_absmax
+
+cvma_sse_scalar:
+    MOVSS (SI), X1
+    MOVSS (DI), X2
+    MULSS X2, X1
+    ADDSS X1, X0
+    ADDQ $4, SI
+    ADDQ $4, DI
+    DECQ CX
+    JNZ  cvma_sse_scalar
+
+cvma_sse_absmax:
+    ANDPS X6, X0                  // |dot|
+    MAXSS X0, X7                 // running max = max(X7, X0)
+    ADDQ $4, R10
+    DECQ R9
+    JNZ  cvma_sse_outer
+
+    MOVSS X7, ret+48(FP)
     RET
 
 // func dotProduct4AVX(results, row0, row1, row2, row3, vec *float32, n int)

--- a/f32/f32_arm64.go
+++ b/f32/f32_arm64.go
@@ -310,6 +310,19 @@ func convolveDecimate32(dst, signal, kernel []float32, factor, phase int) {
 	convolveDecimate32Go(dst, signal, kernel, factor, phase)
 }
 
+func convolveValidMaxAbs32(signal, kernel []float32) float32 {
+	// Mirror dotProduct's NEON threshold (>= 4) so the fused kernel and the
+	// per-window dotProduct in ConvolveValid pick the same backend, keeping the
+	// peak bit-identical.
+	if hasNEON && len(kernel) >= 4 {
+		return convolveValidMaxAbsNEON(signal, kernel)
+	}
+	return convolveValidMaxAbsGo(signal, kernel)
+}
+
+//go:noescape
+func convolveValidMaxAbsNEON(signal, kernel []float32) float32
+
 //go:noescape
 func convolveDecimateNEON(dst, signal, kernel []float32, factor, phase int)
 

--- a/f32/f32_arm64.s
+++ b/f32/f32_arm64.s
@@ -2920,6 +2920,89 @@ cd_neon_store:
 cd_neon_done:
     RET
 
+// func convolveValidMaxAbsNEON(signal, kernel []float32) float32
+//
+// Fused valid convolution + abs-max: returns max_i |dot(signal[i:i+kLen], kernel)|
+// over the n = len(signal)-kLen+1 windows. The inner dot replicates
+// convolveDecimateNEON (two FMLA accumulators, 8/4/scalar reduction, FADDP), so
+// each window is bit-identical to dotProductNEON / ConvolveValid; the per-window
+// store is replaced by FABS into a running max (F6). Caller guarantees kLen >= 4
+// and len(signal) >= kLen (kLen < 4 takes the Go fallback), so n >= 1.
+TEXT ·convolveValidMaxAbsNEON(SB), NOSPLIT, $0-52
+    MOVD signal_base+0(FP), R11    // R11 = &signal[pos], advances 4 bytes/output
+    MOVD signal_len+8(FP), R10
+    MOVD kernel_base+24(FP), R12
+    MOVD kernel_len+32(FP), R13     // R13 = kLen
+
+    SUB R13, R10                   // signal_len - kLen
+    ADD $1, R10                    // R10 = n
+    VEOR V6.B16, V6.B16, V6.B16    // running max F6 = 0
+
+cvma_neon_outer:
+    MOVD R11, R0                   // R0 = &signal[pos]
+    MOVD R12, R1                   // R1 = &kernel[0]
+    MOVD R13, R2                   // R2 = kLen
+
+    VEOR V0.B16, V0.B16, V0.B16
+    VEOR V1.B16, V1.B16, V1.B16
+
+    LSR $3, R2, R3                 // kLen / 8
+    CBZ R3, cvma_neon_rem4
+
+cvma_neon_loop8:
+    VLD1.P 16(R0), [V2.S4]
+    VLD1.P 16(R0), [V3.S4]
+    VLD1.P 16(R1), [V4.S4]
+    VLD1.P 16(R1), [V5.S4]
+    WORD $0x4E24CC40              // FMLA V0.4S, V2.4S, V4.4S
+    WORD $0x4E25CC61              // FMLA V1.4S, V3.4S, V5.4S
+    SUB $1, R3
+    CBNZ R3, cvma_neon_loop8
+
+    WORD $0x4E21D400             // FADD V0.4S, V0.4S, V1.4S
+
+cvma_neon_rem4:
+    AND $7, R2, R3
+    LSR $2, R3, R4
+    CBZ R4, cvma_neon_rem
+
+    VLD1.P 16(R0), [V2.S4]
+    VLD1.P 16(R1), [V4.S4]
+    WORD $0x4E24CC40              // FMLA V0.4S, V2.4S, V4.4S
+
+cvma_neon_rem:
+    AND $3, R3, R4
+    CBZ R4, cvma_neon_reduce
+
+    // Reduce vector FIRST before scalar ops (scalar ops zero upper V bits).
+    WORD $0x6E20D400             // FADDP V0.4S, V0.4S, V0.4S
+    WORD $0x7E30D800             // FADDP S0, V0.2S
+
+cvma_neon_scalar:
+    FMOVS (R0), F2
+    FMOVS (R1), F4
+    FMADDS F4, F0, F2, F0         // F0 = F2 * F4 + F0
+    ADD $4, R0
+    ADD $4, R1
+    SUB $1, R4
+    CBNZ R4, cvma_neon_scalar
+
+    B cvma_neon_absmax
+
+cvma_neon_reduce:
+    WORD $0x6E20D400             // FADDP V0.4S, V0.4S, V0.4S
+    WORD $0x7E30D800             // FADDP S0, V0.2S
+
+cvma_neon_absmax:
+    FABSS F0, F0
+    FMAXS F0, F6, F6           // F6 = max(F6, |dot|)
+    ADD $4, R11               // pos += 1
+    SUB $1, R10
+    CBNZ R10, cvma_neon_outer
+
+    FMOVS F6, ret+48(FP)
+    RET
+
 // ============================================================================
 // INTERLEAVE / DEINTERLEAVE N=6 and N=8 (profiling-gated, 5.1/7.1 audio)
 // The pair trick: ZIP adjacent channel pairs at .4S so each 64-bit lane holds a

--- a/f32/f32_go.go
+++ b/f32/f32_go.go
@@ -323,6 +323,26 @@ func convolveValid32Go(dst, signal, kernel []float32) {
 	}
 }
 
+// convolveValidMaxAbsGo is the Go-level fused fallback for ConvolveValidMaxAbs:
+// it loops over the dispatched dotProduct (matching convolveValid32) and folds
+// the abs-max in, so it is bit-identical to max|ConvolveValid output| on every
+// backend. The dedicated convolveValidMaxAbs* kernels supersede it where present.
+func convolveValidMaxAbsGo(signal, kernel []float32) float32 {
+	kLen := len(kernel)
+	validLen := len(signal) - kLen + 1
+	var m float32 // abs values are >= 0, so 0 is the correct identity
+	for i := range validLen {
+		v := dotProduct(signal[i:i+kLen], kernel)
+		if v < 0 {
+			v = -v
+		}
+		if v > m {
+			m = v
+		}
+	}
+	return m
+}
+
 // convolveDecimate32Go is the pure-Go decimating valid convolution. It is the
 // correctness oracle for the SIMD paths and the fallback on non-asm platforms.
 func convolveDecimate32Go(dst, signal, kernel []float32, factor, phase int) {

--- a/f32/f32_other.go
+++ b/f32/f32_other.go
@@ -30,6 +30,9 @@ func dotProductStrided(dst, base, query []float32, rowCount, dims, stride int) b
 	return false
 }
 func convolveValid32(dst, signal, kernel []float32) { convolveValid32Go(dst, signal, kernel) }
+func convolveValidMaxAbs32(signal, kernel []float32) float32 {
+	return convolveValidMaxAbsGo(signal, kernel)
+}
 func convolveDecimate32(dst, signal, kernel []float32, factor, phase int) {
 	convolveDecimate32Go(dst, signal, kernel, factor, phase)
 }

--- a/f32/go_impl_amd64_test.go
+++ b/f32/go_impl_amd64_test.go
@@ -13,6 +13,9 @@ import (
 
 func TestInitGo(t *testing.T) {
 	savedDotProduct := dotProductImpl
+	// init* also reassigns convolveValidMaxAbsImpl; restore it so the fused kernel
+	// stays consistent with dotProductImpl for the exact-equality convolution tests.
+	savedConvolveValidMaxAbs := convolveValidMaxAbsImpl
 
 	initGo()
 
@@ -26,10 +29,14 @@ func TestInitGo(t *testing.T) {
 	}
 
 	dotProductImpl = savedDotProduct
+	convolveValidMaxAbsImpl = savedConvolveValidMaxAbs
 }
 
 func TestInitSSE(t *testing.T) {
 	savedDotProduct := dotProductImpl
+	// init* also reassigns convolveValidMaxAbsImpl; restore it so the fused kernel
+	// stays consistent with dotProductImpl for the exact-equality convolution tests.
+	savedConvolveValidMaxAbs := convolveValidMaxAbsImpl
 
 	initSSE()
 
@@ -43,6 +50,7 @@ func TestInitSSE(t *testing.T) {
 	}
 
 	dotProductImpl = savedDotProduct
+	convolveValidMaxAbsImpl = savedConvolveValidMaxAbs
 }
 
 func TestInitAVX512(t *testing.T) {
@@ -51,6 +59,9 @@ func TestInitAVX512(t *testing.T) {
 	}
 
 	savedDotProduct := dotProductImpl
+	// init* also reassigns convolveValidMaxAbsImpl; restore it so the fused kernel
+	// stays consistent with dotProductImpl for the exact-equality convolution tests.
+	savedConvolveValidMaxAbs := convolveValidMaxAbsImpl
 	savedMinSIMD := minSIMDElements
 
 	initAVX512()
@@ -69,5 +80,6 @@ func TestInitAVX512(t *testing.T) {
 	}
 
 	dotProductImpl = savedDotProduct
+	convolveValidMaxAbsImpl = savedConvolveValidMaxAbs
 	minSIMDElements = savedMinSIMD
 }

--- a/f64/benchmark_test.go
+++ b/f64/benchmark_test.go
@@ -627,6 +627,44 @@ func BenchmarkConvolveValid(b *testing.B) {
 	}
 }
 
+// BenchmarkConvolveValidMaxAbs compares the fused kernel against the Go-level
+// fusion it replaces (rc.1 behavior: a loop over the dispatched dotProduct). The
+// fused kernel keeps the kernel resident and folds the abs-max in, removing the
+// per-output dispatch overhead; the win is largest for short kernels.
+func BenchmarkConvolveValidMaxAbs(b *testing.B) {
+	signalSizes := []int{4096, 48000}
+	kernelSizes := []int{16, 32, 64}
+
+	for _, sigSize := range signalSizes {
+		for _, kerSize := range kernelSizes {
+			signal := make([]float64, sigSize)
+			kernel := make([]float64, kerSize)
+			for i := range signal {
+				signal[i] = float64(i%100) - 50
+			}
+			for i := range kernel {
+				kernel[i] = float64(i%10) - 5
+			}
+
+			name := fmt.Sprintf("sig%d_ker%d", sigSize, kerSize)
+			b.Run(fmt.Sprintf("Fused_%s", name), func(b *testing.B) {
+				var sink float64
+				for i := 0; i < b.N; i++ {
+					sink = ConvolveValidMaxAbs(signal, kernel)
+				}
+				_ = sink
+			})
+			b.Run(fmt.Sprintf("GoFusion_%s", name), func(b *testing.B) {
+				var sink float64
+				for i := 0; i < b.N; i++ {
+					sink = convolveValidMaxAbsGo(signal, kernel)
+				}
+				_ = sink
+			})
+		}
+	}
+}
+
 // =============================================================================
 // Activation Functions
 // =============================================================================

--- a/f64/convolve_maxabs_amd64_test.go
+++ b/f64/convolve_maxabs_amd64_test.go
@@ -66,4 +66,16 @@ func TestConvolveValidMaxAbsKernelsAMD64(t *testing.T) {
 			}
 		}
 	})
+
+	t.Run("NoAlloc", func(t *testing.T) {
+		s, k := mkPair(256, 32)
+		if n := testing.AllocsPerRun(50, func() { _ = convolveValidMaxAbsSSE2(s, k) }); n != 0 {
+			t.Errorf("convolveValidMaxAbsSSE2 allocated %v, want 0", n)
+		}
+		if cpu.X86.AVX && cpu.X86.FMA {
+			if n := testing.AllocsPerRun(50, func() { _ = convolveValidMaxAbsAVX(s, k) }); n != 0 {
+				t.Errorf("convolveValidMaxAbsAVX allocated %v, want 0", n)
+			}
+		}
+	})
 }

--- a/f64/convolve_maxabs_amd64_test.go
+++ b/f64/convolve_maxabs_amd64_test.go
@@ -1,0 +1,69 @@
+//go:build amd64
+
+package f64
+
+import (
+	"math"
+	"testing"
+
+	"github.com/tphakala/simd/cpu"
+)
+
+// refConvMaxAbsDot computes max|valid-conv output| using the given per-window dot
+// product, so each amd64 fused kernel can be checked for bit-exactness against the
+// exact dotProduct kernel whose accumulation it replicates.
+func refConvMaxAbsDot(signal, kernel []float64, dot func(a, b []float64) float64) float64 {
+	kLen := len(kernel)
+	validLen := len(signal) - kLen + 1
+	var m float64
+	for i := range validLen {
+		if v := math.Abs(dot(signal[i:i+kLen], kernel)); v > m {
+			m = v
+		}
+	}
+	return m
+}
+
+// TestConvolveValidMaxAbsKernelsAMD64 exercises each fused kernel directly
+// (bypassing dispatch) so SSE2 is covered even on an AVX2 host, and asserts each
+// is bit-identical to max|its matching per-window dotProduct|.
+func TestConvolveValidMaxAbsKernelsAMD64(t *testing.T) {
+	mkPair := func(sl, kl int) ([]float64, []float64) {
+		s := make([]float64, sl)
+		k := make([]float64, kl)
+		for i := range s {
+			s[i] = math.Sin(float64(i)*0.31) - 0.3*float64(i%4)
+		}
+		for i := range k {
+			k[i] = 0.4 - float64(i)*0.07
+		}
+		return s, k
+	}
+	type cfg struct{ sl, kl int }
+	cfgs := []cfg{{4, 1}, {8, 2}, {16, 3}, {17, 4}, {33, 5}, {64, 8}, {128, 16}, {200, 17}, {256, 32}}
+
+	t.Run("SSE2", func(t *testing.T) {
+		for _, c := range cfgs {
+			s, k := mkPair(c.sl, c.kl)
+			got := convolveValidMaxAbsSSE2(s, k)
+			want := refConvMaxAbsDot(s, k, dotProductSSE2)
+			if got != want {
+				t.Errorf("sl=%d kl=%d: SSE2=%v want %v", c.sl, c.kl, got, want)
+			}
+		}
+	})
+
+	t.Run("AVX", func(t *testing.T) {
+		if !cpu.X86.AVX || !cpu.X86.FMA {
+			t.Skip("AVX+FMA not supported on this CPU")
+		}
+		for _, c := range cfgs {
+			s, k := mkPair(c.sl, c.kl)
+			got := convolveValidMaxAbsAVX(s, k)
+			want := refConvMaxAbsDot(s, k, dotProductAVX)
+			if got != want {
+				t.Errorf("sl=%d kl=%d: AVX=%v want %v", c.sl, c.kl, got, want)
+			}
+		}
+	})
+}

--- a/f64/convolve_maxabs_test.go
+++ b/f64/convolve_maxabs_test.go
@@ -112,3 +112,39 @@ func TestConvolveValidMaxAbsNoAlloc(t *testing.T) {
 		t.Errorf("ConvolveValidMaxAbsMulti allocated %v, want 0", n)
 	}
 }
+
+// TestConvolveValidMaxAbsScalarOracle checks the dispatched (SIMD) path against an
+// independent pure-Go math.FMA oracle rather than ConvolveValid, so a bug shared
+// by the fused convolution and the dot-product path is still caught. Tolerance,
+// since the SIMD lane-parallel summation order differs from the sequential oracle.
+func TestConvolveValidMaxAbsScalarOracle(t *testing.T) {
+	for _, kl := range []int{1, 2, 3, 4, 5, 8, 13, 16, 17, 31, 32, 33, 64} {
+		for _, sl := range []int{kl, kl + 1, 65, 128, 257} {
+			if sl < kl {
+				continue
+			}
+			signal := make([]float64, sl)
+			kernel := make([]float64, kl)
+			for i := range signal {
+				signal[i] = math.Sin(float64(i)*0.17) - 0.25*float64(i%5)
+			}
+			for i := range kernel {
+				kernel[i] = math.Cos(float64(i)*0.23) * 0.6
+			}
+			got := ConvolveValidMaxAbs(signal, kernel)
+			var want float64
+			for i := range sl - kl + 1 {
+				var s float64
+				for j := range kl {
+					s = math.FMA(signal[i+j], kernel[j], s)
+				}
+				if a := math.Abs(s); a > want {
+					want = a
+				}
+			}
+			if d := math.Abs(got - want); d > 1e-9*(1+want) {
+				t.Errorf("sl=%d kl=%d: got %v want(scalar) %v diff=%g", sl, kl, got, want, d)
+			}
+		}
+	}
+}

--- a/f64/f64.go
+++ b/f64/f64.go
@@ -650,21 +650,6 @@ func ConvolveValidMaxAbs(signal, kernel []float64) float64 {
 	return convolveValidMaxAbs64(signal, kernel)
 }
 
-// convolveValidMaxAbs64 fuses the valid convolution with the abs-max reduction.
-// It calls the dispatched SIMD dotProduct per output position, so it is
-// vectorized on every backend without a dedicated kernel.
-func convolveValidMaxAbs64(signal, kernel []float64) float64 {
-	kLen := len(kernel)
-	validLen := len(signal) - kLen + 1
-	var m float64 // abs values are >= 0, so 0 is the correct identity
-	for i := range validLen {
-		if v := math.Abs(dotProduct(signal[i:i+kLen], kernel)); v > m {
-			m = v
-		}
-	}
-	return m
-}
-
 // ConvolveValidMaxAbsMulti returns the single maximum of |valid-convolution
 // output| across every kernel applied to signal, without materializing any
 // output. This is the polyphase true-peak primitive: pass the N phase kernels and

--- a/f64/f64_amd64.go
+++ b/f64/f64_amd64.go
@@ -27,47 +27,49 @@ var hasAVX2 = cpu.X86.AVX2
 
 // Function pointer types for SIMD operations
 type (
-	dotProductFunc        func(a, b []float64) float64
-	binaryOpFunc          func(dst, a, b []float64)
-	scaleFunc             func(dst, a []float64, s float64)
-	unaryOpFunc           func(dst, a []float64)
-	reduceFunc            func(a []float64) float64
-	fmaFunc               func(dst, a, b, c []float64)
-	clampFunc             func(dst, a []float64, minVal, maxVal float64)
-	varianceFunc          func(a []float64, mean float64) float64
-	euclideanDistanceFunc func(a, b []float64) float64
-	interleave2Func       func(dst, a, b []float64)
-	deinterleave2Func     func(a, b, src []float64)
-	addScaledFunc         func(dst []float64, alpha float64, s []float64)
-	convolveDecimateFunc  func(dst, signal, kernel []float64, factor, phase int)
+	dotProductFunc          func(a, b []float64) float64
+	binaryOpFunc            func(dst, a, b []float64)
+	scaleFunc               func(dst, a []float64, s float64)
+	unaryOpFunc             func(dst, a []float64)
+	reduceFunc              func(a []float64) float64
+	fmaFunc                 func(dst, a, b, c []float64)
+	clampFunc               func(dst, a []float64, minVal, maxVal float64)
+	varianceFunc            func(a []float64, mean float64) float64
+	euclideanDistanceFunc   func(a, b []float64) float64
+	interleave2Func         func(dst, a, b []float64)
+	deinterleave2Func       func(a, b, src []float64)
+	addScaledFunc           func(dst []float64, alpha float64, s []float64)
+	convolveDecimateFunc    func(dst, signal, kernel []float64, factor, phase int)
+	convolveValidMaxAbsFunc func(signal, kernel []float64) float64
 )
 
 // Function pointers - assigned at init time based on CPU features
 var (
-	dotProductImpl        dotProductFunc
-	addImpl               binaryOpFunc
-	subImpl               binaryOpFunc
-	mulImpl               binaryOpFunc
-	divImpl               binaryOpFunc
-	scaleImpl             scaleFunc
-	addScalarImpl         scaleFunc
-	sumImpl               reduceFunc
-	minImpl               reduceFunc
-	maxImpl               reduceFunc
-	maxAbsImpl            reduceFunc
-	absImpl               unaryOpFunc
-	negImpl               unaryOpFunc
-	sqrtImpl              unaryOpFunc
-	reciprocalImpl        unaryOpFunc
-	roundImpl             unaryOpFunc
-	fmaImpl               fmaFunc
-	clampImpl             clampFunc
-	varianceImpl          varianceFunc
-	euclideanDistanceImpl euclideanDistanceFunc
-	interleave2Impl       interleave2Func
-	deinterleave2Impl     deinterleave2Func
-	addScaledImpl         addScaledFunc
-	convolveDecimateImpl  convolveDecimateFunc
+	dotProductImpl          dotProductFunc
+	addImpl                 binaryOpFunc
+	subImpl                 binaryOpFunc
+	mulImpl                 binaryOpFunc
+	divImpl                 binaryOpFunc
+	scaleImpl               scaleFunc
+	addScalarImpl           scaleFunc
+	sumImpl                 reduceFunc
+	minImpl                 reduceFunc
+	maxImpl                 reduceFunc
+	maxAbsImpl              reduceFunc
+	absImpl                 unaryOpFunc
+	negImpl                 unaryOpFunc
+	sqrtImpl                unaryOpFunc
+	reciprocalImpl          unaryOpFunc
+	roundImpl               unaryOpFunc
+	fmaImpl                 fmaFunc
+	clampImpl               clampFunc
+	varianceImpl            varianceFunc
+	euclideanDistanceImpl   euclideanDistanceFunc
+	interleave2Impl         interleave2Func
+	deinterleave2Impl       deinterleave2Func
+	addScaledImpl           addScaledFunc
+	convolveDecimateImpl    convolveDecimateFunc
+	convolveValidMaxAbsImpl convolveValidMaxAbsFunc
 )
 
 func init() {
@@ -113,6 +115,7 @@ func initAVX512() {
 	deinterleave2Impl = deinterleave2AVX
 	addScaledImpl = addScaledAVX512
 	convolveDecimateImpl = convolveDecimateAVX512
+	convolveValidMaxAbsImpl = convolveValidMaxAbsGo
 }
 
 func initAVX() {
@@ -141,6 +144,7 @@ func initAVX() {
 	deinterleave2Impl = deinterleave2AVX
 	addScaledImpl = addScaledAVX
 	convolveDecimateImpl = convolveDecimateAVX
+	convolveValidMaxAbsImpl = convolveValidMaxAbsGo
 }
 
 // initAVXNoFMA runs on AVX-capable CPUs that lack FMA (rare but possible:
@@ -173,6 +177,7 @@ func initAVXNoFMA() {
 	deinterleave2Impl = deinterleave2AVX
 	addScaledImpl = addScaledSSE2
 	convolveDecimateImpl = convolveDecimateSSE2
+	convolveValidMaxAbsImpl = convolveValidMaxAbsGo
 }
 
 func initSSE2() {
@@ -200,6 +205,7 @@ func initSSE2() {
 	deinterleave2Impl = deinterleave2SSE2
 	addScaledImpl = addScaledSSE2
 	convolveDecimateImpl = convolveDecimateSSE2
+	convolveValidMaxAbsImpl = convolveValidMaxAbsGo
 }
 
 func initGo() {
@@ -227,6 +233,7 @@ func initGo() {
 	deinterleave2Impl = deinterleave2Go
 	addScaledImpl = addScaledGo64
 	convolveDecimateImpl = convolveDecimate64Go
+	convolveValidMaxAbsImpl = convolveValidMaxAbsGo
 }
 
 // Dispatch functions - call function pointers (zero overhead after init)
@@ -461,6 +468,10 @@ func convolveValid64(dst, signal, kernel []float64) {
 
 func convolveDecimate64(dst, signal, kernel []float64, factor, phase int) {
 	convolveDecimateImpl(dst, signal, kernel, factor, phase)
+}
+
+func convolveValidMaxAbs64(signal, kernel []float64) float64 {
+	return convolveValidMaxAbsImpl(signal, kernel)
 }
 
 func accumulateAdd64(dst, src []float64) {

--- a/f64/f64_amd64.go
+++ b/f64/f64_amd64.go
@@ -115,7 +115,7 @@ func initAVX512() {
 	deinterleave2Impl = deinterleave2AVX
 	addScaledImpl = addScaledAVX512
 	convolveDecimateImpl = convolveDecimateAVX512
-	convolveValidMaxAbsImpl = convolveValidMaxAbsGo
+	convolveValidMaxAbsImpl = convolveValidMaxAbsAVX
 }
 
 func initAVX() {
@@ -144,7 +144,7 @@ func initAVX() {
 	deinterleave2Impl = deinterleave2AVX
 	addScaledImpl = addScaledAVX
 	convolveDecimateImpl = convolveDecimateAVX
-	convolveValidMaxAbsImpl = convolveValidMaxAbsGo
+	convolveValidMaxAbsImpl = convolveValidMaxAbsAVX
 }
 
 // initAVXNoFMA runs on AVX-capable CPUs that lack FMA (rare but possible:
@@ -177,7 +177,7 @@ func initAVXNoFMA() {
 	deinterleave2Impl = deinterleave2AVX
 	addScaledImpl = addScaledSSE2
 	convolveDecimateImpl = convolveDecimateSSE2
-	convolveValidMaxAbsImpl = convolveValidMaxAbsGo
+	convolveValidMaxAbsImpl = convolveValidMaxAbsSSE2
 }
 
 func initSSE2() {
@@ -205,7 +205,7 @@ func initSSE2() {
 	deinterleave2Impl = deinterleave2SSE2
 	addScaledImpl = addScaledSSE2
 	convolveDecimateImpl = convolveDecimateSSE2
-	convolveValidMaxAbsImpl = convolveValidMaxAbsGo
+	convolveValidMaxAbsImpl = convolveValidMaxAbsSSE2
 }
 
 func initGo() {
@@ -804,6 +804,12 @@ func convolveDecimateAVX512(dst, signal, kernel []float64, factor, phase int)
 
 //go:noescape
 func convolveDecimateSSE2(dst, signal, kernel []float64, factor, phase int)
+
+//go:noescape
+func convolveValidMaxAbsAVX(signal, kernel []float64) float64
+
+//go:noescape
+func convolveValidMaxAbsSSE2(signal, kernel []float64) float64
 
 //go:noescape
 func addAVX(dst, a, b []float64)

--- a/f64/f64_amd64.go
+++ b/f64/f64_amd64.go
@@ -115,7 +115,12 @@ func initAVX512() {
 	deinterleave2Impl = deinterleave2AVX
 	addScaledImpl = addScaledAVX512
 	convolveDecimateImpl = convolveDecimateAVX512
-	convolveValidMaxAbsImpl = convolveValidMaxAbsAVX
+	// AVX-512 keeps the Go-level fusion over the 8-wide dotProductAVX512: the fused
+	// kernel is 4-wide (AVX2) and its dot summation order would diverge from
+	// ConvolveValid here. A dedicated 8-wide fused kernel needs AVX-512 hardware to
+	// validate (none available; see #138), so the AVX-512 tier forgoes the fused
+	// speedup but stays bit-identical to ConvolveValid.
+	convolveValidMaxAbsImpl = convolveValidMaxAbsGo
 }
 
 func initAVX() {

--- a/f64/f64_amd64.s
+++ b/f64/f64_amd64.s
@@ -4935,6 +4935,108 @@ cd_avx_ret:
     VZEROUPPER
     RET
 
+// func convolveValidMaxAbsAVX(signal, kernel []float64) float64
+//
+// Fused valid convolution + abs-max: returns max_i |dot(signal[i:i+kLen], kernel)|
+// over the n = len(signal)-kLen+1 valid windows without materializing the output.
+// The inner dot replicates convolveDecimateAVX / dotProductAVX (4 Y accumulators,
+// 16/4/scalar reduction), so each window's value is bit-identical to ConvolveValid;
+// the per-window store is replaced by an abs (VANDPD) into a running max (X7).
+// Caller guarantees kLen >= 1 and len(signal) >= kLen, so n >= 1.
+TEXT ·convolveValidMaxAbsAVX(SB), NOSPLIT, $0-56
+    MOVQ signal_base+0(FP), R10    // R10 = &signal[pos], advances by 1 elem/output
+    MOVQ signal_len+8(FP), R9
+    MOVQ kernel_base+24(FP), R11
+    MOVQ kernel_len+32(FP), R12    // R12 = kLen
+
+    SUBQ R12, R9
+    INCQ R9                        // R9 = n = signal_len - kLen + 1
+
+    VMOVUPD absf64mask<>(SB), X6   // X6 = abs mask
+    VXORPD X7, X7, X7              // X7 = running max = 0
+
+cvma_avx_outer:
+    MOVQ R10, SI                   // SI = &signal[pos]
+    MOVQ R11, DI                   // DI = &kernel[0]
+
+    VXORPD Y0, Y0, Y0
+    VXORPD Y3, Y3, Y3
+    VXORPD Y4, Y4, Y4
+    VXORPD Y5, Y5, Y5
+
+    MOVQ R12, CX
+    MOVQ CX, AX
+    SHRQ $4, AX                    // kLen / 16
+    JZ   cvma_avx_loop4_check
+
+cvma_avx_loop16:
+    VMOVUPD (SI), Y1
+    VMOVUPD (DI), Y2
+    VFMADD231PD Y1, Y2, Y0
+    VMOVUPD 32(SI), Y1
+    VMOVUPD 32(DI), Y2
+    VFMADD231PD Y1, Y2, Y3
+    VMOVUPD 64(SI), Y1
+    VMOVUPD 64(DI), Y2
+    VFMADD231PD Y1, Y2, Y4
+    VMOVUPD 96(SI), Y1
+    VMOVUPD 96(DI), Y2
+    VFMADD231PD Y1, Y2, Y5
+    ADDQ $128, SI
+    ADDQ $128, DI
+    DECQ AX
+    JNZ  cvma_avx_loop16
+
+    VADDPD Y3, Y0, Y0
+    VADDPD Y4, Y0, Y0
+    VADDPD Y5, Y0, Y0
+
+cvma_avx_loop4_check:
+    MOVQ R12, CX
+    ANDQ $15, CX
+    MOVQ CX, AX
+    SHRQ $2, AX
+    JZ   cvma_avx_reduce
+
+cvma_avx_loop4:
+    VMOVUPD (SI), Y1
+    VMOVUPD (DI), Y2
+    VFMADD231PD Y1, Y2, Y0
+    ADDQ $32, SI
+    ADDQ $32, DI
+    DECQ AX
+    JNZ  cvma_avx_loop4
+
+cvma_avx_reduce:
+    VEXTRACTF128 $1, Y0, X1
+    VADDPD X1, X0, X0
+    VHADDPD X0, X0, X0
+
+    MOVQ R12, CX
+    ANDQ $3, CX
+    JZ   cvma_avx_absmax
+
+cvma_avx_scalar:
+    VMOVSD (SI), X1
+    VMOVSD (DI), X2
+    VFMADD231SD X1, X2, X0
+    ADDQ $8, SI
+    ADDQ $8, DI
+    DECQ CX
+    JNZ  cvma_avx_scalar
+
+cvma_avx_absmax:
+    VANDPD X0, X6, X0             // |dot|
+    VMAXSD X0, X7, X7            // running max = max(running, |dot|)
+
+    ADDQ $8, R10                  // pos += 1
+    DECQ R9
+    JNZ  cvma_avx_outer
+
+    VMOVSD X7, ret+48(FP)
+    VZEROUPPER
+    RET
+
 // func convolveDecimateAVX512(dst, signal, kernel []float64, factor, phase int)
 //
 // AVX-512 fused decimating valid convolution. Inner dot replicates
@@ -5095,6 +5197,68 @@ cd_sse2_store:
     JNZ  cd_sse2_outer
 
 cd_sse2_ret:
+    RET
+
+// func convolveValidMaxAbsSSE2(signal, kernel []float64) float64
+//
+// SSE2 fused valid convolution + abs-max. Inner dot replicates
+// convolveDecimateSSE2 / dotProductSSE2 (single accumulator, MULPD+ADDPD, 2/scalar
+// reduction); the per-window store is replaced by an abs (ANDPD) into a running
+// max (X7). Caller guarantees kLen >= 1 and len(signal) >= kLen, so n >= 1.
+TEXT ·convolveValidMaxAbsSSE2(SB), NOSPLIT, $0-56
+    MOVQ signal_base+0(FP), R10
+    MOVQ signal_len+8(FP), R9
+    MOVQ kernel_base+24(FP), R11
+    MOVQ kernel_len+32(FP), R12
+
+    SUBQ R12, R9
+    INCQ R9                        // n
+
+    MOVUPD absf64mask<>(SB), X6
+    XORPD X7, X7                   // running max = 0
+
+cvma_sse2_outer:
+    MOVQ R10, SI
+    MOVQ R11, DI
+    XORPD X0, X0
+
+    MOVQ R12, CX
+    MOVQ CX, AX
+    SHRQ $1, AX                    // kLen / 2
+    JZ   cvma_sse2_reduce
+
+cvma_sse2_loop2:
+    MOVUPD (SI), X1
+    MOVUPD (DI), X2
+    MULPD X2, X1
+    ADDPD X1, X0
+    ADDQ $16, SI
+    ADDQ $16, DI
+    DECQ AX
+    JNZ  cvma_sse2_loop2
+
+cvma_sse2_reduce:
+    MOVAPD X0, X1
+    SHUFPD $1, X1, X1
+    ADDSD X1, X0
+
+    MOVQ R12, CX
+    ANDQ $1, CX
+    JZ   cvma_sse2_absmax
+
+    MOVSD (SI), X1
+    MOVSD (DI), X2
+    MULSD X2, X1
+    ADDSD X1, X0
+
+cvma_sse2_absmax:
+    ANDPD X6, X0                  // |dot|
+    MAXSD X0, X7                 // running max = max(X7, X0)
+    ADDQ $8, R10
+    DECQ R9
+    JNZ  cvma_sse2_outer
+
+    MOVSD X7, ret+48(FP)
     RET
 
 // ============================================================================

--- a/f64/f64_arm64.go
+++ b/f64/f64_arm64.go
@@ -286,8 +286,17 @@ func convolveDecimate64(dst, signal, kernel []float64, factor, phase int) {
 }
 
 func convolveValidMaxAbs64(signal, kernel []float64) float64 {
+	// Mirror dotProduct's NEON threshold (>= 2) so the fused kernel and the
+	// per-window dotProduct in ConvolveValid pick the same backend, keeping the
+	// peak bit-identical.
+	if hasNEON && len(kernel) >= 2 {
+		return convolveValidMaxAbsNEON(signal, kernel)
+	}
 	return convolveValidMaxAbsGo(signal, kernel)
 }
+
+//go:noescape
+func convolveValidMaxAbsNEON(signal, kernel []float64) float64
 
 //go:noescape
 func convolveDecimateNEON(dst, signal, kernel []float64, factor, phase int)

--- a/f64/f64_arm64.go
+++ b/f64/f64_arm64.go
@@ -285,6 +285,10 @@ func convolveDecimate64(dst, signal, kernel []float64, factor, phase int) {
 	convolveDecimate64Go(dst, signal, kernel, factor, phase)
 }
 
+func convolveValidMaxAbs64(signal, kernel []float64) float64 {
+	return convolveValidMaxAbsGo(signal, kernel)
+}
+
 //go:noescape
 func convolveDecimateNEON(dst, signal, kernel []float64, factor, phase int)
 

--- a/f64/f64_arm64.s
+++ b/f64/f64_arm64.s
@@ -1728,6 +1728,80 @@ cd_neon_store:
 cd_neon_done:
     RET
 
+// func convolveValidMaxAbsNEON(signal, kernel []float64) float64
+//
+// Fused valid convolution + abs-max: returns max_i |dot(signal[i:i+kLen], kernel)|
+// over the n = len(signal)-kLen+1 windows. The inner dot replicates
+// convolveDecimateNEON (two FMLA accumulators, 4/2/scalar reduction, FADDP), so
+// each window is bit-identical to dotProductNEON / ConvolveValid; the per-window
+// store is replaced by FABS into a running max (F6). Caller guarantees kLen >= 2
+// and len(signal) >= kLen (kLen < 2 takes the Go fallback), so n >= 1.
+TEXT ·convolveValidMaxAbsNEON(SB), NOSPLIT, $0-56
+    MOVD signal_base+0(FP), R11   // R11 = &signal[pos], advances 8 bytes/output
+    MOVD signal_len+8(FP), R10
+    MOVD kernel_base+24(FP), R12
+    MOVD kernel_len+32(FP), R13    // R13 = kLen
+
+    SUB R13, R10                  // signal_len - kLen
+    ADD $1, R10                   // R10 = n
+    VEOR V6.B16, V6.B16, V6.B16   // running max F6 = 0
+
+cvma_neon_outer:
+    MOVD R11, R0                  // R0 = &signal[pos]
+    MOVD R12, R1                  // R1 = &kernel[0]
+    MOVD R13, R2                  // R2 = kLen
+
+    VEOR V0.B16, V0.B16, V0.B16
+    VEOR V1.B16, V1.B16, V1.B16
+
+    LSR $2, R2, R3                // kLen / 4
+    CBZ R3, cvma_neon_rem2
+
+cvma_neon_loop4:
+    VLD1.P 16(R0), [V2.D2]
+    VLD1.P 16(R0), [V3.D2]
+    VLD1.P 16(R1), [V4.D2]
+    VLD1.P 16(R1), [V5.D2]
+    WORD $0x4E64CC40             // FMLA V0.2D, V2.2D, V4.2D
+    WORD $0x4E65CC61             // FMLA V1.2D, V3.2D, V5.2D
+    SUB $1, R3
+    CBNZ R3, cvma_neon_loop4
+
+    WORD $0x4E61D400            // FADD V0.2D, V0.2D, V1.2D
+
+cvma_neon_rem2:
+    AND $3, R2, R3
+    LSR $1, R3, R4
+    CBZ R4, cvma_neon_rem1
+
+    VLD1.P 16(R0), [V2.D2]
+    VLD1.P 16(R1), [V4.D2]
+    WORD $0x4E64CC40            // FMLA V0.2D, V2.2D, V4.2D
+
+cvma_neon_rem1:
+    AND $1, R3, R4
+    CBZ R4, cvma_neon_reduce
+
+    // Reduce vector FIRST before scalar op (scalar ops zero upper V bits).
+    WORD $0x7E70D800           // FADDP D0, V0.2D
+    FMOVD (R0), F2
+    FMOVD (R1), F4
+    FMADDD F4, F0, F2, F0        // F0 = F2 * F4 + F0
+    B cvma_neon_absmax
+
+cvma_neon_reduce:
+    WORD $0x7E70D800           // FADDP D0, V0.2D
+
+cvma_neon_absmax:
+    FABSD F0, F0
+    FMAXD F0, F6, F6           // F6 = max(F6, |dot|)
+    ADD $8, R11               // pos += 1
+    SUB $1, R10
+    CBNZ R10, cvma_neon_outer
+
+    FMOVD F6, ret+48(FP)
+    RET
+
 // func autocorrStep2NEON(acc, broadcast, window *float64, count int)
 // Steady-region accumulation for two autocorrelation lags at once. V0 holds the
 // two seeded accumulators (lanes = lags base..base+1). Each iteration broadcasts

--- a/f64/f64_go.go
+++ b/f64/f64_go.go
@@ -315,6 +315,22 @@ func convolveValid64Go(dst, signal, kernel []float64) {
 	}
 }
 
+// convolveValidMaxAbsGo is the Go-level fused fallback for ConvolveValidMaxAbs:
+// it loops over the dispatched dotProduct (matching convolveValid64) and folds
+// the abs-max in, so it is bit-identical to max|ConvolveValid output| on every
+// backend. The dedicated convolveValidMaxAbs* kernels supersede it where present.
+func convolveValidMaxAbsGo(signal, kernel []float64) float64 {
+	kLen := len(kernel)
+	validLen := len(signal) - kLen + 1
+	var m float64 // abs values are >= 0, so 0 is the correct identity
+	for i := range validLen {
+		if v := math.Abs(dotProduct(signal[i:i+kLen], kernel)); v > m {
+			m = v
+		}
+	}
+	return m
+}
+
 // convolveDecimate64Go is the pure-Go decimating valid convolution. It is the
 // correctness oracle for the SIMD paths and the fallback on non-asm platforms.
 func convolveDecimate64Go(dst, signal, kernel []float64, factor, phase int) {

--- a/f64/f64_other.go
+++ b/f64/f64_other.go
@@ -30,6 +30,9 @@ func dotProductBatch64(results []float64, rows [][]float64, vec []float64) {
 	dotProductBatch64Go(results, rows, vec)
 }
 func convolveValid64(dst, signal, kernel []float64) { convolveValid64Go(dst, signal, kernel) }
+func convolveValidMaxAbs64(signal, kernel []float64) float64 {
+	return convolveValidMaxAbsGo(signal, kernel)
+}
 func convolveDecimate64(dst, signal, kernel []float64, factor, phase int) {
 	convolveDecimate64Go(dst, signal, kernel, factor, phase)
 }

--- a/f64/go_impl_amd64_test.go
+++ b/f64/go_impl_amd64_test.go
@@ -12,58 +12,60 @@ import (
 // snapshotImpls captures every dispatch function pointer plus minSIMDElements
 // so a test that calls one of the init* functions can restore them in t.Cleanup.
 type implSnapshot struct {
-	dotProduct        dotProductFunc
-	add               binaryOpFunc
-	sub               binaryOpFunc
-	mul               binaryOpFunc
-	div               binaryOpFunc
-	scale             scaleFunc
-	addScalar         scaleFunc
-	sum               reduceFunc
-	min               reduceFunc
-	max               reduceFunc
-	maxAbs            reduceFunc
-	abs               unaryOpFunc
-	neg               unaryOpFunc
-	sqrt              unaryOpFunc
-	reciprocal        unaryOpFunc
-	round             unaryOpFunc
-	fma               fmaFunc
-	clamp             clampFunc
-	variance          varianceFunc
-	euclideanDistance euclideanDistanceFunc
-	interleave2       interleave2Func
-	deinterleave2     deinterleave2Func
-	addScaled         addScaledFunc
-	minSIMDElements   int
+	dotProduct          dotProductFunc
+	add                 binaryOpFunc
+	sub                 binaryOpFunc
+	mul                 binaryOpFunc
+	div                 binaryOpFunc
+	scale               scaleFunc
+	addScalar           scaleFunc
+	sum                 reduceFunc
+	min                 reduceFunc
+	max                 reduceFunc
+	maxAbs              reduceFunc
+	abs                 unaryOpFunc
+	neg                 unaryOpFunc
+	sqrt                unaryOpFunc
+	reciprocal          unaryOpFunc
+	round               unaryOpFunc
+	fma                 fmaFunc
+	clamp               clampFunc
+	variance            varianceFunc
+	euclideanDistance   euclideanDistanceFunc
+	interleave2         interleave2Func
+	deinterleave2       deinterleave2Func
+	addScaled           addScaledFunc
+	convolveValidMaxAbs convolveValidMaxAbsFunc
+	minSIMDElements     int
 }
 
 func snapshotDispatch() implSnapshot {
 	return implSnapshot{
-		dotProduct:        dotProductImpl,
-		add:               addImpl,
-		sub:               subImpl,
-		mul:               mulImpl,
-		div:               divImpl,
-		scale:             scaleImpl,
-		addScalar:         addScalarImpl,
-		sum:               sumImpl,
-		min:               minImpl,
-		max:               maxImpl,
-		maxAbs:            maxAbsImpl,
-		abs:               absImpl,
-		neg:               negImpl,
-		sqrt:              sqrtImpl,
-		reciprocal:        reciprocalImpl,
-		round:             roundImpl,
-		fma:               fmaImpl,
-		clamp:             clampImpl,
-		variance:          varianceImpl,
-		euclideanDistance: euclideanDistanceImpl,
-		interleave2:       interleave2Impl,
-		deinterleave2:     deinterleave2Impl,
-		addScaled:         addScaledImpl,
-		minSIMDElements:   minSIMDElements,
+		dotProduct:          dotProductImpl,
+		add:                 addImpl,
+		sub:                 subImpl,
+		mul:                 mulImpl,
+		div:                 divImpl,
+		scale:               scaleImpl,
+		addScalar:           addScalarImpl,
+		sum:                 sumImpl,
+		min:                 minImpl,
+		max:                 maxImpl,
+		maxAbs:              maxAbsImpl,
+		abs:                 absImpl,
+		neg:                 negImpl,
+		sqrt:                sqrtImpl,
+		reciprocal:          reciprocalImpl,
+		round:               roundImpl,
+		fma:                 fmaImpl,
+		clamp:               clampImpl,
+		variance:            varianceImpl,
+		euclideanDistance:   euclideanDistanceImpl,
+		interleave2:         interleave2Impl,
+		deinterleave2:       deinterleave2Impl,
+		addScaled:           addScaledImpl,
+		convolveValidMaxAbs: convolveValidMaxAbsImpl,
+		minSIMDElements:     minSIMDElements,
 	}
 }
 
@@ -91,6 +93,7 @@ func restoreDispatch(s *implSnapshot) {
 	interleave2Impl = s.interleave2
 	deinterleave2Impl = s.deinterleave2
 	addScaledImpl = s.addScaled
+	convolveValidMaxAbsImpl = s.convolveValidMaxAbs
 	minSIMDElements = s.minSIMDElements
 }
 
@@ -218,6 +221,7 @@ func TestInitAVXNoFMA(t *testing.T) {
 		{"varianceImpl", varianceImpl, varianceSSE2},
 		{"euclideanDistanceImpl", euclideanDistanceImpl, euclideanDistanceSSE2},
 		{"addScaledImpl", addScaledImpl, addScaledSSE2},
+		{"convolveValidMaxAbsImpl", convolveValidMaxAbsImpl, convolveValidMaxAbsSSE2},
 	} {
 		if !samePointer(c.got, c.want) {
 			t.Errorf("initAVXNoFMA: %s should fall back to SSE2 (FMA-free)", c.name)


### PR DESCRIPTION
## Summary

Follow-up to #139. `ConvolveValidMaxAbs` / `ConvolveValidMaxAbsMulti` were shipped in v1.4.0-rc.1 as a Go-level fusion that looped over the dispatched `dotProduct`. A downstream true-peak consumer measured only ~3-5% over their old `ConvolveValid`-into-a-buffer + scalar abs-max scan, because that fusion removes the output store and the second scan but keeps the per-output dispatch/slice-header overhead, which dominates the MAC work for short kernels.

This replaces the Go-level fusion with a dedicated fused assembly kernel per backend, modeled on the existing `ConvolveDecimate` kernel (with a stride of one): the kernel coefficients stay resident across output positions and the abs-max is folded into each window's reduce, so the per-output call/dispatch/slice-header overhead is gone too.

- f64: `convolveValidMaxAbsAVX` (FMA), `convolveValidMaxAbsSSE2`, `convolveValidMaxAbsNEON`
- f32: `convolveValidMaxAbsAVX` (FMA), `convolveValidMaxAbsSSE`, `convolveValidMaxAbsNEON`
- AVX-512 reuses the AVX2 kernel; FMA-less AVX CPUs use the SSE kernel; ARM64 uses NEON for kLen >= 2 (f64) / >= 4 (f32), Go below that. The Go-level fusion remains the fallback.

**Bit-exactness:** each kernel's inner dot accumulation is byte-identical to the matching `convolveDecimate*` / `dotProduct*` kernel, so the peak stays bit-identical to `max|ConvolveValid output|`. The existing exact-equality tests (and a new direct per-kernel test asserting each kernel equals `max|its per-window dotProduct|`) confirm this; no tolerance was introduced.

**Speedup** (fused vs the rc.1 Go-level fusion / materialized baseline), 32-tap kernels:

| shape | f64 | f32 |
| --- | --- | --- |
| sig 4096, AVX2 | ~1.8x | ~1.6x |
| sig 48000, AVX2 | ~2.2x | ~1.4x |
| sig 4096/48000, NEON (Pi 5) | - | ~1.5x |

Largest win at short kernels, where per-output overhead dominates.

## Related Issues

Relates to #138

## Test Plan

- [x] Existing exact-equality parity tests now exercise the fused kernels via dispatch
- [x] New direct per-kernel test: each fused kernel == `max|matching per-window dotProduct|` (covers SSE/SSE2 on an AVX2 host)
- [x] Edge cases, mismatched-kernel panic, `AllocsPerRun == 0`, fuzz (exact)
- [x] FMA-routing test: the FMA-based AVX kernel falls back to SSE on FMA-less CPUs
- [x] Fixed a pre-existing dispatch-snapshot gap that leaked the fused impl across init-routing tests
- [x] asmcheck validates the NEON `WORD`s (all reused from the validated `convolveDecimate` kernels)
- [x] Full suite green on amd64 (SSE2/AVX2/Go) and a Raspberry Pi 5 (NEON); `golangci-lint run ./...` clean

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Expanded the fused “valid convolution + max-absolute peak” operation with optimized SIMD implementations across amd64 (SSE/AVX variants) and arm64 (NEON).

* **Tests**
  * Added new scalar-oracle validation coverage plus amd64 correctness checks, including zero-allocation assertions where supported.

* **Benchmarks**
  * Introduced benchmarks comparing fused performance against a Go fallback across multiple signal/kernel sizes.

* **Documentation**
  * Clarified fused peak behavior (including bit-identical expectations) and updated performance wording for short-kernel ranges.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->