### PR TITLE
i16/i32: add tier-3 integer DSP ops (Sum, Abs, MaxAbs, MulQ15)

### DIFF
--- a/README.md
+++ b/README.md
@@ -534,7 +534,9 @@ SIMD-accelerated integer-domain operations for integer-DSP hot loops, where the 
 |                | `Deinterleave2(a, b, src)` | Split interleaved stereo into two channels             | 8x (AVX) / 4x (NEON)  |
 | **Arithmetic** | `Add(dst, a, b)`           | Element-wise add `dst = a + b`                         | 8x (AVX2) / 4x (NEON) |
 |                | `Sub(dst, a, b)`           | Element-wise subtract `dst = a - b`                    | 8x (AVX2) / 4x (NEON) |
+|                | `Abs(dst, a)`              | Wrapping absolute value (`abs(MinInt32) = MinInt32`)   | 8x (AVX2) / 4x (NEON) |
 | **Reduction**  | `MinMax(res) (min, max)`   | Signed int32 per-slice minimum and maximum in one pass | 8x (AVX2) / 4x (NEON) |
+|                | `Sum(a) int32`             | Wrapping int32 total of a slice                        | 8x (AVX2) / 4x (NEON) |
 
 ```go
 import "github.com/tphakala/simd/i32"
@@ -549,11 +551,13 @@ i32.Deinterleave2(left, right, stereo) // inverse: split back to channels
 dst := make([]int32, n)
 i32.Add(dst, left, right) // element-wise dst = left + right
 i32.Sub(dst, left, right) // element-wise dst = left - right
+i32.Abs(dst, left)        // element-wise |left|, wrapping at MinInt32
 
 mn, mx := i32.MinMax(left) // smallest and largest value in one signed pass
+total := i32.Sum(left)     // wrapping int32 total
 ```
 
