### PR TITLE
i16: fix dotAVX2's scalar tail (8-wide block before the 16-wide loop)

### DIFF
--- a/i16/benchmark_test.go
+++ b/i16/benchmark_test.go
@@ -67,6 +67,13 @@ func BenchmarkDeinterleave2Go_1000(b *testing.B) {
 // Dot benchmarks sweep the lengths fixed-point codecs actually call at: n=8 is
 // a short CELT band (where call overhead is the concern), n=240 a 20 ms frame
 // at 12 kHz, n=480 one at 24 kHz. SetBytes counts both operands: 2*n int16.
+//
+// 24 and 248 are the regression guard for the 8-wide AVX2 block, and they are
+// here because every other length above is a multiple of 16 (8 aside), which is
+// exactly how #149's sawtooth stayed invisible: a parity test cannot see a
+// performance defect, so only a benchmark at a length the block serves can. 24
+// is the worst case #149 measured (AVX2 was 1.41x slower than SSE2 there) and
+// 248 is the same residue at a high block count.
 
 func benchmarkDot(b *testing.B, n int, fn func(a, c []int16) int32) {
 	b.Helper()
@@ -83,14 +90,18 @@ func benchmarkDot(b *testing.B, n int, fn func(a, c []int16) int32) {
 }
 
 func BenchmarkDotProduct_8(b *testing.B)    { benchmarkDot(b, 8, DotProduct) }
+func BenchmarkDotProduct_24(b *testing.B)   { benchmarkDot(b, 24, DotProduct) }
 func BenchmarkDotProduct_64(b *testing.B)   { benchmarkDot(b, 64, DotProduct) }
 func BenchmarkDotProduct_240(b *testing.B)  { benchmarkDot(b, 240, DotProduct) }
+func BenchmarkDotProduct_248(b *testing.B)  { benchmarkDot(b, 248, DotProduct) }
 func BenchmarkDotProduct_480(b *testing.B)  { benchmarkDot(b, 480, DotProduct) }
 func BenchmarkDotProduct_4096(b *testing.B) { benchmarkDot(b, 4096, DotProduct) }
 
 func BenchmarkDotProductGo_8(b *testing.B)    { benchmarkDot(b, 8, dotGo) }
+func BenchmarkDotProductGo_24(b *testing.B)   { benchmarkDot(b, 24, dotGo) }
 func BenchmarkDotProductGo_64(b *testing.B)   { benchmarkDot(b, 64, dotGo) }
 func BenchmarkDotProductGo_240(b *testing.B)  { benchmarkDot(b, 240, dotGo) }
+func BenchmarkDotProductGo_248(b *testing.B)  { benchmarkDot(b, 248, dotGo) }
 func BenchmarkDotProductGo_480(b *testing.B)  { benchmarkDot(b, 480, dotGo) }
 func BenchmarkDotProductGo_4096(b *testing.B) { benchmarkDot(b, 4096, dotGo) }
 
@@ -129,18 +140,24 @@ func BenchmarkXCorr_480x64(b *testing.B) { benchmarkXCorr(b, 480, 64, XCorr) }
 // xcorrLagBlock, so the remainder-lag path never runs either. The cases below
 // exist to make both visible.
 //
-// x=25 currently shows the AVX2 tail costing more than SSE2 would (issue
-// filed): a remainder of 8-15 elements is served by a 4-lag scalar tail rather
-// than an 8-wide block. x=248 is the same shape at a realistic length, and
-// lags=61 is the pitch-analysis count from the motivating caller, which leaves
-// one remainder lag.
+// x=25 and x=248 leave len(x) % 16 in 8..15, the remainder #151 gave xcorr4AVX2
+// an 8-wide block to absorb; AVX2 had been up to 1.75x slower than SSE2 there.
+// x=248 is that shape at a realistic length.
+//
+// lags=61 is the pitch-analysis count from the motivating caller, and it is not
+// a multiple of xcorrLagBlock, so it leaves one remainder lag. That lag runs
+// through dotI16 rather than xcorr4, which makes 248x61 the only case here that
+// reaches dotAVX2's own 8-wide block (#149): 240x61 takes the same remainder-lag
+// path but hands dotI16 a residue of 0, so the block never runs.
 func BenchmarkXCorr_25x64(b *testing.B)  { benchmarkXCorr(b, 25, 64, XCorr) }
 func BenchmarkXCorr_248x64(b *testing.B) { benchmarkXCorr(b, 248, 64, XCorr) }
 func BenchmarkXCorr_240x61(b *testing.B) { benchmarkXCorr(b, 240, 61, XCorr) }
+func BenchmarkXCorr_248x61(b *testing.B) { benchmarkXCorr(b, 248, 61, XCorr) }
 
 func BenchmarkXCorrGo_25x64(b *testing.B)  { benchmarkXCorr(b, 25, 64, xcorrGo) }
 func BenchmarkXCorrGo_248x64(b *testing.B) { benchmarkXCorr(b, 248, 64, xcorrGo) }
 func BenchmarkXCorrGo_240x61(b *testing.B) { benchmarkXCorr(b, 240, 61, xcorrGo) }
+func BenchmarkXCorrGo_248x61(b *testing.B) { benchmarkXCorr(b, 248, 61, xcorrGo) }
 
 func BenchmarkXCorrGo_240x4(b *testing.B)   { benchmarkXCorr(b, 240, 4, xcorrGo) }
 func BenchmarkXCorrGo_240x64(b *testing.B)  { benchmarkXCorr(b, 240, 64, xcorrGo) }

--- a/i16/dot_test.go
+++ b/i16/dot_test.go
@@ -43,10 +43,11 @@ func dotOracle(a, b []int16) int32 {
 //
 // The exhaustive low range is deliberate rather than lazy. Both wide kernels
 // (dotNEON, and dotAVX2 now that it has one too) run an 8-wide block when
-// n mod 16 >= 8 and follow it with an (n mod 8) scalar tail. A hand-picked list
-// of block boundaries and their immediate neighbours yields only residues
-// {0, 1, 7, 8, 9, 15} mod 16, so it never runs that block together with a tail
-// of 2 to 6 elements (residues 10 to 14).
+// n mod 16 >= 8 and follow it with an (n mod 8) scalar tail. Sweeping 0 to 64
+// reaches every residue mod 16, and that is the point of doing it that way: the
+// tempting shortcut, a hand-picked list of block boundaries and their immediate
+// neighbours, would yield only residues {0, 1, 7, 8, 9, 15}, so it would never
+// run that block together with a tail of 2 to 6 elements (residues 10 to 14).
 //
 // The all-MinInt16 sweep in TestDotProduct_MinInt16 does visit every length, but
 // it cannot stand in for this list on either count. Its operands are

--- a/i16/dot_test.go
+++ b/i16/dot_test.go
@@ -41,14 +41,20 @@ func dotOracle(a, b []int16) int32 {
 
 // dotLengths sweeps EVERY length from 0 to 64, then a spread of larger ones.
 //
-// The exhaustive low range is deliberate rather than lazy. The arm64 kernel
-// runs an 8-wide block when n mod 16 >= 8 and follows it with an (n mod 8)
-// scalar tail, so reaching that block with a short tail needs n mod 16 in
-// {10, 11, 13, 14}. A hand-picked list of block boundaries and their immediate
-// neighbours never produces those combinations. The all-MinInt16 sweep in
-// TestDotProduct_MinInt16 does visit every length, but its operands are
-// sign-symmetric ((-32768)*(-32768) == 32768*32768), so it can only catch a
-// miscounted element, never a sign, lane, or index error. This list is what the
+// The exhaustive low range is deliberate rather than lazy. Both wide kernels
+// (dotNEON, and dotAVX2 now that it has one too) run an 8-wide block when
+// n mod 16 >= 8 and follow it with an (n mod 8) scalar tail. A hand-picked list
+// of block boundaries and their immediate neighbours yields only residues
+// {0, 1, 7, 8, 9, 15} mod 16, so it never runs that block together with a tail
+// of 2 to 6 elements (residues 10 to 14).
+//
+// The all-MinInt16 sweep in TestDotProduct_MinInt16 does visit every length, but
+// it cannot stand in for this list on either count. Its operands are
+// sign-symmetric ((-32768)*(-32768) == 32768*32768), so it cannot catch a sign,
+// lane, or index error. Nor can it reliably catch a miscount: every product is
+// 2^30, so any four of them sum to 2^32 and vanish from the wrapping
+// accumulator, which leaves a miscount of any multiple of four elements (the
+// 8-wide block itself included) invisible to it. This list is what the
 // non-uniform tests sweep, so it has to be the exhaustive one.
 var dotLengths = func() []int {
 	lens := make([]int, 0, 75)

--- a/i16/i16_amd64.go
+++ b/i16/i16_amd64.go
@@ -27,17 +27,23 @@ var (
 	hasSSE2 = cpu.X86.SSE2
 )
 
-// Dot dispatch thresholds: one vector block each. They are independent literals
-// rather than aliases of the interleave block sizes they happen to equal, so
-// retuning the interleave kernels cannot silently retune the dot dispatch.
+// Dot dispatch thresholds. They are independent literals rather than aliases of
+// the interleave block sizes they happen to equal, so retuning the interleave
+// kernels cannot silently retune the dot dispatch.
 //
 // The dot kernels are correct at any n (each falls through to a scalar tail), so
 // these are performance cuts only, never a safety requirement. Measured kernel
 // against Go reference at n=8, SSE2 wins 2.2x, so unlike NEON there is no
 // break-even region to step around here.
+//
+// Both kernels vectorize from 8 (see dotAVX2's 8-wide block), so the AVX2 cut at
+// 16 is not about AVX2 needing 16 elements to vectorize. It is that AVX2's fold
+// pays a VEXTRACTI128 and a VZEROUPPER that SSE2's identical one-XMM block does
+// not, a flat cost only the 16-wide body amortizes: measured kernel-direct, at
+// n=8-15 AVX2 is 7-20% slower than SSE2, and at n >= 16 it is never slower.
 const (
 	minSSE2Dot = 8  // PMADDWL retires 8 int16 pairs per iteration
-	minAVX2Dot = 16 // VPMADDWD retires 16
+	minAVX2Dot = 16 // below this AVX2's fold overhead outweighs its width
 )
 
 // XCorr vectorizes once x is long enough that reusing each x load across four

--- a/i16/i16_amd64.s
+++ b/i16/i16_amd64.s
@@ -319,6 +319,30 @@ dot_sse2_done:
 
 // func dotAVX2(a, b []int16) int32
 // Handles mismatched slice lengths: uses min(len(a), len(b)).
+//
+// An 8-wide XMM block runs BEFORE the 16-wide loop, so a remainder of 8-15
+// elements costs one vector block plus at most 7 scalar iterations rather than
+// 8-15 iterations of a serial ADDL chain. Without it AVX2 lost to SSE2 wherever
+// n mod 16 was 8-15, which is exactly where dotI16 prefers AVX2; see #149 for
+// the measurements. dotNEON carries the same 8-wide tier (dot_neon_block8 in
+// i16_arm64.s), though it sits after the body, in the one slot the hazard below
+// closes off here; NEON has no upper-lane hazard to keep it out. dotSSE2 needs
+// no such tier at all: its 8-wide loop already is that width.
+//
+// The placement is constrained, though not down to one slot as in xcorr4AVX2
+// below. Accumulating into X0 with a VEX.128 write zeroes bits 255:128 of Y0,
+// so a block between the 16-wide loop and the VEXTRACTI128 fold would silently
+// discard the loop's upper-lane sums. Two slots survive that: before the body,
+// while Y0 is still freshly VPXOR'd so the zeroing writes zero over zero, or
+// after the fold, once the upper lane is dead (xcorr4AVX2 folds too late to
+// have the second option). This kernel takes the first, so that this file
+// carries one block shape rather than two.
+//
+// Summing the remainder before the body is bit-exact only because the
+// accumulation wraps: wrapping int32 addition is associative and commutative,
+// so regrouping the terms cannot change the result. That is the property the
+// lane split already rests on and that DotProduct's doc guarantees to callers.
+// It would not hold in a saturating kernel.
 TEXT ·dotAVX2(SB), NOSPLIT, $0-52
     MOVQ a_base+0(FP), SI
     MOVQ a_len+8(FP), CX
@@ -329,6 +353,21 @@ TEXT ·dotAVX2(SB), NOSPLIT, $0-52
 
     VPXOR Y0, Y0, Y0           // int32 accumulator
 
+    TESTQ $8, CX               // n % 16 >= 8? one XMM block absorbs the 8
+    JZ   dot_avx2_blocks16
+
+    VMOVDQU (SI), X1
+    VMOVDQU (DI), X2
+    VPMADDWD X2, X1, X1        // 8 int16 pairs -> 4 int32
+    VPADDD X1, X0, X0          // VEX-128 zeroes Y0[255:128]; it is still zero
+    ADDQ $16, SI
+    ADDQ $16, DI
+
+    // The block count is computed AFTER the 8-wide block, not before, so SHRQ's
+    // own ZF still drives the branch below; computing it first would need a
+    // separate TESTQ BX, BX. CX keeps the full n either way: the 8 elements the
+    // block consumed are exactly the ones n/16 already excludes.
+dot_avx2_blocks16:
     MOVQ CX, BX
     SHRQ $4, BX                // BX = n / 16
     JZ   dot_avx2_reduce
@@ -352,7 +391,7 @@ dot_avx2_reduce:
     VPADDD X1, X0, X0
     MOVQ X0, AX                // low int32 = vector total (in EAX)
 
-    ANDQ $15, CX
+    ANDQ $7, CX                // the 8-wide block above took n % 16 down to n % 8
     JZ   dot_avx2_done
 
 dot_avx2_scalar:

--- a/i16/i16_amd64_test.go
+++ b/i16/i16_amd64_test.go
@@ -211,6 +211,19 @@ func TestDotAMD64_MinInt16(t *testing.T) {
 
 // TestDotAMD64_Clamp verifies the in-assembly min(len(a), len(b)): the kernel
 // must not read the longer operand past the shorter one's length.
+//
+// short MUST be a prefix of a longer allocation. A kernel that consumes past
+// the clamped n reads the memory following short, and past a standalone slice
+// that is zeroed, which multiplies to 0 and leaves every sum correct. Non-zero
+// bytes after short are what make over-consumption observable rather than a
+// coin flip on heap layout, and the slack has to cover a whole block of the
+// widest kernel here (16 elements, dotAVX2's body). Same reasoning as
+// TestXCorr4AMD64_LongWindowIsClamped; without it this test detects nothing on
+// amd64 at any n.
+//
+// This is the only dot test that watches the kernels directly with non-zero
+// memory past an operand. TestDotProduct_UnalignedOperands does it through the
+// dispatcher, so it cannot reach the kernels below their thresholds.
 func TestDotAMD64_Clamp(t *testing.T) {
 	for _, k := range dotKernels() {
 		t.Run(k.name, func(t *testing.T) {
@@ -221,7 +234,7 @@ func TestDotAMD64_Clamp(t *testing.T) {
 				if n == 0 {
 					continue
 				}
-				long, short := genI16(n+37, 63), genI16(n, 64)
+				long, short := genI16(n+37, 63), genI16(n+64, 64)[:n]
 				if got, want := k.fn(long, short), dotOracle(long, short); got != want {
 					t.Errorf("dot%s clamp n=%d: got %d, want %d", k.name, n, got, want)
 				}

--- a/i16/xcorr_test.go
+++ b/i16/xcorr_test.go
@@ -169,9 +169,11 @@ func TestXCorr_ExactWindow(t *testing.T) {
 // The lengths must keep reaching every kernel path that reorders the sum, since
 // wrapping is the property that makes reordering legal at all. 24 and 25 are
 // here for that: XCorr routes len(x) >= 16 to AVX2, so the residues mod 16 must
-// include some >= 8 or the amd64 8-wide block (which sums the remainder BEFORE
-// the 16-wide body) never runs under forced overflow. {8,9,16,17,33} alone left
-// AVX2 seeing only residues {0,1,1}.
+// include some >= 8 or the amd64 8-wide blocks never run under forced overflow.
+// {8,9,16,17,33} alone left AVX2 seeing only residues {0,1,1}. Both blocks sum
+// their remainder BEFORE the 16-wide body, which is the ordering that needs the
+// wrapping: xcorr4AVX2's, and dotAVX2's, which the lags that are not a multiple
+// of xcorrLagBlock reach through dotI16.
 func TestXCorr_MinInt16(t *testing.T) {
 	for _, xn := range []int{8, 9, 16, 17, 24, 25, 33} {
 		for _, lags := range []int{1, 4, 5, 8, 9} {


### PR DESCRIPTION
Fixes the `dotAVX2` half of #149. Same defect and same shape as the `xcorr4AVX2` fix in #151.

## The defect

`dotAVX2` dropped from its 16-wide body straight to a scalar tail, so a remainder of 8-15 elements cost 8-15 iterations on a serial `ADDL` chain, where `dotSSE2` served the same remainder in one 8-wide block. Since `dotI16` dispatches on `n >= minAVX2Dot`, it picked AVX2 exactly where AVX2 was the worse kernel. Bit-exact throughout, so this was purely a performance defect. `dotNEON` already had the block.

## The fix

One 8-wide XMM block before the 16-wide loop, and the tail mask drops from `ANDQ $15` to `ANDQ $7`.

Unlike `xcorr4AVX2`, this kernel has **two** legal slots rather than one. A VEX.128 write zeroes bits 255:128 of its destination, so a block may not sit between the 16-wide loop and the `VEXTRACTI128` fold, but it may sit either before the body (where Y0 is still freshly `VPXOR`-ed, so the zeroing writes zero over zero) or after the fold (where the upper lane is already dead). The two cost the same statically, so before-the-body wins on keeping one block shape in this file. Putting the remainder first is bit-exact only because the accumulation wraps, which `DotProduct`-s doc already guarantees to callers.

## Measurements

i7-1260P, kernels called directly, P-core pinned, `GOMAXPROCS=1`, benchstat over 15 interleaved samples. AVX2 against SSE2 at the same n (negative = AVX2 slower than the tier below it):

| n | n%16 | before | after |
| --- | --- | --- | --- |
| 8 | 8 | -147% | -19.6% |
| 15 | 15 | -86% | -7.3% |
| 16 | 0 | +8.9% | +2.8% |
| **24** | **8** | **-67%** | **+17.2%** |
| **28** | **12** | **-61%** | **+14.8%** |
| 32 | 0 | +30% | +26.6% |
| **40** | **8** | **-54%** | **+26.5%** |
| **56** | **8** | **-23%** | **+32.6%** |
| **88** | **8** | **-9%** | **+31.5%** |

The sawtooth is gone: at every n the dispatcher routes to AVX2, AVX2 is now faster than SSE2, where before it lost at every residue >= 8. `dotAVX2` itself improves 43-53% across those residues. (n=8 and n=15 are below the cut, so SSE2 runs there; they are listed to show the kernel, not the dispatch.)

Where the block does not run it costs exactly 2 instructions, a `TESTQ` and a `JZ`, measured kernel-direct at +3-4% at n=16 and n=32.

### A caveat on the aligned-length numbers, because they look better than they are

A first pass through the dispatcher showed n=480 getting **25% faster**, which is impossible: the block is skipped at n=480 and the change only adds two instructions. The 16-wide loop is 29 bytes, so whether it straddles a 64-byte fetch line depends on where the linker puts the function, and the block-s 33 bytes happen to move it off a boundary the baseline straddled. Go aligns amd64 functions to 32, not 64, so an unrelated code-size change can invert it. Aligned-length wall-clock from either build measures that lottery, not this change; the +3-4% kernel-direct figure is the honest cost. Filed as #159, since it has now confounded two consecutive tail fixes (#151 hit the same thing).

## Threshold

`minAVX2Dot` stays at 16, but its rationale was made stale and is rewritten. Both kernels now vectorize from 8, so the cut is not about AVX2 needing 16 elements. It is that AVX2-s fold pays a `VEXTRACTI128` and a `VZEROUPPER` that SSE2-s identical one-XMM block does not, a flat cost only the 16-wide body amortizes. Measured: at n=8-15 AVX2 is 7-20% slower, at n >= 16 never slower.

## Tests

`TestDotAMD64_Clamp` now builds its short operand as a prefix of a longer allocation. It is the only dot test that watches the kernels directly with non-zero memory past an operand, and **without that it detected nothing**: a kernel consuming past the clamped n reads zeroed memory, which multiplies to 0 and leaves every sum correct. Verified by mutation, a mutant keeping the old `ANDQ $15` tail passes the test as it stood on main and fails with the prefix. The dispatcher-level tests do kill that mutant, but only at n >= 16, so the kernel-direct 8-15 band was blind. This catches over-CONSUMPTION only; a pure over-read needs a guard page.

`dotLengths`-s comment carried two errors, both corrected here since the paragraph was being retargeted anyway: the residue set it says a boundary-and-neighbours list misses omitted 12, and the all-MinInt16 sweep is weaker than it claimed. Every MinInt16 product is 2^30, so any four sum to 2^32 and vanish from the wrapping accumulator, which makes a miscount of **any multiple of four elements invisible to that sweep, the new 8-wide block included**. Confirmed by mutation: a mutant dropping the whole block passes all eight MinInt16 tests in the package. The non-uniform `genI16` sweeps are what cover it.

## Benchmarks

`DotProduct_24` and `_248` are the regression guard. Every committed dot length was a multiple of 16 (8 aside), which is exactly how this stayed invisible, and a parity test cannot see a performance defect. `XCorr_248x61` covers the remainder-lag path that reaches `dotAVX2` through `dotI16`, which #149 flagged as unmeasured; 240x61 takes that path but hands `dotI16` a residue of 0. Also corrects the XCorr benchmark note, which still described the pre-#151 scalar tail as current.

## Verification

- Full i16 suite passes on real linux/amd64 (i7-1260P, AVX2), with the AVX2 subtests confirmed running rather than skipping.
- Old vs new vs oracle compared bit-for-bit over 3631 cases: every n in 0..300 across five data classes (full-range random, all-MinInt16, alternating extremes, random extremes, small values), mismatched lengths both directions with non-zero memory past the short operand, plus aliased and overlapping operands. All bit-exact.
- 55M fuzz executions on `FuzzI16Dot` under AVX2.
- `GOOS=linux GOARCH=amd64` build, vet, and lint (a native run on an arm64 box silently skips these amd64-only files, so it proves nothing about them). The 2 `goconst` hits in `i16_amd64_test.go` are pre-existing on main.
- `SIMD_DISABLE=avx2|sse2|neon` cascade with `-count=1`.

## Scope

`interleave2AVX2`, `deinterleave2AVX2` and the i8 kernels have the same shape and are left to a follow-up, per the convention in #145 that new kernel assembly gets its own correctness round. Both are unmeasured, and #149 notes the interleave tail is pure `MOVW` load/store with no serial dependency chain, so the stake is much lower and wants a benchmark before an assumption. #149 stays open for them.

Refs #149, #142

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Performance**
  * Improved AVX2 dot-product remainder processing to better handle lengths with 8-element remainders.

* **Tests**
  * Strengthened dot-product validation to better catch accidental reads past the clamped input length.
  * Expanded dot-product and cross-correlation benchmark coverage across additional vector sizes (including new exported benchmark variants).

* **Documentation**
  * Clarified how SIMD dispatch thresholds work for dot-product and updated test/benchmark coverage notes for dot and cross-correlation scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->