### PR TITLE
i16: fix xcorr4AVX2 scalar tail (8-wide block before the 16-wide loop)

### DIFF
--- a/i16/i16_amd64.go
+++ b/i16/i16_amd64.go
@@ -36,8 +36,13 @@ const (
 )
 
 // XCorr vectorizes once x is long enough that reusing each x load across four
-// lags pays for the kernel call. The AVX2 body needs 16 elements; below that
-// SSE2's 8 still wins, and below 8 the Go reference runs.
+// lags pays for the kernel call, and below 8 the Go reference runs.
+//
+// Both kernels vectorize from 8 (see xcorr4AVX2's 8-wide block), so the cut at
+// 16 is not about AVX2 needing 16 elements to vectorize. It is that AVX2's fold
+// pays four extra VEXTRACTI128 plus VZEROUPPER, a flat cost only the 16-wide
+// body amortizes: measured at len(x) 8-15 AVX2 is 5-13% slower than SSE2, and at
+// len(x) >= 16 it is never slower.
 const (
 	minSSE2XCorr = 8
 	minAVX2XCorr = 16

--- a/i16/i16_amd64.s
+++ b/i16/i16_amd64.s
@@ -488,40 +488,44 @@ xcorr4_sse2_store:
     RET
 
 // func xcorr4AVX2(dst []int32, x, y []int16)
-// As xcorr4SSE2 at twice the width; VPMADDWD's three-operand form also spares
-// the reload-into-destination dance.
+// As xcorr4SSE2 at twice the width, plus an 8-wide tier SSE2 has no need for;
+// VPMADDWD's three-operand form also spares the reload-into-destination dance.
 //
 // An 8-wide XMM block runs BEFORE the 16-wide loop, so a remainder of 8-15
 // elements costs one vector block plus at most 7 scalar iterations rather than
-// 8-15 scalar iterations across four lags. Without it AVX2 was up to 1.75x
-// SLOWER than SSE2 for half the len(x) domain, which is exactly where the
-// dispatcher prefers it (issue #145). This is the epilogue-vectorization shape
-// LLVM emits for the same reason, except placed before the body rather than
-// after; see below for why that direction is available here.
+// 8-15 scalar iterations across four lags. Without it AVX2 lost to SSE2 across
+// half the len(x) domain, which is exactly where the dispatcher prefers it; see
+// #145 for the measurements. A narrow tier below the wide body is the usual
+// shape here (f32/f32_amd64.s dot32_loop8_check, f64/f64_amd64.s var_avx_loop4),
+// but both of those put it after the body, and get it for free from their
+// unroll: at float32 a YMM holds 8, so the 8-wide tier IS one register. At int16
+// a YMM holds 16, so the tier below the body has to be written by hand, and it
+// goes before the body for the reason below.
 //
-// The ordering is the whole trick, and it is not stylistic. A VEX.128 write
-// zeroes bits 255:128 of the destination (Intel SDM Vol 2, 14.1), so
-// accumulating an XMM block into X4-X7 AFTER the 16-wide loop would silently
-// discard that loop's upper-lane sums. Running it FIRST, while Y4-Y7 are still
-// freshly VPXOR'd, means the zeroing writes zero over zero; the 16-wide loop
-// then accumulates on top with VEX.256, which preserves the low lane, and the
-// fold is untouched. Mixing VEX.128 and VEX.256 costs nothing: the transition
-// penalty applies to legacy-SSE encodings, not to VEX at either width.
+// Accumulating into X4-X7 with VEX.128 writes is what forces that order, not
+// taste. A VEX.128 write zeroes bits 255:128 of its destination (the hazard the
+// f32 kernels flag as "VEX scalar ops zero upper YMM"), so a block running AFTER
+// the 16-wide loop would silently discard that loop's upper-lane sums. Running
+// it FIRST, while Y4-Y7 are still freshly VPXOR'd, means the zeroing writes zero
+// over zero; the loop then accumulates on top with VEX.256, which preserves the
+// low lane, and the fold needs no extra instructions. Mixing VEX.128 and VEX.256
+// costs nothing: the transition penalty is a legacy-SSE-encoding problem, not a
+// VEX one. (A block that LOADED VEX.128 but COMPUTED VEX.256 could sit after the
+// body instead, since the zeroed upper lanes would contribute zero. That shape
+// would not need the reordering, nor the argument below. This one does.)
 //
-// Reordering the input this way is legal only because the accumulation wraps:
-// wrapping int32 addition is associative and commutative, so summing the
-// remainder before the body is bit-identical to summing it after. This is the
-// same property XCorr's doc comment guarantees to callers. A saturating
-// accumulator could not be reordered like this.
+// Summing the remainder before the body is bit-exact only because the
+// accumulation wraps: wrapping int32 addition is associative and commutative, so
+// regrouping the terms cannot change the result. The regrouping is real, not
+// just a lane permutation: these 8 elements used to go through the scalar tail
+// one product at a time, and now go through VPMADDWD, which adds each adjacent
+// pair before accumulating. XCorr's doc comment guarantees to callers the
+// wrapping this rests on. VPMADDWD itself is safe for the same reason: a pair of
+// 0x8000*0x8000 products sums to 0x80000000 and it WRAPS there, it does not
+// saturate. A saturating accumulator could not be reordered like this at all.
 //
-// Cost at len(x)%16 == 0, measured with perf on an i7-1260P (retired
-// instructions, which unlike wall time are immune to this part's wandering
-// clock and to the code-layout shift the inserted block causes): +2.017
-// instructions per kernel call against a 360-instruction baseline, i.e. exactly
-// the TESTQ and its predicted-taken JZ, for +0.7% cycles. The obvious
-// alternative, accumulating the block into separate X8-X11 and folding them in
-// afterwards, needs four extra unconditional fold VPADDDs; #145 measured that
-// shape at 3-4% on the aligned lengths the motivating fixed-point caller uses.
+// At len(x)%16 == 0 the block is branched over and the kernel pays only the
+// TESTQ and its predicted-taken JZ.
 TEXT ·xcorr4AVX2(SB), NOSPLIT, $0-72
     MOVQ dst_base+0(FP), DI
     MOVQ x_base+24(FP), SI
@@ -564,9 +568,8 @@ xcorr4_avx2_blocks:
     ADDQ $16, BX               // y slides by the same 8, lag offsets unchanged
 
     // The block count is computed AFTER the 8-wide block, not before, so SHRQ's
-    // own ZF still drives the branch below. Computing it first would cost a
-    // separate TESTQ AX, AX; perf puts the aligned-length overhead at exactly 2
-    // extra instructions per call this way versus 3.
+    // own ZF still drives the branch below; computing it first would need a
+    // separate TESTQ AX, AX.
 xcorr4_avx2_blocks16:
     MOVQ CX, AX
     SHRQ $4, AX                // AX = n / 16, the 16-wide block count

--- a/i16/i16_amd64.s
+++ b/i16/i16_amd64.s
@@ -490,6 +490,38 @@ xcorr4_sse2_store:
 // func xcorr4AVX2(dst []int32, x, y []int16)
 // As xcorr4SSE2 at twice the width; VPMADDWD's three-operand form also spares
 // the reload-into-destination dance.
+//
+// An 8-wide XMM block runs BEFORE the 16-wide loop, so a remainder of 8-15
+// elements costs one vector block plus at most 7 scalar iterations rather than
+// 8-15 scalar iterations across four lags. Without it AVX2 was up to 1.75x
+// SLOWER than SSE2 for half the len(x) domain, which is exactly where the
+// dispatcher prefers it (issue #145). This is the epilogue-vectorization shape
+// LLVM emits for the same reason, except placed before the body rather than
+// after; see below for why that direction is available here.
+//
+// The ordering is the whole trick, and it is not stylistic. A VEX.128 write
+// zeroes bits 255:128 of the destination (Intel SDM Vol 2, 14.1), so
+// accumulating an XMM block into X4-X7 AFTER the 16-wide loop would silently
+// discard that loop's upper-lane sums. Running it FIRST, while Y4-Y7 are still
+// freshly VPXOR'd, means the zeroing writes zero over zero; the 16-wide loop
+// then accumulates on top with VEX.256, which preserves the low lane, and the
+// fold is untouched. Mixing VEX.128 and VEX.256 costs nothing: the transition
+// penalty applies to legacy-SSE encodings, not to VEX at either width.
+//
+// Reordering the input this way is legal only because the accumulation wraps:
+// wrapping int32 addition is associative and commutative, so summing the
+// remainder before the body is bit-identical to summing it after. This is the
+// same property XCorr's doc comment guarantees to callers. A saturating
+// accumulator could not be reordered like this.
+//
+// Cost at len(x)%16 == 0, measured with perf on an i7-1260P (retired
+// instructions, which unlike wall time are immune to this part's wandering
+// clock and to the code-layout shift the inserted block causes): +2.017
+// instructions per kernel call against a 360-instruction baseline, i.e. exactly
+// the TESTQ and its predicted-taken JZ, for +0.7% cycles. The obvious
+// alternative, accumulating the block into separate X8-X11 and folding them in
+// afterwards, needs four extra unconditional fold VPADDDs; #145 measured that
+// shape at 3-4% on the aligned lengths the motivating fixed-point caller uses.
 TEXT ·xcorr4AVX2(SB), NOSPLIT, $0-72
     MOVQ dst_base+0(FP), DI
     MOVQ x_base+24(FP), SI
@@ -512,8 +544,32 @@ xcorr4_avx2_empty:
     XORQ CX, CX
 
 xcorr4_avx2_blocks:
+    TESTQ $8, CX               // n % 16 >= 8? one XMM block absorbs the 8
+    JZ   xcorr4_avx2_blocks16
+
+    VMOVDQU (SI), X0           // x[0..8), reused by all four lags
+    VMOVDQU (BX), X1           // lag 0
+    VPMADDWD X0, X1, X1
+    VPADDD X1, X4, X4          // VEX-128 zeroes Y4[255:128]; it is still zero
+    VMOVDQU 2(BX), X1          // lag 1
+    VPMADDWD X0, X1, X1
+    VPADDD X1, X5, X5
+    VMOVDQU 4(BX), X1          // lag 2
+    VPMADDWD X0, X1, X1
+    VPADDD X1, X6, X6
+    VMOVDQU 6(BX), X1          // lag 3
+    VPMADDWD X0, X1, X1
+    VPADDD X1, X7, X7
+    ADDQ $16, SI               // 8 int16 consumed from x
+    ADDQ $16, BX               // y slides by the same 8, lag offsets unchanged
+
+    // The block count is computed AFTER the 8-wide block, not before, so SHRQ's
+    // own ZF still drives the branch below. Computing it first would cost a
+    // separate TESTQ AX, AX; perf puts the aligned-length overhead at exactly 2
+    // extra instructions per call this way versus 3.
+xcorr4_avx2_blocks16:
     MOVQ CX, AX
-    SHRQ $4, AX                // AX = n / 16
+    SHRQ $4, AX                // AX = n / 16, the 16-wide block count
     JZ   xcorr4_avx2_fold
 
 xcorr4_avx2_loop16:
@@ -565,7 +621,7 @@ xcorr4_avx2_fold:
     VPADDD X0, X7, X7
     MOVQ X7, R11               // lag 3
 
-    ANDQ $15, CX
+    ANDQ $7, CX                // not $15: the 8-wide block above took that bit
     JZ   xcorr4_avx2_store
 
 xcorr4_avx2_scalar:

--- a/i16/i16_amd64_test.go
+++ b/i16/i16_amd64_test.go
@@ -271,6 +271,24 @@ func xcorr4Kernels() []xcorr4Kernel {
 	}
 }
 
