### PR TITLE
i16: add widening DotProduct (int16 x int16 -> int32)

### DIFF
--- a/README.md
+++ b/README.md
@@ -580,7 +580,7 @@ stereo := make([]int16, n*2)
 i16.Interleave2(stereo, left, right)   // [l0, r0, l1, r1, ...]
 i16.Deinterleave2(left, right, stereo) // inverse: split back to channels
 
-sum := i16.DotProduct(samples, coeffs) // sum(a[i]*b[i]) widened into int32
+sum := i16.DotProduct(left, right)     // sum(left[i]*right[i]) widened into int32
 ```
 
 The interleave kernels are pure 16-bit-lane movement (AVX2/SSE2 word unpacks plus a lane permute, NEON `ZIP`/`UZP` on `.8H`), so the bit pattern of each lane is irrelevant and every value round-trips exactly: negative values and the int16 extremes are preserved.

--- a/README.md
+++ b/README.md
@@ -559,16 +559,16 @@ Interleaving is pure 32-bit-lane movement, so those kernels reuse the proven `f3
 
 ### `i16` - int16 Operations
 
-The 16-bit integer counterpart to `i32`, for raw-PCM hot loops where the source samples are 16-bit and the cheapest place to vectorize is the channel (de)interleaving that happens before samples are widened to int32. Inter-channel decorrelation can exceed the source bit depth by one bit, so arithmetic is done after widening to `i32`; this package carries only the operations that provably help at 16-bit width:
+The 16-bit integer counterpart to `i32`, serving two kinds of hot loop. First, raw-PCM movement, where the source samples are 16-bit and the cheapest place to vectorize is the channel (de)interleaving that happens before samples are widened to int32. Second, fixed-point DSP, where int16 inputs are multiplied and accumulated into int32.
 
-**Scope:** `i16` is deliberately movement-only (interleave/deinterleave). There are
-no int16 arithmetic primitives on purpose: widen to `i32` and use its arithmetic
-surface, because 16-bit arithmetic overflows as soon as channels are decorrelated.
+**Scope:** element-wise int16 arithmetic still belongs in `i32`, because inter-channel decorrelation can exceed the source bit depth by one bit. What this package adds at 16-bit width is the *widening* direction: operations that read int16 and accumulate into int32, where the narrow input is the point.
 
 | Category       | Function                   | Description                                | SIMD Width                         |
 | -------------- | -------------------------- | ------------------------------------------ | ---------------------------------- |
 | **Interleave** | `Interleave2(dst, a, b)`   | Pack two channels into interleaved stereo  | 16x (AVX2) / 8x (SSE2) / 8x (NEON) |
 |                | `Deinterleave2(a, b, src)` | Split interleaved stereo into two channels | 16x (AVX2) / 8x (SSE2) / 8x (NEON) |
+| **Reduction**  | `DotProduct(a, b)`         | Widening dot product, wrapping int32       | 16x (AVX2) / 8x (SSE2) / 16x (NEON) |
+|                | `DotProductUnsafe(a, b)`   | As above, without the empty-slice guard    | 16x (AVX2) / 8x (SSE2) / 16x (NEON) |
 
 ```go
 import "github.com/tphakala/simd/i16"
@@ -579,9 +579,13 @@ stereo := make([]int16, n*2)
 
 i16.Interleave2(stereo, left, right)   // [l0, r0, l1, r1, ...]
 i16.Deinterleave2(left, right, stereo) // inverse: split back to channels
+
+sum := i16.DotProduct(samples, coeffs) // sum(a[i]*b[i]) widened into int32
 ```
 
-Like the `i32` interleave kernels, these are pure 16-bit-lane movement (AVX2/SSE2 word unpacks plus a lane permute, NEON `ZIP`/`UZP` on `.8H`), so the bit pattern of each lane is irrelevant and every value round-trips exactly: negative values and the int16 extremes are preserved. Both kernels are zero-allocation.
+The interleave kernels are pure 16-bit-lane movement (AVX2/SSE2 word unpacks plus a lane permute, NEON `ZIP`/`UZP` on `.8H`), so the bit pattern of each lane is irrelevant and every value round-trips exactly: negative values and the int16 extremes are preserved.
+
+`DotProduct` is the opposite case: the bit pattern is the whole point. It widens each product to int32 and accumulates with **two's-complement wraparound, never saturation**, and that is a guarantee callers may rely on. Wrapping addition is associative and commutative modulo 2^32, so any lane grouping and any horizontal reduction order is bit-identical to the scalar loop, including on operands engineered to overflow; a saturating accumulator is not associative and could not be vectorized without changing results. Fixed-point codecs (Opus/CELT, FLAC LPC) use integer arithmetic precisely because it is exactly reproducible, so this property is the feature. The kernels are `PMADDWD` (SSE2, hence always present on the `GOAMD64=v1` baseline) with an AVX2 tier at twice the width, and `SMLAL`/`SMLAL2` on NEON. All kernels are zero-allocation.
 
 ### `i8` - int8 Operations
 
@@ -862,7 +866,17 @@ a Raspberry Pi 5):
 | Interleave2   | 53 ns vs 560 ns (**10.6x**) | 165 ns vs 2105 ns (**12.8x**) |
 | Deinterleave2 | 54 ns vs 607 ns (**11.3x**) | 165 ns vs 2120 ns (**12.9x**) |
 
-Both i16 kernels are zero-allocation and bit-exact against the pure-Go reference (verified with negative values and the int16 extremes); they move whole 16-bit lanes, so the bit pattern of each sample is irrelevant to correctness.
+`DotProduct` is benchmarked separately, because the lengths that matter for it are the ones fixed-point codecs call at (a CELT band can be a handful of coefficients; 240 and 480 are 20 ms frames at 12 and 24 kHz), not 1000:
+
+| Elements | AMD64 (AVX2)                | ARM64 (NEON, Pi 5)            |
+| -------- | --------------------------- | ----------------------------- |
+| 8        | 3.6 ns vs 5.5 ns (**1.5x**) | 11.2 ns vs 10.8 ns (**0.97x**) |
+| 64       | 5.2 ns vs 30 ns (**5.8x**)  | 17 ns vs 58 ns (**3.5x**)     |
+| 240      | 10 ns vs 86 ns (**8.5x**)   | 35 ns vs 205 ns (**5.8x**)    |
+| 480      | 14 ns vs 159 ns (**11.8x**) | 61 ns vs 434 ns (**7.1x**)    |
+| 4096     | 92 ns vs 1282 ns (**13.9x**) | 439 ns vs 3436 ns (**7.8x**)  |
+
+At n=8 the dispatch and call overhead is most of the work, so the win is small on AMD64 and slightly negative on the Pi 5; the kernels pull away from 64 elements up. All i16 kernels are zero-allocation and bit-exact against the pure-Go reference. The interleave kernels move whole 16-bit lanes, so the bit pattern of each sample is irrelevant to correctness; `DotProduct` is bit-exact for the opposite reason, because wrapping accumulation is associative, so lane grouping and reduction order cannot change the result even when the accumulator overflows (its tests plant `MinInt16` operands specifically to force that wrap).
 
 All int32 kernels are zero-allocation and bit-exact against the pure-Go reference (verified across the sign and high bits with negative values and the type extremes). The interleave kernels move whole 32-bit lanes, so the bit pattern of each sample is irrelevant to correctness. `Add` and `Sub` are element-wise integer-ALU ops with two's-complement wraparound, matching the scalar reference across the full int32 range. `MinMax` is exact by construction (signed min/max has no accumulation order or wrapping); its parity tests plant `MinInt32`/`MaxInt32` in both a mid-block lane and the scalar tail, in both orderings, to catch a dropped vector lane or a skipped tail.
 

--- a/doc.go
+++ b/doc.go
@@ -8,7 +8,7 @@
 //   - [github.com/tphakala/simd/f32] - float32 SIMD operations (audio/FFT/ML surface)
 //   - [github.com/tphakala/simd/f16] - float16 storage type (ARM64 NEON+FP16 compute; amd64 F16C slice conversions)
 //   - [github.com/tphakala/simd/i32] - int32 SIMD operations (integer DSP)
