### PR TITLE
fix: repoint Taskfile bench/test tasks at the real package layout (#158)

### DIFF
--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -26,12 +26,12 @@ tasks:
   test:f32:
     desc: Run float32 tests
     cmds:
-      - go test -v ./pkg/simd/f32/
+      - go test -v ./f32/
 
   test:f64:
     desc: Run float64 tests
     cmds:
-      - go test -v ./pkg/simd/f64/
+      - go test -v ./f64/
 
   test:race:
     desc: Run tests with race detector
@@ -40,26 +40,24 @@ tasks:
 
   # Benchmarks
   bench:
-    desc: Run all benchmarks
+    desc: Run all benchmarks across every package
     cmds:
-      - go test -bench=. -benchmem -benchtime={{.BENCH_TIME}} ./pkg/simd/f32/
-      - go test -bench=. -benchmem -benchtime={{.BENCH_TIME}} ./pkg/simd/f64/
+      - go test -bench=. -benchmem -benchtime={{.BENCH_TIME}} -run='^$' ./...
 
   bench:f32:
     desc: Run float32 benchmarks
     cmds:
-      - go test -bench=. -benchmem -benchtime={{.BENCH_TIME}} ./pkg/simd/f32/
+      - go test -bench=. -benchmem -benchtime={{.BENCH_TIME}} -run='^$' ./f32/
 
   bench:f64:
     desc: Run float64 benchmarks
     cmds:
-      - go test -bench=. -benchmem -benchtime={{.BENCH_TIME}} ./pkg/simd/f64/
+      - go test -bench=. -benchmem -benchtime={{.BENCH_TIME}} -run='^$' ./f64/
 
   bench:dot:
-    desc: Run DotProduct benchmarks only
+    desc: Run DotProduct benchmarks across every package that has them
     cmds:
-      - go test -bench=BenchmarkDotProduct -benchmem -benchtime={{.BENCH_TIME}} ./pkg/simd/f32/
-      - go test -bench=BenchmarkDotProduct -benchmem -benchtime={{.BENCH_TIME}} ./pkg/simd/f64/
+      - go test -bench=BenchmarkDotProduct -benchmem -benchtime={{.BENCH_TIME}} -run='^$' ./...
 
   bench:compare:
     desc: Run SIMD vs Pure Go comparison benchmark


### PR DESCRIPTION
## What

The `bench:*` and `test:f32`/`test:f64` tasks in `Taskfile.yml` targeted `./pkg/simd/f32/` and `./pkg/simd/f64/`, a layout the repo moved away from. The packages live at the module root (`./f32`, `./f64`, ...), so every one of those tasks failed immediately:

```
$ go test -bench=BenchmarkDotProduct ./pkg/simd/f32/
stat .../simd/pkg/simd/f32: directory not found
FAIL	./pkg/simd/f32 [setup failed]
```

They failed loudly rather than silently passing, so nothing reported false benchmark results; the cost was just that the convenience wrappers were unusable. That matters now that benchmarks are the only regression guard for the tail-sawtooth work (#145, #149): a perf defect is bit-exact, so a benchmark is the only thing that can catch it.

## Changes

- `test:f32` / `test:f64`: `./pkg/simd/fNN` -> `./fNN`
- `bench` and `bench:dot`: broadened to `./...` so they cover `i16`/`i32`/`i8`/`f16`, which have benchmarks now, not just f32/f64
- `bench:f32` / `bench:f64`: `./pkg/simd/fNN` -> `./fNN`
- added `-run='^$'` to the bench tasks so they run benchmarks only instead of also executing the full verbose test suite on every bench run

`bench:compare`'s imports are Go import paths (`github.com/tphakala/simd/f32`), not filesystem paths, so they were already correct and are untouched.

## Verification

```
$ go test -bench=BenchmarkDotProduct -benchtime=1x -run='^$' ./...   # runs, exit 0, covers f16/f32/f64/i16/i8
$ go test -v ./f32/                                                  # resolves
$ grep pkg/simd Taskfile.yml                                         # none
```

Closes #158