-Interleaving is pure 32-bit-lane movement, so those kernels reuse the proven `f32` shuffle/permute encodings (AVX `VUNPCKLPS`/`VPERM2F128`, NEON `ZIP`/`UZP` on `.4S`); the bit pattern of each lane is irrelevant, so negative values and the type extremes round-trip exactly. `Add` and `Sub` do element-wise integer-ALU work on 256-bit (AVX2) / 128-bit (NEON) lanes with two's-complement wraparound, so they are bit-identical to the pure-Go reference across the full int32 range. `MinMax` returns the smallest and largest int32 in one signed pass (`VPMINSD`/`VPMAXSD` on AVX2, `SMIN`/`SMAX` with single-instruction `SMINV`/`SMAXV` folds on NEON); since min/max of int32 has no accumulation order, the SIMD paths are bit-identical to the pure-Go reference by construction (~10x AVX2, ~5x NEON). All zero-allocation.
+Interleaving is pure 32-bit-lane movement, so those kernels reuse the proven `f32` shuffle/permute encodings (AVX `VUNPCKLPS`/`VPERM2F128`, NEON `ZIP`/`UZP` on `.4S`); the bit pattern of each lane is irrelevant, so negative values and the type extremes round-trip exactly. `Add`, `Sub` and `Abs` do element-wise integer-ALU work on 256-bit (AVX2) / 128-bit (NEON) lanes with two's-complement wraparound, so they are bit-identical to the pure-Go reference across the full int32 range; `Abs` wraps the one out-of-range magnitude (`abs(MinInt32) = MinInt32`) rather than saturating. `Sum` accumulates in int32 with the same wraparound, and because wrapping addition is associative its lane split and horizontal reduction are bit-identical to the sequential loop even on overflowing inputs. `MinMax` returns the smallest and largest int32 in one signed pass (`VPMINSD`/`VPMAXSD` on AVX2, `SMIN`/`SMAX` with single-instruction `SMINV`/`SMAXV` folds on NEON); since min/max of int32 has no accumulation order, the SIMD paths are bit-identical to the pure-Go reference by construction (~10x AVX2, ~5x NEON). All zero-allocation.
 
 > The FLAC-specific integer kernels (fixed predictors, quantized-LPC residual/restore, mid/side decorrelation, and the Rice cost search) that previously lived here now live in the codec that owns them ([go-flac](https://github.com/tphakala/go-flac)); this package keeps only the generic integer ops above.
 
@@ -561,7 +565,7 @@ Interleaving is pure 32-bit-lane movement, so those kernels reuse the proven `f3
 
 The 16-bit integer counterpart to `i32`, serving two kinds of hot loop. First, raw-PCM movement, where the source samples are 16-bit and the cheapest place to vectorize is the channel (de)interleaving that happens before samples are widened to int32. Second, fixed-point DSP, where int16 inputs are multiplied and accumulated into int32.
 
-**Scope:** element-wise int16 arithmetic still belongs in `i32`, because inter-channel decorrelation can exceed the source bit depth by one bit. What this package adds at 16-bit width is the *widening* direction: operations that read int16 and accumulate into int32, where the narrow input is the point.
+**Scope:** element-wise int16 add/sub still belongs in `i32`, because inter-channel decorrelation can exceed the source bit depth by one bit. What lives here is the *widening* direction (operations that read int16 and accumulate into int32, where the narrow input is the point) plus the element-wise operations that are well-defined at 16-bit width: the wrapping absolute value (`Abs`, with the `MaxAbs` reduction) and the rounding Q15 fixed-point multiply (`MulQ15`).
 
 | Category       | Function                   | Description                                | SIMD Width                         |
 | -------------- | -------------------------- | ------------------------------------------ | ---------------------------------- |
@@ -569,7 +573,10 @@ The 16-bit integer counterpart to `i32`, serving two kinds of hot loop. First, r
 |                | `Deinterleave2(a, b, src)` | Split interleaved stereo into two channels | 16x (AVX2) / 8x (SSE2) / 8x (NEON) |
 | **Reduction**  | `DotProduct(a, b)`         | Widening dot product, wrapping int32       | 16x (AVX2) / 8x (SSE2) / 16x (NEON) |
 |                | `DotProductUnsafe(a, b)`   | As above, without the empty-slice guard    | 16x (AVX2) / 8x (SSE2) / 16x (NEON) |
+|                | `MaxAbs(a) int`            | Abs-max headroom probe, range `[0, 32768]` | 16x (AVX2) / 8x (NEON) |
 | **Correlation**| `XCorr(dst, x, y)`         | Dot product of x against y at every lag    | 4 lags/call, 16x (AVX2) / 8x (SSE2/NEON) |
+| **Element-wise**| `Abs(dst, a)`             | Wrapping absolute value (`abs(-32768) = -32768`) | 16x (AVX2) / 8x (NEON) |
+|                | `MulQ15(dst, a, b)`        | Rounding Q15 multiply (libopus `MULT16_16_P15`) | 16x (AVX2) / 8x (NEON) |
 
 ```go
 import "github.com/tphakala/simd/i16"
@@ -582,6 +589,11 @@ i16.Interleave2(stereo, left, right)   // [l0, r0, l1, r1, ...]
 i16.Deinterleave2(left, right, stereo) // inverse: split back to channels
 
 sum := i16.DotProduct(left, right)     // sum(left[i]*right[i]) widened into int32
+
+peak := i16.MaxAbs(left)               // headroom probe: |-32768| reports 32768
+gain := make([]int16, n)               // Q15 gains, e.g. 16384 = 0.5
+i16.MulQ15(left, left, gain)           // rounding Q15 multiply, in place
+i16.Abs(left, left)                    // wrapping |x|, in place
 
 // Correlate a short pattern against a longer signal at every lag.
 pattern := make([]int16, 32)
@@ -596,6 +608,8 @@ The interleave kernels are pure 16-bit-lane movement (AVX2/SSE2 word unpacks plu
 `DotProduct` is the opposite case: the bit pattern is the whole point. It widens each product to int32 and accumulates with **two's-complement wraparound, never saturation**, and that is a guarantee callers may rely on. Wrapping addition is associative and commutative modulo 2^32, so any lane grouping and any horizontal reduction order is bit-identical to the scalar loop, including on operands engineered to overflow; a saturating accumulator is not associative and could not be vectorized without changing results. Fixed-point codecs (Opus/CELT, FLAC LPC) use integer arithmetic precisely because it is exactly reproducible, so this property is the feature. The kernels are `PMADDWD` (SSE2, hence always present on the `GOAMD64=v1` baseline) with an AVX2 tier at twice the width, and `SMLAL`/`SMLAL2` on NEON. All kernels are zero-allocation.
 
 `XCorr` is the same arithmetic evaluated at every lag, and `dst[k]` is defined to equal `DotProduct(x, y[k:k+len(x)])` exactly. The win over calling `DotProduct` in a loop is that it loads `x` once and multiply-accumulates it against four overlapping `y` windows at a time (the libopus `xcorr_kernel` shape), rather than re-reading `x` for every lag. Only lags whose full window fits in `y` are computed, and `dst` beyond that is left untouched rather than zeroed.
+
+`Abs`, `MaxAbs` and `MulQ15` are the fixed-point envelope/gain trio. `Abs` wraps rather than saturates (`abs(-32768) = -32768`, the opposite of `i8.Abs`), `MaxAbs` returns an `int` because `|-32768| = 32768` does not fit int16 (libopus `celt_maxabs16`), and `MulQ15` is the *rounding* Q15 multiply (`MULT16_16_P15`): `dst[i] = int16((a[i]*b[i] + 1<<14) >> 15)` with the single out-of-range product `(-32768)^2` wrapping to `-32768`. All three are bit-exact against their pure-Go references for every input. On amd64 these three are AVX2-or-Go (no SSE2 tier, matching `i8` and the `i32` arithmetic); on ARM64 they run NEON (`MulQ15` via `SMULL`/`SRSHR`/`XTN`, since the single-instruction `SQRDMULH` saturates the `(-32768)^2` case and would break the wrap guarantee).
 
 ### `i8` - int8 Operations
 
@@ -951,14 +965,16 @@ each package's `*_amd64.go` dispatch):
 | `f64`   | SSE2                    | AVX (no FMA), AVX+FMA, AVX-512 | pure Go (baseline guarantees SSE2) |
 | `c128`  | SSE2                    | AVX (no FMA), AVX+FMA, AVX-512 | pure Go (baseline guarantees SSE2) |
 | `c64`   | SSE4.1 (BLENDPS)        | AVX+FMA, AVX-512        | pure Go |
-| `i16`   | SSE2                    | AVX2                    | pure Go (baseline guarantees SSE2) |
+| `i16`   | SSE2 (interleave, dot, xcorr); AVX2 (Abs, MulQ15, MaxAbs) | AVX2 | pure Go (baseline guarantees SSE2 for the SSE2-tier ops) |
 | `i32`   | AVX (interleave), AVX2 (arithmetic) | -           | pure Go |
 | `i8`    | AVX2                    | -                       | pure Go |
 | `f16`   | F16C (slice conversions only) | -                 | pure Go (all f16 compute is pure Go on amd64) |
 | `crc`   | PCLMULQDQ               | -                       | scalar slice-by-16 |
 
-SSE2 is part of the amd64 baseline, so `f32`/`f64`/`c128`/`i16` always run SIMD on
-amd64 (their pure-Go path is effectively a non-amd64 safety net). AVX-512 uses the
+SSE2 is part of the amd64 baseline, so `f32`/`f64`/`c128` always run SIMD on amd64
+(their pure-Go path is effectively a non-amd64 safety net), and so do `i16`'s
+interleave/dot/xcorr kernels; `i16`'s element-wise `Abs`/`MulQ15` and its `MaxAbs`
+reduction are AVX2-or-Go, like `i8` and the `i32` arithmetic. AVX-512 uses the
 `AVX512F && AVX512VL` gate. `cpu.Info()` reports the host-wide tier (AVX-512 /
 AVX+FMA / AVX / SSE2 / scalar); a package whose minimum is above that tier (e.g.
 `i32` on an SSE-only host) runs pure Go even though `Info()` shows SSE2.

--- a/doc.go
+++ b/doc.go
@@ -21,11 +21,14 @@
 // (each package only ships the kernels its workload needs):
 //
 //   - AMD64: AVX-512 (8x float64, 16x float32) > AVX+FMA (4x float64, 8x float32) >
-//     AVX (no FMA, f64/c128) > SSE2 (f32/f64/c128/i16) or SSE4.1 (c64) > pure Go.
+//     AVX (no FMA, f64/c128) > SSE2 (f32/f64/c128, i16 interleave/dot/xcorr)
+//     or SSE4.1 (c64) > pure Go.
 //     i32 needs AVX/AVX2, i8 needs AVX2, crc needs PCLMULQDQ, and f16 uses F16C
 //     for its slice conversions only (every other f16 op is pure Go on amd64).
-//     SSE2 is part of the amd64 baseline, so f32/f64/c128/i16 always get SIMD on
-//     amd64.
+//     SSE2 is part of the amd64 baseline, so f32/f64/c128 always get SIMD on
+//     amd64, as do i16's interleave/dot/xcorr kernels; i16's element-wise ops
+//     (Abs, MulQ15) and its MaxAbs reduction are AVX2-or-Go, like i8 and the
+//     i32 arithmetic.
 //   - ARM64: NEON/ASIMD throughout (2x float64, 4x float32), with an FP16
 //     (FEAT_FP16) fast path in the f16 package and an SDOT (FEAT_DotProd) fast
 //     path for i8.DotProduct, and SMLAL/SMLAL2 widening multiply-accumulate
@@ -88,9 +91,9 @@
 //
 // Spectral (f64, f32): STFTPlan (NewSTFTPlan, STFT, STFTPower, STFTPowerInto, NumFrames) - fused real-input short-time Fourier transform with optional librosa-style center=true framing (PadMode: NoPad/PadZero/PadReflect)
 //
-// Integer DSP (i16): Interleave2, Deinterleave2, DotProduct, DotProductUnsafe, XCorr (widening int16 x int16 -> wrapping int32; ARM64 SMLAL/SMLAL2, amd64 PMADDWD/VPMADDWD; XCorr evaluates 4 correlation lags per kernel call)
+// Integer DSP (i16): Interleave2, Deinterleave2, DotProduct, DotProductUnsafe, XCorr (widening int16 x int16 -> wrapping int32; ARM64 SMLAL/SMLAL2, amd64 PMADDWD/VPMADDWD; XCorr evaluates 4 correlation lags per kernel call), Abs, MaxAbs, MulQ15 (wrapping 16-bit absolute value, widened abs-max, rounding Q15 multiply)
 //
-// Integer DSP (i32): Interleave2, Deinterleave2, Add, Sub, MinMax
+// Integer DSP (i32): Interleave2, Deinterleave2, Add, Sub, Abs, Sum, MinMax
 //
 // Integer DSP (i8): AddSaturate, SubSaturate, AddScalarSaturate, SubScalarSaturate, Min, Max, Clamp, Abs, Neg, AbsDiff, MaxAbs, SumAbs, SAD, ToInt16, ToInt32, Sum, MinMax, DotProduct (int32-accumulated; ARM64 SDOT / amd64 VPMADDWD)
 //

--- a/i16/abs.go
+++ b/i16/abs.go
@@ -1,0 +1,34 @@
+package i16
+
+// Wrapping absolute value at 16-bit width, element-wise and as a reduction.
+// Both serve the fixed-point envelope and peak scans that precede gain
+// decisions: Abs feeds an envelope follower, MaxAbs is the headroom probe.
+// Neither saturates, so the SIMD lanes and the Go reference are bit-identical
+// for every input including the type minimum.
+
+// Abs writes dst[i] = |a[i]| for i in [0, n), n = min(len(dst), len(a)). The
+// negation wraps in int16 rather than saturating: |MinInt16| does not fit
+// int16, so Abs maps -32768 to -32768 (compare [github.com/tphakala/simd/i8.Abs],
+// which saturates by design). Every other input yields the true magnitude.
+// Any trailing capacity in dst is left untouched.
+//
+// dst and a may overlap only if they start at the same address.
+func Abs(dst, a []int16) {
+	n := min(len(dst), len(a))
+	if n == 0 {
+		return
+	}
+	absI16(dst[:n], a[:n])
+}
+
+// MaxAbs returns max_i |a[i]| as int, in [0, 32768]: |-32768| = 32768 does not
+// fit int16, which is why the result widens (mirroring
+// [github.com/tphakala/simd/i8.MaxAbs] and libopus celt_maxabs16) and why this
+// is not equivalent to Abs followed by a signed max reduction. An empty a
+// returns 0. a is read-only; the call allocates nothing.
+func MaxAbs(a []int16) int {
+	if len(a) == 0 {
+		return 0
+	}
+	return maxAbsI16(a)
+}

--- a/i16/abs_test.go
+++ b/i16/abs_test.go
@@ -202,9 +202,16 @@ func TestMaxAbs_MinInt16(t *testing.T) {
 // possible magnitude. Past a standalone slice lies zeroed memory and |0| is
 // the identity element of this reduction, so an over-reading kernel would
 // pass every other test in this file; the planted extreme is what makes one
-// visible.
+// visible. Unlike the wrapping sum, max is idempotent, so no repeat count of
+// the extreme can cancel it and any over-read shows up.
+//
+// The slack past the longest case must cover a whole vector block of the
+// widest kernel this can dispatch to, which is AVX2 at 16 int16. With less,
+// a full-block over-read runs off the end of the backing array itself and
+// reads unpoisoned memory, so the test stops reliably failing on the defect
+// it exists to catch.
 func TestMaxAbs_NoOverRead(t *testing.T) {
-	backing := make([]int16, 128+8)
+	backing := make([]int16, 128+16)
 	for i := range backing {
 		backing[i] = math.MinInt16
 	}

--- a/i16/abs_test.go
+++ b/i16/abs_test.go
@@ -1,0 +1,234 @@
+package i16
+
+import (
+	"math"
+	"testing"
+)
+
+// Tests for Abs and MaxAbs, the wrapping absolute value and the abs-max
+// reduction. The load-bearing input is MinInt16: Abs must wrap it in place
+// while MaxAbs must report its magnitude as the out-of-int16 value 32768,
+// and the two contracts meet in no other case.
+
+// absOracle computes |v| in int, independent of absGo, narrowed to int16 the
+// same way a 16-bit lane store truncates.
+func absOracle(v int16) int16 {
+	av := int(v)
+	if av < 0 {
+		av = -av
+	}
+	return int16(av)
+}
+
+func TestAbs(t *testing.T) {
+	for _, n := range tier3Lengths {
+		a := genI16(n, 81)
+		dst := make([]int16, n)
+		ref := make([]int16, n)
+		Abs(dst, a)
+		absGo(ref, a)
+		for i := range dst {
+			if dst[i] != ref[i] {
+				t.Fatalf("Abs n=%d: dst[%d] = %d, want %d (reference)", n, i, dst[i], ref[i])
+			}
+			if want := absOracle(a[i]); dst[i] != want {
+				t.Fatalf("Abs n=%d: dst[%d] = %d, want %d (oracle)", n, i, dst[i], want)
+			}
+		}
+	}
+}
+
+// TestAbs_MinInt16 walks the wrap input through every lane position: a single
+// planted MinInt16 must come back unchanged while its neighbours are truly
+// absolute. The rotating position is what catches lane and index errors; an
+// all-MinInt16 fill could only catch a miscount.
+func TestAbs_MinInt16(t *testing.T) {
+	for n := 1; n <= 40; n++ {
+		for pos := range n {
+			a := genI16(n, uint32(90+n))
+			a[pos] = math.MinInt16
+			dst := make([]int16, n)
+			Abs(dst, a)
+			for i := range dst {
+				if want := absOracle(a[i]); dst[i] != want {
+					t.Fatalf("Abs n=%d pos=%d: dst[%d] = %d, want %d", n, pos, i, dst[i], want)
+				}
+			}
+		}
+	}
+}
+
+// TestAbs_TailUntouched plants sentinels past the clamp point at n=19: one
+// 16-wide AVX2 block plus a 3-tail, and two 8-wide NEON blocks plus the same
+// tail, so both vector bodies run and both scalar tails must stop exactly
+// at n.
+func TestAbs_TailUntouched(t *testing.T) {
+	const n = 19
+	a := genI16(n, 83)
+	dst := make([]int16, n+8)
+	for i := range dst {
+		dst[i] = math.MaxInt16 // sentinel
+	}
+	Abs(dst[:n], a)
+	for i := n; i < len(dst); i++ {
+		if dst[i] != math.MaxInt16 {
+			t.Errorf("Abs wrote past end at dst[%d] = %d", i, dst[i])
+		}
+	}
+}
+
+// TestAbs_Clamp covers mismatched lengths in both directions plus the empty
+// no-op.
+func TestAbs_Clamp(t *testing.T) {
+	a := genI16(40, 84)
+	short := make([]int16, 25)
+	Abs(short, a) // dst shorter: n = 25
+	for i := range short {
+		if want := absOracle(a[i]); short[i] != want {
+			t.Fatalf("Abs short dst: dst[%d] = %d, want %d", i, short[i], want)
+		}
+	}
+	long := make([]int16, 40)
+	for i := range long {
+		long[i] = -7 // sentinel
+	}
+	Abs(long, a[:25]) // a shorter: long[25:] untouched
+	for i := 25; i < len(long); i++ {
+		if long[i] != -7 {
+			t.Fatalf("Abs wrote past clamp at dst[%d] = %d", i, long[i])
+		}
+	}
+	Abs(nil, nil)
+	one := []int16{42}
+	Abs(one, nil)
+	if one[0] != 42 {
+		t.Errorf("Abs wrote on empty input: %v", one)
+	}
+}
+
+// TestAbs_UnalignedOperands sweeps all eight element offsets, holding dst and
+// a at different offsets from each other, so neither is reliably aligned and
+// an aligned-load or aligned-store substitution cannot survive the suite: a
+// 16-byte-aligned access needs an element offset that is a multiple of 8,
+// which only one of the eight iterations supplies. MaxAbs rides the same
+// windows so its loads are pinned too.
+func TestAbs_UnalignedOperands(t *testing.T) {
+	const span = 300
+	base := genI16(span, 87)
+	backing := make([]int16, span)
+	for _, n := range []int{16, 17, 19, 25, 33, 64, 240} {
+		for off := range 8 {
+			a := base[off+1 : off+1+n]
+			dst := backing[off+3 : off+3+n]
+			Abs(dst, a)
+			for i := range n {
+				if want := absOracle(a[i]); dst[i] != want {
+					t.Fatalf("Abs unaligned n=%d off=%d: dst[%d] = %d, want %d", n, off, i, dst[i], want)
+				}
+			}
+			if got, want := MaxAbs(a), maxAbsGo(a); got != want {
+				t.Fatalf("MaxAbs unaligned n=%d off=%d: got %d, want %d", n, off, got, want)
+			}
+		}
+	}
+}
+
+// TestAbs_AllocFree: buffers INSIDE the closure, see TestMulQ15_AllocFree.
+func TestAbs_AllocFree(t *testing.T) {
+	if n := testing.AllocsPerRun(50, func() {
+		var a, dst [240]int16
+		Abs(dst[:], a[:])
+	}); n != 0 {
+		t.Errorf("Abs forces %v caller allocations per run, want 0", n)
+	}
+}
+
+func TestMaxAbs(t *testing.T) {
+	if got := MaxAbs(nil); got != 0 {
+		t.Errorf("MaxAbs(nil) = %d, want 0", got)
+	}
+	for _, n := range tier3Lengths {
+		a := genI16(n, 85)
+		got := MaxAbs(a)
+		if want := maxAbsGo(a); got != want {
+			t.Errorf("MaxAbs n=%d: got %d, want %d (reference)", n, got, want)
+		}
+		// Independent oracle: an int scan over the same data.
+		oracle := 0
+		for _, v := range a {
+			av := int(v)
+			if av < 0 {
+				av = -av
+			}
+			oracle = max(oracle, av)
+		}
+		if got != oracle {
+			t.Errorf("MaxAbs n=%d: got %d, want %d (oracle)", n, got, oracle)
+		}
+	}
+}
+
+// TestMaxAbs_MinInt16 pins the widened result: a planted -32768 must report
+// 32768 (not 32767 and not -32768) from every lane position and from the
+// scalar tail, at lengths that reach the vector bodies.
+func TestMaxAbs_MinInt16(t *testing.T) {
+	for _, n := range []int{1, 7, 8, 9, 15, 16, 17, 19, 24, 31, 32, 33, 64, 100} {
+		for pos := range n {
+			a := make([]int16, n)
+			for i := range a {
+				a[i] = int16(i%100 - 50) // tame body keeps the plant the unique max
+			}
+			a[pos] = math.MinInt16
+			if got := MaxAbs(a); got != 32768 {
+				t.Fatalf("MaxAbs n=%d pos=%d: got %d, want 32768", n, pos, got)
+			}
+		}
+	}
+	// Without the plant the result stays inside int16 range.
+	a := genI16(33, 86)
+	for i := range a {
+		if a[i] == math.MinInt16 {
+			a[i] = math.MaxInt16
+		}
+	}
+	a[17] = math.MaxInt16
+	if got := MaxAbs(a); got != math.MaxInt16 {
+		t.Errorf("MaxAbs without MinInt16 = %d, want %d", got, math.MaxInt16)
+	}
+}
+
+// TestMaxAbs_NoOverRead hands MaxAbs a prefix of a longer allocation whose
+// every element past the prefix is -32768, the input with the largest
+// possible magnitude. Past a standalone slice lies zeroed memory and |0| is
+// the identity element of this reduction, so an over-reading kernel would
+// pass every other test in this file; the planted extreme is what makes one
+// visible.
+func TestMaxAbs_NoOverRead(t *testing.T) {
+	backing := make([]int16, 128+8)
+	for i := range backing {
+		backing[i] = math.MinInt16
+	}
+	for _, n := range []int{1, 3, 7, 8, 9, 15, 16, 17, 19, 24, 31, 32, 33, 64, 100, 128} {
+		a := backing[:n]
+		for i := range a {
+			a[i] = int16(i%50 - 25)
+		}
+		want := maxAbsGo(a)
+		if got := MaxAbs(a); got != want {
+			t.Fatalf("MaxAbs n=%d: got %d, want %d (read past the operand?)", n, got, want)
+		}
+		for i := range a {
+			backing[i] = math.MinInt16 // restore the poison for the next length
+		}
+	}
+}
+
+// TestMaxAbs_AllocFree: buffers INSIDE the closure, see TestMulQ15_AllocFree.
+func TestMaxAbs_AllocFree(t *testing.T) {
+	if n := testing.AllocsPerRun(50, func() {
+		var a [240]int16
+		_ = MaxAbs(a[:])
+	}); n != 0 {
+		t.Errorf("MaxAbs forces %v caller allocations per run, want 0", n)
+	}
+}

--- a/i16/benchmark_test.go
+++ b/i16/benchmark_test.go
@@ -146,3 +146,89 @@ func BenchmarkXCorrGo_240x4(b *testing.B)   { benchmarkXCorr(b, 240, 4, xcorrGo)
 func BenchmarkXCorrGo_240x64(b *testing.B)  { benchmarkXCorr(b, 240, 64, xcorrGo) }
 func BenchmarkXCorrGo_240x288(b *testing.B) { benchmarkXCorr(b, 240, 288, xcorrGo) }
 func BenchmarkXCorrGo_480x64(b *testing.B)  { benchmarkXCorr(b, 480, 64, xcorrGo) }
+
+// Tier-3 benchmarks. These ops are store-bound (far cheaper per element than
+// dot), so the SIMD-vs-Go crossover at small n is what the 8 case exists to
+// measure: 8 is one NEON block and half an AVX2 one, so it sits exactly at the
+// NEON dispatch cut and below the AVX2 one.
+//
+// 240 is a multiple of both vector widths; 8 is a multiple of the NEON width
+// only, which is the previous paragraph's point. 25 and 1003 are deliberate
+// non-multiples of 8 and 16, so the scalar tails are always on the clock (the
+// original XCorr lengths were all multiples of 16 and structurally hid a
+// tail-cost defect; see BenchmarkXCorr_25x64 above). 1000 is a multiple of the
+// NEON width but not the AVX2 one (1000 mod 16 = 8), so it also charges an
+// AVX2 tail.
+//
+// MulQ15 SetBytes counts a + b read and dst written; Abs counts a + dst;
+// MaxAbs counts a.
+
+func benchmarkMulQ15(b *testing.B, n int, fn func(dst, a, c []int16)) {
+	b.Helper()
+	a := make([]int16, n)
+	c := make([]int16, n)
+	dst := make([]int16, n)
+	for i := range a {
+		a[i] = int16(i*7 - 3000)
+		c[i] = int16(i*-5 + 2000)
+	}
+	b.SetBytes(int64(n) * 2 * 3)
+	for b.Loop() {
+		fn(dst, a, c)
+	}
+}
+
+func BenchmarkMulQ15_8(b *testing.B)    { benchmarkMulQ15(b, 8, MulQ15) }
+func BenchmarkMulQ15_25(b *testing.B)   { benchmarkMulQ15(b, 25, MulQ15) }
+func BenchmarkMulQ15_240(b *testing.B)  { benchmarkMulQ15(b, 240, MulQ15) }
+func BenchmarkMulQ15_1003(b *testing.B) { benchmarkMulQ15(b, 1003, MulQ15) }
+
+func BenchmarkMulQ15Go_8(b *testing.B)    { benchmarkMulQ15(b, 8, mulQ15Go) }
+func BenchmarkMulQ15Go_25(b *testing.B)   { benchmarkMulQ15(b, 25, mulQ15Go) }
+func BenchmarkMulQ15Go_240(b *testing.B)  { benchmarkMulQ15(b, 240, mulQ15Go) }
+func BenchmarkMulQ15Go_1003(b *testing.B) { benchmarkMulQ15(b, 1003, mulQ15Go) }
+
+func benchmarkAbs(b *testing.B, n int, fn func(dst, a []int16)) {
+	b.Helper()
+	a := make([]int16, n)
+	dst := make([]int16, n)
+	for i := range a {
+		a[i] = int16(i*7 - 3000)
+	}
+	b.SetBytes(int64(n) * 2 * 2)
+	for b.Loop() {
+		fn(dst, a)
+	}
+}
+
+func BenchmarkAbs_8(b *testing.B)    { benchmarkAbs(b, 8, Abs) }
+func BenchmarkAbs_25(b *testing.B)   { benchmarkAbs(b, 25, Abs) }
+func BenchmarkAbs_1000(b *testing.B) { benchmarkAbs(b, 1000, Abs) }
+func BenchmarkAbs_1003(b *testing.B) { benchmarkAbs(b, 1003, Abs) }
+
+func BenchmarkAbsGo_8(b *testing.B)    { benchmarkAbs(b, 8, absGo) }
+func BenchmarkAbsGo_25(b *testing.B)   { benchmarkAbs(b, 25, absGo) }
+func BenchmarkAbsGo_1000(b *testing.B) { benchmarkAbs(b, 1000, absGo) }
+func BenchmarkAbsGo_1003(b *testing.B) { benchmarkAbs(b, 1003, absGo) }
+
+func benchmarkMaxAbs(b *testing.B, n int, fn func(a []int16) int) {
+	b.Helper()
+	a := make([]int16, n)
+	for i := range a {
+		a[i] = int16(i*7 - 3000)
+	}
+	b.SetBytes(int64(n) * 2)
+	for b.Loop() {
+		_ = fn(a)
+	}
+}
+
+func BenchmarkMaxAbs_8(b *testing.B)    { benchmarkMaxAbs(b, 8, MaxAbs) }
+func BenchmarkMaxAbs_25(b *testing.B)   { benchmarkMaxAbs(b, 25, MaxAbs) }
+func BenchmarkMaxAbs_1000(b *testing.B) { benchmarkMaxAbs(b, 1000, MaxAbs) }
+func BenchmarkMaxAbs_1003(b *testing.B) { benchmarkMaxAbs(b, 1003, MaxAbs) }
+
+func BenchmarkMaxAbsGo_8(b *testing.B)    { benchmarkMaxAbs(b, 8, maxAbsGo) }
+func BenchmarkMaxAbsGo_25(b *testing.B)   { benchmarkMaxAbs(b, 25, maxAbsGo) }
+func BenchmarkMaxAbsGo_1000(b *testing.B) { benchmarkMaxAbs(b, 1000, maxAbsGo) }
+func BenchmarkMaxAbsGo_1003(b *testing.B) { benchmarkMaxAbs(b, 1003, maxAbsGo) }

--- a/i16/example_test.go
+++ b/i16/example_test.go
@@ -36,6 +36,40 @@ func ExampleDotProduct() {
 	// Output: -65536000
 }
 
+func ExampleMulQ15() {
+	// Apply a Q15 gain of 0.5 (16384/32768) to a frame of samples. The
+	// product rounds to nearest: 1 * 16384 rounds up to 1 where a
+	// truncating Q15 multiply would give 0.
+	samples := []int16{1000, -1000, 32767, -32768, 1}
+	gain := []int16{16384, 16384, 16384, 16384, 16384}
+	out := make([]int16, len(samples))
+
+	i16.MulQ15(out, samples, gain)
+	fmt.Println(out)
+	// Output: [500 -500 16384 -16384 1]
+}
+
+func ExampleAbs() {
+	// Rectify a frame for an envelope follower. The negation wraps rather
+	// than saturating, so -32768 maps to itself: |-32768| = 32768 does not
+	// fit int16. This is the opposite of i8.Abs, which saturates by design.
+	samples := []int16{-1000, 3000, -32768, 0}
+	out := make([]int16, len(samples))
+
+	i16.Abs(out, samples)
+	fmt.Println(out)
+	// Output: [1000 3000 -32768 0]
+}
+
+func ExampleMaxAbs() {
+	// Headroom probe before applying gain: |-32768| = 32768 does not fit
+	// int16, which is why the result is an int.
+	frame := []int16{100, -32768, 3000, 15}
+
+	fmt.Println(i16.MaxAbs(frame))
+	// Output: 32768
+}
+
 func ExampleXCorr() {
 	// Correlate a short pattern against a longer signal at every lag. The
 	// pattern occurs at lag 2, which is where the correlation peaks.

--- a/i16/fuzz_test.go
+++ b/i16/fuzz_test.go
@@ -127,6 +127,93 @@ func FuzzI16Dot(f *testing.F) {
 	})
 }
 
+// FuzzI16MulQ15 differentially fuzzes the rounding Q15 multiply against the
+// pure-Go reference and the int64 oracle. The raw bytes reach MinInt16
+// freely, so the fuzzer readily lands on the one wrapping product; the
+// shortened-operand probes cover every clamp order.
+func FuzzI16MulQ15(f *testing.F) {
+	addLenSeeds(f)
+	f.Fuzz(func(t *testing.T, raw []byte) {
+		v := i16sFromBits(raw)
+		h := len(v) / 2
+		a, b := v[:h], v[h:2*h]
+		dst := make([]int16, h)
+		ref := make([]int16, h)
+		MulQ15(dst, a, b)
+		mulQ15Go(ref, a, b)
+		equalI16(t, "MulQ15", dst, ref)
+		for i := range dst {
+			if want := mulQ15Oracle(a[i], b[i]); dst[i] != want {
+				t.Fatalf("MulQ15(%d, %d) = %d, want %d (oracle)", a[i], b[i], dst[i], want)
+			}
+		}
+		// Mismatched lengths must clamp, not read or write out of bounds; each
+		// operand is the short one in turn.
+		if h > 1 {
+			short := make([]int16, h-1)
+			MulQ15(short, a, b)
+			for i := range short {
+				if want := mulQ15Oracle(a[i], b[i]); short[i] != want {
+					t.Fatalf("MulQ15 short-dst [%d] = %d, want %d", i, short[i], want)
+				}
+			}
+			// A short a or b clamps n to h-1, so the final dst element must
+			// survive untouched. Assert that: without a sentinel these calls
+			// would only prove the absence of a panic.
+			const sentinel = int16(-21846)
+			for _, shortA := range []bool{true, false} {
+				for i := range dst {
+					dst[i] = sentinel
+				}
+				if shortA {
+					MulQ15(dst, a[:h-1], b)
+				} else {
+					MulQ15(dst, a, b[:h-1])
+				}
+				for i := range dst[:h-1] {
+					if want := mulQ15Oracle(a[i], b[i]); dst[i] != want {
+						t.Fatalf("MulQ15 shortA=%v [%d] = %d, want %d", shortA, i, dst[i], want)
+					}
+				}
+				if dst[h-1] != sentinel {
+					t.Fatalf("MulQ15 shortA=%v wrote dst[%d] = %d past the clamp, want the sentinel %d", shortA, h-1, dst[h-1], sentinel)
+				}
+			}
+		}
+	})
+}
+
+// FuzzI16AbsMaxAbs differentially fuzzes Abs and MaxAbs together and asserts
+// the relation between them: MaxAbs equals the int-widened maximum over
+// Abs's output, where the only element Abs leaves negative (-32768, the
+// wrap) contributes its true magnitude 32768.
+func FuzzI16AbsMaxAbs(f *testing.F) {
+	addLenSeeds(f)
+	f.Fuzz(func(t *testing.T, raw []byte) {
+		a := i16sFromBits(raw)
+		dst := make([]int16, len(a))
+		ref := make([]int16, len(a))
+		Abs(dst, a)
+		absGo(ref, a)
+		equalI16(t, "Abs", dst, ref)
+		got := MaxAbs(a)
+		if want := maxAbsGo(a); got != want {
+			t.Fatalf("MaxAbs = %d, want %d (len=%d)", got, want, len(a))
+		}
+		want := 0
+		for i := range dst {
+			av := int(dst[i])
+			if av < 0 { // only the -32768 wrap survives Abs negative
+				av = 32768
+			}
+			want = max(want, av)
+		}
+		if got != want {
+			t.Fatalf("MaxAbs = %d inconsistent with Abs-derived max %d (len=%d)", got, want, len(a))
+		}
+	})
+}
+
 // FuzzI16XCorr differentially fuzzes multi-lag correlation. The high-value bug
 // class is the lag blocking: the kernel evaluates 4 lags per call and the
 // dispatcher finishes the remainder with the dot kernel, so arbitrary lag

--- a/i16/i16.go
+++ b/i16/i16.go
@@ -15,10 +15,15 @@
 // results. Fixed-point codecs (Opus/CELT, FLAC LPC) depend on that
 // reproducibility, which is the whole reason they use integer arithmetic.
 //
-// Element-wise int16 arithmetic still belongs in the i32 package, because
+// Element-wise int16 add/sub still belongs in the i32 package, because
 // inter-channel decorrelation can exceed the source bit depth by one bit. What
-// this package adds at 16-bit width is the widening direction, where the narrow
-// input is the point.
+// lives here is the widening direction (DotProduct, XCorr), where the narrow
+// input is the point, plus the element-wise operations that are well-defined
+// at 16-bit width: the wrapping absolute value (Abs) and the rounding Q15
+// fixed-point multiply (MulQ15). Those two produce a result that fits int16
+// for every input except the single wrapping case each documents. The MaxAbs reduction is the
+// deliberate exception: it widens to int, because |-32768| = 32768 is the
+// headroom value callers need and it does not fit the element type.
 //
 // All functions automatically select the optimal implementation based on
 // runtime CPU feature detection and fall back to a pure-Go implementation on

--- a/i16/i16_amd64.go
+++ b/i16/i16_amd64.go
@@ -15,8 +15,13 @@ const (
 
 // Dispatch priority mirrors f32/f64: AVX2 > SSE2 > Go. The kernels gate on the
 // CPU feature explicitly (rather than relying on length alone) so the package is
-// correct on every amd64 baseline. SSE2 is part of the amd64 baseline, so the
-// pure-Go fallback below is effectively a non-amd64 safety net here.
+// correct on every amd64 baseline.
+//
+// SSE2 is part of the amd64 baseline, so for the ops that ship an SSE2 tier
+// (interleave, dot, xcorr) the pure-Go fallback is effectively a non-amd64
+// safety net. That is not true package-wide: the tier-3 ops below (MulQ15, Abs,
+// MaxAbs) are AVX2-or-Go, so on a pre-AVX2 amd64 host their Go reference is a
+// live, reachable path rather than a formality.
 var (
 	hasAVX2 = cpu.X86.AVX2
 	hasSSE2 = cpu.X86.SSE2
@@ -107,6 +112,54 @@ func deinterleave2I16(a, b, src []int16) {
 		deinterleave2Go(a, b, src)
 	}
 }
+
+// Tier-3 thresholds: one 16-wide (256-bit) vector block each, independent
+// literals per the dot precedent above. These ops are AVX2-or-Go: unlike
+// dot/xcorr/interleave they ship no SSE2 tier, matching i8 and the i32
+// arithmetic, because cheap store-bound element work does not earn a third
+// tier's maintenance. Below AVX2 the Go reference runs.
+//
+// The kernels are correct at any length (each falls through to a scalar tail),
+// so these are performance cuts only, never a safety requirement. Nothing here
+// keeps a kernel in bounds: the tier-3 kernels carry no in-assembly clamp, and
+// the public wrappers are what reconcile the operand lengths.
+const (
+	minAVX2MulQ15 = 16
+	minAVX2Abs    = 16
+	minAVX2MaxAbs = 16
+)
+
+func mulQ15I16(dst, a, b []int16) {
+	if hasAVX2 && len(dst) >= minAVX2MulQ15 {
+		mulQ15AVX2(dst, a, b)
+		return
+	}
+	mulQ15Go(dst, a, b)
+}
+
+func absI16(dst, a []int16) {
+	if hasAVX2 && len(dst) >= minAVX2Abs {
+		absAVX2(dst, a)
+		return
+	}
+	absGo(dst, a)
+}
+
+func maxAbsI16(a []int16) int {
+	if hasAVX2 && len(a) >= minAVX2MaxAbs {
+		return maxAbsAVX2(a)
+	}
+	return maxAbsGo(a)
+}
+
+//go:noescape
+func mulQ15AVX2(dst, a, b []int16)
+
+//go:noescape
+func absAVX2(dst, a []int16)
+
+//go:noescape
+func maxAbsAVX2(a []int16) int
 
 //go:noescape
 func xcorr4AVX2(dst []int32, x, y []int16)

--- a/i16/i16_amd64.s
+++ b/i16/i16_amd64.s
@@ -653,3 +653,162 @@ xcorr4_avx2_store:
     MOVL R11, 12(DI)
     VZEROUPPER
     RET
+
+// Tier-3 element-wise and reduction kernels (AVX2).
+//
+// All three receive pre-clamped slices from the public API, so unlike the dot
+// kernels there is no in-assembly length clamp anywhere below: dst_len (or
+// a_len) is the trusted element count. These ops are AVX2-or-Go by dispatch
+// (see i16_amd64.go); no SSE2 tier exists for them.
+
+// func mulQ15AVX2(dst, a, b []int16)
+// Rounding Q15 multiply, 16 lanes per iteration. VPMULHRSW computes
+// ((a*b >> 14) + 1) >> 1, bit-identical to the rounding form
+// (a*b + 2^14) >> 15 for every int16 pair, and it WRAPS the one product
+// outside int16 range: (-32768)^2 -> 0x8000 = -32768, matching mulQ15Go.
+// NEON's SQRDMULH saturates that pair and can never be used for this op; see
+// mulq15.go. The scalar tail does the widen/round/narrow in 32-bit GPR math;
+// the MOVW store keeps the low 16 bits, wrapping identically.
+TEXT ·mulQ15AVX2(SB), NOSPLIT, $0-72
+    MOVQ dst_base+0(FP), DX
+    MOVQ dst_len+8(FP), CX
+    MOVQ a_base+24(FP), SI
+    MOVQ b_base+48(FP), DI
+
+    MOVQ CX, AX
+    SHRQ $4, AX                // AX = n / 16
+    JZ   mulq15_avx2_tail
+
+mulq15_avx2_loop16:
+    VMOVDQU (SI), Y0
+    VMOVDQU (DI), Y1
+    VPMULHRSW Y1, Y0, Y2       // 16 rounded Q15 products
+    VMOVDQU Y2, (DX)
+    ADDQ $32, SI
+    ADDQ $32, DI
+    ADDQ $32, DX
+    DECQ AX
+    JNZ  mulq15_avx2_loop16
+
+mulq15_avx2_tail:
+    ANDQ $15, CX
+    JZ   mulq15_avx2_done
+
+mulq15_avx2_scalar:
+    MOVWLSX (SI), AX           // a[i], sign-extended
+    MOVWLSX (DI), BX           // b[i], sign-extended
+    IMULL BX, AX               // product, |p| <= 2^30
+    ADDL $16384, AX            // + q15Round
+    SARL $15, AX               // rounding shift
+    MOVW AX, (DX)              // low 16 bits: 32768 wraps to -32768
+    ADDQ $2, SI
+    ADDQ $2, DI
+    ADDQ $2, DX
+    DECQ CX
+    JNZ  mulq15_avx2_scalar
+
+mulq15_avx2_done:
+    VZEROUPPER
+    RET
+
+// func absAVX2(dst, a []int16)
+// Wrapping absolute value, 16 lanes per iteration: VPABSW wraps at the type
+// minimum (abs(-32768) = -32768 in a 16-bit lane), which is absGo's contract.
+// The scalar tail negates only the negative elements in 32-bit GPR math,
+// where -(-32768) is +32768, and the MOVW store keeps the low 16 bits,
+// wrapping it back to -32768 identically.
+TEXT ·absAVX2(SB), NOSPLIT, $0-48
+    MOVQ dst_base+0(FP), DX
+    MOVQ dst_len+8(FP), CX
+    MOVQ a_base+24(FP), SI
+
+    MOVQ CX, AX
+    SHRQ $4, AX                // AX = n / 16
+    JZ   abs_avx2_tail
+
+abs_avx2_loop16:
+    VPABSW (SI), Y0
+    VMOVDQU Y0, (DX)
+    ADDQ $32, SI
+    ADDQ $32, DX
+    DECQ AX
+    JNZ  abs_avx2_loop16
+
+abs_avx2_tail:
+    ANDQ $15, CX
+    JZ   abs_avx2_done
+
+abs_avx2_scalar:
+    MOVWLSX (SI), AX           // v, sign-extended
+    TESTL AX, AX
+    JGE  abs_avx2_store
+    NEGL AX                    // |v|; -(-32768) = 32768
+abs_avx2_store:
+    MOVW AX, (DX)              // low 16 bits: 32768 wraps to -32768
+    ADDQ $2, SI
+    ADDQ $2, DX
+    DECQ CX
+    JNZ  abs_avx2_scalar
+
+abs_avx2_done:
+    VZEROUPPER
+    RET
+
+// func maxAbsAVX2(a []int16) int
+// Per-frame abs-max (the headroom probe): VPABSW maps each lane to its
+// magnitude (abs(-32768) -> 0x8000, i.e. 32768 read unsigned), VPMAXUW folds
+// 16-lane blocks into an unsigned-max accumulator, a VPMAXUW/VPSRLDQ cascade
+// reduces a 128-bit lane to one word, and a scalar tail folds the (n mod 16)
+// remainder. The word is read zero-extended, so the result lands in
+// [0, 32768], and the tail compare can stay signed because both sides fit
+// that range.
+TEXT ·maxAbsAVX2(SB), NOSPLIT, $0-32
+    MOVQ a_base+0(FP), SI
+    MOVQ a_len+8(FP), CX
+
+    VPXOR Y0, Y0, Y0           // unsigned-max accumulator = 0
+
+    MOVQ CX, AX
+    SHRQ $4, AX                // AX = n / 16
+    JZ   maxabs_avx2_reduce
+
+maxabs_avx2_loop16:
+    VPABSW (SI), Y1            // |a| as unsigned words
+    VPMAXUW Y1, Y0, Y0         // unsigned max accumulate
+    ADDQ $32, SI
+    DECQ AX
+    JNZ  maxabs_avx2_loop16
+
+maxabs_avx2_reduce:
+    VEXTRACTI128 $1, Y0, X1
+    VPMAXUW X1, X0, X0         // fold 16 -> 8 words
+    VPSRLDQ $8, X0, X1
+    VPMAXUW X1, X0, X0         // 4 words
+    VPSRLDQ $4, X0, X1
+    VPMAXUW X1, X0, X0         // 2 words
+    VPSRLDQ $2, X0, X1
+    VPMAXUW X1, X0, X0         // 1 word
+    MOVQ X0, AX
+    ANDQ $0xFFFF, AX           // running abs-max (unsigned word) in [0, 32768]
+
+    ANDQ $15, CX
+    JZ   maxabs_avx2_done
+
+maxabs_avx2_scalar:
+    MOVWLSX (SI), BX           // v, sign-extended
+    TESTL BX, BX
+    JGE  maxabs_avx2_cmp
+    NEGL BX                    // |v|; -(-32768) = 32768
+maxabs_avx2_cmp:
+    CMPL BX, AX                // both in [0, 32768], signed compare is safe
+    JLE  maxabs_avx2_next
+    MOVL BX, AX                // new running max
+maxabs_avx2_next:
+    ADDQ $2, SI
+    DECQ CX
+    JNZ  maxabs_avx2_scalar
+
+maxabs_avx2_done:
+    MOVQ AX, ret+24(FP)
+    VZEROUPPER
+    RET

--- a/i16/i16_amd64_test.go
+++ b/i16/i16_amd64_test.go
@@ -380,6 +380,175 @@ func TestXCorrDispatch_ReachesSIMD(t *testing.T) {
 	}
 }
 
+// TestMulQ15AVX2_ParityWithGo drives the kernel directly, over lengths the
+// dispatcher would never route to it, so a threshold change cannot quietly
+// reduce this to a test of the Go reference against itself.
+func TestMulQ15AVX2_ParityWithGo(t *testing.T) {
+	if !cpu.X86.AVX2 {
+		t.Skip("AVX2 not available")
+	}
+	for _, n := range tier3Lengths {
+		a, b := genI16(n, 141), genI16(n, 142)
+		got := make([]int16, n)
+		want := make([]int16, n)
+		mulQ15AVX2(got, a, b)
+		mulQ15Go(want, a, b)
+		for i := range want {
+			if got[i] != want[i] {
+				t.Fatalf("mulQ15AVX2 n=%d: dst[%d] = %d, want %d", n, i, got[i], want[i])
+			}
+		}
+	}
+}
+
+// TestMulQ15AVX2_MinInt16 pins VPMULHRSW's wrap at the one product outside
+// int16 range: (-32768)^2 rounds to +32768 and must land as -32768 in the
+// vector lanes and in the scalar tail. This is the load-bearing runtime check
+// for the instruction's non-saturating behavior; a saturating substitute
+// would return 32767 in every position.
+func TestMulQ15AVX2_MinInt16(t *testing.T) {
+	if !cpu.X86.AVX2 {
+		t.Skip("AVX2 not available")
+	}
+	for n := 1; n <= 48; n++ {
+		a := make([]int16, n)
+		for i := range a {
+			a[i] = math.MinInt16
+		}
+		got := make([]int16, n)
+		mulQ15AVX2(got, a, a)
+		for i := range got {
+			if got[i] != math.MinInt16 {
+				t.Fatalf("mulQ15AVX2 all-MinInt16 n=%d: dst[%d] = %d, want %d", n, i, got[i], math.MinInt16)
+			}
+		}
+	}
+}
+
+// TestAbsAVX2_ParityWithGo drives the kernel directly across the full sweep;
+// the wrap input MinInt16 rides at index 0 of every non-empty case.
+func TestAbsAVX2_ParityWithGo(t *testing.T) {
+	if !cpu.X86.AVX2 {
+		t.Skip("AVX2 not available")
+	}
+	for _, n := range tier3Lengths {
+		a := genI16(n, 143)
+		if n > 0 {
+			a[0] = math.MinInt16
+		}
+		got := make([]int16, n)
+		want := make([]int16, n)
+		absAVX2(got, a)
+		absGo(want, a)
+		for i := range want {
+			if got[i] != want[i] {
+				t.Fatalf("absAVX2 n=%d: dst[%d] = %d, want %d", n, i, got[i], want[i])
+			}
+		}
+	}
+}
+
+// TestMaxAbsAVX2_ParityWithGo drives the kernel directly across the sweep,
+// then pins the widened extreme: a planted -32768 must come back as 32768
+// from every lane position and from the scalar tail.
+func TestMaxAbsAVX2_ParityWithGo(t *testing.T) {
+	if !cpu.X86.AVX2 {
+		t.Skip("AVX2 not available")
+	}
+	for _, n := range tier3Lengths {
+		a := genI16(n, 144)
+		if got, want := maxAbsAVX2(a), maxAbsGo(a); got != want {
+			t.Errorf("maxAbsAVX2 n=%d: got %d, want %d", n, got, want)
+		}
+	}
+	for _, n := range []int{16, 17, 24, 32, 33} {
+		for pos := range n {
+			a := make([]int16, n)
+			a[pos] = math.MinInt16
+			if got := maxAbsAVX2(a); got != 32768 {
+				t.Fatalf("maxAbsAVX2 n=%d pos=%d: got %d, want 32768", n, pos, got)
+			}
+		}
+	}
+}
+
+// TestMaxAbsAVX2_NoOverRead is the kernel-direct over-read check: the operand
+// is a prefix of a longer allocation whose every element past the prefix is
+// -32768. Zeroed past-slice memory is the identity element of this reduction,
+// so only the planted extreme makes an over-read observable.
+func TestMaxAbsAVX2_NoOverRead(t *testing.T) {
+	if !cpu.X86.AVX2 {
+		t.Skip("AVX2 not available")
+	}
+	backing := make([]int16, 64+16)
+	for i := range backing {
+		backing[i] = math.MinInt16
+	}
+	for _, n := range []int{1, 7, 15, 16, 17, 24, 31, 32, 33, 64} {
+		a := backing[:n]
+		for i := range a {
+			a[i] = int16(i%50 - 25)
+		}
+		if got, want := maxAbsAVX2(a), maxAbsGo(a); got != want {
+			t.Fatalf("maxAbsAVX2 n=%d: got %d, want %d (read past the operand?)", n, got, want)
+		}
+		for i := range a {
+			backing[i] = math.MinInt16
+		}
+	}
+}
+
+// TestTier3Dispatch_ReachesSIMD pins the dispatch state the tier-3 SIMD paths
+// depend on. It has to be a white-box check: the kernels are bit-identical to
+// the Go references by design, so a dispatcher that silently routed every
+// call to Go would pass every parity test in this package, and the
+// kernel-direct tests above are threshold-independent by construction, so
+// they cannot notice either. Unlike the dot ops there is no SSE2 leg here:
+// below AVX2 the Go reference is the intended path. It must not call
+// t.Parallel(): it reads package-level dispatch state.
+//
+// Scope, so the next reader does not over-trust it: this pins the INPUTS the
+// dispatcher reads (the feature flag, and thresholds low enough to vectorize),
+// not that the dispatcher consults them. It kills a mis-wired flag and an
+// out-of-range threshold; it does not kill a dispatch branch deleted outright,
+// which leaves the kernel dead while every test here still passes. Closing
+// that needs the call to be observable, e.g. a counter behind a build tag.
+func TestTier3Dispatch_ReachesSIMD(t *testing.T) {
+	if hasAVX2 != cpu.X86.AVX2 {
+		t.Fatalf("hasAVX2 = %v but cpu.X86.AVX2 = %v: dispatch flag is not wired to CPU detection", hasAVX2, cpu.X86.AVX2)
+	}
+	if minAVX2MulQ15 > 32 || minAVX2Abs > 32 || minAVX2MaxAbs > 32 {
+		t.Fatalf("tier-3 AVX2 thresholds exceed two vector blocks (MulQ15 %d, Abs %d, MaxAbs %d): the ops would not vectorize at the frame lengths they were written for",
+			minAVX2MulQ15, minAVX2Abs, minAVX2MaxAbs)
+	}
+}
+
+// TestTier3AVX2Kernels_AllocFree enforces the zero-allocation contract
+// directly at the kernel boundary (the public-API alloc tests cover the
+// dispatch, these cover the kernels).
+func TestTier3AVX2Kernels_AllocFree(t *testing.T) {
+	if !cpu.X86.AVX2 {
+		t.Skip("AVX2 not available")
+	}
+	const n = 1024
+	a := make([]int16, n)
+	b := make([]int16, n)
+	dst := make([]int16, n)
+	checks := []struct {
+		name string
+		fn   func()
+	}{
+		{"mulQ15AVX2", func() { mulQ15AVX2(dst, a, b) }},
+		{"absAVX2", func() { absAVX2(dst, a) }},
+		{"maxAbsAVX2", func() { _ = maxAbsAVX2(a) }},
+	}
+	for _, c := range checks {
+		if got := testing.AllocsPerRun(100, c.fn); got != 0 {
+			t.Errorf("%s allocated %v times per run, want 0", c.name, got)
+		}
+	}
+}
+
 // TestXCorr4AMD64_LongWindowIsClamped covers the other half of the kernel's
 // n = min(len(x), len(y)-3) clamp. ShortWindowIsBounded only probes
 // len(y)-3 < len(x); ParityWithGo passes len(y) == len(x)+3, where both

--- a/i16/i16_arm64.go
+++ b/i16/i16_arm64.go
@@ -93,6 +93,49 @@ func dotI16(a, b []int16) int32 {
 	return dotGo(a, b)
 }
 
+// Tier-3 thresholds: one 8-wide (.8H) vector block each. Like minNEONDot they
+// are independent literals rather than aliases of minNEONElements, so retuning
+// one op can never silently move another's cut. All three kernels are correct
+// at any length (each falls through to a scalar tail), so these are
+// performance cuts only, never a safety requirement.
+const (
+	minNEONMulQ15 = 8
+	minNEONAbs    = 8
+	minNEONMaxAbs = 8
+)
+
+func mulQ15I16(dst, a, b []int16) {
+	if hasNEON && len(dst) >= minNEONMulQ15 {
+		mulQ15NEON(dst, a, b)
+		return
+	}
+	mulQ15Go(dst, a, b)
+}
+
+func absI16(dst, a []int16) {
+	if hasNEON && len(dst) >= minNEONAbs {
+		absNEON(dst, a)
+		return
+	}
+	absGo(dst, a)
+}
+
+func maxAbsI16(a []int16) int {
+	if hasNEON && len(a) >= minNEONMaxAbs {
+		return maxAbsNEON(a)
+	}
+	return maxAbsGo(a)
+}
+
+//go:noescape
+func mulQ15NEON(dst, a, b []int16)
+
+//go:noescape
+func absNEON(dst, a []int16)
+
+//go:noescape
+func maxAbsNEON(a []int16) int
+
 //go:noescape
 func dotNEON(a, b []int16) int32
 

--- a/i16/i16_arm64.s
+++ b/i16/i16_arm64.s
@@ -280,3 +280,143 @@ xcorr4_neon_store:
     MOVW R9, 8(R0)
     MOVW R10, 12(R0)
     RET
+
+// Tier-3 element-wise and reduction kernels (NEON / ASIMD).
+//
+// All three receive pre-clamped slices from the public API, so unlike
+// dotNEON there is no in-assembly length clamp anywhere below: dst_len (or
+// a_len) is the trusted element count. SMULL/SRSHR/XTN/ABS/UMAXV have no Go
+// assembler mnemonics and are hand-encoded as WORD with the decoded form in
+// the trailing comment (cross-checked by asmcheck_test.go); VUMAX does have a
+// mnemonic and uses it.
+
+// func mulQ15NEON(dst, a, b []int16)
+// Rounding Q15 multiply, 8 lanes per iteration: SMULL/SMULL2 widen the int16
+// products to int32, SRSHR #15 is the rounding shift ((p + 2^14) >> 15,
+// computed on a wider intermediate, and |p| <= 2^30 anyway, so the rounding
+// add cannot overflow), and XTN/XTN2 narrow back to int16 by truncation,
+// which is the wrap: the one product outside int16 range, (-32768)^2 ->
+// +32768, lands as -32768, matching mulQ15Go.
+//
+// SQRDMULH would do all of this in one instruction and must never be used:
+// it saturates exactly that pair to 32767 (see mulq15.go). The scalar tail
+// does the same widen/round/narrow in a 64-bit GPR; the MOVH store keeps the
+// low 16 bits, wrapping identically.
+TEXT ·mulQ15NEON(SB), NOSPLIT, $0-72
+    MOVD dst_base+0(FP), R0
+    MOVD dst_len+8(FP), R3
+    MOVD a_base+24(FP), R1
+    MOVD b_base+48(FP), R2
+
+    LSR  $3, R3, R4            // R4 = n / 8
+    CBZ  R4, mulq15_neon_remainder
+
+mulq15_neon_loop8:
+    VLD1.P 16(R1), [V0.H8]
+    VLD1.P 16(R2), [V1.H8]
+    WORD $0x0E61C002           // SMULL V2.4S, V0.4H, V1.4H
+    WORD $0x4E61C003           // SMULL2 V3.4S, V0.8H, V1.8H
+    WORD $0x4F312442           // SRSHR V2.4S, V2.4S, #15
+    WORD $0x4F312463           // SRSHR V3.4S, V3.4S, #15
+    WORD $0x0E612844           // XTN V4.4H, V2.4S
+    WORD $0x4E612864           // XTN2 V4.8H, V3.4S
+    VST1.P [V4.H8], 16(R0)
+    SUB  $1, R4
+    CBNZ R4, mulq15_neon_loop8
+
+mulq15_neon_remainder:
+    AND  $7, R3
+    CBZ  R3, mulq15_neon_done
+
+mulq15_neon_scalar:
+    MOVH.P 2(R1), R5           // a[i], sign-extended
+    MOVH.P 2(R2), R6           // b[i], sign-extended
+    MUL  R6, R5, R5            // 64-bit product, |p| <= 2^30
+    ADD  $16384, R5            // + q15Round
+    ASR  $15, R5               // rounding shift
+    MOVH.P R5, 2(R0)           // low 16 bits: 32768 wraps to -32768
+    SUB  $1, R3
+    CBNZ R3, mulq15_neon_scalar
+
+mulq15_neon_done:
+    RET
+
+// func absNEON(dst, a []int16)
+// Wrapping absolute value, 8 lanes per iteration: vector ABS wraps at the
+// type minimum (abs(-32768) = -32768 in a 16-bit lane), which is absGo's
+// contract. The scalar tail computes |v| in a 64-bit GPR, where -(-32768) is
+// +32768, and the MOVH store keeps the low 16 bits, wrapping it back to
+// -32768 identically.
+TEXT ·absNEON(SB), NOSPLIT, $0-48
+    MOVD dst_base+0(FP), R0
+    MOVD dst_len+8(FP), R3
+    MOVD a_base+24(FP), R1
+
+    LSR  $3, R3, R4            // R4 = n / 8
+    CBZ  R4, abs_neon_remainder
+
+abs_neon_loop8:
+    VLD1.P 16(R1), [V0.H8]
+    WORD $0x4E60B800           // ABS V0.8H, V0.8H
+    VST1.P [V0.H8], 16(R0)
+    SUB  $1, R4
+    CBNZ R4, abs_neon_loop8
+
+abs_neon_remainder:
+    AND  $7, R3
+    CBZ  R3, abs_neon_done
+
+abs_neon_scalar:
+    MOVH.P 2(R1), R5           // v, sign-extended
+    NEG  R5, R6                // -v
+    CMP  $0, R5
+    CSEL LT, R6, R5, R5        // |v| = v < 0 ? -v : v   (can be 32768)
+    MOVH.P R5, 2(R0)           // low 16 bits: 32768 wraps to -32768
+    SUB  $1, R3
+    CBNZ R3, abs_neon_scalar
+
+abs_neon_done:
+    RET
+
+// func maxAbsNEON(a []int16) int
+// Per-frame abs-max (the headroom probe): ABS maps each lane to its magnitude
+// (abs(-32768) -> 0x8000, i.e. 32768 read unsigned), VUMAX folds 8-lane
+// blocks into an unsigned-max accumulator, UMAXV reduces it to one halfword,
+// and a scalar tail folds the (n mod 8) remainder. FMOVS reads the S view of
+// the H result with the upper 16 bits zero, which is why 0x8000 compares
+// correctly as unsigned 32768; the result lands in [0, 32768].
+TEXT ·maxAbsNEON(SB), NOSPLIT, $0-32
+    MOVD a_base+0(FP), R1
+    MOVD a_len+8(FP), R3
+
+    VEOR V2.B16, V2.B16, V2.B16   // unsigned-max accumulator = 0
+    LSR  $3, R3, R4               // R4 = n / 8
+    CBZ  R4, maxabs_neon_reduce
+
+maxabs_neon_loop8:
+    VLD1.P 16(R1), [V0.H8]
+    WORD $0x4E60B800             // ABS V0.8H, V0.8H
+    VUMAX V0.H8, V2.H8, V2.H8    // unsigned max accumulate
+    SUB  $1, R4
+    CBNZ R4, maxabs_neon_loop8
+
+maxabs_neon_reduce:
+    WORD $0x6E70A841             // UMAXV H1, V2.8H
+    FMOVS F1, R5                  // abs-max halfword, zero-extended
+
+    AND  $7, R3
+    CBZ  R3, maxabs_neon_done
+
+maxabs_neon_scalar:
+    MOVH.P 2(R1), R6              // v, sign-extended
+    NEG  R6, R7                   // -v
+    CMP  $0, R6
+    CSEL LT, R7, R6, R6           // |v| = v < 0 ? -v : v   (can be 32768)
+    CMP  R5, R6
+    CSEL HI, R6, R5, R5           // unsigned: |v| > max ? |v| : max
+    SUB  $1, R3
+    CBNZ R3, maxabs_neon_scalar
+
+maxabs_neon_done:
+    MOVD R5, ret+24(FP)
+    RET

--- a/i16/i16_arm64_test.go
+++ b/i16/i16_arm64_test.go
@@ -259,6 +259,175 @@ func TestXCorrDispatch_ReachesNEON(t *testing.T) {
 	}
 }
 
+// TestMulQ15NEON_ParityWithGo drives the kernel directly, over lengths the
+// dispatcher would never route to it, so a threshold change cannot quietly
+// reduce this to a test of the Go reference against itself.
+func TestMulQ15NEON_ParityWithGo(t *testing.T) {
+	if !cpu.ARM64.NEON {
+		t.Skip("NEON not available")
+	}
+	for _, n := range tier3Lengths {
+		a, b := genI16(n, 131), genI16(n, 132)
+		got := make([]int16, n)
+		want := make([]int16, n)
+		mulQ15NEON(got, a, b)
+		mulQ15Go(want, a, b)
+		for i := range want {
+			if got[i] != want[i] {
+				t.Fatalf("mulQ15NEON n=%d: dst[%d] = %d, want %d", n, i, got[i], want[i])
+			}
+		}
+	}
+}
+
+// TestMulQ15NEON_MinInt16 pins the SRSHR+XTN wrap at the kernel: (-32768)^2
+// must narrow to -32768 in the vector lanes and in the scalar tail. A
+// saturating substitute (SQRDMULH) would return 32767 in every position.
+func TestMulQ15NEON_MinInt16(t *testing.T) {
+	if !cpu.ARM64.NEON {
+		t.Skip("NEON not available")
+	}
+	for n := 1; n <= 32; n++ {
+		a := make([]int16, n)
+		for i := range a {
+			a[i] = math.MinInt16
+		}
+		got := make([]int16, n)
+		mulQ15NEON(got, a, a)
+		for i := range got {
+			if got[i] != math.MinInt16 {
+				t.Fatalf("mulQ15NEON all-MinInt16 n=%d: dst[%d] = %d, want %d", n, i, got[i], math.MinInt16)
+			}
+		}
+	}
+}
+
+// TestAbsNEON_ParityWithGo drives the kernel directly across the full sweep;
+// the wrap input MinInt16 rides at index 0 of every non-empty case.
+func TestAbsNEON_ParityWithGo(t *testing.T) {
+	if !cpu.ARM64.NEON {
+		t.Skip("NEON not available")
+	}
+	for _, n := range tier3Lengths {
+		a := genI16(n, 133)
+		if n > 0 {
+			a[0] = math.MinInt16
+		}
+		got := make([]int16, n)
+		want := make([]int16, n)
+		absNEON(got, a)
+		absGo(want, a)
+		for i := range want {
+			if got[i] != want[i] {
+				t.Fatalf("absNEON n=%d: dst[%d] = %d, want %d", n, i, got[i], want[i])
+			}
+		}
+	}
+}
+
+// TestMaxAbsNEON_ParityWithGo drives the kernel directly across the sweep,
+// then pins the widened extreme: a planted -32768 must come back as 32768
+// from every lane position and from the scalar tail.
+func TestMaxAbsNEON_ParityWithGo(t *testing.T) {
+	if !cpu.ARM64.NEON {
+		t.Skip("NEON not available")
+	}
+	for _, n := range tier3Lengths {
+		a := genI16(n, 134)
+		if got, want := maxAbsNEON(a), maxAbsGo(a); got != want {
+			t.Errorf("maxAbsNEON n=%d: got %d, want %d", n, got, want)
+		}
+	}
+	for _, n := range []int{8, 9, 16, 17, 24} {
+		for pos := range n {
+			a := make([]int16, n)
+			a[pos] = math.MinInt16
+			if got := maxAbsNEON(a); got != 32768 {
+				t.Fatalf("maxAbsNEON n=%d pos=%d: got %d, want 32768", n, pos, got)
+			}
+		}
+	}
+}
+
+// TestMaxAbsNEON_NoOverRead is the kernel-direct over-read check: the operand
+// is a prefix of a longer allocation whose every element past the prefix is
+// -32768. Zeroed past-slice memory is the identity element of this reduction,
+// so only the planted extreme makes an over-read observable.
+func TestMaxAbsNEON_NoOverRead(t *testing.T) {
+	if !cpu.ARM64.NEON {
+		t.Skip("NEON not available")
+	}
+	backing := make([]int16, 64+8)
+	for i := range backing {
+		backing[i] = math.MinInt16
+	}
+	for _, n := range []int{1, 7, 8, 9, 15, 16, 17, 24, 33, 64} {
+		a := backing[:n]
+		for i := range a {
+			a[i] = int16(i%50 - 25)
+		}
+		if got, want := maxAbsNEON(a), maxAbsGo(a); got != want {
+			t.Fatalf("maxAbsNEON n=%d: got %d, want %d (read past the operand?)", n, got, want)
+		}
+		for i := range a {
+			backing[i] = math.MinInt16
+		}
+	}
+}
+
+// TestTier3Dispatch_ReachesNEON pins the dispatch state the tier-3 SIMD paths
+// depend on. It has to be a white-box check: the kernels are bit-identical to
+// the Go references by design, so a dispatcher that silently routed every
+// call to Go would pass every parity test in this package, and the
+// kernel-direct tests above are threshold-independent by construction, so
+// they cannot notice either. It must not call t.Parallel(): it reads
+// package-level dispatch state.
+//
+// Scope, so the next reader does not over-trust it: this pins the INPUTS the
+// dispatcher reads (the feature flag, and thresholds low enough to vectorize),
+// not that the dispatcher consults them. It kills a mis-wired flag and an
+// out-of-range threshold; it does not kill a dispatch branch deleted outright,
+// which leaves the kernel dead while every test here still passes. Closing
+// that needs the call to be observable, e.g. a counter behind a build tag.
+func TestTier3Dispatch_ReachesNEON(t *testing.T) {
+	if !cpu.ARM64.NEON {
+		t.Skip("NEON not available")
+	}
+	if !hasNEON {
+		t.Fatal("hasNEON is false though cpu.ARM64.NEON is true: the tier-3 ops silently run the Go reference on every call")
+	}
+	if minNEONMulQ15 > 16 || minNEONAbs > 16 || minNEONMaxAbs > 16 {
+		t.Fatalf("tier-3 NEON thresholds exceed two vector blocks (MulQ15 %d, Abs %d, MaxAbs %d): the ops would not vectorize at the frame lengths they were written for",
+			minNEONMulQ15, minNEONAbs, minNEONMaxAbs)
+	}
+}
+
+// TestTier3NEONKernels_AllocFree enforces the zero-allocation contract
+// directly at the kernel boundary (the public-API alloc tests cover the
+// dispatch, these cover the kernels).
+func TestTier3NEONKernels_AllocFree(t *testing.T) {
+	if !cpu.ARM64.NEON {
+		t.Skip("NEON not available")
+	}
+	const n = 1024
+	a := make([]int16, n)
+	b := make([]int16, n)
+	dst := make([]int16, n)
+	checks := []struct {
+		name string
+		fn   func()
+	}{
+		{"mulQ15NEON", func() { mulQ15NEON(dst, a, b) }},
+		{"absNEON", func() { absNEON(dst, a) }},
+		{"maxAbsNEON", func() { _ = maxAbsNEON(a) }},
+	}
+	for _, c := range checks {
+		if got := testing.AllocsPerRun(100, c.fn); got != 0 {
+			t.Errorf("%s allocated %v times per run, want 0", c.name, got)
+		}
+	}
+}
+
 // TestXCorr4NEON_LongWindowIsClamped covers the other half of the kernel's
 // n = min(len(x), len(y)-3) clamp. TestXCorr4NEON_ShortWindowIsBounded only
 // probes len(y)-3 < len(x); ParityWithGo passes len(y) == len(x)+3, where both

--- a/i16/i16_go.go
+++ b/i16/i16_go.go
@@ -72,6 +72,53 @@ func xcorrGo(dst []int32, x, y []int16) {
 	}
 }
 
+// Q15 fixed-point rounding constants: the Q15 product of a and b is
+// (a*b + q15Round) >> q15Shift. q15Round is half the divisor, so the shift
+// rounds to nearest instead of truncating toward negative infinity; this is
+// the libopus MULT16_16_P15 form, not the truncating MULT16_16_Q15.
+const (
+	q15Round = 1 << 14
+	q15Shift = 15
+)
+
+// mulQ15Go is the bit-exact source of truth for the MulQ15 kernels. The int16
+// conversion keeps the low 16 bits, so the one product outside int16 range,
+// (-32768 * -32768) -> +32768, wraps to -32768 rather than saturating; both
+// SIMD paths reproduce that wrap exactly (SMULL/SRSHR/XTN on NEON, VPMULHRSW
+// on AVX2).
+func mulQ15Go(dst, a, b []int16) {
+	for i := range dst {
+		dst[i] = int16((int32(a[i])*int32(b[i]) + q15Round) >> q15Shift)
+	}
+}
+
+// absGo writes the wrapping absolute value: int16 negation wraps in Go, so
+// abs(-32768) stays -32768, exactly what a 16-bit ABS/VPABSW lane computes.
+func absGo(dst, a []int16) {
+	for i := range dst {
+		if a[i] < 0 {
+			dst[i] = -a[i]
+		} else {
+			dst[i] = a[i]
+		}
+	}
+}
+
+// maxAbsGo returns max_i |a[i]| as int. |-32768| = 32768 does not fit int16,
+// hence the int accumulator and return. It is the bit-exact source of truth
+// for the MaxAbs kernels.
+func maxAbsGo(a []int16) int {
+	m := 0
+	for _, v := range a {
+		av := int(v)
+		if av < 0 {
+			av = -av
+		}
+		m = max(m, av)
+	}
+	return m
+}
+
 // xcorrWindow returns the y window the 4-lag kernel may read for the block at
 // lag k: lag k+3 reaches y[k+3+len(x)-1], so the block needs len(x)+3 elements
 // from y[k]. That is in bounds precisely when k+xcorrLagBlock <= m, which is

--- a/i16/i16_other.go
+++ b/i16/i16_other.go
@@ -6,3 +6,6 @@ func interleave2I16(dst, a, b []int16)   { interleave2Go(dst, a, b) }
 func deinterleave2I16(a, b, src []int16) { deinterleave2Go(a, b, src) }
 func dotI16(a, b []int16) int32          { return dotGo(a, b) }
 func xcorrI16(dst []int32, x, y []int16) { xcorrGo(dst, x, y) }
+func mulQ15I16(dst, a, b []int16)        { mulQ15Go(dst, a, b) }
+func absI16(dst, a []int16)              { absGo(dst, a) }
+func maxAbsI16(a []int16) int            { return maxAbsGo(a) }

--- a/i16/mulq15.go
+++ b/i16/mulq15.go
@@ -1,0 +1,33 @@
+package i16
+
+// Q15 fixed-point multiply.
+//
+// Kernel selection constraint: NEON's single-instruction SQRDMULH computes the
+// same rounding product but SATURATES (-32768 * -32768) to 32767, so it can
+// never implement this op. The NEON kernel widens with SMULL, rounds with
+// SRSHR and narrows with XTN, which wraps; amd64's VPMULHRSW computes the
+// identical ((a*b >> 14) + 1) >> 1 and wraps that pair too, so it is safe.
+// Do not "optimize" either kernel toward the saturating instruction.
+
+// MulQ15 writes the rounding Q15 fixed-point product
+//
+//	dst[i] = int16((int32(a[i])*int32(b[i]) + 1<<14) >> 15)
+//
+// for i in [0, n), n = min(len(dst), len(a), len(b)). This is the rounding
+// form (libopus MULT16_16_P15), not the truncating MULT16_16_Q15: the 1<<14
+// term rounds to nearest, so MulQ15(1, 16384) = 1 where truncation would
+// give 0.
+//
+// The int16 conversion wraps rather than saturates. Exactly one input pair
+// produces a value outside int16 range: MulQ15(-32768, -32768) is +32768 and
+// wraps to -32768. That wrap is a guarantee the SIMD paths reproduce
+// bit-exactly. Any trailing capacity in dst is left untouched.
+//
+// dst may overlap a or b only if it starts at the same address.
+func MulQ15(dst, a, b []int16) {
+	n := min(len(dst), len(a), len(b))
+	if n == 0 {
+		return
+	}
+	mulQ15I16(dst[:n], a[:n], b[:n])
+}

--- a/i16/mulq15_test.go
+++ b/i16/mulq15_test.go
@@ -1,0 +1,218 @@
+package i16
+
+import (
+	"math"
+	"testing"
+)
+
+// Tests for MulQ15, the rounding Q15 fixed-point multiply.
+//
+// Two properties carry this suite: the ROUNDING form (add 2^14 before the
+// shift, libopus MULT16_16_P15) rather than truncation, and the narrowing
+// WRAP at the one input pair whose product exceeds int16 range. Both have
+// tiny discriminating inputs, pinned below at lengths that put the vector
+// bodies on the hook rather than just the Go path or a scalar tail.
+
+// mulQ15Oracle computes one rounded Q15 product in int64, independent of
+// mulQ15Go: the widening, the rounding add and the shift cannot overflow
+// int64, and the final int16 conversion is the same defined Go truncation, so
+// it pins the reference rather than trusting it.
+func mulQ15Oracle(a, b int16) int16 {
+	return int16((int64(a)*int64(b) + q15Round) >> q15Shift)
+}
+
+// tier3Lengths sweeps EVERY length 0..64, then a spread of larger ones. The
+// exhaustive low range covers each vector-block/scalar-tail split of the
+// 8-wide NEON and 16-wide AVX2 bodies (a hand-picked list of block boundaries
+// misses combinations, see dotLengths); the spread keeps non-multiples of
+// both widths so the tails also run at realistic lengths.
+var tier3Lengths = func() []int {
+	lens := make([]int, 0, 76)
+	for n := range 65 {
+		lens = append(lens, n)
+	}
+	return append(lens, 100, 127, 128, 129, 240, 255, 256, 257, 1000, 1003, 1024)
+}()
+
+func TestMulQ15(t *testing.T) {
+	for _, n := range tier3Lengths {
+		a, b := genI16(n, 71), genI16(n, 72)
+		dst := make([]int16, n)
+		ref := make([]int16, n)
+		MulQ15(dst, a, b)
+		mulQ15Go(ref, a, b)
+		for i := range dst {
+			if dst[i] != ref[i] {
+				t.Fatalf("MulQ15 n=%d: dst[%d] = %d, want %d (reference)", n, i, dst[i], ref[i])
+			}
+			if want := mulQ15Oracle(a[i], b[i]); dst[i] != want {
+				t.Fatalf("MulQ15 n=%d: dst[%d] = %d, want %d (int64 oracle)", n, i, dst[i], want)
+			}
+		}
+	}
+}
+
+// TestMulQ15_Rounding pins the rounding form with the smallest discriminating
+// inputs, at n=19 so the vector bodies (one 16-wide AVX2 block, two 8-wide
+// NEON blocks) compute most positions and the scalar tails the rest.
+// 1 * 16384 = 2^14 rounds up to 1 where a truncating shift gives 0, and
+// -1 * 16384 = -2^14 rounds up to 0 where a truncating (floor) shift gives -1.
+func TestMulQ15_Rounding(t *testing.T) {
+	const n = 19
+	cases := []struct {
+		a, b, want int16
+	}{
+		{1, 16384, 1},
+		{-1, 16384, 0},
+		{16384, 16384, 8192},
+		{-16384, 16384, -8192},
+		{32767, 32767, 32766},
+	}
+	for _, c := range cases {
+		a := make([]int16, n)
+		b := make([]int16, n)
+		for i := range a {
+			a[i], b[i] = c.a, c.b
+		}
+		dst := make([]int16, n)
+		MulQ15(dst, a, b)
+		for i := range dst {
+			if dst[i] != c.want {
+				t.Errorf("MulQ15(%d, %d): dst[%d] = %d, want %d", c.a, c.b, i, dst[i], c.want)
+			}
+		}
+	}
+}
+
+// TestMulQ15_MinInt16 pins the narrowing wrap at the one product outside
+// int16 range: (-32768)^2 rounds to +32768 and must wrap to -32768. A
+// saturating implementation (NEON SQRDMULH) returns 32767 here, which is why
+// that instruction is banned from the kernels. The sweep walks the pair
+// through every lane position and into the scalar tails.
+func TestMulQ15_MinInt16(t *testing.T) {
+	// n=1 is below every dispatch threshold, pinning the reference itself.
+	one := []int16{math.MinInt16}
+	first := make([]int16, 1)
+	MulQ15(first, one, one)
+	if first[0] != math.MinInt16 {
+		t.Errorf("MulQ15(MinInt16, MinInt16) = %d, want %d (saturation would give %d)",
+			first[0], math.MinInt16, math.MaxInt16)
+	}
+	for n := 1; n <= 64; n++ {
+		a := make([]int16, n)
+		for i := range a {
+			a[i] = math.MinInt16
+		}
+		got := make([]int16, n)
+		MulQ15(got, a, a)
+		for i := range got {
+			if got[i] != math.MinInt16 {
+				t.Fatalf("MulQ15 all-MinInt16 n=%d: dst[%d] = %d, want %d", n, i, got[i], math.MinInt16)
+			}
+		}
+	}
+}
+
+// TestMulQ15_MinInt16Exhaustive multiplies -32768 by every int16 value, so
+// the full b axis of the extreme row is pinned against the oracle. It is
+// cheap (one 65536-element pass) and deterministic, and unlike the
+// all-MinInt16 sweep it is not sign-symmetric, so a lane or index error is
+// visible, not just a miscount.
+func TestMulQ15_MinInt16Exhaustive(t *testing.T) {
+	const total = 1 << 16
+	a := make([]int16, total)
+	b := make([]int16, total)
+	for i := range b {
+		a[i] = math.MinInt16
+		b[i] = int16(i - 32768)
+	}
+	dst := make([]int16, total)
+	ref := make([]int16, total)
+	MulQ15(dst, a, b)
+	mulQ15Go(ref, a, b)
+	for i := range dst {
+		if dst[i] != ref[i] {
+			t.Fatalf("MulQ15(-32768, %d) = %d, want %d (reference)", b[i], dst[i], ref[i])
+		}
+		if want := mulQ15Oracle(a[i], b[i]); dst[i] != want {
+			t.Fatalf("MulQ15(-32768, %d) = %d, want %d (oracle)", b[i], dst[i], want)
+		}
+	}
+}
+
+// TestMulQ15_Clamp covers mismatched operand lengths in every order: n is
+// min(len(dst), len(a), len(b)) and the trailing dst elements stay untouched.
+func TestMulQ15_Clamp(t *testing.T) {
+	a := genI16(40, 73)
+	b := genI16(40, 74)
+	for _, tc := range []struct{ nd, na, nb int }{
+		{40, 40, 25}, {40, 25, 40}, {25, 40, 40},
+		{40, 25, 19}, {19, 40, 25}, {25, 19, 40},
+	} {
+		dst := make([]int16, 48)
+		for i := range dst {
+			dst[i] = math.MaxInt16 // sentinel
+		}
+		MulQ15(dst[:tc.nd], a[:tc.na], b[:tc.nb])
+		n := min(tc.nd, tc.na, tc.nb)
+		for i := range n {
+			if want := mulQ15Oracle(a[i], b[i]); dst[i] != want {
+				t.Fatalf("MulQ15(%d,%d,%d): dst[%d] = %d, want %d", tc.nd, tc.na, tc.nb, i, dst[i], want)
+			}
+		}
+		for i := n; i < len(dst); i++ {
+			if dst[i] != math.MaxInt16 {
+				t.Fatalf("MulQ15(%d,%d,%d) wrote past clamp at dst[%d] = %d", tc.nd, tc.na, tc.nb, i, dst[i])
+			}
+		}
+	}
+}
+
+// TestMulQ15_Empty: no panics and no writes on empty or nil inputs.
+func TestMulQ15_Empty(t *testing.T) {
+	MulQ15(nil, nil, nil)
+	dst := []int16{99}
+	MulQ15(dst, nil, []int16{1})
+	if dst[0] != 99 {
+		t.Errorf("MulQ15 wrote on empty input: %v", dst)
+	}
+}
+
+// TestMulQ15_UnalignedOperands sweeps all eight element offsets, holding the
+// three operands at three different offsets from each other, so no operand is
+// reliably aligned and an aligned-load or aligned-store substitution
+// (VMOVDQU -> VMOVDQA) cannot survive the suite: a 16-byte-aligned access
+// needs an element offset that is a multiple of 8, which only one of the eight
+// iterations supplies. Every other test builds operands with make, which is
+// aligned.
+func TestMulQ15_UnalignedOperands(t *testing.T) {
+	const span = 300
+	base, other := genI16(span, 75), genI16(span, 76)
+	backing := make([]int16, span)
+	for _, n := range []int{16, 17, 19, 25, 33, 64, 100, 240} {
+		for off := range 8 {
+			a := base[off : off+n]
+			b := other[off+1 : off+1+n]
+			dst := backing[off+3 : off+3+n]
+			MulQ15(dst, a, b)
+			for i := range n {
+				if want := mulQ15Oracle(a[i], b[i]); dst[i] != want {
+					t.Fatalf("MulQ15 unaligned n=%d off=%d: dst[%d] = %d, want %d", n, off, i, dst[i], want)
+				}
+			}
+		}
+	}
+}
+
+// TestMulQ15_AllocFree pins the zero-allocation contract from the CALLER's
+// side. The buffers are declared INSIDE the measured closure deliberately:
+// hoisting them out measures only MulQ15's own allocations and passes even
+// when MulQ15 leaks its parameters, forcing every caller to heap-allocate.
+func TestMulQ15_AllocFree(t *testing.T) {
+	if n := testing.AllocsPerRun(50, func() {
+		var a, b, dst [240]int16
+		MulQ15(dst[:], a[:], b[:])
+	}); n != 0 {
+		t.Errorf("MulQ15 forces %v caller allocations per run, want 0", n)
+	}
+}

--- a/i32/abs_test.go
+++ b/i32/abs_test.go
@@ -1,0 +1,144 @@
+package i32
+
+import (
+	"math"
+	"testing"
+)
+
+// Tests for Abs, the wrapping int32 absolute value. The load-bearing input is
+// MinInt32, whose magnitude does not fit int32 and must wrap in place. Kept
+// separate from arith_test.go: Abs is single-operand and its edge case is the
+// wrap, not two-operand overflow.
+
+// absOracle computes |v| in int64, independent of absGo, narrowed to int32
+// the same way a 32-bit lane store truncates.
+func absOracle(v int32) int32 {
+	av := int64(v)
+	if av < 0 {
+		av = -av
+	}
+	return int32(av)
+}
+
+func TestAbs(t *testing.T) {
+	for _, n := range tier3Lengths {
+		a := genI32(n, 21)
+		dst := make([]int32, n)
+		ref := make([]int32, n)
+		Abs(dst, a)
+		absGo(ref, a)
+		for i := range dst {
+			if dst[i] != ref[i] {
+				t.Fatalf("Abs n=%d: dst[%d] = %d, want %d (reference)", n, i, dst[i], ref[i])
+			}
+			if want := absOracle(a[i]); dst[i] != want {
+				t.Fatalf("Abs n=%d: dst[%d] = %d, want %d (oracle)", n, i, dst[i], want)
+			}
+		}
+	}
+}
+
+// TestAbs_MinInt32 walks the wrap input through every lane position: a single
+// planted MinInt32 must come back unchanged while its neighbours are truly
+// absolute. The rotating position is what catches lane and index errors.
+func TestAbs_MinInt32(t *testing.T) {
+	for n := 1; n <= 24; n++ {
+		for pos := range n {
+			a := genI32(n, uint32(40+n))
+			a[pos] = math.MinInt32
+			dst := make([]int32, n)
+			Abs(dst, a)
+			for i := range dst {
+				if want := absOracle(a[i]); dst[i] != want {
+					t.Fatalf("Abs n=%d pos=%d: dst[%d] = %d, want %d", n, pos, i, dst[i], want)
+				}
+			}
+		}
+	}
+}
+
+// TestAbs_TailUntouched plants sentinels past the clamp point at n=11: one
+// 8-wide AVX2 block plus a 3-tail, and two 4-wide NEON blocks plus the same
+// tail, so both vector bodies run and both scalar tails must stop exactly
+// at n.
+func TestAbs_TailUntouched(t *testing.T) {
+	const n = 11
+	a := genI32(n, 42)
+	dst := make([]int32, n+8)
+	for i := range dst {
+		dst[i] = math.MaxInt32 // sentinel
+	}
+	Abs(dst[:n], a)
+	for i := n; i < len(dst); i++ {
+		if dst[i] != math.MaxInt32 {
+			t.Errorf("Abs wrote past end at dst[%d] = %d", i, dst[i])
+		}
+	}
+}
+
+// TestAbs_Clamp covers mismatched lengths in both directions plus the empty
+// no-op.
+func TestAbs_Clamp(t *testing.T) {
+	a := genI32(40, 43)
+	short := make([]int32, 25)
+	Abs(short, a) // dst shorter: n = 25
+	for i := range short {
+		if want := absOracle(a[i]); short[i] != want {
+			t.Fatalf("Abs short dst: dst[%d] = %d, want %d", i, short[i], want)
+		}
+	}
+	long := make([]int32, 40)
+	for i := range long {
+		long[i] = -7 // sentinel
+	}
+	Abs(long, a[:25]) // a shorter: long[25:] untouched
+	for i := 25; i < len(long); i++ {
+		if long[i] != -7 {
+			t.Fatalf("Abs wrote past clamp at dst[%d] = %d", i, long[i])
+		}
+	}
+	Abs(nil, nil)
+	one := []int32{42}
+	Abs(one, nil)
+	if one[0] != 42 {
+		t.Errorf("Abs wrote on empty input: %v", one)
+	}
+}
+
+// TestAbs_UnalignedOperands sweeps all eight element offsets, holding dst and
+// a at different offsets from each other, so neither is reliably aligned and
+// an aligned-load or aligned-store substitution cannot survive the suite: a
+// 16-byte-aligned access needs an element offset that is a multiple of 4, and
+// the sweep leaves most iterations 4-byte aligned rather than 16- or 32-byte.
+// Sum rides the same windows so its loads are pinned too.
+func TestAbs_UnalignedOperands(t *testing.T) {
+	const span = 300
+	base := genI32(span, 44)
+	backing := make([]int32, span)
+	for _, n := range []int{8, 9, 11, 17, 25, 33, 64, 240} {
+		for off := range 8 {
+			a := base[off+1 : off+1+n]
+			dst := backing[off+3 : off+3+n]
+			Abs(dst, a)
+			for i := range n {
+				if want := absOracle(a[i]); dst[i] != want {
+					t.Fatalf("Abs unaligned n=%d off=%d: dst[%d] = %d, want %d", n, off, i, dst[i], want)
+				}
+			}
+			if got, want := Sum(a), sumOracle(a); got != want {
+				t.Fatalf("Sum unaligned n=%d off=%d: got %d, want %d", n, off, got, want)
+			}
+		}
+	}
+}
+
+// TestAbs_AllocFree declares the buffers INSIDE the measured closure, see
+// TestSum_AllocFree.
+func TestAbs_AllocFree(t *testing.T) {
+	if n := testing.AllocsPerRun(50, func() {
+		var a, dst [1000]int32
+		Abs(dst[:], a[:])
+	}); n != 0 {
+		t.Errorf("Abs forces %v caller allocations per run, want 0", n)
+	}
+}

--- a/i32/arith.go
+++ b/i32/arith.go
@@ -3,10 +3,10 @@ package i32
 // Element-wise integer arithmetic on int32 slices.
 //
 // Add and Sub are the generic building blocks for combining two int32 streams
-// element by element (for example summing or differencing two channels). Both
-// clamp to the shortest operand, write into the caller-provided dst, and use
-// int32 wraparound (two's complement) so the SIMD and pure-Go paths are
-// bit-identical across the full int32 range.
+// element by element (for example summing or differencing two channels); Abs
+// is the single-operand magnitude. All clamp to the shortest operand, write
+// into the caller-provided dst, and use int32 wraparound (two's complement) so
+// the SIMD and pure-Go paths are bit-identical across the full int32 range.
 
 // Add writes dst[i] = a[i] + b[i] for i in [0, n), n = min(len(dst), len(a),
 // len(b)). Any trailing capacity in dst is left untouched.
@@ -26,4 +26,21 @@ func Sub(dst, a, b []int32) {
 		return
 	}
 	subI32(dst[:n], a[:n], b[:n])
+}
+
+// Abs writes dst[i] = |a[i]| for i in [0, n), n = min(len(dst), len(a)). The
+// negation wraps in int32 rather than saturating: |MinInt32| does not fit
+// int32, so Abs maps MinInt32 to MinInt32 (as does
+// [github.com/tphakala/simd/i16.Abs] at its own minimum; compare
+// [github.com/tphakala/simd/i8.Abs], which saturates by design). Every other
+// input yields the true magnitude. Any trailing capacity in dst is left
+// untouched.
+//
+// dst and a may overlap only if they start at the same address.
+func Abs(dst, a []int32) {
+	n := min(len(dst), len(a))
+	if n == 0 {
+		return
+	}
+	absI32(dst[:n], a[:n])
 }

--- a/i32/benchmark_test.go
+++ b/i32/benchmark_test.go
@@ -120,3 +120,49 @@ func BenchmarkMinMaxGo_1000(b *testing.B) {
 		minMaxGo(res)
 	}
 }
+
+// Tier-3 benchmarks. 1000 is a multiple of both vector widths; 25 and 1003
+// are deliberate non-multiples of 4 and 8, so the scalar tails are always on
+// the clock rather than structurally idle. Sum SetBytes counts a; Abs counts
+// a read and dst written.
+
+func benchmarkSum(b *testing.B, n int, fn func(a []int32) int32) {
+	b.Helper()
+	a := make([]int32, n)
+	for i := range a {
+		a[i] = int32(i*7 - 3000)
+	}
+	b.SetBytes(int64(n) * 4)
+	for b.Loop() {
+		_ = fn(a)
+	}
+}
+
+func BenchmarkSum_25(b *testing.B)   { benchmarkSum(b, 25, Sum) }
+func BenchmarkSum_1000(b *testing.B) { benchmarkSum(b, 1000, Sum) }
+func BenchmarkSum_1003(b *testing.B) { benchmarkSum(b, 1003, Sum) }
+
+func BenchmarkSumGo_25(b *testing.B)   { benchmarkSum(b, 25, sumGo) }
+func BenchmarkSumGo_1000(b *testing.B) { benchmarkSum(b, 1000, sumGo) }
+func BenchmarkSumGo_1003(b *testing.B) { benchmarkSum(b, 1003, sumGo) }
+
+func benchmarkAbs(b *testing.B, n int, fn func(dst, a []int32)) {
+	b.Helper()
+	a := make([]int32, n)
+	dst := make([]int32, n)
+	for i := range a {
+		a[i] = int32(i*7 - 3000)
+	}
+	b.SetBytes(int64(n) * 4 * 2)
+	for b.Loop() {
+		fn(dst, a)
+	}
+}
+
+func BenchmarkAbs_25(b *testing.B)   { benchmarkAbs(b, 25, Abs) }
+func BenchmarkAbs_1000(b *testing.B) { benchmarkAbs(b, 1000, Abs) }
+func BenchmarkAbs_1003(b *testing.B) { benchmarkAbs(b, 1003, Abs) }
+
+func BenchmarkAbsGo_25(b *testing.B)   { benchmarkAbs(b, 25, absGo) }
+func BenchmarkAbsGo_1000(b *testing.B) { benchmarkAbs(b, 1000, absGo) }
+func BenchmarkAbsGo_1003(b *testing.B) { benchmarkAbs(b, 1003, absGo) }

--- a/i32/example_test.go
+++ b/i32/example_test.go
@@ -2,6 +2,7 @@ package i32_test
 
 import (
 	"fmt"
+	"math"
 
 	"github.com/tphakala/simd/i32"
 )
@@ -35,6 +36,25 @@ func ExampleSub() {
 	i32.Sub(dst, a, b)
 	fmt.Println(dst)
 	// Output: [9 18 27]
+}
+
+// ExampleSum shows the wrapping int32 total of a slice.
+func ExampleSum() {
+	a := []int32{5, -3, 10, 2}
+
+	fmt.Println(i32.Sum(a))
+	// Output: 14
+}
+
+// ExampleAbs shows the wrapping absolute value: |MinInt32| does not fit
+// int32, so that one input wraps in place.
+func ExampleAbs() {
+	a := []int32{-5, 3, math.MinInt32}
+	dst := make([]int32, len(a))
+
+	i32.Abs(dst, a)
+	fmt.Println(dst)
+	// Output: [5 3 -2147483648]
 }
 
 // ExampleMinMax shows the signed min/max reduction over a slice.

--- a/i32/fuzz_test.go
+++ b/i32/fuzz_test.go
@@ -84,6 +84,30 @@ func FuzzI32MinMax(f *testing.F) {
 	})
 }
 
