### PR TITLE
i16: add XCorr (multi-lag widening cross-correlation)

### DIFF
--- a/README.md
+++ b/README.md
@@ -569,6 +569,7 @@ The 16-bit integer counterpart to `i32`, serving two kinds of hot loop. First, r
 |                | `Deinterleave2(a, b, src)` | Split interleaved stereo into two channels | 16x (AVX2) / 8x (SSE2) / 8x (NEON) |
 | **Reduction**  | `DotProduct(a, b)`         | Widening dot product, wrapping int32       | 16x (AVX2) / 8x (SSE2) / 16x (NEON) |
 |                | `DotProductUnsafe(a, b)`   | As above, without the empty-slice guard    | 16x (AVX2) / 8x (SSE2) / 16x (NEON) |
+| **Correlation**| `XCorr(dst, x, y)`         | Dot product of x against y at every lag    | 4 lags/call, 16x (AVX2) / 8x (SSE2/NEON) |
 
 ```go
 import "github.com/tphakala/simd/i16"
@@ -581,11 +582,16 @@ i16.Interleave2(stereo, left, right)   // [l0, r0, l1, r1, ...]
 i16.Deinterleave2(left, right, stereo) // inverse: split back to channels
 
 sum := i16.DotProduct(left, right)     // sum(left[i]*right[i]) widened into int32
+
+lags := make([]int32, 32)
+i16.XCorr(lags, left, stereo)          // lags[k] = DotProduct(left, stereo[k:])
 ```
 
 The interleave kernels are pure 16-bit-lane movement (AVX2/SSE2 word unpacks plus a lane permute, NEON `ZIP`/`UZP` on `.8H`), so the bit pattern of each lane is irrelevant and every value round-trips exactly: negative values and the int16 extremes are preserved.
 
 `DotProduct` is the opposite case: the bit pattern is the whole point. It widens each product to int32 and accumulates with **two's-complement wraparound, never saturation**, and that is a guarantee callers may rely on. Wrapping addition is associative and commutative modulo 2^32, so any lane grouping and any horizontal reduction order is bit-identical to the scalar loop, including on operands engineered to overflow; a saturating accumulator is not associative and could not be vectorized without changing results. Fixed-point codecs (Opus/CELT, FLAC LPC) use integer arithmetic precisely because it is exactly reproducible, so this property is the feature. The kernels are `PMADDWD` (SSE2, hence always present on the `GOAMD64=v1` baseline) with an AVX2 tier at twice the width, and `SMLAL`/`SMLAL2` on NEON. All kernels are zero-allocation.
+
+`XCorr` is the same arithmetic evaluated at every lag, and `dst[k]` is defined to equal `DotProduct(x, y[k:k+len(x)])` exactly. The win over calling `DotProduct` in a loop is that it loads `x` once and multiply-accumulates it against four overlapping `y` windows at a time (the libopus `xcorr_kernel` shape), rather than re-reading `x` for every lag. Only lags whose full window fits in `y` are computed, and `dst` beyond that is left untouched rather than zeroed.
 
 ### `i8` - int8 Operations
 
@@ -875,6 +881,14 @@ a Raspberry Pi 5):
 | 240      | 10 ns vs 86 ns (**8.5x**)   | 35 ns vs 205 ns (**5.8x**)    |
 | 480      | 14 ns vs 159 ns (**11.8x**) | 61 ns vs 434 ns (**7.1x**)    |
 | 4096     | 92 ns vs 1282 ns (**13.9x**) | 439 ns vs 3436 ns (**7.8x**)  |
+
+`XCorr` at a 240-element frame, by lag count. The speedup is larger than `DotProduct`'s because the pure-Go baseline re-reads `x` once per lag, which is exactly the work the 4-lag blocking removes:
+
+| Lags | AMD64 (AVX2)                   | ARM64 (NEON, Pi 5)              |
+| ---- | ------------------------------ | ------------------------------- |
+| 4    | 17 ns vs 479 ns (**27.5x**)    | 164 ns vs 847 ns (**5.2x**)     |
+| 64   | 286 ns vs 7292 ns (**25.5x**)  | 1889 ns vs 13558 ns (**7.2x**)  |
+| 288  | 1110 ns vs 33698 ns (**30.4x**) | 8412 ns vs 60900 ns (**7.2x**) |
 
 At n=8 the dispatch and call overhead is most of the work, so the win is small on AMD64 and slightly negative on the Pi 5; the kernels pull away from 64 elements up. All i16 kernels are zero-allocation and bit-exact against the pure-Go reference. The interleave kernels move whole 16-bit lanes, so the bit pattern of each sample is irrelevant to correctness; `DotProduct` is bit-exact for the opposite reason, because wrapping accumulation is associative, so lane grouping and reduction order cannot change the result even when the accumulator overflows (its tests plant `MinInt16` operands specifically to force that wrap).
 

--- a/README.md
+++ b/README.md
@@ -583,8 +583,12 @@ i16.Deinterleave2(left, right, stereo) // inverse: split back to channels
 
 sum := i16.DotProduct(left, right)     // sum(left[i]*right[i]) widened into int32
 