-//   - [github.com/tphakala/simd/i16] - int16 SIMD operations (movement only; widen to i32 for arithmetic)
+//   - [github.com/tphakala/simd/i16] - int16 SIMD operations (PCM movement, and widening int16 x int16 -> int32 reductions)
 //   - [github.com/tphakala/simd/i8] - int8 SIMD operations (saturating arithmetic, int32-accumulated reductions, quantized DSP)
 //   - [github.com/tphakala/simd/c64] - complex64 SIMD operations (FFT-pipeline helpers)
 //   - [github.com/tphakala/simd/c128] - complex128 SIMD operations (FFT-pipeline helpers)
@@ -28,7 +28,8 @@
 //     amd64.
 //   - ARM64: NEON/ASIMD throughout (2x float64, 4x float32), with an FP16
 //     (FEAT_FP16) fast path in the f16 package and an SDOT (FEAT_DotProd) fast
-//     path for i8.DotProduct. SVE/SVE2 is detected by cpu.Info() but no SVE
+//     path for i8.DotProduct, and SMLAL/SMLAL2 widening multiply-accumulate
+//     for i16.DotProduct. SVE/SVE2 is detected by cpu.Info() but no SVE
 //     kernels exist yet, so SVE hosts run the NEON path.
 //   - Other: Pure Go fallback
 //
@@ -86,6 +87,8 @@
 // Audio DSP: Interleave2, Deinterleave2, ConvolveValid, ConvolveValidMulti, ConvolveValidMaxAbs, ConvolveValidMaxAbsMulti, ConvolveDecimate, AccumulateAdd, CumulativeSum, CubicInterpDot, Int32ToFloat32Scale, Int16ToFloat32Scale, Float32ToInt16Scale
 //
 // Spectral (f64, f32): STFTPlan (NewSTFTPlan, STFT, STFTPower, STFTPowerInto, NumFrames) - fused real-input short-time Fourier transform with optional librosa-style center=true framing (PadMode: NoPad/PadZero/PadReflect)
+//
+// Integer DSP (i16): Interleave2, Deinterleave2, DotProduct, DotProductUnsafe (widening int16 x int16 -> wrapping int32; ARM64 SMLAL/SMLAL2, amd64 PMADDWD/VPMADDWD)
 //
 // Integer DSP (i32): Interleave2, Deinterleave2, Add, Sub, MinMax
 //

--- a/i16/benchmark_test.go
+++ b/i16/benchmark_test.go
@@ -63,3 +63,33 @@ func BenchmarkDeinterleave2Go_1000(b *testing.B) {
 		deinterleave2Go(a, c, src)
 	}
 }
+
+// Dot benchmarks sweep the lengths fixed-point codecs actually call at: n=8 is
+// a short CELT band (where call overhead is the concern), n=240 a 20 ms frame
+// at 12 kHz, n=480 one at 24 kHz. SetBytes counts both operands: 2*n int16.
+
+func benchmarkDot(b *testing.B, n int, fn func(a, c []int16) int32) {
+	b.Helper()
+	a := make([]int16, n)
+	c := make([]int16, n)
+	for i := range a {
+		a[i] = int16(i*7 - 3000)
+		c[i] = int16(i*-5 + 2000)
+	}
+	b.SetBytes(int64(n) * 2 * 2)
+	for b.Loop() {
+		_ = fn(a, c)
+	}
+}
+
+func BenchmarkDotProduct_8(b *testing.B)    { benchmarkDot(b, 8, DotProduct) }
+func BenchmarkDotProduct_64(b *testing.B)   { benchmarkDot(b, 64, DotProduct) }
+func BenchmarkDotProduct_240(b *testing.B)  { benchmarkDot(b, 240, DotProduct) }
+func BenchmarkDotProduct_480(b *testing.B)  { benchmarkDot(b, 480, DotProduct) }
+func BenchmarkDotProduct_4096(b *testing.B) { benchmarkDot(b, 4096, DotProduct) }
+
+func BenchmarkDotProductGo_8(b *testing.B)    { benchmarkDot(b, 8, dotGo) }
+func BenchmarkDotProductGo_64(b *testing.B)   { benchmarkDot(b, 64, dotGo) }
+func BenchmarkDotProductGo_240(b *testing.B)  { benchmarkDot(b, 240, dotGo) }
+func BenchmarkDotProductGo_480(b *testing.B)  { benchmarkDot(b, 480, dotGo) }
+func BenchmarkDotProductGo_4096(b *testing.B) { benchmarkDot(b, 4096, dotGo) }

--- a/i16/dot.go
+++ b/i16/dot.go
@@ -1,0 +1,42 @@
+package i16
+
+// DotProduct returns sum_i int32(a[i]) * int32(b[i]) over i in [0, n),
+// n = min(len(a), len(b)), accumulated in int32 with two's-complement
+// wraparound. An empty operand returns 0. a and b are read-only; the call
+// allocates nothing.
+//
+// The accumulator wraps rather than saturates, and that is a guarantee callers
+// may rely on: wrapping addition is associative and commutative modulo 2^32,
+// so every SIMD lane grouping and horizontal reduction below is bit-identical
+// to the scalar loop for all inputs, including operands engineered to overflow.
+// This is what makes the result reproducible across architectures, and it is
+// the property fixed-point codecs (Opus/CELT, FLAC LPC) need to stay bit-exact.
+// A saturating accumulator would not be associative and could not be vectorized
+// this way.
+//
+// This is the inner loop of fixed-point correlation and filtering. On ARM64 it
+// uses SMLAL/SMLAL2 (4 widening int16 multiply-accumulates per instruction); on
+// AMD64 it uses PMADDWD, which is SSE2 and therefore always present on the
+// GOAMD64=v1 baseline, with an AVX2 path at twice the width.
+func DotProduct(a, b []int16) int32 {
+	if len(a) == 0 || len(b) == 0 {
+		return 0
+	}
+	return dotI16(a, b)
+}
+
+// DotProductUnsafe computes the dot product without empty-slice checks.
+// It skips the len==0 guard in [DotProduct] but is otherwise identical:
+// the underlying SIMD kernels and Go fallback clamp to min(len(a), len(b))
+// internally, so mismatched lengths do not cause out-of-bounds access.
+//
+// The precondition is deliberately conservative: the kernels and the Go
+// reference all handle n==0 safely today, so an empty operand would in fact
+// return 0 here. Requiring non-empty inputs keeps that an implementation
+// detail rather than a promise.
+//
+// PRECONDITIONS (caller must ensure):
+//   - len(a) > 0 && len(b) > 0
+func DotProductUnsafe(a, b []int16) int32 {
+	return dotI16(a, b)
+}

