### PR TITLE
docs: correct the arch test-host claims in CLAUDE.md

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -58,10 +58,18 @@ verify the encoding with `aarch64-linux-gnu-as` + objdump or `arm64asm`.
 
 ## Testing across architectures
 
-- AMD64 tests run natively here.
-- ARM64 is exercised on a native Raspberry Pi 5 host (`thakala@rpi5.local`,
-  aarch64, go installed). Cross-compile here, copy the test binary over, run it
-  there. No qemu emulation needed.
+- The dev machine is darwin/arm64 (Apple Silicon), so ARM64/NEON tests run
+  natively here. AMD64 is the one that needs a remote.
+- AMD64 is exercised on a native x86-64 Linux host (`thakala@192.168.4.176`,
+  go installed, AVX2 + SSE2 but **no AVX-512**). Cross-compile here, copy the
+  test binary over, run it there.
+- ARM64 Linux (a different microarchitecture from the Apple Silicon dev box, so
+  worth running for kernels whose timing or tuning matters) is exercised on a
+  native Raspberry Pi 5 host (`thakala@rpi5.local`, aarch64, go installed).
+  Same cross-compile-and-copy flow. No qemu emulation needed.
+- No AVX-512 hardware is available on any of these, so an AVX-512 kernel cannot
+  be runtime-verified locally; see issue #96 (execute the AVX-512 tier under
+  Intel SDE) and #75.
 - Each SIMD primitive ships a Go reference, parity tests against the active SIMD
   path, a bit-exactness check vs the per-element scalar path where applicable, and
   a `testing.AllocsPerRun == 0` allocation-free assertion.


### PR DESCRIPTION
`CLAUDE.md` claimed "AMD64 tests run natively here", but the dev machine is darwin/arm64 (Apple Silicon). It is the reverse: ARM64/NEON runs natively and AMD64 is the architecture that needs a remote host. This surfaced while adding the i16 dot-product kernels in #143: following the stale note would mean believing the amd64 kernels had been exercised locally, when in fact nothing had run them.

This records the actual amd64 host, notes that neither it nor the Pi 5 has AVX-512 (so the AVX-512 tier cannot be runtime-verified here, which is what #96 and #75 exist for), and notes that the Pi is still worth running separately from the Apple Silicon box because it is a different microarchitecture.

Docs only, no code change.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified cross-platform SIMD testing guidance for native x86-64 Linux and ARM64 environments.
  * Documented the cross-compilation, file-transfer, and runtime verification workflow.
  * Noted local limitations for AVX-512 testing and added references to related tracking issues.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->