-lags := make([]int32, 32)
-i16.XCorr(lags, left, stereo)          // lags[k] = DotProduct(left, stereo[k:])
+// Correlate a short pattern against a longer signal at every lag.
+pattern := make([]int16, 32)
+signal := make([]int16, 512)
+lags := make([]int32, len(signal)-len(pattern)+1)
+
+i16.XCorr(lags, pattern, signal)       // lags[k] = DotProduct(pattern, signal[k:])
 ```
 
 The interleave kernels are pure 16-bit-lane movement (AVX2/SSE2 word unpacks plus a lane permute, NEON `ZIP`/`UZP` on `.8H`), so the bit pattern of each lane is irrelevant and every value round-trips exactly: negative values and the int16 extremes are preserved.
@@ -882,15 +886,18 @@ a Raspberry Pi 5):
 | 480      | 14 ns vs 159 ns (**11.8x**) | 61 ns vs 434 ns (**7.1x**)    |
 | 4096     | 92 ns vs 1282 ns (**13.9x**) | 439 ns vs 3436 ns (**7.8x**)  |
 
+
+`DotProduct` at n=8 is dominated by dispatch and call overhead, so the win is small on AMD64 and slightly negative on the Pi 5; the kernels pull away from 64 elements up.
+
 `XCorr` at a 240-element frame, by lag count. The speedup is larger than `DotProduct`'s because the pure-Go baseline re-reads `x` once per lag, which is exactly the work the 4-lag blocking removes:
 
-| Lags | AMD64 (AVX2)                   | ARM64 (NEON, Pi 5)              |
-| ---- | ------------------------------ | ------------------------------- |
-| 4    | 17 ns vs 479 ns (**27.5x**)    | 164 ns vs 847 ns (**5.2x**)     |
-| 64   | 286 ns vs 7292 ns (**25.5x**)  | 1889 ns vs 13558 ns (**7.2x**)  |
-| 288  | 1110 ns vs 33698 ns (**30.4x**) | 8412 ns vs 60900 ns (**7.2x**) |
+| Lags | AMD64 (AVX2)                    | ARM64 (NEON, Pi 5)              |
+| ---- | ------------------------------- | ------------------------------- |
+| 4    | 17 ns vs 460 ns (**26.6x**)     | 122 ns vs 849 ns (**6.9x**)     |
+| 64   | 246 ns vs 7376 ns (**29.9x**)   | 1870 ns vs 13536 ns (**7.2x**)  |
+| 288  | 1058 ns vs 34642 ns (**32.7x**) | 8352 ns vs 60814 ns (**7.3x**)  |
 
-At n=8 the dispatch and call overhead is most of the work, so the win is small on AMD64 and slightly negative on the Pi 5; the kernels pull away from 64 elements up. All i16 kernels are zero-allocation and bit-exact against the pure-Go reference. The interleave kernels move whole 16-bit lanes, so the bit pattern of each sample is irrelevant to correctness; `DotProduct` is bit-exact for the opposite reason, because wrapping accumulation is associative, so lane grouping and reduction order cannot change the result even when the accumulator overflows (its tests plant `MinInt16` operands specifically to force that wrap).
+All i16 kernels are zero-allocation and bit-exact against the pure-Go reference. The interleave kernels move whole 16-bit lanes, so the bit pattern of each sample is irrelevant to correctness; `DotProduct` is bit-exact for the opposite reason, because wrapping accumulation is associative, so lane grouping and reduction order cannot change the result even when the accumulator overflows (its tests plant `MinInt16` operands specifically to force that wrap).
 
 All int32 kernels are zero-allocation and bit-exact against the pure-Go reference (verified across the sign and high bits with negative values and the type extremes). The interleave kernels move whole 32-bit lanes, so the bit pattern of each sample is irrelevant to correctness. `Add` and `Sub` are element-wise integer-ALU ops with two's-complement wraparound, matching the scalar reference across the full int32 range. `MinMax` is exact by construction (signed min/max has no accumulation order or wrapping); its parity tests plant `MinInt32`/`MaxInt32` in both a mid-block lane and the scalar tail, in both orderings, to catch a dropped vector lane or a skipped tail.
 

--- a/doc.go
+++ b/doc.go
@@ -88,7 +88,7 @@
 //
 // Spectral (f64, f32): STFTPlan (NewSTFTPlan, STFT, STFTPower, STFTPowerInto, NumFrames) - fused real-input short-time Fourier transform with optional librosa-style center=true framing (PadMode: NoPad/PadZero/PadReflect)
 //
-// Integer DSP (i16): Interleave2, Deinterleave2, DotProduct, DotProductUnsafe (widening int16 x int16 -> wrapping int32; ARM64 SMLAL/SMLAL2, amd64 PMADDWD/VPMADDWD)
+// Integer DSP (i16): Interleave2, Deinterleave2, DotProduct, DotProductUnsafe, XCorr (widening int16 x int16 -> wrapping int32; ARM64 SMLAL/SMLAL2, amd64 PMADDWD/VPMADDWD; XCorr evaluates 4 correlation lags per kernel call)
 //
 // Integer DSP (i32): Interleave2, Deinterleave2, Add, Sub, MinMax
 //

--- a/i16/benchmark_test.go
+++ b/i16/benchmark_test.go
@@ -93,3 +93,37 @@ func BenchmarkDotProductGo_64(b *testing.B)   { benchmarkDot(b, 64, dotGo) }
 func BenchmarkDotProductGo_240(b *testing.B)  { benchmarkDot(b, 240, dotGo) }
 func BenchmarkDotProductGo_480(b *testing.B)  { benchmarkDot(b, 480, dotGo) }
 func BenchmarkDotProductGo_4096(b *testing.B) { benchmarkDot(b, 4096, dotGo) }
+
+// XCorr benchmarks use the shape pitch analysis calls at: a 240-element frame
+// correlated over a sweep of lags. SetBytes counts x once plus the y span the
+// lags cover.
+
+func benchmarkXCorr(b *testing.B, xn, lags int, fn func(dst []int32, x, y []int16)) {
+	b.Helper()
+	x := make([]int16, xn)
+	y := make([]int16, xn+lags-1)
+	for i := range x {
+		x[i] = int16(i*7 - 3000)
+	}
+	for i := range y {
+		y[i] = int16(i*-5 + 2000)
+	}
+	dst := make([]int32, lags)
+	b.SetBytes(int64(xn+len(y)) * 2)
+	for b.Loop() {
+		fn(dst, x, y)
+	}
+}
+
+func BenchmarkXCorr_240x4(b *testing.B)   { benchmarkXCorr(b, 240, 4, XCorr) }
+func BenchmarkXCorr_240x64(b *testing.B)  { benchmarkXCorr(b, 240, 64, XCorr) }
+func BenchmarkXCorr_240x288(b *testing.B) { benchmarkXCorr(b, 240, 288, XCorr) }
+
+// 480 is a 20 ms frame at 24 kHz, and covers a second x length through the
+// 16-wide AVX2 body.
+func BenchmarkXCorr_480x64(b *testing.B) { benchmarkXCorr(b, 480, 64, XCorr) }
+
+func BenchmarkXCorrGo_240x4(b *testing.B)   { benchmarkXCorr(b, 240, 4, xcorrGo) }
+func BenchmarkXCorrGo_240x64(b *testing.B)  { benchmarkXCorr(b, 240, 64, xcorrGo) }
+func BenchmarkXCorrGo_240x288(b *testing.B) { benchmarkXCorr(b, 240, 288, xcorrGo) }
+func BenchmarkXCorrGo_480x64(b *testing.B)  { benchmarkXCorr(b, 480, 64, xcorrGo) }

--- a/i16/benchmark_test.go
+++ b/i16/benchmark_test.go
@@ -123,6 +123,25 @@ func BenchmarkXCorr_240x288(b *testing.B) { benchmarkXCorr(b, 240, 288, XCorr) }
 // 16-wide AVX2 body.
 func BenchmarkXCorr_480x64(b *testing.B) { benchmarkXCorr(b, 480, 64, XCorr) }
 
+// The lengths above are all multiples of 16 and 4, which is precisely why they
+// hide things. 240 % 16 == 0 and 480 % 16 == 0, so the AVX2 kernel's scalar
+// tail never runs in any of them; 4, 64 and 288 are all multiples of
+// xcorrLagBlock, so the remainder-lag path never runs either. The cases below
+// exist to make both visible.
+//
+// x=25 currently shows the AVX2 tail costing more than SSE2 would (issue
+// filed): a remainder of 8-15 elements is served by a 4-lag scalar tail rather
+// than an 8-wide block. x=248 is the same shape at a realistic length, and
+// lags=61 is the pitch-analysis count from the motivating caller, which leaves
+// one remainder lag.
+func BenchmarkXCorr_25x64(b *testing.B)  { benchmarkXCorr(b, 25, 64, XCorr) }
+func BenchmarkXCorr_248x64(b *testing.B) { benchmarkXCorr(b, 248, 64, XCorr) }
+func BenchmarkXCorr_240x61(b *testing.B) { benchmarkXCorr(b, 240, 61, XCorr) }
+
+func BenchmarkXCorrGo_25x64(b *testing.B)  { benchmarkXCorr(b, 25, 64, xcorrGo) }
+func BenchmarkXCorrGo_248x64(b *testing.B) { benchmarkXCorr(b, 248, 64, xcorrGo) }
+func BenchmarkXCorrGo_240x61(b *testing.B) { benchmarkXCorr(b, 240, 61, xcorrGo) }
+
 func BenchmarkXCorrGo_240x4(b *testing.B)   { benchmarkXCorr(b, 240, 4, xcorrGo) }
 func BenchmarkXCorrGo_240x64(b *testing.B)  { benchmarkXCorr(b, 240, 64, xcorrGo) }
 func BenchmarkXCorrGo_240x288(b *testing.B) { benchmarkXCorr(b, 240, 288, xcorrGo) }

--- a/i16/example_test.go
+++ b/i16/example_test.go
@@ -35,3 +35,16 @@ func ExampleDotProduct() {
 	fmt.Println(i16.DotProduct(samples, coeffs))
 	// Output: -65536000
 }
+
+func ExampleXCorr() {
+	// Correlate a short pattern against a longer signal at every lag. The
+	// pattern occurs at lag 2, which is where the correlation peaks.
+	pattern := []int16{1000, -2000, 1000}
+	signal := []int16{0, 0, 1000, -2000, 1000, 0}
+
+	lags := make([]int32, len(signal)-len(pattern)+1)
+	i16.XCorr(lags, pattern, signal)
+
+	fmt.Println(lags)
+	// Output: [1000000 -4000000 6000000 -4000000]
+}

--- a/i16/fuzz_test.go
+++ b/i16/fuzz_test.go
@@ -134,13 +134,17 @@ func FuzzI16Dot(f *testing.F) {
 // every lag equals the dot product at that offset, which also catches a kernel
 // that drifted from DotProduct even if xcorrGo drifted with it.
 func FuzzI16XCorr(f *testing.F) {
+	// The body derives lags as lagsRaw%32+1, so a seed must pass lags-1 to run
+	// at the lag count it names. Passing lags directly shifts the whole set by
+	// one and makes lags==1 (the single-remainder-lag case, no kernel block)
+	// unreachable from any seed.
 	for _, xn := range []int{1, 4, 8, 9, 15, 16, 17, 32, 33} {
 		for _, lags := range []int{1, 3, 4, 5, 8, 9} {
 			raw := make([]byte, (xn+xn+lags)*2)
 			for i := range raw {
 				raw[i] = byte(i*29 + 7)
 			}
-			f.Add(raw, uint8(xn), uint8(lags))
+			f.Add(raw, uint8(xn), uint8(lags-1))
 		}
 	}
 	f.Fuzz(func(t *testing.T, raw []byte, xnRaw, lagsRaw uint8) {

--- a/i16/fuzz_test.go
+++ b/i16/fuzz_test.go
@@ -126,3 +126,44 @@ func FuzzI16Dot(f *testing.F) {
 		}
 	})
 }
+
+// FuzzI16XCorr differentially fuzzes multi-lag correlation. The high-value bug
+// class is the lag blocking: the kernel evaluates 4 lags per call and the
+// dispatcher finishes the remainder with the dot kernel, so arbitrary lag
+// counts exercise that seam. It asserts the defining property directly, that
+// every lag equals the dot product at that offset, which also catches a kernel
+// that drifted from DotProduct even if xcorrGo drifted with it.
+func FuzzI16XCorr(f *testing.F) {
+	for _, xn := range []int{1, 4, 8, 9, 15, 16, 17, 32, 33} {
+		for _, lags := range []int{1, 3, 4, 5, 8, 9} {
+			raw := make([]byte, (xn+xn+lags)*2)
+			for i := range raw {
+				raw[i] = byte(i*29 + 7)
+			}
+			f.Add(raw, uint8(xn), uint8(lags))
+		}
+	}
+	f.Fuzz(func(t *testing.T, raw []byte, xnRaw, lagsRaw uint8) {
+		v := i16sFromBits(raw)
+		xn := int(xnRaw) % 64
+		lags := int(lagsRaw)%32 + 1
+		if xn == 0 || len(v) < xn {
+			return
+		}
+		x := v[:xn]
+		y := v[xn:]
+		dst := make([]int32, lags)
+		ref := make([]int32, lags)
+		XCorr(dst, x, y)
+		xcorrGo(ref, x, y)
+		for k := range xcorrLags(dst, x, y) {
+			if dst[k] != ref[k] {
+				t.Fatalf("XCorr(xn=%d, lags=%d, len(y)=%d): dst[%d] = %d, want %d", xn, lags, len(y), k, dst[k], ref[k])
+			}
+			// The defining property: every lag is the dot product at that offset.
+			if want := DotProduct(x, y[k:k+xn]); dst[k] != want {
+				t.Fatalf("XCorr(xn=%d, lags=%d): dst[%d] = %d, want DotProduct = %d", xn, lags, k, dst[k], want)
+			}
+		}
+	})
+}

--- a/i16/i16_amd64.go
+++ b/i16/i16_amd64.go
@@ -44,13 +44,23 @@ const (
 )
 
 func xcorrI16(dst []int32, x, y []int16) {
+	m := xcorrLags(dst, x, y)
+	k := 0
 	switch {
 	case hasAVX2 && len(x) >= minAVX2XCorr:
-		xcorrBlocked(dst, x, y, xcorr4AVX2, dotI16)
+		for ; k+xcorrLagBlock <= m; k += xcorrLagBlock {
+			xcorr4AVX2(dst[k:k+xcorrLagBlock], x, xcorrWindow(x, y, k))
+		}
 	case hasSSE2 && len(x) >= minSSE2XCorr:
-		xcorrBlocked(dst, x, y, xcorr4SSE2, dotI16)
+		for ; k+xcorrLagBlock <= m; k += xcorrLagBlock {
+			xcorr4SSE2(dst[k:k+xcorrLagBlock], x, xcorrWindow(x, y, k))
+		}
 	default:
 		xcorrGo(dst, x, y)
+		return
+	}
+	for ; k < m; k++ {
+		dst[k] = dotI16(x, y[k:k+len(x)])
 	}
 }
 

--- a/i16/i16_amd64.go
+++ b/i16/i16_amd64.go
@@ -35,6 +35,25 @@ const (
 	minAVX2Dot = 16 // VPMADDWD retires 16
 )
 
+// XCorr vectorizes once x is long enough that reusing each x load across four
+// lags pays for the kernel call. The AVX2 body needs 16 elements; below that
+// SSE2's 8 still wins, and below 8 the Go reference runs.
+const (
+	minSSE2XCorr = 8
+	minAVX2XCorr = 16
+)
+
+func xcorrI16(dst []int32, x, y []int16) {
+	switch {
+	case hasAVX2 && len(x) >= minAVX2XCorr:
+		xcorrBlocked(dst, x, y, xcorr4AVX2, dotI16)
+	case hasSSE2 && len(x) >= minSSE2XCorr:
+		xcorrBlocked(dst, x, y, xcorr4SSE2, dotI16)
+	default:
+		xcorrGo(dst, x, y)
+	}
+}
+
 func dotI16(a, b []int16) int32 {
 	n := min(len(a), len(b))
 	switch {
@@ -68,6 +87,12 @@ func deinterleave2I16(a, b, src []int16) {
 		deinterleave2Go(a, b, src)
 	}
 }
+
+//go:noescape
+func xcorr4AVX2(dst []int32, x, y []int16)
+
+//go:noescape
+func xcorr4SSE2(dst []int32, x, y []int16)
 
 //go:noescape
 func dotAVX2(a, b []int16) int32

--- a/i16/i16_amd64.go
+++ b/i16/i16_amd64.go
@@ -43,6 +43,11 @@ const (
 	minAVX2XCorr = 16
 )
 
+// The two block loops below are identical except for the kernel they call, and
+// extracting that difference into a shared driver taking the kernel as a
+// parameter is exactly the refactor that must not happen: an indirect call
+// defeats escape analysis and forces every caller of XCorr to heap-allocate.
+// See xcorrWindow in i16_go.go. TestXCorr_AllocFree catches it if it returns.
 func xcorrI16(dst []int32, x, y []int16) {
 	m := xcorrLags(dst, x, y)
 	k := 0

--- a/i16/i16_amd64.s
+++ b/i16/i16_amd64.s
@@ -382,8 +382,10 @@ dot_avx2_done:
 // across all four lags. y is reloaded per lag regardless.
 //
 // The four y loads are deliberately unaligned relative to one another, being
-// the same window stepped by 2 bytes, so MOVOU/VMOVDQU are load-bearing: an
-// aligned-load substitution would fault on three lags out of four.
+// the same window stepped by 2 bytes, so MOVOU/VMOVDQU are load-bearing: at
+// most one lag in four can be 16-byte aligned, so an aligned-load substitution
+// would fault on at least three lags out of four, and on all four whenever y's
+// own base is unaligned (which is the common case, since callers slide y).
 
 // func xcorr4SSE2(dst []int32, x, y []int16)
 // n = min(len(x), len(y)-3) is a safety net; the dispatcher passes a y window of

--- a/i16/i16_amd64.s
+++ b/i16/i16_amd64.s
@@ -369,3 +369,226 @@ dot_avx2_done:
     MOVL AX, ret+48(FP)
     VZEROUPPER
     RET
+
+// Multi-lag cross-correlation: four lags per call.
+//
+// Load x once, then multiply-accumulate it against four overlapping y windows
+// at element offsets 0/1/2/3. Reusing the x load across four lags is the point
+// of the op.
+//
+// PMADDWD is per-lane commutative (it multiplies elementwise, then adds
+// pairwise), so the destructive two-operand SSE2 form costs nothing here: put
+// the freshly loaded y in the destination and x survives in its own register
+// across all four lags. y is reloaded per lag regardless.
+//
+// The four y loads are deliberately unaligned relative to one another, being
+// the same window stepped by 2 bytes, so MOVOU/VMOVDQU are load-bearing: an
+// aligned-load substitution would fault on three lags out of four.
+
+// func xcorr4SSE2(dst []int32, x, y []int16)
+// n = min(len(x), len(y)-3) is a safety net; the dispatcher passes a y window of
+// exactly len(x)+3, so the clamp never fires. It turns a wrapper bug into a
+// wrong number instead of an out-of-bounds read.
+TEXT ·xcorr4SSE2(SB), NOSPLIT, $0-72
+    MOVQ dst_base+0(FP), DI
+    MOVQ x_base+24(FP), SI
+    MOVQ x_len+32(FP), CX
+    MOVQ y_base+48(FP), BX
+    MOVQ y_len+56(FP), DX
+
+    PXOR X4, X4                // lag 0 accumulator
+    PXOR X5, X5                // lag 1
+    PXOR X6, X6                // lag 2
+    PXOR X7, X7                // lag 3
+
+    SUBQ $3, DX                // DX = len(y) - 3
+    JLE  xcorr4_sse2_empty
+    CMPQ DX, CX
+    CMOVQLT DX, CX             // CX = n = min(len(x), len(y)-3)
+    JMP  xcorr4_sse2_blocks
+
+xcorr4_sse2_empty:
+    XORQ CX, CX                // n = 0: fold zeros, store zeros
+
+xcorr4_sse2_blocks:
+    MOVQ CX, AX
+    SHRQ $3, AX                // AX = n / 8
+    JZ   xcorr4_sse2_fold
+
+xcorr4_sse2_loop8:
+    MOVOU (SI), X0             // x[j..j+8), reused by all four lags
+    MOVOU (BX), X1             // y[j+0 ..) lag 0
+    PMADDWL X0, X1
+    PADDD X1, X4
+    MOVOU 2(BX), X1            // y[j+1 ..) lag 1
+    PMADDWL X0, X1
+    PADDD X1, X5
+    MOVOU 4(BX), X1            // y[j+2 ..) lag 2
+    PMADDWL X0, X1
+    PADDD X1, X6
+    MOVOU 6(BX), X1            // y[j+3 ..) lag 3
+    PMADDWL X0, X1
+    PADDD X1, X7
+    ADDQ $16, SI
+    ADDQ $16, BX
+    DECQ AX
+    JNZ  xcorr4_sse2_loop8
+
+xcorr4_sse2_fold:
+    PSHUFD $0x4E, X4, X0
+    PADDD X0, X4
+    PSHUFD $0xB1, X4, X0
+    PADDD X0, X4
+    MOVQ X4, R8                // lag 0 partial sum
+    PSHUFD $0x4E, X5, X0
+    PADDD X0, X5
+    PSHUFD $0xB1, X5, X0
+    PADDD X0, X5
+    MOVQ X5, R9                // lag 1
+    PSHUFD $0x4E, X6, X0
+    PADDD X0, X6
+    PSHUFD $0xB1, X6, X0
+    PADDD X0, X6
+    MOVQ X6, R10               // lag 2
+    PSHUFD $0x4E, X7, X0
+    PADDD X0, X7
+    PSHUFD $0xB1, X7, X0
+    PADDD X0, X7
+    MOVQ X7, R11               // lag 3
+
+    ANDQ $7, CX
+    JZ   xcorr4_sse2_store
+
+xcorr4_sse2_scalar:
+    MOVWLSX (SI), AX           // x[j], sign-extended
+    MOVWLSX (BX), DX
+    IMULL AX, DX
+    ADDL DX, R8
+    MOVWLSX 2(BX), DX
+    IMULL AX, DX
+    ADDL DX, R9
+    MOVWLSX 4(BX), DX
+    IMULL AX, DX
+    ADDL DX, R10
+    MOVWLSX 6(BX), DX
+    IMULL AX, DX
+    ADDL DX, R11
+    ADDQ $2, SI
+    ADDQ $2, BX
+    DECQ CX
+    JNZ  xcorr4_sse2_scalar
+
+xcorr4_sse2_store:
+    MOVL R8, 0(DI)
+    MOVL R9, 4(DI)
+    MOVL R10, 8(DI)
+    MOVL R11, 12(DI)
+    RET
+
+// func xcorr4AVX2(dst []int32, x, y []int16)
+// As xcorr4SSE2 at twice the width; VPMADDWD's three-operand form also spares
+// the reload-into-destination dance.
+TEXT ·xcorr4AVX2(SB), NOSPLIT, $0-72
+    MOVQ dst_base+0(FP), DI
+    MOVQ x_base+24(FP), SI
+    MOVQ x_len+32(FP), CX
+    MOVQ y_base+48(FP), BX
+    MOVQ y_len+56(FP), DX
+
+    VPXOR Y4, Y4, Y4           // lag 0 accumulator
+    VPXOR Y5, Y5, Y5           // lag 1
+    VPXOR Y6, Y6, Y6           // lag 2
+    VPXOR Y7, Y7, Y7           // lag 3
+
+    SUBQ $3, DX                // DX = len(y) - 3
+    JLE  xcorr4_avx2_empty
+    CMPQ DX, CX
+    CMOVQLT DX, CX             // CX = n = min(len(x), len(y)-3)
+    JMP  xcorr4_avx2_blocks
+
+xcorr4_avx2_empty:
+    XORQ CX, CX
+
+xcorr4_avx2_blocks:
+    MOVQ CX, AX
+    SHRQ $4, AX                // AX = n / 16
+    JZ   xcorr4_avx2_fold
+
+xcorr4_avx2_loop16:
+    VMOVDQU (SI), Y0           // x[j..j+16), reused by all four lags
+    VMOVDQU (BX), Y1           // lag 0
+    VPMADDWD Y0, Y1, Y1
+    VPADDD Y1, Y4, Y4
+    VMOVDQU 2(BX), Y1          // lag 1
+    VPMADDWD Y0, Y1, Y1
+    VPADDD Y1, Y5, Y5
+    VMOVDQU 4(BX), Y1          // lag 2
+    VPMADDWD Y0, Y1, Y1
+    VPADDD Y1, Y6, Y6
+    VMOVDQU 6(BX), Y1          // lag 3
+    VPMADDWD Y0, Y1, Y1
+    VPADDD Y1, Y7, Y7
+    ADDQ $32, SI
+    ADDQ $32, BX
+    DECQ AX
+    JNZ  xcorr4_avx2_loop16
+
+xcorr4_avx2_fold:
+    VEXTRACTI128 $1, Y4, X0
+    VPADDD X0, X4, X4
+    VPSHUFD $0x4E, X4, X0
+    VPADDD X0, X4, X4
+    VPSHUFD $0xB1, X4, X0
+    VPADDD X0, X4, X4
+    MOVQ X4, R8                // lag 0 partial sum
+    VEXTRACTI128 $1, Y5, X0
+    VPADDD X0, X5, X5
+    VPSHUFD $0x4E, X5, X0
+    VPADDD X0, X5, X5
+    VPSHUFD $0xB1, X5, X0
+    VPADDD X0, X5, X5
+    MOVQ X5, R9                // lag 1
+    VEXTRACTI128 $1, Y6, X0
+    VPADDD X0, X6, X6
+    VPSHUFD $0x4E, X6, X0
+    VPADDD X0, X6, X6
+    VPSHUFD $0xB1, X6, X0
+    VPADDD X0, X6, X6
+    MOVQ X6, R10               // lag 2
+    VEXTRACTI128 $1, Y7, X0
+    VPADDD X0, X7, X7
+    VPSHUFD $0x4E, X7, X0
+    VPADDD X0, X7, X7
+    VPSHUFD $0xB1, X7, X0
+    VPADDD X0, X7, X7
+    MOVQ X7, R11               // lag 3
+
+    ANDQ $15, CX
+    JZ   xcorr4_avx2_store
+
+xcorr4_avx2_scalar:
+    MOVWLSX (SI), AX           // x[j], sign-extended
+    MOVWLSX (BX), DX
+    IMULL AX, DX
+    ADDL DX, R8
+    MOVWLSX 2(BX), DX
+    IMULL AX, DX
+    ADDL DX, R9
+    MOVWLSX 4(BX), DX
+    IMULL AX, DX
+    ADDL DX, R10
+    MOVWLSX 6(BX), DX
+    IMULL AX, DX
+    ADDL DX, R11
+    ADDQ $2, SI
+    ADDQ $2, BX
+    DECQ CX
+    JNZ  xcorr4_avx2_scalar
+
+xcorr4_avx2_store:
+    MOVL R8, 0(DI)
+    MOVL R9, 4(DI)
+    MOVL R10, 8(DI)
+    MOVL R11, 12(DI)
+    VZEROUPPER
+    RET

--- a/i16/i16_amd64_test.go
+++ b/i16/i16_amd64_test.go
@@ -320,9 +320,10 @@ func TestXCorr4AMD64_ShortWindowIsBounded(t *testing.T) {
 }
 
 // TestXCorrDispatch_ReachesSIMD pins the dispatch STATE that XCorr's SIMD path
-// depends on. See the arm64 counterpart for what it does NOT prove: nothing
+// depends on. See the arm64 counterpart for what it does NOT prove (nothing
 // here establishes that xcorrI16 calls a kernel, because the kernel is
-// bit-identical to the Go reference and a dead dispatcher passes every test.
+// bit-identical to the Go reference and a dead dispatcher passes every test)
+// and for the build-tagged hook that would close that gap.
 func TestXCorrDispatch_ReachesSIMD(t *testing.T) {
 	if hasSSE2 != cpu.X86.SSE2 {
 		t.Fatalf("hasSSE2 = %v but cpu.X86.SSE2 = %v: dispatch flag is not wired to CPU detection", hasSSE2, cpu.X86.SSE2)
@@ -353,7 +354,15 @@ func TestXCorr4AMD64_LongWindowIsClamped(t *testing.T) {
 				t.Skipf("%s not available", k.name)
 			}
 			for _, xn := range []int{1, 8, 9, 16, 17, 32} {
-				x := genI16(xn, 209)
+				// x MUST be a prefix of a longer allocation: the mutant this
+				// test exists for reads past the end of x, and past a
+				// standalone slice that is zeroed memory, which multiplies to
+				// 0 and leaves the answer correct. Non-zero bytes past x are
+				// what make the over-read observable rather than a coin flip
+				// on heap layout. Without this, the test detects nothing on
+				// amd64 at any xn.
+				backing := genI16(xn+200, 209)
+				x := backing[:xn]
 				y := genI16(xn+40, 210) // len(y)-3 far exceeds len(x)
 				dst := make([]int32, xcorrLagBlock)
 				k.fn(dst, x, y)

--- a/i16/i16_amd64_test.go
+++ b/i16/i16_amd64_test.go
@@ -319,14 +319,50 @@ func TestXCorr4AMD64_ShortWindowIsBounded(t *testing.T) {
 	}
 }
 
-// TestXCorrDispatch_ReachesSIMD asserts XCorr actually routes to a kernel.
-// See the arm64 counterpart for why this must be white-box.
+// TestXCorrDispatch_ReachesSIMD pins the dispatch STATE that XCorr's SIMD path
+// depends on. See the arm64 counterpart for what it does NOT prove: nothing
+// here establishes that xcorrI16 calls a kernel, because the kernel is
+// bit-identical to the Go reference and a dead dispatcher passes every test.
 func TestXCorrDispatch_ReachesSIMD(t *testing.T) {
+	if hasSSE2 != cpu.X86.SSE2 {
+		t.Fatalf("hasSSE2 = %v but cpu.X86.SSE2 = %v: dispatch flag is not wired to CPU detection", hasSSE2, cpu.X86.SSE2)
+	}
+	if hasAVX2 != cpu.X86.AVX2 {
+		t.Fatalf("hasAVX2 = %v but cpu.X86.AVX2 = %v: dispatch flag is not wired to CPU detection", hasAVX2, cpu.X86.AVX2)
+	}
 	if !hasSSE2 {
 		t.Fatal("hasSSE2 is false on amd64: PMADDWD is SSE2 baseline, so XCorr should never fall back to Go here")
 	}
-	if minSSE2XCorr > 16 || minAVX2XCorr > 32 {
+	// One vector block each, matching the kernel bodies. A bound of 2x the
+	// block would be a tautology against the real values (8 and 16).
+	if minSSE2XCorr > 8 || minAVX2XCorr > 16 {
 		t.Fatalf("XCorr thresholds too high (SSE2 %d, AVX2 %d): would not vectorize at the x lengths it was written for",
 			minSSE2XCorr, minAVX2XCorr)
+	}
+}
+
+// TestXCorr4AMD64_LongWindowIsClamped covers the other half of the kernel's
+// n = min(len(x), len(y)-3) clamp. ShortWindowIsBounded only probes
+// len(y)-3 < len(x); ParityWithGo passes len(y) == len(x)+3, where both
+// operands of the min are equal and a mutant that dropped the min entirely
+// would still agree.
+func TestXCorr4AMD64_LongWindowIsClamped(t *testing.T) {
+	for _, k := range xcorr4Kernels() {
+		t.Run(k.name, func(t *testing.T) {
+			if !k.available {
+				t.Skipf("%s not available", k.name)
+			}
+			for _, xn := range []int{1, 8, 9, 16, 17, 32} {
+				x := genI16(xn, 209)
+				y := genI16(xn+40, 210) // len(y)-3 far exceeds len(x)
+				dst := make([]int32, xcorrLagBlock)
+				k.fn(dst, x, y)
+				for lag := range xcorrLagBlock {
+					if got, want := dst[lag], dotOracle(x, y[lag:]); got != want {
+						t.Errorf("xcorr4%s long window xn=%d: dst[%d] = %d, want %d", k.name, xn, lag, got, want)
+					}
+				}
+			}
+		})
 	}
 }

--- a/i16/i16_amd64_test.go
+++ b/i16/i16_amd64_test.go
@@ -256,3 +256,77 @@ func TestDotDispatch_ReachesSIMD(t *testing.T) {
 			minSSE2Dot, minAVX2Dot)
 	}
 }
+
+// xcorr4Kernels mirrors dotKernels for the 4-lag cross-correlation tiers.
+type xcorr4Kernel struct {
+	name      string
+	available bool
+	fn        func(dst []int32, x, y []int16)
+}
+
+func xcorr4Kernels() []xcorr4Kernel {
+	return []xcorr4Kernel{
+		{"AVX2", cpu.X86.AVX2, xcorr4AVX2},
+		{"SSE2", cpu.X86.SSE2, xcorr4SSE2},
+	}
+}
+
+// TestXCorr4AMD64_ParityWithGo drives each 4-lag kernel directly, over lengths
+// the dispatcher would never route to it, so a threshold change cannot quietly
+// reduce this to a test of the Go reference against itself.
+func TestXCorr4AMD64_ParityWithGo(t *testing.T) {
+	for _, k := range xcorr4Kernels() {
+		t.Run(k.name, func(t *testing.T) {
+			if !k.available {
+				t.Skipf("%s not available", k.name)
+			}
+			for _, xn := range []int{1, 2, 7, 8, 9, 15, 16, 17, 23, 31, 32, 33, 64, 240} {
+				x := genI16(xn, 121)
+				y := genI16(xn+3, 122) // exactly the window the dispatcher passes
+				dst := make([]int32, xcorrLagBlock)
+				k.fn(dst, x, y)
+				for lag := range xcorrLagBlock {
+					if got, want := dst[lag], dotOracle(x, y[lag:]); got != want {
+						t.Errorf("xcorr4%s xn=%d: dst[%d] = %d, want %d", k.name, xn, lag, got, want)
+					}
+				}
+			}
+		})
+	}
+}
+
+// TestXCorr4AMD64_ShortWindowIsBounded feeds each kernel a y window shorter
+// than its contract and asserts it clamps rather than reading past the end.
+func TestXCorr4AMD64_ShortWindowIsBounded(t *testing.T) {
+	for _, k := range xcorr4Kernels() {
+		t.Run(k.name, func(t *testing.T) {
+			if !k.available {
+				t.Skipf("%s not available", k.name)
+			}
+			x := genI16(32, 123)
+			for _, yn := range []int{0, 1, 2, 3, 4, 8, 16, 31, 34} {
+				y := genI16(yn, 124)
+				dst := make([]int32, xcorrLagBlock)
+				k.fn(dst, x, y) // must not fault or read past y
+				n := max(min(len(x), yn-3), 0)
+				for lag := range xcorrLagBlock {
+					if got, want := dst[lag], dotOracle(x[:n], y[min(lag, yn):]); got != want {
+						t.Errorf("xcorr4%s short window yn=%d: dst[%d] = %d, want %d", k.name, yn, lag, got, want)
+					}
+				}
+			}
+		})
+	}
+}
+
+// TestXCorrDispatch_ReachesSIMD asserts XCorr actually routes to a kernel.
+// See the arm64 counterpart for why this must be white-box.
+func TestXCorrDispatch_ReachesSIMD(t *testing.T) {
+	if !hasSSE2 {
+		t.Fatal("hasSSE2 is false on amd64: PMADDWD is SSE2 baseline, so XCorr should never fall back to Go here")
+	}
+	if minSSE2XCorr > 16 || minAVX2XCorr > 32 {
+		t.Fatalf("XCorr thresholds too high (SSE2 %d, AVX2 %d): would not vectorize at the x lengths it was written for",
+			minSSE2XCorr, minAVX2XCorr)
+	}
+}

--- a/i16/i16_arm64.go
+++ b/i16/i16_arm64.go
@@ -51,13 +51,24 @@ func deinterleave2I16(a, b, src []int16) {
 // XCorr vectorizes once x is long enough that reusing each x load across four
 // lags pays for the kernel call. Below that the Go reference runs.
 //
-// Unlike minNEONDot above, this value is inherited rather than measured: it is
-// set to minNEONDot because the dot product is the per-lag work, and the 4-lag
-// amortisation can only move the break-even down from there, never up. It has
-// not been measured at the boundary, and the committed benchmarks start at
-// x=240, so they do not cover it either. Measure before lowering it.
+// This is set to minNEONDot because the dot product is the per-lag work and the
+// 4-lag amortisation should move the break-even down from there, not up. That
+// is a heuristic rather than an implication: the minNEONDot measurement put
+// both sides behind an indirect call so neither got a call-depth advantage,
+// whereas here the Go side inlines fully while the kernel cannot, so the two
+// break-evens are not directly comparable.
+//
+// Measured at the boundary (public XCorr against xcorrGo, 16 lags): at x=8 the
+// kernel is 3.5x ahead on Apple M (12.5 vs 43.8 ns) and 2.8x on Cortex-A76
+// (58.6 vs 164.3 ns), so 8 is safe and in fact conservative; the lag reuse
+// dominates well before the SIMD width does. The committed benchmarks start at
+// x=240 and do not cover this, so re-measure before moving it.
 const minNEONXCorr = 8
 
+// The block loop is inlined here rather than shared with amd64 through a driver
+// taking the kernel as a parameter: an indirect call defeats escape analysis
+// and forces every caller of XCorr to heap-allocate. See xcorrWindow in
+// i16_go.go. TestXCorr_AllocFree catches it if that refactor returns.
 func xcorrI16(dst []int32, x, y []int16) {
 	if !hasNEON || len(x) < minNEONXCorr {
 		xcorrGo(dst, x, y)

--- a/i16/i16_arm64.go
+++ b/i16/i16_arm64.go
@@ -48,6 +48,18 @@ func deinterleave2I16(a, b, src []int16) {
 	deinterleave2Go(a, b, src)
 }
 
+// XCorr vectorizes once x is long enough that reusing each x load across four
+// lags pays for the kernel call. Below that the Go reference runs.
+const minNEONXCorr = 8
+
+func xcorrI16(dst []int32, x, y []int16) {
+	if hasNEON && len(x) >= minNEONXCorr {
+		xcorrBlocked(dst, x, y, xcorr4NEON, dotNEON)
+		return
+	}
+	xcorrGo(dst, x, y)
+}
+
 func dotI16(a, b []int16) int32 {
 	if hasNEON && min(len(a), len(b)) >= minNEONDot {
 		return dotNEON(a, b)
@@ -57,6 +69,9 @@ func dotI16(a, b []int16) int32 {
 
 //go:noescape
 func dotNEON(a, b []int16) int32
+
+//go:noescape
+func xcorr4NEON(dst []int32, x, y []int16)
 
 //go:noescape
 func interleave2NEON(dst, a, b []int16)

--- a/i16/i16_arm64.go
+++ b/i16/i16_arm64.go
@@ -50,14 +50,29 @@ func deinterleave2I16(a, b, src []int16) {
 
 // XCorr vectorizes once x is long enough that reusing each x load across four
 // lags pays for the kernel call. Below that the Go reference runs.
+//
+// Unlike minNEONDot above, this value is inherited rather than measured: it is
+// set to minNEONDot because the dot product is the per-lag work, and the 4-lag
+// amortisation can only move the break-even down from there, never up. It has
+// not been measured at the boundary, and the committed benchmarks start at
+// x=240, so they do not cover it either. Measure before lowering it.
 const minNEONXCorr = 8
 
 func xcorrI16(dst []int32, x, y []int16) {
-	if hasNEON && len(x) >= minNEONXCorr {
-		xcorrBlocked(dst, x, y, xcorr4NEON, dotNEON)
+	if !hasNEON || len(x) < minNEONXCorr {
+		xcorrGo(dst, x, y)
 		return
 	}
-	xcorrGo(dst, x, y)
+	m := xcorrLags(dst, x, y)
+	k := 0
+	for ; k+xcorrLagBlock <= m; k += xcorrLagBlock {
+		xcorr4NEON(dst[k:k+xcorrLagBlock], x, xcorrWindow(x, y, k))
+	}
+	// Remainder lags go through the dot dispatcher, not dotNEON directly, so
+	// they still honour minNEONDot if minNEONXCorr is ever lowered below it.
+	for ; k < m; k++ {
+		dst[k] = dotI16(x, y[k:k+len(x)])
+	}
 }
 
 func dotI16(a, b []int16) int32 {

--- a/i16/i16_arm64.s
+++ b/i16/i16_arm64.s
@@ -165,3 +165,118 @@ dot_neon_scalar:
 dot_neon_done:
     MOVW R5, ret+48(FP)
     RET
+
+// func xcorr4NEON(dst []int32, x, y []int16)
+// Evaluates four consecutive correlation lags in one pass.
+//
+// This is the libopus xcorr_kernel shape: load eight x elements once, then
+// multiply-accumulate them against four overlapping y windows at element
+// offsets 0/1/2/3. Reusing the x load across four lags is the whole point of
+// the op, and it is why this beats calling the dot kernel once per lag. Eight
+// accumulators (two per lag) keep four independent SMLAL chains in flight.
+//
+// The four y loads are deliberately unaligned relative to each other: NEON
+// loads have no alignment requirement, so the overlapping windows are just
+// loads at +0/+2/+4/+6 bytes. That is cheaper than VEXT-ing the window along,
+// and it is why no aligned-load instruction may ever be substituted here.
+//
+// Accumulation wraps in int32 exactly as dotNEON's does, so dst[k] is
+// bit-identical to DotProduct(x, y[k:]).
+//
+// n = min(len(x), len(y)-3) is a safety net rather than a semantic: the
+// dispatcher hands this kernel a y window of exactly len(x)+3 elements, so the
+// clamp never fires in practice. It is here so that a wrapper bug becomes a
+// wrong number instead of an out-of-bounds read.
+TEXT ·xcorr4NEON(SB), NOSPLIT, $0-72
+    MOVD dst_base+0(FP), R0
+    MOVD x_base+24(FP), R1
+    MOVD x_len+32(FP), R2
+    MOVD y_base+48(FP), R3
+    MOVD y_len+56(FP), R4
+
+    // Two accumulators per lag: V16/V17 lag0, V18/V19 lag1, V20/V21 lag2,
+    // V22/V23 lag3.
+    VEOR V16.B16, V16.B16, V16.B16
+    VEOR V17.B16, V17.B16, V17.B16
+    VEOR V18.B16, V18.B16, V18.B16
+    VEOR V19.B16, V19.B16, V19.B16
+    VEOR V20.B16, V20.B16, V20.B16
+    VEOR V21.B16, V21.B16, V21.B16
+    VEOR V22.B16, V22.B16, V22.B16
+    VEOR V23.B16, V23.B16, V23.B16
+
+    SUBS $3, R4, R4            // R4 = len(y) - 3
+    BLE  xcorr4_neon_empty     // len(y) <= 3: no lag has a window
+    CMP  R4, R2
+    CSEL LT, R2, R4, R2        // R2 = n = min(len(x), len(y)-3)
+    B    xcorr4_neon_blocks
+
+xcorr4_neon_empty:
+    MOVD $0, R2                // n = 0: fold zeroed accumulators, store zeros
+
+xcorr4_neon_blocks:
+    LSR  $3, R2, R5            // R5 = n / 8
+    CBZ  R5, xcorr4_neon_fold
+
+xcorr4_neon_loop8:
+    VLD1.P 16(R1), [V0.H8]     // x[j..j+8), consumed by all four lags
+    VLD1   (R3), [V1.H8]       // y[j+0 .. j+8)  lag 0
+    ADD    $2, R3, R6
+    VLD1   (R6), [V2.H8]       // y[j+1 .. j+9)  lag 1
+    ADD    $2, R6, R6
+    VLD1   (R6), [V3.H8]       // y[j+2 .. j+10) lag 2
+    ADD    $2, R6, R6
+    VLD1   (R6), [V4.H8]       // y[j+3 .. j+11) lag 3
+    ADD    $16, R3             // advance y by 8 elements
+    WORD $0x0E618010           // SMLAL V16.4S, V0.4H, V1.4H
+    WORD $0x4E618011           // SMLAL2 V17.4S, V0.8H, V1.8H
+    WORD $0x0E628012           // SMLAL V18.4S, V0.4H, V2.4H
+    WORD $0x4E628013           // SMLAL2 V19.4S, V0.8H, V2.8H
+    WORD $0x0E638014           // SMLAL V20.4S, V0.4H, V3.4H
+    WORD $0x4E638015           // SMLAL2 V21.4S, V0.8H, V3.8H
+    WORD $0x0E648016           // SMLAL V22.4S, V0.4H, V4.4H
+    WORD $0x4E648017           // SMLAL2 V23.4S, V0.8H, V4.8H
+    SUB  $1, R5
+    CBNZ R5, xcorr4_neon_loop8
+
+xcorr4_neon_fold:
+    VADD V17.S4, V16.S4, V16.S4
+    VADD V19.S4, V18.S4, V18.S4
+    VADD V21.S4, V20.S4, V20.S4
+    VADD V23.S4, V22.S4, V22.S4
+    VADDV V16.S4, V16          // ADDV S16, V16.4S
+    VADDV V18.S4, V18          // ADDV S18, V18.4S
+    VADDV V20.S4, V20          // ADDV S20, V20.4S
+    VADDV V22.S4, V22          // ADDV S22, V22.4S
+    FMOVS F16, R7              // lag 0 partial sum
+    FMOVS F18, R8              // lag 1
+    FMOVS F20, R9              // lag 2
+    FMOVS F22, R10             // lag 3
+
+    AND  $7, R2, R11           // R11 = n mod 8
+    CBZ  R11, xcorr4_neon_store
+
+xcorr4_neon_scalar:
+    MOVH.P 2(R1), R12          // x[j], sign-extended
+    MOVH   0(R3), R13          // y[j+0]
+    MUL    R12, R13, R13
+    ADDW   R13, R7, R7
+    MOVH   2(R3), R13          // y[j+1]
+    MUL    R12, R13, R13
+    ADDW   R13, R8, R8
+    MOVH   4(R3), R13          // y[j+2]
+    MUL    R12, R13, R13
+    ADDW   R13, R9, R9
+    MOVH   6(R3), R13          // y[j+3]
+    MUL    R12, R13, R13
+    ADDW   R13, R10, R10
+    ADD    $2, R3
+    SUB    $1, R11
+    CBNZ   R11, xcorr4_neon_scalar
+
+xcorr4_neon_store:
+    MOVW R7, 0(R0)
+    MOVW R8, 4(R0)
+    MOVW R9, 8(R0)
+    MOVW R10, 12(R0)
+    RET

--- a/i16/i16_arm64_test.go
+++ b/i16/i16_arm64_test.go
@@ -187,3 +187,62 @@ func TestDotDispatch_ReachesNEON(t *testing.T) {
 		t.Fatalf("minNEONDot = %d exceeds two vector blocks: DotProduct would not vectorize at the short lengths it was written for", minNEONDot)
 	}
 }
+
+// TestXCorr4NEON_ParityWithGo drives the 4-lag kernel directly, over lengths
+// the dispatcher would never route to it, so a threshold change cannot quietly
+// reduce this to a test of the Go reference against itself.
+func TestXCorr4NEON_ParityWithGo(t *testing.T) {
+	if !cpu.ARM64.NEON {
+		t.Skip("NEON not available")
+	}
+	for _, xn := range []int{1, 2, 7, 8, 9, 15, 16, 17, 23, 31, 32, 33, 64, 240} {
+		x := genI16(xn, 111)
+		y := genI16(xn+3, 112) // exactly the window the dispatcher passes
+		dst := make([]int32, xcorrLagBlock)
+		xcorr4NEON(dst, x, y)
+		for k := range xcorrLagBlock {
+			if got, want := dst[k], dotOracle(x, y[k:]); got != want {
+				t.Errorf("xcorr4NEON xn=%d: dst[%d] = %d, want %d", xn, k, got, want)
+			}
+		}
+	}
+}
+
+// TestXCorr4NEON_ShortWindowIsBounded feeds the kernel a y window shorter than
+// its contract (len(x)+3) and asserts it clamps instead of reading past the
+// end. The dispatcher never does this; the in-assembly clamp exists so that a
+// future wrapper bug is a wrong number rather than an out-of-bounds read, and
+// this is what proves the net is really there.
+func TestXCorr4NEON_ShortWindowIsBounded(t *testing.T) {
+	if !cpu.ARM64.NEON {
+		t.Skip("NEON not available")
+	}
+	x := genI16(32, 113)
+	for _, yn := range []int{0, 1, 2, 3, 4, 8, 16, 31, 34} {
+		y := genI16(yn, 114)
+		dst := make([]int32, xcorrLagBlock)
+		xcorr4NEON(dst, x, y) // must not fault or read past y
+		n := max(min(len(x), yn-3), 0)
+		for k := range xcorrLagBlock {
+			if got, want := dst[k], dotOracle(x[:n], y[min(k, yn):]); got != want {
+				t.Errorf("xcorr4NEON short window yn=%d: dst[%d] = %d, want %d", yn, k, got, want)
+			}
+		}
+	}
+}
+
+// TestXCorrDispatch_ReachesNEON asserts XCorr actually routes to the kernel.
+// As with the dot product this must be white-box: the kernel is bit-identical
+// to the Go reference by design, so a dead dispatcher would pass every parity
+// test above while the SIMD path sat unused.
+func TestXCorrDispatch_ReachesNEON(t *testing.T) {
+	if !cpu.ARM64.NEON {
+		t.Skip("NEON not available")
+	}
+	if !hasNEON {
+		t.Fatal("hasNEON is false though cpu.ARM64.NEON is true: XCorr silently runs the Go reference")
+	}
+	if minNEONXCorr > 16 {
+		t.Fatalf("minNEONXCorr = %d: XCorr would not vectorize at the x lengths it was written for", minNEONXCorr)
+	}
+}

--- a/i16/i16_arm64_test.go
+++ b/i16/i16_arm64_test.go
@@ -235,14 +235,18 @@ func TestXCorr4NEON_ShortWindowIsBounded(t *testing.T) {
 // depends on: the feature flag is wired to CPU detection, and the threshold is
 // not absurd.
 //
-// Be clear about its limit: it does NOT prove xcorrI16 calls a kernel. Nothing
-// can, from the outside. The kernel is bit-identical to the Go reference by
-// design, so deleting the SIMD branch outright leaves every parity test green
-// and this test green too. Catching that would need an observable seam (a
-// package-level kernel func var to spy on), which would reintroduce the
-// indirect call that forces caller allocations (see xcorrWindow's comment).
-// The classes this does catch are a flag left unwired and a threshold retuned
-// out of range, which are the realistic regressions.
+// Be clear about its limit: it does NOT prove xcorrI16 calls a kernel. The
+// kernel is bit-identical to the Go reference by design, so deleting the SIMD
+// branch outright leaves every parity test green and this test green too. The
+// classes this does catch are a flag left unwired and a threshold retuned out
+// of range, which are the realistic regressions.
+//
+// That blind spot is closable and this test does not close it. A build-tagged
+// no-op hook in the dispatcher (a counter under a `simdspy` tag, an empty func
+// otherwise) would make routing observable while keeping the kernel call
+// direct, so it costs nothing in the default build. It is not done here only
+// because the gate judged the blind spot narrower than the change; do not read
+// this comment as evidence that it cannot be done.
 func TestXCorrDispatch_ReachesNEON(t *testing.T) {
 	if !cpu.ARM64.NEON {
 		t.Skip("NEON not available")
@@ -266,7 +270,13 @@ func TestXCorr4NEON_LongWindowIsClamped(t *testing.T) {
 		t.Skip("NEON not available")
 	}
 	for _, xn := range []int{1, 8, 9, 16, 17, 32} {
-		x := genI16(xn, 207)
+		// x MUST be a prefix of a longer allocation: the mutant this test
+		// exists for reads past the end of x, and past a standalone slice that
+		// is zeroed memory, which multiplies to 0 and leaves the answer
+		// correct. Non-zero bytes past x are what make the over-read
+		// observable rather than a coin flip on heap layout.
+		backing := genI16(xn+200, 207)
+		x := backing[:xn]
 		y := genI16(xn+40, 208) // len(y)-3 far exceeds len(x)
 		dst := make([]int32, xcorrLagBlock)
 		xcorr4NEON(dst, x, y)

--- a/i16/i16_arm64_test.go
+++ b/i16/i16_arm64_test.go
@@ -231,10 +231,18 @@ func TestXCorr4NEON_ShortWindowIsBounded(t *testing.T) {
 	}
 }
 
-// TestXCorrDispatch_ReachesNEON asserts XCorr actually routes to the kernel.
-// As with the dot product this must be white-box: the kernel is bit-identical
-// to the Go reference by design, so a dead dispatcher would pass every parity
-// test above while the SIMD path sat unused.
+// TestXCorrDispatch_ReachesNEON pins the dispatch STATE that XCorr's SIMD path
+// depends on: the feature flag is wired to CPU detection, and the threshold is
+// not absurd.
+//
+// Be clear about its limit: it does NOT prove xcorrI16 calls a kernel. Nothing
+// can, from the outside. The kernel is bit-identical to the Go reference by
+// design, so deleting the SIMD branch outright leaves every parity test green
+// and this test green too. Catching that would need an observable seam (a
+// package-level kernel func var to spy on), which would reintroduce the
+// indirect call that forces caller allocations (see xcorrWindow's comment).
+// The classes this does catch are a flag left unwired and a threshold retuned
+// out of range, which are the realistic regressions.
 func TestXCorrDispatch_ReachesNEON(t *testing.T) {
 	if !cpu.ARM64.NEON {
 		t.Skip("NEON not available")
@@ -244,5 +252,28 @@ func TestXCorrDispatch_ReachesNEON(t *testing.T) {
 	}
 	if minNEONXCorr > 16 {
 		t.Fatalf("minNEONXCorr = %d: XCorr would not vectorize at the x lengths it was written for", minNEONXCorr)
+	}
+}
+
+// TestXCorr4NEON_LongWindowIsClamped covers the other half of the kernel's
+// n = min(len(x), len(y)-3) clamp. TestXCorr4NEON_ShortWindowIsBounded only
+// probes len(y)-3 < len(x); ParityWithGo passes len(y) == len(x)+3, where both
+// operands of the min are equal and a mutant that dropped the min entirely
+// would still agree. This is the case that pins it: a y far longer than the
+// contract must not make the kernel read x past its end.
+func TestXCorr4NEON_LongWindowIsClamped(t *testing.T) {
+	if !cpu.ARM64.NEON {
+		t.Skip("NEON not available")
+	}
+	for _, xn := range []int{1, 8, 9, 16, 17, 32} {
+		x := genI16(xn, 207)
+		y := genI16(xn+40, 208) // len(y)-3 far exceeds len(x)
+		dst := make([]int32, xcorrLagBlock)
+		xcorr4NEON(dst, x, y)
+		for k := range xcorrLagBlock {
+			if got, want := dst[k], dotOracle(x, y[k:]); got != want {
+				t.Errorf("xcorr4NEON long window xn=%d: dst[%d] = %d, want %d", xn, k, got, want)
+			}
+		}
 	}
 }

--- a/i16/i16_go.go
+++ b/i16/i16_go.go
@@ -42,6 +42,14 @@ func dotGo(a, b []int16) int32 {
 // is the libopus xcorr_kernel shape: it is the point where each x load is
 // amortised across enough accumulators to hide the multiply-accumulate latency,
 // while still fitting the lag accumulators in registers.
+//
+// This is NOT a tunable. All three kernels hardcode four lags: their
+// accumulator count, their y load offsets (+0/+2/+4/+6 bytes), their
+// len(y)-3 clamp, and their four dst stores. Changing this constant compiles
+// cleanly and then breaks at runtime, in both directions: raising it leaves
+// the extra dst words unwritten, and lowering it makes the assembly store past
+// the end of the dst slice the dispatcher hands it, which is an out-of-bounds
+// write. Moving it means rewriting xcorr4NEON, xcorr4SSE2 and xcorr4AVX2.
 const xcorrLagBlock = 4
 
 // xcorrLags returns the number of lags whose full window fits in y, which is
@@ -64,25 +72,19 @@ func xcorrGo(dst []int32, x, y []int16) {
 	}
 }
 
-// xcorrBlocked drives a 4-lag SIMD kernel over as many full blocks of lags as
-// fit, then finishes the remaining one to three lags with the dot kernel. It is
-// shared by the amd64 and arm64 dispatchers, which differ only in the kernels
-// they pass.
+// xcorrWindow returns the y window the 4-lag kernel may read for the block at
+// lag k: lag k+3 reaches y[k+3+len(x)-1], so the block needs len(x)+3 elements
+// from y[k]. That is in bounds precisely when k+xcorrLagBlock <= m, which is
+// the loop condition every dispatcher uses, so the slice cannot panic.
 //
-// The y slice handed to kernel4 is exactly the window that block may read:
-// lag k+3 reaches y[k+3+len(x)-1], so the block needs len(x)+3 elements from
-// y[k]. That is in bounds precisely when k+xcorrLagBlock <= m, which is the
-// loop condition, so the slice expression cannot panic.
-func xcorrBlocked(dst []int32, x, y []int16,
-	kernel4 func(dst []int32, x, y []int16),
-	dot func(a, b []int16) int32,
-) {
-	m := xcorrLags(dst, x, y)
-	k := 0
-	for ; k+xcorrLagBlock <= m; k += xcorrLagBlock {
-		kernel4(dst[k:k+xcorrLagBlock], x, y[k:k+len(x)+xcorrLagBlock-1])
-	}
-	for ; k < m; k++ {
-		dst[k] = dot(x, y[k:k+len(x)])
-	}
+// The per-arch dispatchers each inline their own block loop rather than sharing
+// one driver parameterised by the kernel. That looks like needless duplication
+// and is not: passing the kernel as a func value makes the call indirect, and
+// escape analysis cannot see through an indirect call, so it must assume the
+// slices escape. That defeats the //go:noescape on the kernels and propagates
+// out to XCorr itself, forcing every CALLER to heap-allocate its dst, x and y.
+// Direct calls keep the whole path allocation-free. Do not "simplify" the
+// dispatchers back into a shared higher-order driver.
+func xcorrWindow(x, y []int16, k int) []int16 {
+	return y[k : k+len(x)+xcorrLagBlock-1]
 }

--- a/i16/i16_go.go
+++ b/i16/i16_go.go
@@ -37,3 +37,52 @@ func dotGo(a, b []int16) int32 {
 	}
 	return s
 }
+
+// xcorrLagBlock is the number of lags the SIMD kernels evaluate per call. Four
+// is the libopus xcorr_kernel shape: it is the point where each x load is
+// amortised across enough accumulators to hide the multiply-accumulate latency,
+// while still fitting the lag accumulators in registers.
+const xcorrLagBlock = 4
+
+// xcorrLags returns the number of lags whose full window fits in y, which is
+// what XCorr computes. Lags past this point would read off the end of y, so
+// they are not computed and dst is left untouched there.
+func xcorrLags(dst []int32, x, y []int16) int {
+	if len(x) == 0 || len(y) < len(x) {
+		return 0
+	}
+	return min(len(dst), len(y)-len(x)+1)
+}
+
+// xcorrGo is the pure-Go reference: one wrapping int32 dot product per lag. It
+// is the bit-exact source of truth the SIMD XCorr kernels are validated
+// against, and it is defined in terms of dotGo so the two primitives cannot
+// drift apart.
+func xcorrGo(dst []int32, x, y []int16) {
+	for k := range xcorrLags(dst, x, y) {
+		dst[k] = dotGo(x, y[k:])
+	}
+}
+
+// xcorrBlocked drives a 4-lag SIMD kernel over as many full blocks of lags as
+// fit, then finishes the remaining one to three lags with the dot kernel. It is
+// shared by the amd64 and arm64 dispatchers, which differ only in the kernels
+// they pass.
+//
+// The y slice handed to kernel4 is exactly the window that block may read:
+// lag k+3 reaches y[k+3+len(x)-1], so the block needs len(x)+3 elements from
+// y[k]. That is in bounds precisely when k+xcorrLagBlock <= m, which is the
+// loop condition, so the slice expression cannot panic.
+func xcorrBlocked(dst []int32, x, y []int16,
+	kernel4 func(dst []int32, x, y []int16),
+	dot func(a, b []int16) int32,
+) {
+	m := xcorrLags(dst, x, y)
+	k := 0
+	for ; k+xcorrLagBlock <= m; k += xcorrLagBlock {
+		kernel4(dst[k:k+xcorrLagBlock], x, y[k:k+len(x)+xcorrLagBlock-1])
+	}
+	for ; k < m; k++ {
+		dst[k] = dot(x, y[k:k+len(x)])
+	}
+}

--- a/i16/i16_other.go
+++ b/i16/i16_other.go
@@ -5,3 +5,4 @@ package i16
 func interleave2I16(dst, a, b []int16)   { interleave2Go(dst, a, b) }
 func deinterleave2I16(a, b, src []int16) { deinterleave2Go(a, b, src) }
 func dotI16(a, b []int16) int32          { return dotGo(a, b) }
+func xcorrI16(dst []int32, x, y []int16) { xcorrGo(dst, x, y) }

--- a/i16/xcorr.go
+++ b/i16/xcorr.go
@@ -20,7 +20,15 @@ package i16
 // therefore always identical to DotProduct(x, y[k:k+len(x)]), which is the
 // property the tests pin.
 //
-// x and y are read-only; the call allocates nothing.
+// x and y are read-only; the call allocates nothing, including for the caller
+// (the parameters do not escape).
+//
+// Note the operand order relative to [github.com/tphakala/simd/f32.ConvolveValid],
+// which computes the same thing for float32: that one takes the long slid
+// operand second and the short stationary operand third, where XCorr takes the
+// short one (x) second. Passing them in f32's order here binds x to the long
+// operand, trips the len(y) < len(x) guard, and returns having written nothing,
+// with no panic and no diagnostic.
 func XCorr(dst []int32, x, y []int16) {
 	if len(dst) == 0 || len(x) == 0 || len(y) < len(x) {
 		return

--- a/i16/xcorr.go
+++ b/i16/xcorr.go
@@ -1,0 +1,29 @@
+package i16
+
+// XCorr fills dst[k] with the wrapping int32 dot product of x against y[k:]:
+//
+//	dst[k] = sum_j int32(x[j]) * int32(y[k+j])   for j in [0, len(x))
+//
+// for k in [0, m), where m = min(len(dst), len(y)-len(x)+1). This is multi-lag
+// cross-correlation, the shape pitch analysis and filtering call at: it reuses
+// each x load across several lag accumulators instead of re-reading x per lag.
+//
+// Only lags whose full window fits in y are computed. dst[m:] is left untouched
+// rather than zeroed, matching the library's clamp-and-leave-the-tail
+// convention, so a caller can size dst generously without losing prior contents.
+// A call with len(x) == 0, len(y) < len(x), or empty dst computes nothing.
+//
+// Each lag accumulates in int32 with two's-complement wraparound, exactly as
+// [DotProduct] does and for the same reason: wrapping addition is associative,
+// so the lane grouping and horizontal reduction are bit-identical to the scalar
+// loop for every input, including operands engineered to overflow. dst[k] is
+// therefore always identical to DotProduct(x, y[k:k+len(x)]), which is the
+// property the tests pin.
+//
+// x and y are read-only; the call allocates nothing.
+func XCorr(dst []int32, x, y []int16) {
+	if len(dst) == 0 || len(x) == 0 || len(y) < len(x) {
+		return
+	}
+	xcorrI16(dst, x, y)
+}

--- a/i16/xcorr_test.go
+++ b/i16/xcorr_test.go
@@ -204,6 +204,42 @@ func TestXCorr_UnalignedOperands(t *testing.T) {
 	}
 }
 
+// TestXCorrGo_DegenerateDirect exercises the reference and its lag count with
+// unguarded inputs, which the public API never delivers: XCorr's own guard
+// rejects them first, so xcorrLags' len(x)==0 / len(y)<len(x) branch is
+// unreachable through XCorr and went untested (codecov flagged it at 66.7%).
+//
+// The branch is not dead code. xcorrGo and xcorrLags are called DIRECTLY by
+// the benchmarks, by xcorrOracle, and by the non-SIMD dispatch path, none of
+// which re-check. This pins that contract rather than leaving it to the guard
+// two layers up.
+func TestXCorrGo_DegenerateDirect(t *testing.T) {
+	const sentinel = int32(-5150)
+	cases := []struct {
+		name string
+		x, y []int16
+	}{
+		{"empty x", nil, genI16(8, 211)},
+		{"empty y", genI16(8, 211), nil},
+		{"y shorter than x", genI16(8, 211), genI16(7, 212)},
+		{"both empty", nil, nil},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			dst := []int32{sentinel, sentinel, sentinel}
+			if got := xcorrLags(dst, c.x, c.y); got != 0 {
+				t.Errorf("xcorrLags = %d, want 0", got)
+			}
+			xcorrGo(dst, c.x, c.y) // must not panic
+			for i, v := range dst {
+				if v != sentinel {
+					t.Errorf("xcorrGo wrote dst[%d] = %d, want untouched sentinel %d", i, v, sentinel)
+				}
+			}
+		})
+	}
+}
+
 // TestXCorr_KernelHonoursDstBounds forces the 4-lag kernel to run (m=8, two
 // full blocks, no remainder) while giving dst room past m, so a kernel that
 // wrote a fifth word per block would corrupt dst[8:].

--- a/i16/xcorr_test.go
+++ b/i16/xcorr_test.go
@@ -1,0 +1,204 @@
+package i16
+
+import (
+	"math"
+	"testing"
+)
+
+// Tests for XCorr.
+//
+// The defining property is that XCorr is DotProduct evaluated at every lag:
+// dst[k] must equal DotProduct(x, y[k:k+len(x))) exactly, for every k. That is
+// the invariant most of these tests assert, because it is stronger than
+// checking against a second hand-written loop and it ties the two primitives
+// together: a kernel that drifted from the dot product would be caught even if
+// its own reference drifted with it.
+//
+// The lag-blocking is where the bugs live. The SIMD path evaluates 4 lags per
+// call and finishes the remainder with the dot kernel, so lag counts that are
+// not multiples of 4 exercise the seam, and each lag reads y at a different
+// offset (only one of which can be even-aligned).
+
+// xcorrOracle computes each lag with the independent int64 oracle rather than
+// with dotGo, so a fault in the dot reference cannot hide by being consistent
+// with itself.
+func xcorrOracle(dst []int32, x, y []int16) []int32 {
+	out := make([]int32, len(dst))
+	copy(out, dst)
+	for k := range xcorrLags(dst, x, y) {
+		out[k] = dotOracle(x, y[k:])
+	}
+	return out
+}
+
+func equalI32(t *testing.T, what string, got, want []int32) {
+	t.Helper()
+	for i := range got {
+		if got[i] != want[i] {
+			t.Fatalf("%s: dst[%d] = %d, want %d (len=%d)", what, i, got[i], want[i], len(got))
+		}
+	}
+}
+
+// TestXCorr_MatchesDotProductAtEveryLag is the core property test. The lag
+// counts deliberately straddle the 4-lag block boundary in both directions, and
+// the x lengths straddle the 8- and 16-wide kernel bodies plus their tails.
+func TestXCorr_MatchesDotProductAtEveryLag(t *testing.T) {
+	for _, xn := range []int{1, 2, 3, 7, 8, 9, 11, 15, 16, 17, 23, 24, 31, 32, 33, 64, 240} {
+		for _, lags := range []int{1, 2, 3, 4, 5, 6, 7, 8, 9, 12, 13, 16, 17, 61} {
+			x := genI16(xn, 91)
+			y := genI16(xn+lags-1, 92)
+			dst := make([]int32, lags)
+			XCorr(dst, x, y)
+			for k := range lags {
+				if got, want := dst[k], DotProduct(x, y[k:k+xn]); got != want {
+					t.Fatalf("XCorr(xn=%d, lags=%d): dst[%d] = %d, want DotProduct = %d", xn, lags, k, got, want)
+				}
+			}
+		}
+	}
+}
+
+// TestXCorr_ParityWithReference checks the dispatched path against both the Go
+// reference and the independent int64 oracle across the same grid.
+func TestXCorr_ParityWithReference(t *testing.T) {
+	for _, xn := range []int{1, 8, 9, 16, 17, 33, 64, 240} {
+		for _, lags := range []int{1, 3, 4, 5, 8, 11, 16, 61} {
+			x := genI16(xn, 93)
+			y := genI16(xn+lags+5, 94)
+			dst := make([]int32, lags)
+			ref := make([]int32, lags)
+			XCorr(dst, x, y)
+			xcorrGo(ref, x, y)
+			equalI32(t, "XCorr vs reference", dst, ref)
+			equalI32(t, "XCorr vs oracle", dst, xcorrOracle(make([]int32, lags), x, y))
+		}
+	}
+}
+
+// TestXCorr_ClampLeavesTailUntouched pins the documented contract: only lags
+// with a full window are computed, and dst beyond that keeps its prior value.
+// The sentinel is what catches a kernel that wrote a partial window as if it
+// were a real result.
+func TestXCorr_ClampLeavesTailUntouched(t *testing.T) {
+	const sentinel = int32(-999111)
+	x := genI16(16, 95)
+	// y holds exactly 3 full windows worth of lags (16+2 elements -> lags 0..2).
+	y := genI16(18, 96)
+	dst := make([]int32, 10)
+	for i := range dst {
+		dst[i] = sentinel
+	}
+	XCorr(dst, x, y)
+
+	wantLags := len(y) - len(x) + 1 // 3
+	for k := range wantLags {
+		if got, want := dst[k], DotProduct(x, y[k:k+len(x)]); got != want {
+			t.Errorf("dst[%d] = %d, want %d", k, got, want)
+		}
+	}
+	for k := wantLags; k < len(dst); k++ {
+		if dst[k] != sentinel {
+			t.Errorf("dst[%d] = %d, want the sentinel %d left untouched (lag has no full window)", k, dst[k], sentinel)
+		}
+	}
+}
+
+// TestXCorr_Degenerate covers the inputs that compute nothing. Each must leave
+// dst entirely untouched rather than zeroing or panicking.
+func TestXCorr_Degenerate(t *testing.T) {
+	const sentinel = int32(4242)
+	cases := []struct {
+		name string
+		x, y []int16
+	}{
+		{"empty x", nil, genI16(8, 97)},
+		{"empty y", genI16(8, 97), nil},
+		{"y shorter than x", genI16(8, 97), genI16(7, 98)},
+		{"both empty", nil, nil},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			dst := []int32{sentinel, sentinel, sentinel}
+			XCorr(dst, c.x, c.y)
+			for i, v := range dst {
+				if v != sentinel {
+					t.Errorf("dst[%d] = %d, want untouched sentinel %d", i, v, sentinel)
+				}
+			}
+		})
+	}
+	// Empty dst must not panic.
+	XCorr(nil, genI16(8, 97), genI16(16, 98))
+	XCorr([]int32{}, genI16(8, 97), genI16(16, 98))
+}
+
+// TestXCorr_ExactWindow is the boundary the clamp math turns on: y is exactly
+// len(x) long, so lag 0 is the only one with a full window.
+func TestXCorr_ExactWindow(t *testing.T) {
+	const sentinel = int32(7)
+	x := genI16(16, 99)
+	y := genI16(16, 100)
+	dst := []int32{sentinel, sentinel, sentinel, sentinel, sentinel}
+	XCorr(dst, x, y)
+	if got, want := dst[0], DotProduct(x, y); got != want {
+		t.Errorf("dst[0] = %d, want %d", got, want)
+	}
+	for k := 1; k < len(dst); k++ {
+		if dst[k] != sentinel {
+			t.Errorf("dst[%d] = %d, want untouched: only lag 0 has a full window", k, dst[k])
+		}
+	}
+}
+
+// TestXCorr_MinInt16 drives the int32 accumulator past its range at every lag.
+// Note all-MinInt16 operands are sign-symmetric, so this catches a miscounted
+// element but NOT a sign or lane error; TestXCorr_MatchesDotProductAtEveryLag
+// with genI16 data is what covers those.
+func TestXCorr_MinInt16(t *testing.T) {
+	for _, xn := range []int{8, 9, 16, 17, 33} {
+		for _, lags := range []int{1, 4, 5, 8, 9} {
+			x := make([]int16, xn)
+			y := make([]int16, xn+lags-1)
+			for i := range x {
+				x[i] = math.MinInt16
+			}
+			for i := range y {
+				y[i] = math.MinInt16
+			}
+			dst := make([]int32, lags)
+			XCorr(dst, x, y)
+			equalI32(t, "XCorr all-MinInt16", dst, xcorrOracle(make([]int32, lags), x, y))
+		}
+	}
+}
+
+// TestXCorr_UnalignedOperands is not an edge case for this op, it is the normal
+// shape: lag k reads y at element offset k, so at most one lag in four can be
+// 16-byte aligned and the odd lags are only 2-byte aligned. An aligned-load
+// regression in the kernels would fault here.
+func TestXCorr_UnalignedOperands(t *testing.T) {
+	base := genI16(600, 101)
+	for _, xn := range []int{8, 16, 17, 32} {
+		for off := range 8 {
+			x := base[off : off+xn]
+			y := base[off+3 : off+3+xn+20]
+			dst := make([]int32, 20)
+			XCorr(dst, x, y)
+			for k := range 20 {
+				if got, want := dst[k], DotProduct(x, y[k:k+xn]); got != want {
+					t.Fatalf("XCorr unaligned xn=%d off=%d: dst[%d] = %d, want %d", xn, off, k, got, want)
+				}
+			}
+		}
+	}
+}
+
+func TestXCorr_AllocFree(t *testing.T) {
+	x := genI16(240, 102)
+	y := genI16(600, 103)
+	dst := make([]int32, 64)
+	if n := testing.AllocsPerRun(50, func() { XCorr(dst, x, y) }); n != 0 {
+		t.Errorf("XCorr allocates %v times per run, want 0", n)
+	}
+}

--- a/i16/xcorr_test.go
+++ b/i16/xcorr_test.go
@@ -22,6 +22,11 @@ import (
 // xcorrOracle computes each lag with the independent int64 oracle rather than
 // with dotGo, so a fault in the dot reference cannot hide by being consistent
 // with itself.
+//
+// It pins the per-lag ARITHMETIC only. It calls the production xcorrLags, so a
+// lag-count bug would propagate into the expectation rather than being caught.
+// The lag count is pinned separately by the tests that recompute it inline
+// (TestXCorr_MatchesDotProductAtEveryLag, TestXCorr_ClampLeavesTailUntouched).
 func xcorrOracle(dst []int32, x, y []int16) []int32 {
 	out := make([]int32, len(dst))
 	copy(out, dst)
@@ -33,6 +38,9 @@ func xcorrOracle(dst []int32, x, y []int16) []int32 {
 
 func equalI32(t *testing.T, what string, got, want []int32) {
 	t.Helper()
+	if len(got) != len(want) {
+		t.Fatalf("%s: length got %d want %d", what, len(got), len(want))
+	}
 	for i := range got {
 		if got[i] != want[i] {
 			t.Fatalf("%s: dst[%d] = %d, want %d (len=%d)", what, i, got[i], want[i], len(got))
@@ -78,8 +86,10 @@ func TestXCorr_ParityWithReference(t *testing.T) {
 
 // TestXCorr_ClampLeavesTailUntouched pins the documented contract: only lags
 // with a full window are computed, and dst beyond that keeps its prior value.
-// The sentinel is what catches a kernel that wrote a partial window as if it
-// were a real result.
+//
+// Note this case has m=3, below xcorrLagBlock, so it exercises the remainder
+// path only and never calls the 4-lag kernel. TestXCorr_KernelHonoursDstBounds
+// is the one that pins the kernel's own dst writes.
 func TestXCorr_ClampLeavesTailUntouched(t *testing.T) {
 	const sentinel = int32(-999111)
 	x := genI16(16, 95)
@@ -194,11 +204,52 @@ func TestXCorr_UnalignedOperands(t *testing.T) {
 	}
 }
 
+// TestXCorr_KernelHonoursDstBounds forces the 4-lag kernel to run (m=8, two
+// full blocks, no remainder) while giving dst room past m, so a kernel that
+// wrote a fifth word per block would corrupt dst[8:].
+//
+// The sentinel tests above cannot catch that: each has m < xcorrLagBlock, so
+// the block loop never executes and only the scalar remainder path runs. Every
+// other test that does reach the kernel passes dst with len(dst) == m exactly,
+// which leaves no room for an over-write to land in. This is the only test
+// where a kernel dst over-write is observable.
+func TestXCorr_KernelHonoursDstBounds(t *testing.T) {
+	const sentinel = int32(-31337)
+	for _, xn := range []int{8, 16, 17, 32} {
+		x := genI16(xn, 205)
+		y := genI16(xn+7, 206) // m = 8: exactly two kernel blocks
+		dst := make([]int32, 12)
+		for i := range dst {
+			dst[i] = sentinel
+		}
+		XCorr(dst, x, y)
+		for k := range 8 {
+			if got, want := dst[k], dotOracle(x, y[k:]); got != want {
+				t.Errorf("xn=%d: dst[%d] = %d, want %d", xn, k, got, want)
+			}
+		}
+		for k := 8; k < len(dst); k++ {
+			if dst[k] != sentinel {
+				t.Errorf("xn=%d: dst[%d] = %d, want untouched sentinel %d (kernel wrote past its block)", xn, k, dst[k], sentinel)
+			}
+		}
+	}
+}
+
+// TestXCorr_AllocFree pins the zero-allocation contract from the CALLER's side.
+// The buffers are declared INSIDE the measured closure deliberately: hoisting
+// them out (the obvious way to write this) measures only XCorr's own
+// allocations and passes even when XCorr leaks its parameters, forcing every
+// caller to heap-allocate. That regression is exactly what a shared
+// higher-order dispatcher reintroduces, since escape analysis cannot see
+// through an indirect call.
 func TestXCorr_AllocFree(t *testing.T) {
-	x := genI16(240, 102)
-	y := genI16(600, 103)
-	dst := make([]int32, 64)
-	if n := testing.AllocsPerRun(50, func() { XCorr(dst, x, y) }); n != 0 {
-		t.Errorf("XCorr allocates %v times per run, want 0", n)
+	if n := testing.AllocsPerRun(50, func() {
+		var xa [240]int16
+		var ya [600]int16
+		var da [64]int32
+		XCorr(da[:], xa[:], ya[:])
+	}); n != 0 {
+		t.Errorf("XCorr forces %v caller allocations per run, want 0", n)
 	}
 }


### PR DESCRIPTION
Adds `i16.XCorr(dst []int32, x, y []int16)`, multi-lag cross-correlation. PR B of the three-part stack for #142; PR A (`i16.DotProduct`) landed as #143. Tier-3 ops follow in PR C.

## What it is

Cross-correlation evaluates a dot product at every lag, and the naive shape re-reads `x` once per lag. `XCorr` loads `x` once and multiply-accumulates it against four overlapping `y` windows at element offsets 0/1/2/3, which is the libopus `xcorr_kernel` shape. That reuse is the entire point of the op: per #142 it is where pitch analysis spends its time, at ~61 calls per 20 ms frame.

`dst[k]` is defined to equal `DotProduct(x, y[k:k+len(x)])` exactly, and the tests assert that property directly rather than against a second hand-written loop. Tying the two primitives together means a kernel that drifted from the dot product is caught even if this op's own reference drifted with it. Accumulation wraps in int32 for the same reason it does in `DotProduct`.

Only lags whose full window fits in `y` are computed; `dst` beyond that is left untouched rather than zeroed, matching the library's clamp-and-leave-the-tail convention (and `f32.ConvolveValid`'s).

## Performance

Against the Go reference at x=240:

| Lags | AMD64 (AVX2) | ARM64 (NEON, Pi 5) |
| --- | --- | --- |
| 4 | 26.6x | 6.9x |
| 64 | 29.9x | 7.2x |
| 288 | 32.7x | 7.3x |

The speedup exceeds `DotProduct`'s because the scalar baseline re-reads `x` per lag, which is exactly the work the blocking removes.

## What the review changed

The gate found a real defect worth calling out: `xcorrBlocked` originally took the kernel as a **func-value parameter**, and escape analysis cannot see through an indirect call, so it assumed the slices escape. That defeated the `//go:noescape` on the kernels and propagated to the public API, forcing **every caller** to heap-allocate (3 allocs/call, and 4.3x slower for stack-buffer callers). The dispatchers now call kernels directly; params no longer escape, verified from an external module. Perf improved slightly, so the abstraction was costing rather than paying.