--- a/i16/dot_test.go
+++ b/i16/dot_test.go
@@ -1,0 +1,243 @@
+package i16
+
+import (
+	"math"
+	"testing"
+)
+
+// Tests for DotProduct / DotProductUnsafe.
+//
+// The property under test is bit-exactness with the scalar reference for every
+// input, including inputs that overflow the int32 accumulator. Wrapping
+// accumulation is the documented contract and the reason the kernels may
+// reassociate at all, so overflow is not an edge case here, it is the main
+// event: a kernel that saturated (or that a compiler "helpfully" reassociated
+// under saturation) would pass a small-value test and fail these.
+
+// genI16 produces a deterministic spread across the full int16 range from a
+// cheap LCG, so sign and high bits are exercised at every index.
+func genI16(n int, seed uint32) []int16 {
+	s := make([]int16, n)
+	x := seed*2654435761 + 1
+	for i := range s {
+		x = x*1664525 + 1013904223
+		s[i] = int16(x >> 9)
+	}
+	return s
+}
+
+// dotOracle sums in int64 and truncates to int32. This is independent of
+// dotGo: wrapping int32 addition is addition modulo 2^32, and an int64 sum of
+// at most a few thousand products (each |p| <= 2^30) cannot itself overflow, so
+// truncating the exact sum must equal the wrapping sum. It pins the reference
+// rather than trusting it.
+func dotOracle(a, b []int16) int32 {
+	var s int64
+	for i := range min(len(a), len(b)) {
+		s += int64(a[i]) * int64(b[i])
+	}
+	return int32(s) //nolint:gosec // deliberate truncation: this is the wrapping contract
+}
+
+// dotLengths sweeps EVERY length from 0 to 64, then a spread of larger ones.
+//
+// The exhaustive low range is deliberate rather than lazy. The arm64 kernel
+// runs an 8-wide block when n mod 16 >= 8 and follows it with an (n mod 8)
+// scalar tail, so reaching that block with a short tail needs n mod 16 in
+// {10, 11, 13, 14}. A hand-picked list of block boundaries and their immediate
+// neighbours never produces those combinations. The all-MinInt16 sweep in
+// TestDotProduct_MinInt16 does visit every length, but its operands are
+// sign-symmetric ((-32768)*(-32768) == 32768*32768), so it can only catch a
+// miscounted element, never a sign, lane, or index error. This list is what the
+// non-uniform tests sweep, so it has to be the exhaustive one.
+var dotLengths = func() []int {
+	lens := make([]int, 0, 75)
+	for n := range 65 {
+		lens = append(lens, n)
+	}
+	return append(lens, 100, 127, 128, 129, 240, 255, 256, 257, 300, 1024)
+}()
+
+func TestDotProduct(t *testing.T) {
+	if got := DotProduct(nil, nil); got != 0 {
+		t.Errorf("DotProduct(nil, nil) = %d, want 0", got)
+	}
+	if got := DotProduct([]int16{1, 2}, nil); got != 0 {
+		t.Errorf("DotProduct(a, nil) = %d, want 0", got)
+	}
+
+	// A hand-computed case that exceeds int16 but fits int32, pinning the
+	// widening independently of the reference. n=2 is below every dispatch
+	// threshold, so this exercises dotGo only; the kernels' widening is covered
+	// by the dotLengths sweeps below and by the direct kernel tests.
+	if got, want := DotProduct([]int16{1000, -2000}, []int16{3000, 4000}), int32(1000*3000+-2000*4000); got != want {
+		t.Errorf("DotProduct([1000,-2000],[3000,4000]) = %d, want %d", got, want)
+	}
+
+	for _, n := range dotLengths {
+		a, b := genI16(n, 8), genI16(n, 9)
+		got := DotProduct(a, b)
+		if want := dotGo(a, b); got != want {
+			t.Errorf("DotProduct n=%d: got %d, want %d (reference)", n, got, want)
+		}
+		if want := dotOracle(a, b); got != want {
+			t.Errorf("DotProduct n=%d: got %d, want %d (int64 oracle)", n, got, want)
+		}
+	}
+}
+
+// TestDotProduct_Clamp covers mismatched operand lengths. This matters beyond
+// arithmetic: the kernels read len(a) and len(b) and clamp in assembly, so a
+// regression here is an out-of-bounds read, not a wrong number.
+func TestDotProduct_Clamp(t *testing.T) {
+	if got, want := DotProduct([]int16{1, 2, 3}, []int16{4, 5}), int32(1*4+2*5); got != want {
+		t.Errorf("DotProduct(len 3, len 2) = %d, want %d", got, want)
+	}
+	if got, want := DotProduct([]int16{4, 5}, []int16{1, 2, 3}), int32(4*1+5*2); got != want {
+		t.Errorf("DotProduct(len 2, len 3) = %d, want %d", got, want)
+	}
+	// Long/short pairings across block boundaries: the long side must never be
+	// read past the short side's length.
+	for _, n := range dotLengths {
+		if n == 0 {
+			continue
+		}
+		long := genI16(n+37, 11)
+		short := genI16(n, 12)
+		if got, want := DotProduct(long, short), dotOracle(long, short); got != want {
+			t.Errorf("DotProduct clamp n=%d: got %d, want %d", n, got, want)
+		}
+		if got, want := DotProduct(short, long), dotOracle(short, long); got != want {
+			t.Errorf("DotProduct clamp (swapped) n=%d: got %d, want %d", n, got, want)
+		}
+	}
+}
+
+// TestDotProduct_MinInt16 pins the one input that can overflow int32 inside a
+// single PMADDWD: a pair of (-32768 * -32768) sums to 2^31 and must wrap to
+// MinInt32 rather than saturate to MaxInt32. The length sweep walks the wrap
+// through every lane position and into the scalar tail.
+//
+// The three headline cases below are n=1, 2 and 4, all under every dispatch
+// threshold, so they pin the reference's semantics; the sweep and the direct
+// kernel tests are what reach PMADDWD and SMLAL. Note also that all-MinInt16
+// operands are sign-symmetric, so this test cannot catch a sign-extension or
+// lane error: that is TestDotProduct_ExtremeMix and the dotLengths sweeps.
+func TestDotProduct_MinInt16(t *testing.T) {
+	if got, want := DotProduct([]int16{math.MinInt16}, []int16{math.MinInt16}), int32(1<<30); got != want {
+		t.Errorf("DotProduct(MinInt16, MinInt16) = %d, want %d", got, want)
+	}
+	// Exactly two such products: 2^31 wraps to MinInt32. A saturating
+	// accumulator would return MaxInt32 here.
+	two := []int16{math.MinInt16, math.MinInt16}
+	if got, want := DotProduct(two, two), int32(math.MinInt32); got != want {
+		t.Errorf("DotProduct(2x MinInt16) = %d, want %d (saturation would give %d)", got, want, int32(math.MaxInt32))
+	}
+	// Four such products: 2^32 wraps to exactly 0.
+	four := []int16{math.MinInt16, math.MinInt16, math.MinInt16, math.MinInt16}
+	if got := DotProduct(four, four); got != 0 {
+		t.Errorf("DotProduct(4x MinInt16) = %d, want 0", got)
+	}
+	for n := 1; n <= 64; n++ {
+		a := make([]int16, n)
+		b := make([]int16, n)
+		for i := range a {
+			a[i], b[i] = math.MinInt16, math.MinInt16
+		}
+		got := DotProduct(a, b)
+		if want := dotGo(a, b); got != want {
+			t.Errorf("DotProduct all-MinInt16 n=%d: got %d, want %d (reference)", n, got, want)
+		}
+		if want := dotOracle(a, b); got != want {
+			t.Errorf("DotProduct all-MinInt16 n=%d: got %d, want %d (int64 oracle)", n, got, want)
+		}
+	}
+}
+
+// TestDotProduct_Wraparound drives the accumulator through many wraps with
+// same-sign products, so an implementation that clamped anywhere along the
+// chain diverges well before the end.
+func TestDotProduct_Wraparound(t *testing.T) {
+	for _, n := range []int{8, 16, 17, 240, 1000, 5000} {
+		a := make([]int16, n)
+		b := make([]int16, n)
+		for i := range a {
+			a[i], b[i] = 30000, 30000 // 9e8 per product: wraps roughly every 3
+		}
+		got := DotProduct(a, b)
+		if want := dotOracle(a, b); got != want {
+			t.Errorf("DotProduct wraparound n=%d: got %d, want %d", n, got, want)
+		}
+	}
+}
+
+// TestDotProduct_ExtremeMix mixes the type extremes with ordinary values so the
+// wrap lands at irregular offsets rather than aligning with the block size.
+func TestDotProduct_ExtremeMix(t *testing.T) {
+	for _, n := range dotLengths {
+		a, b := genI16(n, 21), genI16(n, 22)
+		for i := range a {
+			switch i % 5 {
+			case 0:
+				a[i] = math.MinInt16
+			case 1:
+				b[i] = math.MinInt16
+			case 2:
+				a[i], b[i] = math.MaxInt16, math.MinInt16
+			}
+		}
+		if got, want := DotProduct(a, b), dotOracle(a, b); got != want {
+			t.Errorf("DotProduct extreme mix n=%d: got %d, want %d", n, got, want)
+		}
+	}
+}
+
+func TestDotProductUnsafe(t *testing.T) {
+	for _, n := range dotLengths {
+		if n == 0 {
+			continue // Unsafe requires non-empty operands.
+		}
+		a, b := genI16(n, 31), genI16(n, 32)
+		if got, want := DotProductUnsafe(a, b), dotGo(a, b); got != want {
+			t.Errorf("DotProductUnsafe n=%d: got %d, want %d", n, got, want)
+		}
+	}
+	// Documented to tolerate mismatched lengths by clamping internally.
+	if got, want := DotProductUnsafe([]int16{1, 2, 3}, []int16{4, 5}), int32(1*4+2*5); got != want {
+		t.Errorf("DotProductUnsafe mismatched = %d, want %d", got, want)
+	}
+}
+
+// TestDotProduct_UnalignedOperands calls DotProduct on offset subslices, which
+// is the shape the motivating use case actually has: sliding correlation
+// evaluates DotProduct(x[lag:], h) at every lag, so an operand is rarely
+// 16-byte aligned. Every other test here builds operands with make, which is
+// aligned, so an aligned-load regression (MOVOU -> MOVOA, VMOVDQU -> VMOVDQA)
+// would pass the whole suite and then fault in production. The odd offsets
+// matter most: they leave the pointer 2-byte aligned.
+func TestDotProduct_UnalignedOperands(t *testing.T) {
+	const span = 400
+	base, other := genI16(span, 81), genI16(span, 82)
+	for _, n := range dotLengths {
+		if n > 300 {
+			continue // keep off+n inside span
+		}
+		for off := range 8 {
+			a := base[off : off+n]
+			b := other[off+1 : off+1+n]
+			if got, want := DotProduct(a, b), dotOracle(a, b); got != want {
+				t.Errorf("DotProduct unaligned n=%d off=%d: got %d, want %d", n, off, got, want)
+			}
+		}
+	}
+}
+
+func TestDotProduct_AllocFree(t *testing.T) {
+	a, b := genI16(1024, 41), genI16(1024, 42)
+	if n := testing.AllocsPerRun(100, func() { _ = DotProduct(a, b) }); n != 0 {
+		t.Errorf("DotProduct allocates %v times per run, want 0", n)
+	}
+	if n := testing.AllocsPerRun(100, func() { _ = DotProductUnsafe(a, b) }); n != 0 {
+		t.Errorf("DotProductUnsafe allocates %v times per run, want 0", n)
+	}
+}