+// FuzzI32SumAbs differentially fuzzes the wrapping Sum reduction and the
+// wrapping Abs map. Sum is checked against the reference and an int64 oracle
+// so a fault in sumGo itself cannot hide by agreeing with the kernels; Abs is
+// checked for parity, which includes the MinInt32 wrap whenever the raw bytes
+// produce it.
+func FuzzI32SumAbs(f *testing.F) {
+	addLenSeeds(f)
+	f.Fuzz(func(t *testing.T, raw []byte) {
+		a := i32sFromBits(raw)
+		got := Sum(a)
+		if want := sumGo(a); got != want {
+			t.Fatalf("Sum = %d, want %d (reference, len=%d)", got, want, len(a))
+		}
+		if want := sumOracle(a); got != want {
+			t.Fatalf("Sum = %d, want %d (int64 oracle, len=%d)", got, want, len(a))
+		}
+		dst := make([]int32, len(a))
+		ref := make([]int32, len(a))
+		Abs(dst, a)
+		absGo(ref, a)
+		equalI32(t, "Abs", dst, ref)
+	})
+}
+
 func FuzzI32Interleave(f *testing.F) {
 	addLenSeeds(f)
 	f.Fuzz(func(t *testing.T, raw []byte) {

--- a/i32/i32.go
+++ b/i32/i32.go
@@ -1,9 +1,10 @@
 // Package i32 provides SIMD-accelerated operations on int32 slices.
 //
 // It is the integer counterpart to the f32/f64 packages, covering the
-// element-wise integer arithmetic, signed min/max reduction, and channel
-// (de)interleaving that integer-domain DSP hot loops need where the per-sample
-// work is integer arithmetic rather than floating-point math.
+// element-wise integer arithmetic, the signed min/max and wrapping-sum
+// reductions, and the channel (de)interleaving that integer-domain DSP hot
+// loops need where the per-sample work is integer arithmetic rather than
+// floating-point math.
 //
 // All functions automatically select the optimal implementation based on
 // runtime CPU feature detection and fall back to a pure-Go implementation on

--- a/i32/i32_amd64.go
+++ b/i32/i32_amd64.go
@@ -65,6 +65,38 @@ func addAVX2(dst, a, b []int32)
 //go:noescape
 func subAVX2(dst, a, b []int32)
 
+// Tier-3 thresholds: one 8-wide (256-bit) vector block each, independent
+// literals rather than aliases of minAVXElements, which they happen to equal,
+// so retuning the interleave kernels cannot silently move these. Both kernels
+// gate on AVX2 (VPADDD/VPABSD are 256-bit integer ops) and are correct at any
+// length (each falls through to a scalar tail), so these are performance cuts
+// only, never a safety requirement.
+const (
+	minAVX2Sum = 8
+	minAVX2Abs = 8
+)
+
+func sumI32(a []int32) int32 {
+	if hasAVX2 && len(a) >= minAVX2Sum {
+		return sumAVX2(a)
+	}
+	return sumGo(a)
+}
+
+func absI32(dst, a []int32) {
+	if hasAVX2 && len(dst) >= minAVX2Abs {
+		absAVX2(dst, a)
+		return
+	}
+	absGo(dst, a)
+}
+
+//go:noescape
+func sumAVX2(a []int32) int32
+
+//go:noescape
+func absAVX2(dst, a []int32)
+
 // minMaxI32 dispatches the signed int32 min/max reduction. The AVX2 kernel does
 // the reduction in 8-wide VPMINSD/VPMAXSD lanes with a scalar tail, so it gates
 // on AVX2 and at least one full 8-element block; shorter slices use the pure-Go

--- a/i32/i32_amd64.s
+++ b/i32/i32_amd64.s
@@ -290,3 +290,97 @@ mm_done:
     MOVL DX, maxVal+28(FP)
     VZEROUPPER
     RET
+
+// Tier-3 reduction and element-wise kernels (AVX2).
+//
+// Both receive pre-clamped slices from the public API, so a_len (or dst_len)
+// is the trusted element count and no in-assembly clamp exists.
+
+// func sumAVX2(a []int32) int32
+// Wrapping int32 sum: VPADDD folds 8-lane blocks into a vector accumulator, a
+// horizontal add reduces it, and a 32-bit scalar tail adds the (n mod 8)
+// remainder. Every add wraps in a 32-bit lane, and wrapping addition is
+// associative, so the lane split and reduction order are bit-identical to
+// sumGo for every input, including forced overflow.
+TEXT ·sumAVX2(SB), NOSPLIT, $0-28
+    MOVQ a_base+0(FP), SI
+    MOVQ a_len+8(FP), CX
+
+    VPXOR Y0, Y0, Y0           // int32 accumulator = 0
+
+    MOVQ CX, AX
+    SHRQ $3, AX                // AX = n / 8
+    JZ   sum_avx2_reduce
+
+sum_avx2_loop8:
+    VMOVDQU (SI), Y1
+    VPADDD Y1, Y0, Y0          // accumulate (wrapping)
+    ADDQ $32, SI
+    DECQ AX
+    JNZ  sum_avx2_loop8
+
+sum_avx2_reduce:
+    VEXTRACTI128 $1, Y0, X1
+    VPADDD X1, X0, X0          // fold 8 -> 4 int32
+    VPSHUFD $0x4E, X0, X1      // swap 64-bit halves
+    VPADDD X1, X0, X0
+    VPSHUFD $0xB1, X0, X1      // swap 32-bit within pairs
+    VPADDD X1, X0, X0
+    MOVQ X0, AX                // low int32 = vector total (in EAX)
+
+    ANDQ $7, CX
+    JZ   sum_avx2_done
+
+sum_avx2_scalar:
+    MOVL (SI), BX
+    ADDL BX, AX                // 32-bit add: wraps like sumGo
+    ADDQ $4, SI
+    DECQ CX
+    JNZ  sum_avx2_scalar
+
+sum_avx2_done:
+    MOVL AX, ret+24(FP)
+    VZEROUPPER
+    RET
+
+// func absAVX2(dst, a []int32)
+// Wrapping absolute value, 8 lanes per iteration: VPABSD wraps at the type
+// minimum (abs(MinInt32) = MinInt32 in a 32-bit lane), which is absGo's
+// contract. The scalar tail negates only the negative elements; NEGL of
+// 0x80000000 wraps to itself in 32-bit, so the tail needs no special case.
+TEXT ·absAVX2(SB), NOSPLIT, $0-48
+    MOVQ dst_base+0(FP), DX
+    MOVQ dst_len+8(FP), CX
+    MOVQ a_base+24(FP), SI
+
+    MOVQ CX, AX
+    SHRQ $3, AX                // AX = n / 8
+    JZ   abs_avx2_tail
+
+abs_avx2_loop8:
+    VPABSD (SI), Y0
+    VMOVDQU Y0, (DX)
+    ADDQ $32, SI
+    ADDQ $32, DX
+    DECQ AX
+    JNZ  abs_avx2_loop8
+
+abs_avx2_tail:
+    ANDQ $7, CX
+    JZ   abs_avx2_done
+
+abs_avx2_scalar:
+    MOVL (SI), AX
+    TESTL AX, AX
+    JGE  abs_avx2_store
+    NEGL AX                    // |v|; NEGL of MinInt32 wraps to itself
+abs_avx2_store:
+    MOVL AX, (DX)
+    ADDQ $4, SI
+    ADDQ $4, DX
+    DECQ CX
+    JNZ  abs_avx2_scalar
+
+abs_avx2_done:
+    VZEROUPPER
+    RET

--- a/i32/i32_amd64_test.go
+++ b/i32/i32_amd64_test.go
@@ -128,11 +128,112 @@ func TestAVX2Kernels_AllocFree(t *testing.T) {
 		{"addAVX2", func() { addAVX2(dst, a, b) }},
 		{"subAVX2", func() { subAVX2(dst, a, b) }},
 		{"minMaxAVX2", func() { _, _ = minMaxAVX2(a) }},
+		{"sumAVX2", func() { _ = sumAVX2(a) }},
+		{"absAVX2", func() { absAVX2(dst, a) }},
 	}
 	for _, c := range checks {
 		if got := testing.AllocsPerRun(100, c.fn); got != 0 {
 			t.Errorf("%s allocated %v times per run, want 0", c.name, got)
 		}
+	}
+}
+
+// TestSumAVX2_ParityWithGo drives the kernel directly, over lengths the
+// dispatcher would never route to it, so a threshold change cannot quietly
+// reduce this to a test of the Go reference against itself. The forced
+// overflow leg wraps the accumulator in the lanes and in the tail.
+func TestSumAVX2_ParityWithGo(t *testing.T) {
+	if !cpu.X86.AVX2 {
+		t.Skip("AVX2 not available")
+	}
+	for _, n := range tier3Lengths {
+		a := genI32(n, 61)
+		if got, want := sumAVX2(a), sumGo(a); got != want {
+			t.Errorf("sumAVX2 n=%d: got %d, want %d", n, got, want)
+		}
+	}
+	for n := 1; n <= 24; n++ {
+		a := make([]int32, n)
+		for i := range a {
+			a[i] = math.MaxInt32 - int32(i%2)
+		}
+		if got, want := sumAVX2(a), sumGo(a); got != want {
+			t.Errorf("sumAVX2 overflow n=%d: got %d, want %d", n, got, want)
+		}
+	}
+}
+
+// TestSumAVX2_NoOverRead is the kernel-direct over-read check: the operand is
+// a prefix of a longer allocation whose every element past the prefix is
+// poisoned. Zeroed past-slice memory is the identity element of this
+// reduction, so only the poison makes an over-read observable. The poison is
+// deliberately not an extreme; see sumOverReadPoison for why MinInt32 would
+// hide a whole-block over-read here.
+func TestSumAVX2_NoOverRead(t *testing.T) {
+	if !cpu.X86.AVX2 {
+		t.Skip("AVX2 not available")
+	}
+	backing := make([]int32, 64+8)
+	for i := range backing {
+		backing[i] = sumOverReadPoison
+	}
+	for _, n := range []int{1, 3, 7, 8, 9, 11, 16, 17, 33, 64} {
+		a := backing[:n]
+		for i := range a {
+			a[i] = int32(i - 5)
+		}
+		if got, want := sumAVX2(a), sumGo(a); got != want {
+			t.Fatalf("sumAVX2 n=%d: got %d, want %d (read past the operand?)", n, got, want)
+		}
+		for i := range a {
+			backing[i] = sumOverReadPoison
+		}
+	}
+}
+
+// TestAbsAVX2_ParityWithGo drives the kernel directly across the full sweep;
+// the wrap input MinInt32 rides at index 0 of every non-empty case.
+func TestAbsAVX2_ParityWithGo(t *testing.T) {
+	if !cpu.X86.AVX2 {
+		t.Skip("AVX2 not available")
+	}
+	for _, n := range tier3Lengths {
+		a := genI32(n, 62)
+		if n > 0 {
+			a[0] = math.MinInt32
+		}
+		got := make([]int32, n)
+		want := make([]int32, n)
+		absAVX2(got, a)
+		absGo(want, a)
+		for i := range want {
+			if got[i] != want[i] {
+				t.Fatalf("absAVX2 n=%d: dst[%d] = %d, want %d", n, i, got[i], want[i])
+			}
+		}
+	}
+}
+
+// TestTier3Dispatch_ReachesSIMD pins the dispatch state Sum and Abs depend
+// on. It has to be a white-box check: the kernels are bit-identical to the Go
+// references by design, so a dispatcher that silently routed every call to Go
+// would pass every parity test in this package. Below AVX2 the Go reference
+// is the intended path. It must not call t.Parallel(): it reads
+// package-level dispatch state.
+//
+// Scope, so the next reader does not over-trust it: this pins the INPUTS the
+// dispatcher reads (the feature flag, and thresholds low enough to vectorize),
+// not that the dispatcher consults them. It kills a mis-wired flag and an
+// out-of-range threshold; it does not kill a dispatch branch deleted outright,
+// which leaves the kernel dead while every test here still passes. Closing
+// that needs the call to be observable, e.g. a counter behind a build tag.
+func TestTier3Dispatch_ReachesSIMD(t *testing.T) {
+	if hasAVX2 != cpu.X86.AVX2 {
+		t.Fatalf("hasAVX2 = %v but cpu.X86.AVX2 = %v: dispatch flag is not wired to CPU detection", hasAVX2, cpu.X86.AVX2)
+	}
+	if minAVX2Sum > 16 || minAVX2Abs > 16 {
+		t.Fatalf("tier-3 AVX2 thresholds exceed two vector blocks (Sum %d, Abs %d): the ops would not vectorize at the lengths they were written for",
+			minAVX2Sum, minAVX2Abs)
 	}
 }
 

--- a/i32/i32_arm64.go
+++ b/i32/i32_arm64.go
@@ -53,6 +53,37 @@ func addNEON(dst, a, b []int32)
 //go:noescape
 func subNEON(dst, a, b []int32)
 
+// Tier-3 thresholds: one 4-wide (.4S) vector block each, independent literals
+// rather than aliases of minNEONElements, which they happen to equal, so
+// retuning the interleave kernels cannot silently move these. Both kernels are
+// correct at any length (each falls through to a scalar tail), so these are
+// performance cuts only, never a safety requirement.
+const (
+	minNEONSum = 4
+	minNEONAbs = 4
+)
+
+func sumI32(a []int32) int32 {
+	if hasNEON && len(a) >= minNEONSum {
+		return sumNEON(a)
+	}
+	return sumGo(a)
+}
+
+func absI32(dst, a []int32) {
+	if hasNEON && len(dst) >= minNEONAbs {
+		absNEON(dst, a)
+		return
+	}
+	absGo(dst, a)
+}
+
+//go:noescape
+func sumNEON(a []int32) int32
+
+//go:noescape
+func absNEON(dst, a []int32)
+
 // minMaxI32 dispatches the signed int32 min/max reduction. The NEON kernel does
 // the reduction in 4-wide SMIN/SMAX lanes with a single-instruction SMINV/SMAXV
 // across-vector fold and a scalar tail, so it gates on NEON and at least one full

--- a/i32/i32_arm64.s
+++ b/i32/i32_arm64.s
@@ -92,16 +92,18 @@ deinterleave2_neon_loop1:
 deinterleave2_neon_done:
     RET
 
-// Arithmetic, decorrelation and fixed-predictor kernels (NEON / ASIMD).
+// Arithmetic and reduction kernels (NEON / ASIMD).
 //
-// These do integer ALU work on .4S vectors (4 int32/iter): ADD/SUB/SSHR/SHL and
-// the AND/ORR/MOVI used for the mid/side parity bit. The Go assembler has no
-// mnemonics for these vector ops, so they are hand-encoded as WORD with the
-// decoded GNU form in the trailing comment (cross-checked by asmcheck_test.go).
-// Each vector lane is 32 bits, so the SIMD path wraps exactly like the int32 Go
-// reference; the scalar tails use the W-register (32-bit) ALU forms (ADDW/SUBW/
-// ASRW/...) so they wrap identically. Dispatched from i32_arm64.go gated on the
-// NEON CPU feature, with the pure-Go reference as the fallback.
+// These do integer ALU work on .4S vectors (4 int32/iter). Each vector lane is
+// 32 bits, so the SIMD path wraps exactly like the int32 Go reference; the
+// scalar tails use the W-register (32-bit) ALU forms (ADDW/SUBW/...) so they
+// wrap identically. SMIN/SMAX/SMINV/SMAXV and vector ABS have no Go assembler
+// mnemonics and are hand-encoded as WORD with the decoded GNU form in the
+// trailing comment (cross-checked by asmcheck_test.go). The ADD/SUB vector
+// WORDs below are hand-encoded too even though the assembler does accept the
+// native VADD/VSUB spellings on .S4 operands (sumNEON uses one); they stay as
+// verified WORD encodings rather than churn. Dispatched from i32_arm64.go
+// gated on the NEON CPU feature, with the pure-Go reference as the fallback.
 
 // func addNEON(dst, a, b []int32)
 TEXT ·addNEON(SB), NOSPLIT, $0-72
@@ -220,4 +222,79 @@ mm_neon_tail:
 mm_neon_done:
     MOVW R5, minVal+24(FP)
     MOVW R6, maxVal+28(FP)
+    RET
+
+// func sumNEON(a []int32) int32
+// Wrapping int32 sum: VADD folds 4-lane blocks into a vector accumulator,
+// ADDV reduces it to a scalar, and a 32-bit scalar tail adds the (n mod 4)
+// remainder. Every add wraps in a 32-bit lane, and wrapping addition is
+// associative, so the lane split and reduction order are bit-identical to
+// sumGo for every input, including forced overflow. The slice arrives
+// pre-clamped from the public Sum, so a_len is the trusted element count.
+TEXT ·sumNEON(SB), NOSPLIT, $0-28
+    MOVD a_base+0(FP), R1
+    MOVD a_len+8(FP), R3
+
+    VEOR V0.B16, V0.B16, V0.B16
+    LSR  $2, R3, R4            // R4 = n / 4
+    CBZ  R4, sum_neon_reduce
+
+sum_neon_loop4:
+    VLD1.P 16(R1), [V1.S4]
+    VADD V1.S4, V0.S4, V0.S4   // accumulate (wrapping)
+    SUB  $1, R4
+    CBNZ R4, sum_neon_loop4
+
+sum_neon_reduce:
+    VADDV V0.S4, V0            // ADDV S0, V0.4S
+    FMOVS F0, R5               // vector partial sum (low 32 = int32)
+
+    AND  $3, R3
+    CBZ  R3, sum_neon_done
+
+sum_neon_scalar:
+    MOVW.P 4(R1), R6
+    ADDW R6, R5, R5            // 32-bit add: wraps like sumGo
+    SUB  $1, R3
+    CBNZ R3, sum_neon_scalar
+
+sum_neon_done:
+    MOVW R5, ret+24(FP)
+    RET
+
+// func absNEON(dst, a []int32)
+// Wrapping absolute value, 4 lanes per iteration: vector ABS wraps at the
+// type minimum (abs(MinInt32) = MinInt32 in a 32-bit lane), which is absGo's
+// contract. The scalar tail computes |v| in a 64-bit GPR, where -(MinInt32)
+// is +2^31, and the MOVW store keeps the low 32 bits, wrapping it back to
+// MinInt32 identically.
+TEXT ·absNEON(SB), NOSPLIT, $0-48
+    MOVD dst_base+0(FP), R0
+    MOVD dst_len+8(FP), R3
+    MOVD a_base+24(FP), R1
+
+    LSR  $2, R3, R4            // R4 = n / 4
+    CBZ  R4, abs_neon_remainder
+
+abs_neon_loop4:
+    VLD1.P 16(R1), [V0.S4]
+    WORD $0x4EA0B801           // ABS V1.4S, V0.4S
+    VST1.P [V1.S4], 16(R0)
+    SUB  $1, R4
+    CBNZ R4, abs_neon_loop4
+
+abs_neon_remainder:
+    AND  $3, R3
+    CBZ  R3, abs_neon_done
+
+abs_neon_scalar:
+    MOVW.P 4(R1), R5           // v, sign-extended
+    NEG  R5, R6                // -v
+    CMP  $0, R5
+    CSEL LT, R6, R5, R5        // |v| = v < 0 ? -v : v   (can be 2^31)
+    MOVW.P R5, 4(R0)           // low 32 bits: 2^31 wraps to MinInt32
+    SUB  $1, R3
+    CBNZ R3, abs_neon_scalar
+
+abs_neon_done:
     RET

--- a/i32/i32_arm64_test.go
+++ b/i32/i32_arm64_test.go
@@ -128,11 +128,114 @@ func TestNEONKernels_AllocFree(t *testing.T) {
 		{"addNEON", func() { addNEON(dst, a, b) }},
 		{"subNEON", func() { subNEON(dst, a, b) }},
 		{"minMaxNEON", func() { _, _ = minMaxNEON(a) }},
+		{"sumNEON", func() { _ = sumNEON(a) }},
+		{"absNEON", func() { absNEON(dst, a) }},
 	}
 	for _, c := range checks {
 		if got := testing.AllocsPerRun(100, c.fn); got != 0 {
 			t.Errorf("%s allocated %v times per run, want 0", c.name, got)
 		}
+	}
+}
+
+// TestSumNEON_ParityWithGo drives the kernel directly, over lengths the
+// dispatcher would never route to it, so a threshold change cannot quietly
+// reduce this to a test of the Go reference against itself. The forced
+// overflow leg wraps the accumulator in the lanes and in the tail.
+func TestSumNEON_ParityWithGo(t *testing.T) {
+	if !cpu.ARM64.NEON {
+		t.Skip("NEON not available")
+	}
+	for _, n := range tier3Lengths {
+		a := genI32(n, 51)
+		if got, want := sumNEON(a), sumGo(a); got != want {
+			t.Errorf("sumNEON n=%d: got %d, want %d", n, got, want)
+		}
+	}
+	for n := 1; n <= 16; n++ {
+		a := make([]int32, n)
+		for i := range a {
+			a[i] = math.MaxInt32 - int32(i%2)
+		}
+		if got, want := sumNEON(a), sumGo(a); got != want {
+			t.Errorf("sumNEON overflow n=%d: got %d, want %d", n, got, want)
+		}
+	}
+}
+
+// TestSumNEON_NoOverRead is the kernel-direct over-read check: the operand is
+// a prefix of a longer allocation whose every element past the prefix is
+// poisoned. Zeroed past-slice memory is the identity element of this
+// reduction, so only the poison makes an over-read observable. The poison is
+// deliberately not an extreme; see sumOverReadPoison for why MinInt32 would
+// hide a whole-block over-read here.
+func TestSumNEON_NoOverRead(t *testing.T) {
+	if !cpu.ARM64.NEON {
+		t.Skip("NEON not available")
+	}
+	backing := make([]int32, 64+8)
+	for i := range backing {
+		backing[i] = sumOverReadPoison
+	}
+	for _, n := range []int{1, 3, 4, 5, 7, 8, 9, 11, 16, 17, 33, 64} {
+		a := backing[:n]
+		for i := range a {
+			a[i] = int32(i - 5)
+		}
+		if got, want := sumNEON(a), sumGo(a); got != want {
+			t.Fatalf("sumNEON n=%d: got %d, want %d (read past the operand?)", n, got, want)
+		}
+		for i := range a {
+			backing[i] = sumOverReadPoison
+		}
+	}
+}
+
+// TestAbsNEON_ParityWithGo drives the kernel directly across the full sweep;
+// the wrap input MinInt32 rides at index 0 of every non-empty case.
+func TestAbsNEON_ParityWithGo(t *testing.T) {
+	if !cpu.ARM64.NEON {
+		t.Skip("NEON not available")
+	}
+	for _, n := range tier3Lengths {
+		a := genI32(n, 52)
+		if n > 0 {
+			a[0] = math.MinInt32
+		}
+		got := make([]int32, n)
+		want := make([]int32, n)
+		absNEON(got, a)
+		absGo(want, a)
+		for i := range want {
+			if got[i] != want[i] {
+				t.Fatalf("absNEON n=%d: dst[%d] = %d, want %d", n, i, got[i], want[i])
+			}
+		}
+	}
+}
+
+// TestTier3Dispatch_ReachesNEON pins the dispatch state Sum and Abs depend
+// on. It has to be a white-box check: the kernels are bit-identical to the Go
+// references by design, so a dispatcher that silently routed every call to Go
+// would pass every parity test in this package. It must not call
+// t.Parallel(): it reads package-level dispatch state.
+//
+// Scope, so the next reader does not over-trust it: this pins the INPUTS the
+// dispatcher reads (the feature flag, and thresholds low enough to vectorize),
+// not that the dispatcher consults them. It kills a mis-wired flag and an
+// out-of-range threshold; it does not kill a dispatch branch deleted outright,
+// which leaves the kernel dead while every test here still passes. Closing
+// that needs the call to be observable, e.g. a counter behind a build tag.
+func TestTier3Dispatch_ReachesNEON(t *testing.T) {
+	if !cpu.ARM64.NEON {
+		t.Skip("NEON not available")
+	}
+	if !hasNEON {
+		t.Fatal("hasNEON is false though cpu.ARM64.NEON is true: Sum and Abs silently run the Go reference on every call")
+	}
+	if minNEONSum > 8 || minNEONAbs > 8 {
+		t.Fatalf("tier-3 NEON thresholds exceed two vector blocks (Sum %d, Abs %d): the ops would not vectorize at the lengths they were written for",
+			minNEONSum, minNEONAbs)
 	}
 }
 

--- a/i32/i32_go.go
+++ b/i32/i32_go.go
@@ -32,6 +32,31 @@ func subGo(dst, a, b []int32) {
 	}
 }
 