+// xcorr4Lengths sweeps every length 1..80 rather than a hand-picked list.
+// xcorr4AVX2 has three paths whose boundaries interact (16-wide loop, 8-wide
+// block, scalar tail), so covering each residue mod 16 at several block counts
+// is what pins the transitions; a sampled list is how the #145 sawtooth stayed
+// invisible in the first place. 240 is retained as the aligned long case the
+// motivating fixed-point caller actually uses.
+//
+// The data must stay non-uniform across the sweep: a sign-symmetric operand set
+// cannot catch a lane or sign error, which is how a UMLAL-for-SMLAL mutant
+// survived the whole suite in #143.
+func xcorr4Lengths() []int {
+	lengths := make([]int, 0, 81)
+	for xn := 1; xn <= 80; xn++ {
+		lengths = append(lengths, xn)
+	}
+	return append(lengths, 240)
+}
+
 // TestXCorr4AMD64_ParityWithGo drives each 4-lag kernel directly, over lengths
 // the dispatcher would never route to it, so a threshold change cannot quietly
 // reduce this to a test of the Go reference against itself.
@@ -280,7 +298,7 @@ func TestXCorr4AMD64_ParityWithGo(t *testing.T) {
 			if !k.available {
 				t.Skipf("%s not available", k.name)
 			}
-			for _, xn := range []int{1, 2, 7, 8, 9, 15, 16, 17, 23, 31, 32, 33, 64, 240} {
+			for _, xn := range xcorr4Lengths() {
 				x := genI16(xn, 121)
 				y := genI16(xn+3, 122) // exactly the window the dispatcher passes
 				dst := make([]int32, xcorrLagBlock)
@@ -347,13 +365,23 @@ func TestXCorrDispatch_ReachesSIMD(t *testing.T) {
 // len(y)-3 < len(x); ParityWithGo passes len(y) == len(x)+3, where both
 // operands of the min are equal and a mutant that dropped the min entirely
 // would still agree.
+//
+// This is also the ONLY over-read detector in the xcorr4 set, which is why it
+// sweeps densely rather than sampling. ParityWithGo cannot do that job at any
+// length: its operands are standalone slices, so a kernel reading past x lands
+// in zeroed memory that multiplies to 0 and leaves every lag correct. A mutant
+// that consumed the 8-wide block but kept the old ANDQ $15 tail (that is, one
+// that reads 8 elements past x) was verified to pass ParityWithGo across the
+// whole 1..80 sweep and to fail HERE. Since the 8-wide block makes which
+// residues over-read depend on len(x) % 16, sampling lengths would leave most
+// of that domain unchecked.
 func TestXCorr4AMD64_LongWindowIsClamped(t *testing.T) {
 	for _, k := range xcorr4Kernels() {
 		t.Run(k.name, func(t *testing.T) {
 			if !k.available {
 				t.Skipf("%s not available", k.name)
 			}
-			for _, xn := range []int{1, 8, 9, 16, 17, 32} {
+			for _, xn := range xcorr4Lengths() {
 				// x MUST be a prefix of a longer allocation: the mutant this
 				// test exists for reads past the end of x, and past a
 				// standalone slice that is zeroed memory, which multiplies to

--- a/i16/i16_amd64_test.go
+++ b/i16/i16_amd64_test.go
@@ -271,23 +271,26 @@ func xcorr4Kernels() []xcorr4Kernel {
 	}
 }
 
-// xcorr4Lengths sweeps every length 1..80 rather than a hand-picked list.
-// xcorr4AVX2 has three paths whose boundaries interact (16-wide loop, 8-wide
-// block, scalar tail), so covering each residue mod 16 at several block counts
-// is what pins the transitions; a sampled list is how the #145 sawtooth stayed
-// invisible in the first place. 240 is retained as the aligned long case the
-// motivating fixed-point caller actually uses.
+// xcorr4Lengths sweeps every length 1..80, plus 240 and 248. xcorr4AVX2 has
+// three paths whose boundaries interact (16-wide loop, 8-wide block, scalar
+// tail), and which of them a call reaches is a function of len(x) % 16, so the
+// sweep pins every transition at several block counts. 240 is the aligned long
+// case the motivating fixed-point caller uses; 248 is that length plus one
+// 8-wide block, so the block is exercised at a high block count too (every other
+// length here reaches it at four blocks or fewer).
 //
-// The data must stay non-uniform across the sweep: a sign-symmetric operand set
-// cannot catch a lane or sign error, which is how a UMLAL-for-SMLAL mutant
-// survived the whole suite in #143.
-func xcorr4Lengths() []int {
-	lengths := make([]int, 0, 81)
+// Note what this cannot do. #145 is a performance defect: the pre-fix kernel is
+// bit-exact at every length, so no length list, dense or sparse, could have
+// surfaced it, and none of these tests fail on the old code. The benchmarks are
+// what make the sawtooth visible. The sweep is regression armor for the new
+// paths, nothing more.
+var xcorr4Lengths = func() []int {
+	lengths := make([]int, 0, 82)
 	for xn := 1; xn <= 80; xn++ {
 		lengths = append(lengths, xn)
 	}
-	return append(lengths, 240)
-}
+	return append(lengths, 240, 248)
+}()
 
 // TestXCorr4AMD64_ParityWithGo drives each 4-lag kernel directly, over lengths
 // the dispatcher would never route to it, so a threshold change cannot quietly
@@ -298,7 +301,7 @@ func TestXCorr4AMD64_ParityWithGo(t *testing.T) {
 			if !k.available {
 				t.Skipf("%s not available", k.name)
 			}
-			for _, xn := range xcorr4Lengths() {
+			for _, xn := range xcorr4Lengths {
 				x := genI16(xn, 121)
 				y := genI16(xn+3, 122) // exactly the window the dispatcher passes
 				dst := make([]int32, xcorrLagBlock)
@@ -315,6 +318,22 @@ func TestXCorr4AMD64_ParityWithGo(t *testing.T) {
 
 // TestXCorr4AMD64_ShortWindowIsBounded feeds each kernel a y window shorter
 // than its contract and asserts it clamps rather than reading past the end.
+//
+// This is the only test where y, not x, binds the n = min(len(x), len(y)-3)
+// clamp, which makes it the only place the 8-wide block's reach into y is
+// pinned. That reach has zero slack: the block's lag-3 load spans y bytes 6..21,
+// touching y[10], and it runs whenever bit 3 of n is set, so n=8 needs exactly
+// len(y) >= 11 and gets exactly 11. yn is therefore swept rather than sampled,
+// so yn=11 (n=8, the tight case) is actually produced; the old sampled list
+// reached the 8-wide block at a single point and never at its boundary.
+//
+// y is a prefix of a longer allocation for the same reason x is in
+// LongWindowIsClamped, but the case for it is weaker and worth stating honestly:
+// no mutant found so far actually needs it. Every y over-read anyone has
+// constructed also miscounts, and the miscount is what the assertion catches
+// (widening this clamp by one element is caught here either way). It stays
+// because it costs one allocation and closes the same structural hole the x side
+// has a demonstrated mutant for.
 func TestXCorr4AMD64_ShortWindowIsBounded(t *testing.T) {
 	for _, k := range xcorr4Kernels() {
 		t.Run(k.name, func(t *testing.T) {
@@ -322,8 +341,9 @@ func TestXCorr4AMD64_ShortWindowIsBounded(t *testing.T) {
 				t.Skipf("%s not available", k.name)
 			}
 			x := genI16(32, 123)
-			for _, yn := range []int{0, 1, 2, 3, 4, 8, 16, 31, 34} {
-				y := genI16(yn, 124)
+			for yn := 0; yn <= 48; yn++ {
+				backing := genI16(yn+200, 211)
+				y := backing[:yn]
 				dst := make([]int32, xcorrLagBlock)
 				k.fn(dst, x, y) // must not fault or read past y
 				n := max(min(len(x), yn-3), 0)
@@ -366,22 +386,25 @@ func TestXCorrDispatch_ReachesSIMD(t *testing.T) {
 // operands of the min are equal and a mutant that dropped the min entirely
 // would still agree.
 //
-// This is also the ONLY over-read detector in the xcorr4 set, which is why it
-// sweeps densely rather than sampling. ParityWithGo cannot do that job at any
-// length: its operands are standalone slices, so a kernel reading past x lands
-// in zeroed memory that multiplies to 0 and leaves every lag correct. A mutant
-// that consumed the 8-wide block but kept the old ANDQ $15 tail (that is, one
-// that reads 8 elements past x) was verified to pass ParityWithGo across the
-// whole 1..80 sweep and to fail HERE. Since the 8-wide block makes which
-// residues over-read depend on len(x) % 16, sampling lengths would leave most
-// of that domain unchecked.
+// This test and ShortWindowIsBounded are the xcorr4 set's over-consumption
+// detectors, and the backing prefix below is what makes THIS one work: a kernel
+// that consumes past x reads that allocation's non-zero bytes, where past a
+// standalone slice it would read zeroed memory that multiplies to 0 and leaves
+// every lag correct. ParityWithGo is structurally blind to that at every length
+// for exactly this reason, which is why the clamp tests carry the dense sweep
+// too: the 8-wide block makes which residues over-consume depend on len(x) % 16.
+// A mutant keeping the old ANDQ $15 tail (one that consumes 8 elements past x)
+// passes ParityWithGo across the whole sweep and dies here.
+//
+// Neither test detects a pure over-READ, a widened load whose extra lanes never
+// reach the sum. That needs a guard page, which this suite does not do.
 func TestXCorr4AMD64_LongWindowIsClamped(t *testing.T) {
 	for _, k := range xcorr4Kernels() {
 		t.Run(k.name, func(t *testing.T) {
 			if !k.available {
 				t.Skipf("%s not available", k.name)
 			}
-			for _, xn := range xcorr4Lengths() {
+			for _, xn := range xcorr4Lengths {
 				// x MUST be a prefix of a longer allocation: the mutant this
 				// test exists for reads past the end of x, and past a
 				// standalone slice that is zeroed memory, which multiplies to

--- a/i16/xcorr_test.go
+++ b/i16/xcorr_test.go
@@ -165,8 +165,15 @@ func TestXCorr_ExactWindow(t *testing.T) {
 // Note all-MinInt16 operands are sign-symmetric, so this catches a miscounted
 // element but NOT a sign or lane error; TestXCorr_MatchesDotProductAtEveryLag
 // with genI16 data is what covers those.
+//
+// The lengths must keep reaching every kernel path that reorders the sum, since
+// wrapping is the property that makes reordering legal at all. 24 and 25 are
+// here for that: XCorr routes len(x) >= 16 to AVX2, so the residues mod 16 must
+// include some >= 8 or the amd64 8-wide block (which sums the remainder BEFORE
+// the 16-wide body) never runs under forced overflow. {8,9,16,17,33} alone left
+// AVX2 seeing only residues {0,1,1}.
 func TestXCorr_MinInt16(t *testing.T) {
-	for _, xn := range []int{8, 9, 16, 17, 33} {
+	for _, xn := range []int{8, 9, 16, 17, 24, 25, 33} {
 		for _, lags := range []int{1, 4, 5, 8, 9} {
 			x := make([]int16, xn)
 			y := make([]int16, xn+lags-1)


### PR DESCRIPTION
## Summary

`xcorr4AVX2` dropped from its 16-wide body straight to a 4-lag scalar tail, so a remainder of 8-15 elements cost 8-15 scalar iterations times four lags, where `xcorr4SSE2` served the same remainder in a single 8-wide block. Because `xcorrI16` dispatches on `len(x) >= minAVX2XCorr`, it picked AVX2 exactly where AVX2 was the worse kernel. Results were bit-exact throughout; this was purely a performance defect, which is why no test ever caught it.

The fix adds one 8-wide XMM block **before** the 16-wide loop rather than after it. A VEX.128 write zeroes bits 255:128 of its destination, so accumulating into X4-X7 after the body would silently discard the 16-wide loop's upper-lane sums. Running it first, while Y4-Y7 are still freshly `VPXOR`'d, means the zeroing writes zero over zero; the loop then accumulates on top with VEX.256, which preserves the low lane, and the fold needs no extra instructions. Putting the remainder before the body is legal only because the accumulation wraps: wrapping int32 addition is associative, so the reordering is bit-identical, which is the property `XCorr`'s doc comment already guarantees to callers.

This is deliberately not the shape #145 proposed. Accumulating into separate X8-X11 and folding them in afterwards needs four extra unconditional fold `VPADDD`s, which #145 measured at 3-4% on aligned lengths, i.e. a regression on `len(x)=240`, the one length the motivating fixed-point caller in #142 actually uses. Reordering instead of adding fold work avoids that.

## Measurements

i7-1260P (the CPU from the issue), pinned to a verified P-core, `GOMAXPROCS=1`, benchstat over 20 interleaved samples per binary:

| benchmark | len(x)%16 | before | after | delta |
| --- | --- | --- | --- | --- |
| `XCorr_25x64` | 9 | 158.6ns | 88.1ns | **-44.5%** (p=0.000) |
| `XCorr_248x64` | 8 | 336.4ns | 263.2ns | **-21.8%** (p=0.005) |
| `XCorr_240x4` / `240x64` / `240x288` / `240x61` / `480x64` | 0 | | | `~` (no significant change) |

Wall clock cannot settle the aligned case on this part: the governor wanders and the inserted block shifts the loop's address, which moves DSB packing. Retired instructions can, and put the aligned cost at exactly **+2.017 per kernel call** against a 360-instruction baseline (the `TESTQ` and its predicted-taken `JZ`, and nothing else). `idq.dsb_uops` is identical between the two binaries with `idq.mite_uops` under 1%, so the loop is still served ~99% from the uop cache and no `PCALIGN` is needed.

The sawtooth was verified gone across the whole domain, not just at the two benchmark points: every `len(x)` in 1..72 plus 80..256, all 16 residues at five block counts. AVX2 is now never slower than SSE2 at `len(x) >= 16`. `minAVX2XCorr` stays at 16, now for a measured reason: below 16 AVX2 would do identical work to SSE2 but still pay four extra `VEXTRACTI128` plus `VZEROUPPER`, a flat cost with nothing to amortise it, making it 5-13% slower.

## Correctness

Bit-exactness is the whole risk here, since the change reorders a sum. The pre-change kernel was reconstructed from `main` as a second symbol and diffed against the new one on hardware over **22,195 (length, window) case pairs** (`len(x)` 0..300, every residue at 0-18 block counts, 15 window shapes including the degenerate ones), all bit-identical and all matching an independent int64 oracle. `VPMADDWD` was confirmed on silicon to **wrap, not saturate** (`0x8000` pairs sum to `0x80000000`), which is what makes the reordering legal. 21.4M fuzz executions pass. Mutation-tested: an 8-block that never runs, and a tail reverted to the old `ANDQ $15`, both fail the suite.

Note the tests cannot pin this fix and no test could: the pre-fix kernel is bit-exact at every length. The dense sweep is regression armor for the new paths; the benchmarks are what make the sawtooth visible.

## Test changes

- `xcorr4Lengths` sweeps every length 1..80 plus 240 and 248, replacing sampled lists in the parity and clamp tests. 248 is there so the 8-wide block runs at a high block count (240 has residue 0 and skips it).
- `TestXCorr_MinInt16` gains 24 and 25. It is the only test forcing accumulator overflow, and wrapping is the entire reason the reordering is legal, but its lengths gave AVX2 residues `{0,1,1}` mod 16, so the new block never ran under forced overflow. It provably survived every mutant before this.
- `TestXCorr4AMD64_ShortWindowIsBounded` now sweeps `yn`. It is the only test where y binds the `n = min(len(x), len(y)-3)` clamp, and the block's reach into y has zero slack (its lag-3 load touches `y[10]`, so n=8 needs exactly `len(y) >= 11`). The sampled list never produced n=8.

## Related Issues

Fixes #145. Refs #142.

Follow-ups filed rather than bundled, per the convention #145 itself states (new hand-written kernel code wants its own correctness round): #149 (`dotAVX2` has this same sawtooth, measured 1.41x slower than SSE2 at n=24, and the NEON sibling already has the fix) and #150 (AVX-VNNI `VPDPWSSD`, a 4-wide remainder block, a `VPHADDD` fold).

## Test Plan

- [x] Full `i16` suite on linux/amd64 (AVX2 + SSE2), darwin/arm64, and the arm64 host
- [x] Cross-builds for linux/arm, 386, riscv64, js/wasm (pure-Go fallback)
- [x] 21.4M `FuzzI16XCorr` executions on amd64
- [x] Mutation testing against the final kernel
- [x] `asmcheck` green, `go vet` clean, `golangci-lint` clean under `GOOS=linux GOARCH=amd64` (the tags that actually cover the changed file)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Performance**
  * Improved AMD64 cross-correlation performance for input lengths with an 8-element remainder.

* **Bug Fixes**
  * Improved handling of SIMD boundary cases, including short and long windows, clamping, and minimum-value inputs.
  * Preserved bit-exact results across optimized execution paths.

* **Tests**
  * Expanded coverage across a wider range of input lengths and window sizes to detect boundary and overflow regressions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->