--- a/i16/example_test.go
+++ b/i16/example_test.go
@@ -25,3 +25,13 @@ func ExampleDeinterleave2() {
 	fmt.Println(left, right)
 	// Output: [1 2 3] [-1 -2 -3]
 }
+
+func ExampleDotProduct() {
+	// Q15 filter coefficients against a frame of int16 samples: the products
+	// are widened and accumulated in int32.
+	samples := []int16{1000, -2000, 3000, -4000}
+	coeffs := []int16{16384, 8192, -16384, 4096}
+
+	fmt.Println(i16.DotProduct(samples, coeffs))
+	// Output: -65536000
+}

--- a/i16/fuzz_test.go
+++ b/i16/fuzz_test.go
@@ -69,3 +69,60 @@ func FuzzI16Interleave(f *testing.F) {
 		equalI16(t, "Deinterleave2.b", db, dbRef)
 	})
 }
+
+// addDotLenSeeds seeds raw buffers for FuzzI16Dot, which splits the decoded
+// int16s into two operands. The per-operand length is therefore raw/4 bytes,
+// not raw/2, so addLenSeeds cannot be reused: halving its buffers a second time
+// lands the operands on a sparse set that misses 9 and 17, the one-past-the-
+// block tails for the 8-wide and 16-wide bodies, and leaves most seeds below
+// every dispatch threshold where the assertion degrades to dotGo against
+// itself. These sizes make the operand length itself sweep 0..40.
+func addDotLenSeeds(f *testing.F) {
+	f.Helper()
+	sizes := make([]int, 0, 46)
+	for n := range 41 {
+		sizes = append(sizes, n)
+	}
+	sizes = append(sizes, 47, 48, 63, 64, 65, 128)
+	for _, n := range sizes {
+		raw := make([]byte, n*4)
+		for i := range raw {
+			raw[i] = byte(i*37 + 11)
+		}
+		f.Add(raw)
+	}
+}
+
+// FuzzI16Dot differentially fuzzes the widening dot product against the pure-Go
+// reference. Unlike the interleave targets, the interesting bug class here is
+// arithmetic as much as tail handling: the raw bytes reach MinInt16 freely, so
+// the fuzzer readily builds inputs whose int32 accumulator overflows, which is
+// exactly where a saturating or mis-reassociated kernel would diverge. It also
+// checks dotOracle, so a fault in the reference itself cannot hide by agreeing
+// with the kernels.
+func FuzzI16Dot(f *testing.F) {
+	addDotLenSeeds(f)
+	f.Fuzz(func(t *testing.T, raw []byte) {
+		v := i16sFromBits(raw)
+		h := len(v) / 2
+		a, b := v[:h], v[h:2*h]
+		got := DotProduct(a, b)
+		if want := dotGo(a, b); got != want {
+			t.Fatalf("DotProduct(len=%d) = %d, want %d (reference)", h, got, want)
+		}
+		if want := dotOracle(a, b); got != want {
+			t.Fatalf("DotProduct(len=%d) = %d, want %d (int64 oracle)", h, got, want)
+		}
+		// Mismatched lengths must clamp, not read out of bounds. Both orders:
+		// the kernels take min(len(a), len(b)) from two separate slice headers,
+		// so shortening a and shortening b are distinct paths.
+		if h > 1 {
+			if got, want := DotProduct(a, b[:h-1]), dotOracle(a, b[:h-1]); got != want {
+				t.Fatalf("DotProduct(len=%d, len=%d) = %d, want %d", h, h-1, got, want)
+			}
+			if got, want := DotProduct(a[:h-1], b), dotOracle(a[:h-1], b); got != want {
+				t.Fatalf("DotProduct(len=%d, len=%d) = %d, want %d", h-1, h, got, want)
+			}
+		}
+	})
+}

--- a/i16/i16.go
+++ b/i16/i16.go
@@ -1,14 +1,24 @@
 // Package i16 provides SIMD-accelerated operations on int16 slices.
 //
-// It is the 16-bit integer counterpart to the i32 package and exists to serve
-// raw-PCM hot loops (for example a pure-Go FLAC codec) where the source samples
-// are 16-bit and the cheapest place to vectorize is the channel
-// (de)interleaving that happens before samples are widened to int32.
+// It is the 16-bit integer counterpart to the i32 package and serves two kinds
+// of hot loop: raw-PCM shuffling (for example a pure-Go FLAC codec), where the
+// cheapest place to vectorize is the channel (de)interleaving that happens
+// before samples are widened to int32; and fixed-point DSP, where int16 inputs
+// are multiplied and accumulated into int32.
 //
-// Scope note: FLAC decorrelation widens samples (the side and mid channels can
-// exceed the source bit depth by one bit), so the arithmetic primitives live in
-// the i32 package. This package only carries the operations that provably help
-// at 16-bit width, namely splitting and packing raw 16-bit interleaved PCM.
+// Widening semantics: an operation that multiplies int16 inputs accumulates
+// into int32 with two's-complement wraparound, never saturation. This is a
+// guarantee, not an implementation detail. Wrapping addition is associative and
+// commutative modulo 2^32, so any lane grouping and any horizontal reduction
+// order yields bit-identical results to the scalar loop; a saturating
+// accumulator is not associative and could not be vectorized without changing
+// results. Fixed-point codecs (Opus/CELT, FLAC LPC) depend on that
+// reproducibility, which is the whole reason they use integer arithmetic.
+//
+// Element-wise int16 arithmetic still belongs in the i32 package, because
+// inter-channel decorrelation can exceed the source bit depth by one bit. What
+// this package adds at 16-bit width is the widening direction, where the narrow
+// input is the point.
 //
 // All functions automatically select the optimal implementation based on
 // runtime CPU feature detection and fall back to a pure-Go implementation on

--- a/i16/i16_amd64.go
+++ b/i16/i16_amd64.go
@@ -22,15 +22,17 @@ var (
 	hasSSE2 = cpu.X86.SSE2
 )
 