+// sumGo accumulates a into int32 with two's-complement wraparound. Wrapping
+// addition is associative and commutative modulo 2^32, so the SIMD lane split
+// and horizontal reduction are bit-identical to this sequential loop for every
+// input; it is the source of truth the Sum kernels are validated against.
+func sumGo(a []int32) int32 {
+	var s int32
+	for _, v := range a {
+		s += v
+	}
+	return s
+}
+
+// absGo writes the wrapping absolute value: int32 negation wraps in Go, so
+// abs(MinInt32) stays MinInt32, exactly what a 32-bit ABS/VPABSD lane
+// computes.
+func absGo(dst, a []int32) {
+	for i := range dst {
+		if a[i] < 0 {
+			dst[i] = -a[i]
+		} else {
+			dst[i] = a[i]
+		}
+	}
+}
+
 // minMaxGo returns the smallest and largest int32 in res via a single signed
 // scan. res must be non-empty (the public MinMax guards the empty case); it is
 // the bit-exact source of truth the SIMD MinMax kernels are validated against.

--- a/i32/i32_other.go
+++ b/i32/i32_other.go
@@ -7,5 +7,7 @@ func deinterleave2I32(a, b, src []int32) { deinterleave2Go(a, b, src) }
 
 func addI32(dst, a, b []int32) { addGo(dst, a, b) }
 func subI32(dst, a, b []int32) { subGo(dst, a, b) }