`TestXCorr_AllocFree` could not have caught it: it hoisted the buffers out of the measured closure. It now declares them inside, and restoring the old driver makes it report exactly the 3 allocations.

## Testing

Bit-exact on **darwin/arm64, linux/arm64 (Cortex-A76) and linux/amd64 (AVX2 + SSE2)**, plus cross-builds for 386, riscv64, ppc64le, s390x and js/wasm.

Every test in this PR was mutation-tested rather than assumed. Mutations verified to fail: swapping lag accumulators, dropping a lag, off-by-one in the y offset, off-by-one in the block bound, a dropped scalar tail, zeroing `dst[m:]`, deleting the remainder path, dropping either half of the in-assembly clamp, and a kernel writing a fifth `dst` word.

Three of those only died after the review found they survived. A fourth, the clamp test, detected nothing on amd64 until a re-review of the fix wave caught that it read past `x` into zeroed memory.

Independent verification: Agent 6 proved additivity at the machine-code level (0 instructions changed, 377/294 added, all new symbols) and swept ~84k length combinations on every dispatch tier; Agent 2 built guard-page harnesses where any over-read segfaults; Gemini independently derived the same bounds proof for the lag-blocking seam. `asmcheck` cross-checks the eight new `SMLAL` encodings against `arm64asm`.

## Known, filed not fixed

#145: `xcorr4AVX2` is 1.36-1.75x slower than SSE2 when `len(x)%16 >= 8`, because it drops from its 16-wide body to a 4-lag scalar tail. Off the motivating caller's path (x=240 is aligned), and the fix is new hand-written assembly that wants its own correctness round. This PR adds the benchmarks that expose it (x=25, x=248), which the previous lengths structurally could not.

Refs #142

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added `XCorr` for 16-bit integer cross-correlation, producing per-lag 32-bit dot products with valid-lag clamping.
  * Preserves any unused tail of the destination slice.
  * Includes optimized execution paths on supported CPU architectures, with a portable fallback.

* **Documentation**
  * Updated package docs and README with `XCorr` usage guidance and performance notes.

* **Tests**
  * Added extensive correctness coverage (including SIMD parity and tail/edge cases), plus fuzzing, benchmarks, and a runnable example.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->