-// Dot thresholds are named separately from the interleave block sizes they
-// currently equal, so retuning one op cannot silently retune the other. The
-// values are one vector block each: the dot kernels are correct at any n (they
-// fall through to a scalar tail), so these are performance cuts only, never a
-// safety requirement. Measured kernel against Go reference at n=8: SSE2 wins
-// 2.2x, so unlike NEON there is no break-even region to avoid here.
+// Dot dispatch thresholds: one vector block each. They are independent literals
+// rather than aliases of the interleave block sizes they happen to equal, so
+// retuning the interleave kernels cannot silently retune the dot dispatch.
+//
+// The dot kernels are correct at any n (each falls through to a scalar tail), so
+// these are performance cuts only, never a safety requirement. Measured kernel
+// against Go reference at n=8, SSE2 wins 2.2x, so unlike NEON there is no
+// break-even region to step around here.
 const (
-	minSSE2Dot = minSSE2Elements
-	minAVX2Dot = minAVX2Elements
+	minSSE2Dot = 8  // PMADDWL retires 8 int16 pairs per iteration
+	minAVX2Dot = 16 // VPMADDWD retires 16
 )
 
 func dotI16(a, b []int16) int32 {

--- a/i16/i16_amd64.go
+++ b/i16/i16_amd64.go
@@ -22,6 +22,29 @@ var (
 	hasSSE2 = cpu.X86.SSE2
 )
 
+// Dot thresholds are named separately from the interleave block sizes they
+// currently equal, so retuning one op cannot silently retune the other. The
+// values are one vector block each: the dot kernels are correct at any n (they
+// fall through to a scalar tail), so these are performance cuts only, never a
+// safety requirement. Measured kernel against Go reference at n=8: SSE2 wins
+// 2.2x, so unlike NEON there is no break-even region to avoid here.
+const (
+	minSSE2Dot = minSSE2Elements
+	minAVX2Dot = minAVX2Elements
+)
+
+func dotI16(a, b []int16) int32 {
+	n := min(len(a), len(b))
+	switch {
+	case hasAVX2 && n >= minAVX2Dot:
+		return dotAVX2(a, b)
+	case hasSSE2 && n >= minSSE2Dot:
+		return dotSSE2(a, b)
+	default:
+		return dotGo(a, b)
+	}
+}
+
 func interleave2I16(dst, a, b []int16) {
 	switch {
 	case hasAVX2 && len(a) >= minAVX2Elements:
@@ -43,6 +66,12 @@ func deinterleave2I16(a, b, src []int16) {
 		deinterleave2Go(a, b, src)
 	}
 }
+
+//go:noescape
+func dotAVX2(a, b []int16) int32
+
+//go:noescape
+func dotSSE2(a, b []int16) int32
 
 //go:noescape
 func interleave2AVX2(dst, a, b []int16)

--- a/i16/i16_amd64.s
+++ b/i16/i16_amd64.s
@@ -245,3 +245,127 @@ deinterleave2_sse2_scalar:
 
 deinterleave2_sse2_done:
     RET
+
+// Widening int16 dot product.
+//
+// PMADDWD multiplies eight int16 pairs and adds them pairwise into four int32
+// lanes; the AVX2 form does twice that. Note the Plan 9 spelling of the SSE2
+// form is PMADDWL ("long" for the 32-bit result); the VEX form keeps the Intel
+// name VPMADDWD.
+//
+// PMADDWD is SSE2, so it is present on the whole GOAMD64=v1 baseline: there is
+// no availability cliff below the SSE2 tier, and the AVX2 tier is a width win
+// rather than an availability one. The dispatcher still gates on hasSSE2, which
+// is always true on amd64; that mirrors the package's other kernels and keeps
+// the pure-Go path reachable as a non-amd64 safety net.
+//
+// Overflow: the only input that can exceed int32 within one instruction is a
+// pair of (-32768 * -32768), summing to 2^31, which PMADDWD wraps to
+// 0x80000000. The scalar reference wraps identically (two wrapping int32 adds
+// of 2^30), and because wrapping addition is associative the pairwise pre-add
+// inside PMADDWD is invisible. So no special-casing is needed and the kernels
+// are bit-exact with dotGo for every input; the tests pin this with all-MinInt16
+// sweeps.
+
+// func dotSSE2(a, b []int16) int32
+// Handles mismatched slice lengths: uses min(len(a), len(b)).
+TEXT ·dotSSE2(SB), NOSPLIT, $0-52
+    MOVQ a_base+0(FP), SI
+    MOVQ a_len+8(FP), CX
+    MOVQ b_len+32(FP), DX
+    CMPQ DX, CX
+    CMOVQLT DX, CX             // CX = n = min(len(a), len(b))
+    MOVQ b_base+24(FP), DI
+
+    PXOR X0, X0                // int32 accumulator
+
+    MOVQ CX, BX
+    SHRQ $3, BX                // BX = n / 8
+    JZ   dot_sse2_reduce
+
+dot_sse2_loop8:
+    MOVOU (SI), X1
+    MOVOU (DI), X2
+    PMADDWL X2, X1             // X1 = pairwise (a*b) sums -> 4 int32
+    PADDD X1, X0               // accumulate (wrapping)
+    ADDQ $16, SI
+    ADDQ $16, DI
+    DECQ BX
+    JNZ  dot_sse2_loop8
+
+dot_sse2_reduce:
+    PSHUFD $0x4E, X0, X1       // swap 64-bit halves
+    PADDD X1, X0
+    PSHUFD $0xB1, X0, X1       // swap 32-bit within pairs
+    PADDD X1, X0
+    MOVQ X0, AX                // low int32 = vector total (in EAX)
+
+    ANDQ $7, CX
+    JZ   dot_sse2_done
+
+dot_sse2_scalar:
+    MOVWLSX (SI), BX           // sign-extending 16-bit load
+    MOVWLSX (DI), DX
+    IMULL DX, BX
+    ADDL BX, AX                // 32-bit add: wraps like dotGo
+    ADDQ $2, SI
+    ADDQ $2, DI
+    DECQ CX
+    JNZ  dot_sse2_scalar
+
+dot_sse2_done:
+    MOVL AX, ret+48(FP)
+    RET
+
+// func dotAVX2(a, b []int16) int32
+// Handles mismatched slice lengths: uses min(len(a), len(b)).
+TEXT ·dotAVX2(SB), NOSPLIT, $0-52
+    MOVQ a_base+0(FP), SI
+    MOVQ a_len+8(FP), CX
+    MOVQ b_len+32(FP), DX
+    CMPQ DX, CX
+    CMOVQLT DX, CX             // CX = n = min(len(a), len(b))
+    MOVQ b_base+24(FP), DI
+
+    VPXOR Y0, Y0, Y0           // int32 accumulator
+
+    MOVQ CX, BX
+    SHRQ $4, BX                // BX = n / 16
+    JZ   dot_avx2_reduce
+
+dot_avx2_loop16:
+    VMOVDQU (SI), Y1
+    VMOVDQU (DI), Y2
+    VPMADDWD Y2, Y1, Y1        // 16 int16 pairs -> 8 int32
+    VPADDD Y1, Y0, Y0          // accumulate (wrapping)
+    ADDQ $32, SI
+    ADDQ $32, DI
+    DECQ BX
+    JNZ  dot_avx2_loop16
+
+dot_avx2_reduce:
+    VEXTRACTI128 $1, Y0, X1
+    VPADDD X1, X0, X0          // fold 8 -> 4 int32
+    VPSHUFD $0x4E, X0, X1      // swap 64-bit halves
+    VPADDD X1, X0, X0
+    VPSHUFD $0xB1, X0, X1      // swap 32-bit within pairs
+    VPADDD X1, X0, X0
+    MOVQ X0, AX                // low int32 = vector total (in EAX)
+
+    ANDQ $15, CX
+    JZ   dot_avx2_done
+
+dot_avx2_scalar:
+    MOVWLSX (SI), BX           // sign-extending 16-bit load
+    MOVWLSX (DI), DX
+    IMULL DX, BX
+    ADDL BX, AX                // 32-bit add: wraps like dotGo
+    ADDQ $2, SI
+    ADDQ $2, DI
+    DECQ CX
+    JNZ  dot_avx2_scalar
+
+dot_avx2_done:
+    MOVL AX, ret+48(FP)
+    VZEROUPPER
+    RET

--- a/i16/i16_amd64_test.go
+++ b/i16/i16_amd64_test.go
@@ -251,8 +251,8 @@ func TestDotDispatch_ReachesSIMD(t *testing.T) {
 	if !hasSSE2 {
 		t.Fatal("hasSSE2 is false on amd64: PMADDWD is SSE2 baseline, so DotProduct should never fall back to Go here")
 	}
-	if minSSE2Elements > 2*8 || minAVX2Elements > 2*16 {
+	if minSSE2Dot > 2*8 || minAVX2Dot > 2*16 {
 		t.Fatalf("dispatch thresholds too high (SSE2 %d, AVX2 %d): DotProduct would not vectorize at the short lengths it was written for",
-			minSSE2Elements, minAVX2Elements)
+			minSSE2Dot, minAVX2Dot)
 	}
 }

--- a/i16/i16_amd64_test.go
+++ b/i16/i16_amd64_test.go
@@ -151,3 +151,108 @@ func TestDeinterleave2_NoOverwrite(t *testing.T) {
 		})
 	}
 }