+func absI32(dst, a []int32)    { absGo(dst, a) }
+func sumI32(a []int32) int32   { return sumGo(a) }
 
 func minMaxI32(res []int32) (minVal, maxVal int32) { return minMaxGo(res) }

--- a/i32/sum.go
+++ b/i32/sum.go
@@ -1,0 +1,15 @@
+package i32
+
+// Sum returns the sum of all elements of a, accumulated in int32 with
+// two's-complement wraparound, never saturation. Wrapping addition is
+// associative and commutative modulo 2^32, so any SIMD lane grouping and any
+// horizontal reduction order yields the same bits as the sequential loop,
+// including on inputs engineered to overflow; that reproducibility is the
+// contract that lets the kernels vectorize at all. An empty a returns 0. a is
+// read-only; the call allocates nothing.
+func Sum(a []int32) int32 {
+	if len(a) == 0 {
+		return 0
+	}
+	return sumI32(a)
+}

--- a/i32/sum_test.go
+++ b/i32/sum_test.go
@@ -1,0 +1,147 @@
+package i32
+
+import (
+	"math"
+	"testing"
+)
+
+// Tests for Sum, the wrapping int32 total.
+//
+// Wrapping accumulation is the documented contract and the reason the kernels
+// may reassociate at all, so overflow is the main event here, not an edge
+// case: a saturating implementation would pass a small-value test and fail
+// these.
+
+// genI32 produces a deterministic spread across the full int32 range from a
+// cheap LCG, so sign and high bits are exercised at every index.
+func genI32(n int, seed uint32) []int32 {
+	s := make([]int32, n)
+	x := seed*2654435761 + 1
+	for i := range s {
+		x = x*1664525 + 1013904223
+		s[i] = int32(x)
+	}
+	return s
+}
+
+// sumOracle sums in int64 and truncates to int32, independent of sumGo:
+// wrapping int32 addition is addition modulo 2^32, and an int64 sum of a few
+// thousand int32 values cannot itself overflow, so truncating the exact sum
+// must equal the wrapping sum. It pins the reference rather than trusting it.
+func sumOracle(a []int32) int32 {
+	var s int64
+	for _, v := range a {
+		s += int64(v)
+	}
+	return int32(s) // deliberate truncation: this is the wrapping contract
+}
+
+// tier3Lengths sweeps EVERY length 0..64, then a spread of larger ones,
+// covering each vector-block/scalar-tail split of the 4-wide NEON and 8-wide
+// AVX2 bodies, with non-multiples of both widths in the spread.
+var tier3Lengths = func() []int {
+	lens := make([]int, 0, 76)
+	for n := range 65 {
+		lens = append(lens, n)
+	}
+	return append(lens, 100, 127, 128, 129, 240, 255, 256, 257, 1000, 1003, 1024)
+}()
+
+func TestSum(t *testing.T) {
+	if got := Sum(nil); got != 0 {
+		t.Errorf("Sum(nil) = %d, want 0", got)
+	}
+	if got := Sum([]int32{}); got != 0 {
+		t.Errorf("Sum([]) = %d, want 0", got)
+	}
+	for _, n := range tier3Lengths {
+		a := genI32(n, 8)
+		got := Sum(a)
+		if want := sumGo(a); got != want {
+			t.Errorf("Sum n=%d: got %d, want %d (reference)", n, got, want)
+		}
+		if want := sumOracle(a); got != want {
+			t.Errorf("Sum n=%d: got %d, want %d (int64 oracle)", n, got, want)
+		}
+	}
+}
+
+// TestSum_Wraparound drives the accumulator through many wraps with same-sign
+// values, so an implementation that clamped anywhere along the chain diverges
+// well before the end.
+func TestSum_Wraparound(t *testing.T) {
+	for _, n := range []int{4, 8, 11, 25, 240, 1003, 5000} {
+		a := make([]int32, n)
+		for i := range a {
+			a[i] = math.MaxInt32 - int32(i%3) // wraps roughly every 2 elements
+		}
+		if got, want := Sum(a), sumOracle(a); got != want {
+			t.Errorf("Sum wraparound n=%d: got %d, want %d", n, got, want)
+		}
+	}
+	// All-MinInt32 operands are sign-symmetric under wrap (each element
+	// contributes 2^31 modulo 2^32 regardless of sign), so this sweep can only
+	// catch a miscounted element, never a sign, lane, or index error; the
+	// genI32 sweeps above are what catch those.
+	for n := 1; n <= 64; n++ {
+		a := make([]int32, n)
+		for i := range a {
+			a[i] = math.MinInt32
+		}
+		if got, want := Sum(a), sumOracle(a); got != want {
+			t.Errorf("Sum all-MinInt32 n=%d: got %d, want %d", n, got, want)
+		}
+	}
+}
+
+// sumOverReadPoison fills the memory past an operand in the over-read tests.
+//
+// The value has to be chosen with care, and the obvious extreme is wrong.
+// MinInt32 is the one non-zero int32 of additive order 2: 2*MinInt32 = -2^32,
+// which is 0 modulo 2^32. Reading an even number of MinInt32 elements past the
+// operand therefore adds exactly nothing to a wrapping sum, and every kernel
+// block here is an even width (4 on NEON, 8 on AVX2), so a whole-block
+// over-read, the realistic defect, would stay invisible. This is not
+// hypothetical: a sumNEON that reads one block past the operand passes this
+// test under a MinInt32 poison and fails it under the poison below.
+//
+// 0x5555_5555 is odd, so gcd(x, 2^32) = 1 and its additive order is the full
+// 2^32. No over-read length can cancel.
+const sumOverReadPoison = 0x5555_5555
+
+// TestSum_NoOverRead hands Sum a prefix of a longer allocation whose every
+// element past the prefix is poisoned. Past a standalone slice lies zeroed
+// memory and +0 is the identity element of this reduction, so an over-reading
+// kernel would pass every other test in this file; the poison is what makes
+// one visible. See sumOverReadPoison for why the value is not an extreme.
+func TestSum_NoOverRead(t *testing.T) {
+	backing := make([]int32, 64+8)
+	for i := range backing {
+		backing[i] = sumOverReadPoison
+	}
+	for _, n := range []int{1, 3, 4, 5, 7, 8, 9, 11, 15, 16, 17, 25, 32, 33, 64} {
+		a := backing[:n]
+		for i := range a {
+			a[i] = int32(i - 5)
+		}
+		want := sumOracle(a)
+		if got := Sum(a); got != want {
+			t.Fatalf("Sum n=%d: got %d, want %d (read past the operand?)", n, got, want)
+		}
+		for i := range a {
+			backing[i] = sumOverReadPoison // restore the poison for the next length
+		}
+	}
+}
+
+// TestSum_AllocFree declares the buffer INSIDE the measured closure: hoisting
+// it out measures only Sum's own allocations and passes even when Sum leaks
+// its parameter, forcing every caller to heap-allocate.
+func TestSum_AllocFree(t *testing.T) {
+	if n := testing.AllocsPerRun(50, func() {
+		var a [1000]int32
+		_ = Sum(a[:])
+	}); n != 0 {
+		t.Errorf("Sum forces %v caller allocations per run, want 0", n)
+	}
+}