+
+// dotKernel describes one amd64 SIMD tier so the dot parity checks run
+// identically against AVX2 and SSE2.
+type dotKernel struct {
+	name      string
+	available bool
+	fn        func(a, b []int16) int32
+}
+
+func dotKernels() []dotKernel {
+	return []dotKernel{
+		{"AVX2", cpu.X86.AVX2, dotAVX2},
+		{"SSE2", cpu.X86.SSE2, dotSSE2},
+	}
+}
+
+// TestDotAMD64_ParityWithGo exercises each kernel directly rather than through
+// DotProduct, so a dispatch threshold change can never quietly turn this into a
+// test of the Go reference against itself.
+func TestDotAMD64_ParityWithGo(t *testing.T) {
+	for _, k := range dotKernels() {
+		t.Run(k.name, func(t *testing.T) {
+			if !k.available {
+				t.Skipf("%s not available", k.name)
+			}
+			for _, n := range dotLengths {
+				a, b := genI16(n, 61), genI16(n, 62)
+				if got, want := k.fn(a, b), dotGo(a, b); got != want {
+					t.Errorf("dot%s n=%d: got %d, want %d", k.name, n, got, want)
+				}
+			}
+		})
+	}
+}
+
+// TestDotAMD64_MinInt16 pins the PMADDWD overflow case: a pair of
+// (-32768 * -32768) sums to 2^31 inside one instruction and must wrap to
+// MinInt32, matching the scalar reference, rather than saturate.
+func TestDotAMD64_MinInt16(t *testing.T) {
+	for _, k := range dotKernels() {
+		t.Run(k.name, func(t *testing.T) {
+			if !k.available {
+				t.Skipf("%s not available", k.name)
+			}
+			for n := 1; n <= 64; n++ {
+				a := make([]int16, n)
+				b := make([]int16, n)
+				for i := range a {
+					a[i], b[i] = math.MinInt16, math.MinInt16
+				}
+				if got, want := k.fn(a, b), dotOracle(a, b); got != want {
+					t.Errorf("dot%s all-MinInt16 n=%d: got %d, want %d", k.name, n, got, want)
+				}
+			}
+		})
+	}
+}
+
+// TestDotAMD64_Clamp verifies the in-assembly min(len(a), len(b)): the kernel
+// must not read the longer operand past the shorter one's length.
+func TestDotAMD64_Clamp(t *testing.T) {
+	for _, k := range dotKernels() {
+		t.Run(k.name, func(t *testing.T) {
+			if !k.available {
+				t.Skipf("%s not available", k.name)
+			}
+			for _, n := range dotLengths {
+				if n == 0 {
+					continue
+				}
+				long, short := genI16(n+37, 63), genI16(n, 64)
+				if got, want := k.fn(long, short), dotOracle(long, short); got != want {
+					t.Errorf("dot%s clamp n=%d: got %d, want %d", k.name, n, got, want)
+				}
+				if got, want := k.fn(short, long), dotOracle(short, long); got != want {
+					t.Errorf("dot%s clamp (swapped) n=%d: got %d, want %d", k.name, n, got, want)
+				}
+			}
+		})
+	}
+}
+
+// TestDotDispatch_ReachesSIMD asserts that DotProduct actually routes to a SIMD
+// kernel rather than silently falling back to the Go reference. See the arm64
+// counterpart for why this must be a white-box check: the kernels are
+// bit-identical to dotGo, so a dead dispatcher passes every parity test.
+//
+// It must not call t.Parallel(): it reads package-level dispatch state.
+func TestDotDispatch_ReachesSIMD(t *testing.T) {
+	if hasSSE2 != cpu.X86.SSE2 {
+		t.Fatalf("hasSSE2 = %v but cpu.X86.SSE2 = %v: dispatch flag is not wired to CPU detection", hasSSE2, cpu.X86.SSE2)
+	}
+	if hasAVX2 != cpu.X86.AVX2 {
+		t.Fatalf("hasAVX2 = %v but cpu.X86.AVX2 = %v: dispatch flag is not wired to CPU detection", hasAVX2, cpu.X86.AVX2)
+	}
+	// SSE2 is in the GOAMD64=v1 baseline, so on amd64 the dot product must
+	// always have a SIMD path: a false hasSSE2 means every call runs scalar.
+	if !hasSSE2 {
+		t.Fatal("hasSSE2 is false on amd64: PMADDWD is SSE2 baseline, so DotProduct should never fall back to Go here")
+	}
+	if minSSE2Elements > 2*8 || minAVX2Elements > 2*16 {
+		t.Fatalf("dispatch thresholds too high (SSE2 %d, AVX2 %d): DotProduct would not vectorize at the short lengths it was written for",
+			minSSE2Elements, minAVX2Elements)
+	}
+}

--- a/i16/i16_arm64.go
+++ b/i16/i16_arm64.go
@@ -7,6 +7,25 @@ import "github.com/tphakala/simd/cpu"
 // NEON processes 8 int16 pairs (one .8H register) per iteration.
 const minNEONElements = 8
 
+// The dot kernel has an 8-wide block before its scalar tail, so it shares the
+// 8-element threshold. Eight is where the kernel stops losing and starts
+// winning, which is also where the short CELT bands this primitive exists for
+// land.
+//
+// Measured kernel against Go reference, both called through the same indirect
+// pointer so neither gets a call-depth advantage (that is the comparison the
+// dispatch decision turns on, since dotI16 calls both directly). Below 8 the
+// reference wins on both microarchitectures tested: at n=4, 1.8 vs 2.5 ns on
+// Apple M and 8.3 vs 10.7 ns on Cortex-A76. At n=8 the kernel is 1.3x ahead on
+// Cortex-A76 and level on Apple M. From n=10 up it wins on both, reaching 1.8x
+// (Apple M) and 2.0x (Cortex-A76) by n=16.
+//
+// Retuning note: the committed benchmarks compare the public DotProduct against
+// dotGo called directly, so they charge dispatch overhead to the SIMD side only
+// and understate the kernel at small n. They measure what a caller sees, not
+// what this constant should be; reproduce the numbers above before moving it.
+const minNEONDot = minNEONElements
+
 var hasNEON = cpu.ARM64.NEON
 
 func interleave2I16(dst, a, b []int16) {
@@ -24,6 +43,16 @@ func deinterleave2I16(a, b, src []int16) {
 	}
 	deinterleave2Go(a, b, src)
 }
+
+func dotI16(a, b []int16) int32 {
+	if hasNEON && min(len(a), len(b)) >= minNEONDot {
+		return dotNEON(a, b)
+	}
+	return dotGo(a, b)
+}
+
+//go:noescape
+func dotNEON(a, b []int16) int32
 
 //go:noescape
 func interleave2NEON(dst, a, b []int16)

--- a/i16/i16_arm64.go
+++ b/i16/i16_arm64.go
@@ -24,7 +24,11 @@ const minNEONElements = 8
 // dotGo called directly, so they charge dispatch overhead to the SIMD side only
 // and understate the kernel at small n. They measure what a caller sees, not
 // what this constant should be; reproduce the numbers above before moving it.
-const minNEONDot = minNEONElements
+//
+// This is an independent literal rather than an alias of minNEONElements, which
+// it happens to equal, so retuning the interleave kernels cannot silently move
+// the dot threshold.
+const minNEONDot = 8 // the kernel's 8-wide block, below its 16-wide body
 
 var hasNEON = cpu.ARM64.NEON
 

--- a/i16/i16_arm64.s
+++ b/i16/i16_arm64.s
@@ -91,3 +91,77 @@ deinterleave2_neon_loop1:
 
 deinterleave2_neon_done:
     RET
+
+// func dotNEON(a, b []int16) int32
+// Handles mismatched slice lengths: uses min(len(a), len(b)).
+//
+// Widening int16 dot product. SMLAL/SMLAL2 each multiply four int16 pairs into
+// int32 and accumulate, so one iteration retires 16 products into four
+// independent accumulators; the four chains keep the multiply-accumulate
+// latency off the critical path. VADD folds them, ADDV reduces, and an 8-wide
+// block plus a scalar tail finish n mod 16 (short CELT bands are common, so the
+// 8-wide block earns its keep).
+//
+// Accumulation wraps in int32, matching dotGo bit-for-bit: SMLAL wraps per lane
+// and wrapping addition is associative, so the lane split and the ADDV
+// reduction cannot change the result.
+//
+// The Go assembler has no mnemonic for any integer vector multiply (SMLAL and
+// friends are all "unrecognized instruction"), so these are hand-encoded as
+// WORD; the trailing comment is the decoded form and asmcheck_test.go
+// cross-checks it against arm64asm.
+TEXT ·dotNEON(SB), NOSPLIT, $0-52
+    MOVD a_base+0(FP), R0      // a pointer
+    MOVD a_len+8(FP), R2
+    MOVD b_len+32(FP), R3
+    CMP  R3, R2
+    CSEL LT, R2, R3, R2        // R2 = n = min(len(a), len(b))
+    MOVD b_base+24(FP), R1     // b pointer
+
+    VEOR V16.B16, V16.B16, V16.B16
+    VEOR V17.B16, V17.B16, V17.B16
+    VEOR V18.B16, V18.B16, V18.B16
+    VEOR V19.B16, V19.B16, V19.B16
+
+    LSR  $4, R2, R4            // R4 = n / 16
+    CBZ  R4, dot_neon_block8
+
+dot_neon_loop16:
+    VLD1.P 32(R0), [V0.H8, V1.H8]
+    VLD1.P 32(R1), [V2.H8, V3.H8]
+    WORD $0x0E628010           // SMLAL V16.4S, V0.4H, V2.4H
+    WORD $0x4E628011           // SMLAL2 V17.4S, V0.8H, V2.8H
+    WORD $0x0E638032           // SMLAL V18.4S, V1.4H, V3.4H
+    WORD $0x4E638033           // SMLAL2 V19.4S, V1.8H, V3.8H
+    SUB  $1, R4
+    CBNZ R4, dot_neon_loop16
+
+dot_neon_block8:
+    AND  $15, R2, R3           // R3 = n mod 16
+    TBZ  $3, R3, dot_neon_fold // bit 3 clear => fewer than 8 left
+    VLD1.P 16(R0), [V0.H8]
+    VLD1.P 16(R1), [V2.H8]
+    WORD $0x0E628010           // SMLAL V16.4S, V0.4H, V2.4H
+    WORD $0x4E628011           // SMLAL2 V17.4S, V0.8H, V2.8H
+
+dot_neon_fold:
+    VADD V17.S4, V16.S4, V16.S4
+    VADD V19.S4, V18.S4, V18.S4
+    VADD V18.S4, V16.S4, V16.S4
+    VADDV V16.S4, V16          // ADDV S16, V16.4S
+    FMOVS F16, R5              // R5 = vector partial sum
+
+    AND  $7, R2, R3            // R3 = n mod 8
+    CBZ  R3, dot_neon_done
+
+dot_neon_scalar:
+    MOVH.P 2(R0), R6           // sign-extending 16-bit load
+    MOVH.P 2(R1), R7
+    MUL  R7, R6, R6
+    ADDW R6, R5, R5            // 32-bit add: wraps like dotGo
+    SUB  $1, R3
+    CBNZ R3, dot_neon_scalar
+
+dot_neon_done:
+    MOVW R5, ret+48(FP)
+    RET

--- a/i16/i16_arm64_test.go
+++ b/i16/i16_arm64_test.go
@@ -107,3 +107,84 @@ func TestDeinterleave2NEON_NoOverwrite(t *testing.T) {
 		}
 	}
 }
+
+// TestDotNEON_ParityWithGo exercises the kernel directly rather than through
+// DotProduct, so a dispatch threshold change can never quietly turn this into a
+// test of the Go reference against itself.
+func TestDotNEON_ParityWithGo(t *testing.T) {
+	if !cpu.ARM64.NEON {
+		t.Skip("NEON not available")
+	}
+	for _, n := range dotLengths {
+		a, b := genI16(n, 51), genI16(n, 52)
+		if got, want := dotNEON(a, b), dotGo(a, b); got != want {
+			t.Errorf("dotNEON n=%d: got %d, want %d", n, got, want)
+		}
+	}
+}
+
+// TestDotNEON_MinInt16 pins SMLAL's wrapping behaviour at the one overflowing
+// input, directly at the kernel.
+func TestDotNEON_MinInt16(t *testing.T) {
+	if !cpu.ARM64.NEON {
+		t.Skip("NEON not available")
+	}
+	for n := 1; n <= 64; n++ {
+		a := make([]int16, n)
+		b := make([]int16, n)
+		for i := range a {
+			a[i], b[i] = math.MinInt16, math.MinInt16
+		}
+		if got, want := dotNEON(a, b), dotOracle(a, b); got != want {
+			t.Errorf("dotNEON all-MinInt16 n=%d: got %d, want %d", n, got, want)
+		}
+	}
+}
+
+// TestDotNEON_Clamp verifies the in-assembly min(len(a), len(b)): the kernel
+// must not read the longer operand past the shorter one's length.
+func TestDotNEON_Clamp(t *testing.T) {
+	if !cpu.ARM64.NEON {
+		t.Skip("NEON not available")
+	}
+	for _, n := range dotLengths {
+		if n == 0 {
+			continue
+		}
+		long, short := genI16(n+37, 53), genI16(n, 54)
+		if got, want := dotNEON(long, short), dotOracle(long, short); got != want {
+			t.Errorf("dotNEON clamp n=%d: got %d, want %d", n, got, want)
+		}
+		if got, want := dotNEON(short, long), dotOracle(short, long); got != want {
+			t.Errorf("dotNEON clamp (swapped) n=%d: got %d, want %d", n, got, want)
+		}
+	}
+}
+
+// TestDotDispatch_ReachesNEON asserts that DotProduct actually routes to the
+// NEON kernel on NEON hardware.
+//
+// This has to be a white-box check on the dispatch state, because no black-box
+// test can catch the failure. dotNEON is bit-identical to dotGo by design, so a
+// dispatcher that silently sent every call to the Go reference would satisfy
+// every parity assertion in this package while the SIMD path sat dead. The
+// parity tests above call dotNEON directly (deliberately, so a threshold change
+// cannot degrade them into dotGo-vs-dotGo), which means they cannot notice
+// either. Nothing else checks that the two ever meet.
+//
+// It must not call t.Parallel(): it reads package-level dispatch state.
+func TestDotDispatch_ReachesNEON(t *testing.T) {
+	if !cpu.ARM64.NEON {
+		t.Skip("NEON not available")
+	}
+	if !hasNEON {
+		t.Fatal("hasNEON is false though cpu.ARM64.NEON is true: DotProduct silently runs the Go reference on every call")
+	}
+	// The threshold is documented as one vector block. Anything much larger
+	// would leave the codec-length calls this primitive exists for running
+	// scalar, which no other test would report.
+	if minNEONDot > 2*minNEONElements {
+		t.Fatalf("minNEONDot = %d exceeds two vector blocks (%d): DotProduct would not vectorize at the short lengths it was written for",
+			minNEONDot, 2*minNEONElements)
+	}
+}