### PR DESCRIPTION
Final part of the #142 stack, after `DotProduct` (#143) and `XCorr` (#146). Implements the spec in #147.

Adds the fixed-point primitives the integer DSP path still lacked, each with a Go reference plus a NEON and an AVX2 kernel behind per-op dispatch thresholds. No `Unsafe` variants; every public wrapper clamps with `min(...)` and no-ops at `n == 0`.

```go
i16.Abs(dst, a)        // wrapping |x|
i16.MaxAbs(a) int      // headroom probe
i16.MulQ15(dst, a, b)  // rounding Q15 multiply
i32.Sum(a) int32       // wrapping accumulation
i32.Abs(dst, a)        // wrapping |x|
```

## Semantics worth knowing

**`MulQ15` is the rounding form** `(a*b + 1<<14) >> 15`, libopus `MULT16_16_P15`, not the truncating `MULT16_16_Q15` that #142 named it as. The int16 narrowing wraps, so `MulQ15(-32768, -32768)` is `-32768`. `SQRDMULH` cannot implement this op: it saturates that one pair to 32767. `VPMULHRSW` computes the identical rounding product and wraps, so it is safe. Both kernels carry a comment saying so, because the saturating instruction is the obvious "optimization" and it is silently wrong on exactly one input pair.

**`Abs` wraps at the type minimum** on both widths, matching one-instruction NEON `ABS` and AVX2 `VPABSW`/`VPABSD`, which is what makes the SIMD paths bit-exact against the natural Go reference. This is the opposite of `i8.Abs`, which saturates by design, so both directions are cross-referenced where a caller generalizing from i8 will actually find them.