--- a/i16/i16_arm64_test.go
+++ b/i16/i16_arm64_test.go
@@ -183,8 +183,7 @@ func TestDotDispatch_ReachesNEON(t *testing.T) {
 	// The threshold is documented as one vector block. Anything much larger
 	// would leave the codec-length calls this primitive exists for running
 	// scalar, which no other test would report.
-	if minNEONDot > 2*minNEONElements {
-		t.Fatalf("minNEONDot = %d exceeds two vector blocks (%d): DotProduct would not vectorize at the short lengths it was written for",
-			minNEONDot, 2*minNEONElements)
+	if minNEONDot > 16 {
+		t.Fatalf("minNEONDot = %d exceeds two vector blocks: DotProduct would not vectorize at the short lengths it was written for", minNEONDot)
 	}
 }

--- a/i16/i16_go.go
+++ b/i16/i16_go.go
@@ -19,3 +19,21 @@ func deinterleave2Go(a, b, src []int16) {
 		b[i] = src[i*2+1]
 	}
 }
+
+// dotGo computes the widening int16 dot product, accumulating each int32
+// product into an int32 running sum with two's-complement wraparound. It
+// clamps to min(len(a), len(b)) itself so the unsafe entry point can hand it
+// mismatched slices, and it is the bit-exact source of truth the SIMD Dot
+// kernels are validated against.
+//
+// Wrapping (rather than saturating) accumulation is the contract: wrapping
+// addition is associative and commutative modulo 2^32, so the SIMD lane
+// grouping and horizontal reduction produce bit-identical results to this
+// sequential loop for every input, including forced overflow.
+func dotGo(a, b []int16) int32 {
+	var s int32
+	for i := range min(len(a), len(b)) {
+		s += int32(a[i]) * int32(b[i])
+	}
+	return s
+}

--- a/i16/i16_other.go
+++ b/i16/i16_other.go
@@ -4,3 +4,4 @@ package i16
 
 func interleave2I16(dst, a, b []int16)   { interleave2Go(dst, a, b) }
 func deinterleave2I16(a, b, src []int16) { deinterleave2Go(a, b, src) }
+func dotI16(a, b []int16) int32          { return dotGo(a, b) }


### PR DESCRIPTION
Adds `i16.DotProduct` / `i16.DotProductUnsafe`, a widening int16 x int16 -> int32 multiply-accumulate. This is PR A of a three-part stack for #142; `XCorr` (tier 2) and the tier-3 ops (`i32.Sum`, `Abs`, `MaxAbs`, `MulQ15`) follow separately, so this PR carries the semantics contract and the first integer-MAC encodings that the other two build on.

## Why

The float side already has this shape (`f32.DotProduct`), the integer side had nothing: there was no widening integer multiply-accumulate anywhere, which is what currently blocks fixed-point DSP (Opus/CELT, SILK, FLAC LPC) from using this library. Per #142, missing vectorization accounts for 72% of the Go-vs-C gap in a fixed-point Opus codec, and this is the single primitive that closes most of it.

## The semantics contract

Accumulation **wraps** rather than saturates, and that is a documented guarantee rather than an implementation detail. Wrapping addition is associative and commutative modulo 2^32, so any lane grouping and any horizontal reduction order is bit-identical to the scalar loop. A saturating accumulator is not associative, so reassociating it (exactly what a vector horizontal sum does) would change results on rare inputs and silently break a bit-exact codec. The contract is enforced by tests that call each kernel directly, so a future author reaching for a saturating instruction fails CI rather than quietly voiding the doc.

## Kernels

`arm64`: `SMLAL`/`SMLAL2`, 16 products per iteration into four independent accumulators to break the multiply-accumulate latency chain, plus an 8-wide block so short CELT bands still vectorize. Go's assembler cannot express any integer vector multiply (`SMLAL`, `VSMLAL`, `VSMULL`, integer `VMUL` are all `unrecognized instruction`), so these are hand-encoded `WORD` directives; `asmcheck` cross-checks every one against `arm64asm`, and all four decode as `Match` rather than falling through to the lenient objdump path.

`amd64`: `PMADDWD`, which is SSE2 and therefore has no availability cliff on the `GOAMD64=v1` baseline, plus an AVX2 tier at twice the width. Note the Plan 9 spelling of the SSE2 form is `PMADDWL`; `PMADDWD` does not assemble.

`PMADDWD`'s only overflowing input is a pair of `(-32768 * -32768)` summing to 2^31. It wraps to `0x80000000`, exactly like the scalar reference (two wrapping int32 adds of 2^30), so no special case is needed. Verified on hardware rather than assumed.

The kernels clamp to `min(len(a), len(b))` in assembly (matching `f32`), which is what makes `DotProductUnsafe` safe to hand mismatched slices. A regression there is an out-of-bounds read rather than a wrong number, so it is tested at the kernel level in both length orders and fuzzed.

## Performance

Measured against the Go reference at n=240 (a 20 ms frame at 12 kHz):

| n | AVX2 | Cortex-A76 | Apple M |
| --- | --- | --- | --- |
| 8 | 1.5x | 0.97x | 0.85x |
| 240 | 8.5x | 5.8x | 5.4x |
| 4096 | 13.9x | 7.8x | 6.1x |

At n=8 dispatch overhead is most of the work, so the public-API numbers are roughly break-even. Comparing the kernel against the reference at equal call depth (the comparison the dispatch decision actually turns on) n=8 is the crossover: below it the reference wins everywhere, at 8 the kernel is 1.3x ahead on Cortex-A76 and level on Apple M, and from 10 up it wins on both. The threshold is therefore one vector block. The threshold constants are named per-op so retuning the interleave kernels cannot silently retune this one.

## Docs

The package doc, `README.md` and `doc.go` all previously stated that `i16` deliberately carried no arithmetic primitives and that callers should widen to `i32`. That is now the inverse of the truth, so all three are updated. `doc.go` mattered most: it is the pkg.go.dev landing page and would have shipped saying the package cannot do the thing it now does.

## Testing

Bit-exactness against the Go reference on **darwin/arm64 (native), linux/arm64 (Cortex-A76), and linux/amd64 (AVX2 + SSE2)**, plus cross-builds for 386, riscv64, ppc64le, s390x and js/wasm to confirm the pure-Go fallback path.

An independent int64-truncation oracle checks the reference itself rather than trusting it. The length sweep is exhaustive to 64 with non-uniform data, deliberately: all-MinInt16 operands are sign-symmetric (`(-32768)*(-32768) == 32768*32768`), so a uniform sweep can only catch a miscounted element, never a sign or lane error. `TestDotProduct_UnalignedOperands` covers offset subslices, which is the shape sliding correlation actually calls (`DotProduct(x[lag:], h)`), so an aligned-load regression cannot pass and then fault in production. `TestDotDispatch_ReachesSIMD` is a white-box check that the dispatcher is live at all: the kernels are bit-identical to the reference by design, so a dead dispatcher would otherwise satisfy every parity assertion while the SIMD path sat unused.

Each of these was mutation-tested: killing the dispatch, swapping `SMLAL` for `UMLAL`, and raising the threshold each fail the suite.

Zero allocations (`AllocsPerRun == 0`), `golangci-lint` clean, `asmcheck` and the goroutine-register-clobber guard pass.

Refs #142

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added `i16` dot-product operations (`DotProduct` and `DotProductUnsafe`) with widening `int16`→`int32` results and specified modulo-`2^32` wraparound behavior.
  * Optimized AMD64 (SSE2/AVX2) and ARM64 (NEON) execution, with a portable fallback.

* **Documentation**
  * Updated `i16` docs, semantics, and corrected/expanded performance guidance and benchmarking details, including bit-exactness notes.

* **Tests**
  * Added extensive correctness tests, differential fuzzing, SIMD parity checks, allocation checks, and dot-product benchmarks.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->