**`MaxAbs` returns `int`, not the `int16`** #142 asks for. That signature cannot work: `|-32768| = 32768` overflows int16 and is exactly the headroom value the stated use case needs. This follows `i8.MaxAbs` and libopus `celt_maxabs16`, both of which widen for the same reason.

**`Sum` accumulates with wrapping.** Wrapping addition is associative modulo 2^32, which is precisely what makes the vector reassociation and horizontal reduction bit-exact; a saturating accumulator is not associative and would diverge on rare inputs.

## Dispatch: no SSE2 tier

Tier 3 is AVX2-or-Go, matching `i8` and the `i32` arithmetic: cheap store-bound element work does not earn a third tier's maintenance. That makes the Go reference a live, reachable path on a pre-AVX2 amd64 host rather than a formality, so the README, `doc.go` and the amd64 dispatch comment all narrow the old "SSE2 is part of the amd64 baseline, so i16 always runs SIMD on amd64" claim to the ops that still have an SSE2 tier (interleave, dot, xcorr).

The NEON kernels are hand-encoded `WORD`s because the arm64 assembler rejects every integer vector multiply and several neighbours (#148). `asmcheck` cross-checks each against `arm64asm`; all nine decode directly rather than falling through to the lenient objdump path. `VADDV` and `VUMAX` are native mnemonics and are not hand-encoded.

## Verification

100% statement coverage on both architectures with SIMD enabled, and green on the Go fallback tier and every cross-built fallback arch (386, arm, riscv64, ppc64le, s390x, wasm, including `go vet` so the test files compile there too). Zero allocations per op, measured from a caller. Bit-exact against the Go reference and against an independent int64/`math/big` oracle. Every pre-existing kernel in the four shared `.s` files is instruction-identical to main.

Kernels were mutation-tested: `VPMAXUW` to `VPMAXSW`, `SRSHR` to `SSHR`, `XTN` to `SQXTN`, `ABS` to `SQABS`, and a threshold raised past every input are each killed by a specific test.

## Two things this PR fixes about its own spec

#147 shipped two factual errors, both corrected in the issue:

1. It claimed an `SMLAL` to `UMLAL` mutant "passed the whole suite" in #143. #143's body records that mutant **failing**. The accurate lesson is that an all-MinInt16 sweep is sign-symmetric, so it alone could not have caught a sign or lane error; the non-uniform parity data is what killed it.
2. It justified the AVX2 gate by claiming the `cpu` package has no SSSE3 flag. It has one (`cpu/cpu.go:12`, wired at `cpu_amd64.go:15`, with a `SIMD_DISABLE` token and test coverage). The AVX2-only decision stands on the precedent above instead.

Both mattered because a spec's prose gets copied into code comments verbatim; the first error had already reached a comment in #151 before review caught it.

## Note on `MaxAbs` for #142

Per the discussion on #142, the `int` return is a deliberate deviation from that issue's requested `int16`. Noting it there when this lands.

Refs #142
Closes #147
