### PR TITLE
i16: add 8-wide AVX2 block to interleave2/deinterleave2 tails (#149)

### DIFF
--- a/i16/benchmark_test.go
+++ b/i16/benchmark_test.go
@@ -3,66 +3,57 @@ package i16
 import "testing"
 
 // Benchmarks pair the dispatched (SIMD) path with the pure-Go baseline so the
-// speedup is visible directly. SetBytes counts every byte moved: a and b (benchN
+// speedup is visible directly. SetBytes counts every byte moved: a and b (n
 // int16 each) plus the double-width interleaved buffer (dst for interleave, src
-// for deinterleave, 2*benchN int16), so 4*benchN int16 = 8*benchN bytes at 2
-// bytes per int16.
+// for deinterleave, 2*n int16), so 4*n int16 = 8*n bytes at 2 bytes per int16.
+//
+// n=24 is the regression guard for the interleave/deinterleave 8-wide AVX2 block
+// (#149): 24 % 16 = 8, the residue where the block runs, and it was AVX2's worst
+// case (up to 1.55x slower than SSE2 before the block, measured on the i7-1260P).
+// 1000 % 16 = 8 too but at a high block count, where the residue amortizes; a
+// parity test cannot see a performance defect, so only a benchmark at a length
+// the block serves can. n=1000 keeps the historical name for benchstat history.
 
-const benchN = 1000
-
-func BenchmarkInterleave2_1000(b *testing.B) {
-	a := make([]int16, benchN)
-	c := make([]int16, benchN)
-	dst := make([]int16, benchN*2)
+func benchmarkInterleave2(b *testing.B, n int, fn func(dst, a, c []int16)) {
+	b.Helper()
+	a := make([]int16, n)
+	c := make([]int16, n)
+	dst := make([]int16, n*2)
 	for i := range a {
 		a[i] = int16(i)
-		c[i] = int16(i + benchN)
+		c[i] = int16(i + n)
 	}
-	b.SetBytes(benchN * 2 * 4)
+	b.SetBytes(int64(n) * 2 * 4)
 	for b.Loop() {
-		Interleave2(dst, a, c)
+		fn(dst, a, c)
 	}
 }
 
-func BenchmarkInterleave2Go_1000(b *testing.B) {
-	a := make([]int16, benchN)
-	c := make([]int16, benchN)
-	dst := make([]int16, benchN*2)
-	for i := range a {
-		a[i] = int16(i)
-		c[i] = int16(i + benchN)
-	}
-	b.SetBytes(benchN * 2 * 4)
-	for b.Loop() {
-		interleave2Go(dst, a, c)
-	}
-}
+func BenchmarkInterleave2_24(b *testing.B)   { benchmarkInterleave2(b, 24, Interleave2) }
+func BenchmarkInterleave2_1000(b *testing.B) { benchmarkInterleave2(b, 1000, Interleave2) }
 
-func BenchmarkDeinterleave2_1000(b *testing.B) {
-	src := make([]int16, benchN*2)
-	a := make([]int16, benchN)
-	c := make([]int16, benchN)
+func BenchmarkInterleave2Go_24(b *testing.B)   { benchmarkInterleave2(b, 24, interleave2Go) }
+func BenchmarkInterleave2Go_1000(b *testing.B) { benchmarkInterleave2(b, 1000, interleave2Go) }
+
+func benchmarkDeinterleave2(b *testing.B, n int, fn func(a, c, src []int16)) {
+	b.Helper()
+	src := make([]int16, n*2)
+	a := make([]int16, n)
+	c := make([]int16, n)
 	for i := range src {
 		src[i] = int16(i)
 	}
-	b.SetBytes(benchN * 2 * 4)
+	b.SetBytes(int64(n) * 2 * 4)
 	for b.Loop() {
-		Deinterleave2(a, c, src)
+		fn(a, c, src)
 	}
 }
 
-func BenchmarkDeinterleave2Go_1000(b *testing.B) {
-	src := make([]int16, benchN*2)
-	a := make([]int16, benchN)
-	c := make([]int16, benchN)
-	for i := range src {
-		src[i] = int16(i)
-	}
-	b.SetBytes(benchN * 2 * 4)
-	for b.Loop() {
-		deinterleave2Go(a, c, src)
-	}
-}
+func BenchmarkDeinterleave2_24(b *testing.B)   { benchmarkDeinterleave2(b, 24, Deinterleave2) }
+func BenchmarkDeinterleave2_1000(b *testing.B) { benchmarkDeinterleave2(b, 1000, Deinterleave2) }
+
+func BenchmarkDeinterleave2Go_24(b *testing.B)   { benchmarkDeinterleave2(b, 24, deinterleave2Go) }
+func BenchmarkDeinterleave2Go_1000(b *testing.B) { benchmarkDeinterleave2(b, 1000, deinterleave2Go) }
 
 // Dot benchmarks sweep the lengths fixed-point codecs actually call at: n=8 is
 // a short CELT band (where call overhead is the concern), n=240 a 20 ms frame

--- a/i16/i16_amd64.s
+++ b/i16/i16_amd64.s
@@ -31,13 +31,39 @@ GLOBL deinterleave2Mask<>(SB), RODATA|NOPTR, $32
 
 // func interleave2AVX2(dst, a, b []int16)
 // Interleaves two slices: dst[0]=a[0], dst[1]=b[0], dst[2]=a[1], dst[3]=b[1], ...
+//
+// An 8-wide VEX.128 block runs BEFORE the 16-wide loop, so a remainder of 8-15
+// pairs costs one vector block plus at most 7 scalar MOVW iterations rather than
+// 8-15. Without it AVX2 lost to SSE2 wherever len(a) mod 16 was 8-15, which is
+// exactly where interleave2I16 prefers AVX2; measured on the i7-1260P, n=24 went
+// from 1.55x slower than SSE2 to faster. See #149.
+//
+// Unlike dotAVX2 there is no accumulator, so no upper-lane hazard and no ordering
+// constraint: each block independently loads, shuffles and stores, and the
+// VEX.128 writes carry nothing across the body. The block still uses VEX forms
+// (not the SSE2 kernel's legacy MOVOU/PUNPCK) to avoid the SSE/AVX transition
+// penalty against the 256-bit body.
 TEXT ·interleave2AVX2(SB), NOSPLIT, $0-72
     MOVQ dst_base+0(FP), DX    // dst pointer
     MOVQ a_base+24(FP), SI     // a pointer
     MOVQ a_len+32(FP), CX      // n = len(a)
     MOVQ b_base+48(FP), DI     // b pointer
 
-    // Process 16 pairs at a time (32 output elements)
+    TESTQ $8, CX               // n % 16 >= 8? one XMM block absorbs the 8
+    JZ   interleave2_avx2_blocks16
+    VMOVDQU (SI), X0           // [a0..a7]
+    VMOVDQU (DI), X1           // [b0..b7]
+    VPUNPCKLWD X1, X0, X2      // [a0,b0,a1,b1,a2,b2,a3,b3]
+    VPUNPCKHWD X1, X0, X3      // [a4,b4,a5,b5,a6,b6,a7,b7]
+    VMOVDQU X2, (DX)
+    VMOVDQU X3, 16(DX)
+    ADDQ $16, SI               // a += 8 * 2
+    ADDQ $16, DI               // b += 8 * 2
+    ADDQ $32, DX               // dst += 16 * 2
+
+    // Process 16 pairs at a time (32 output elements). The block count is taken
+    // from the full n; the 8 the block consumed are exactly the ones n/16 drops.
+interleave2_avx2_blocks16:
     MOVQ CX, AX
     SHRQ $4, AX                // AX = n / 16
     JZ   interleave2_avx2_remainder
@@ -64,7 +90,7 @@ interleave2_avx2_loop16:
     JNZ  interleave2_avx2_loop16
 
 interleave2_avx2_remainder:
-    ANDQ $15, CX
+    ANDQ $7, CX                // $7 not $15: the 8-wide block above took that bit
     JZ   interleave2_avx2_done
 
 interleave2_avx2_scalar:
@@ -88,6 +114,15 @@ interleave2_avx2_done:
 //    bytes of each 128-bit lane.
 // 2. VPUNPCKLQDQ/VPUNPCKHQDQ split the lanes into a-only and b-only registers.
 // 3. VPERMQ fixes the lane interleave the two 128-bit halves introduced.
+//
+// An 8-wide VEX.128 block runs BEFORE the 16-wide loop, absorbing a remainder of
+// 8-15 pairs in one vector block instead of 8-15 scalar MOVW iterations; without
+// it AVX2 lost to SSE2 wherever len(a) mod 16 was 8-15, which is where the
+// dispatcher prefers it (n=24 measured 1.5x slower on the i7-1260P). See #149.
+// The block needs no VPERMQ: within one 128-bit lane VPSHUFB already lands a's in
+// the low half and b's in the high, so a single VPUNPCKLQDQ/HQDQ pair splits them
+// in order. It reuses X7 (the low lane of the gather mask) and VEX forms, so it
+// carries nothing across the body and pays no SSE/AVX transition penalty.
 TEXT ·deinterleave2AVX2(SB), NOSPLIT, $0-72
     MOVQ a_base+0(FP), DX      // a pointer
     MOVQ a_len+8(FP), CX       // n = len(a)
@@ -96,7 +131,23 @@ TEXT ·deinterleave2AVX2(SB), NOSPLIT, $0-72
 
     VMOVDQU deinterleave2Mask<>(SB), Y7  // even/odd word gather mask
 
-    // Process 16 pairs at a time
+    TESTQ $8, CX               // n % 16 >= 8? one XMM block absorbs the 8
+    JZ   deinterleave2_avx2_blocks16
+    VMOVDQU (SI), X0           // [a0,b0,a1,b1,a2,b2,a3,b3]
+    VMOVDQU 16(SI), X1         // [a4,b4,a5,b5,a6,b6,a7,b7]
+    VPSHUFB X7, X0, X0         // [a0,a1,a2,a3,b0,b1,b2,b3]
+    VPSHUFB X7, X1, X1         // [a4,a5,a6,a7,b4,b5,b6,b7]
+    VPUNPCKLQDQ X1, X0, X2     // a = [a0..a3,a4..a7]
+    VPUNPCKHQDQ X1, X0, X3     // b = [b0..b3,b4..b7]
+    VMOVDQU X2, (DX)           // store a
+    VMOVDQU X3, (R8)           // store b
+    ADDQ $32, SI               // src += 16 * 2
+    ADDQ $16, DX               // a += 8 * 2
+    ADDQ $16, R8               // b += 8 * 2
+
+    // Process 16 pairs at a time. The block count is taken from the full n; the 8
+    // the block consumed are exactly the ones n/16 drops.
+deinterleave2_avx2_blocks16:
     MOVQ CX, AX
     SHRQ $4, AX
     JZ   deinterleave2_avx2_remainder
@@ -124,7 +175,7 @@ deinterleave2_avx2_loop16:
     JNZ  deinterleave2_avx2_loop16
 
 deinterleave2_avx2_remainder:
-    ANDQ $15, CX
+    ANDQ $7, CX                // $7 not $15: the 8-wide block above took that bit
     JZ   deinterleave2_avx2_done
 
 deinterleave2_avx2_scalar:

--- a/i16/i16_amd64_test.go
+++ b/i16/i16_amd64_test.go
@@ -98,23 +98,27 @@ func TestDeinterleave2_ParityWithGo(t *testing.T) {
 // TestInterleave2_NoOverwrite guards the scalar tail: the kernel must not write
 // past n*2 output elements even when n is not a multiple of the block.
 func TestInterleave2_NoOverwrite(t *testing.T) {
-	const n = 23 // one AVX2 block (16) + 7 tail; one SSE2 block (8) leaves a 7 tail too
+	// Sweep tails on both tiers: 25 and 31 set n&8, so they exercise the 8-wide
+	// AVX2 block plus a scalar tail (#149); 23 is the block-skipped path (one
+	// AVX2 body + 7 tail; two SSE2 bodies + 7 tail).
 	for _, k := range interleaveKernels() {
 		t.Run(k.name, func(t *testing.T) {
 			if !k.available {
 				t.Skipf("%s not available", k.name)
 			}
-			a := make([]int16, n)
-			b := make([]int16, n)
-			fillPattern(a, b)
-			dst := make([]int16, n*2+8)
-			for i := range dst {
-				dst[i] = math.MaxInt16 // sentinel
-			}
-			k.fn(dst[:n*2], a, b)
-			for i := n * 2; i < len(dst); i++ {
-				if dst[i] != math.MaxInt16 {
-					t.Errorf("interleave2%s wrote past end at dst[%d] = %d", k.name, i, dst[i])
+			for _, n := range []int{23, 25, 31} {
+				a := make([]int16, n)
+				b := make([]int16, n)
+				fillPattern(a, b)
+				dst := make([]int16, n*2+8)
+				for i := range dst {
+					dst[i] = math.MaxInt16 // sentinel
+				}
+				k.fn(dst[:n*2], a, b)
+				for i := n * 2; i < len(dst); i++ {
+					if dst[i] != math.MaxInt16 {
+						t.Errorf("interleave2%s n=%d wrote past end at dst[%d] = %d", k.name, n, i, dst[i])
+					}
 				}
 			}
 		})
@@ -123,29 +127,31 @@ func TestInterleave2_NoOverwrite(t *testing.T) {
 
 // TestDeinterleave2_NoOverwrite guards both output buffers' scalar tails.
 func TestDeinterleave2_NoOverwrite(t *testing.T) {
-	const n = 23
+	// 25 and 31 set n&8 (the 8-wide AVX2 block path, #149); 23 skips the block.
 	for _, k := range deinterleaveKernels() {
 		t.Run(k.name, func(t *testing.T) {
 			if !k.available {
 				t.Skipf("%s not available", k.name)
 			}
-			src := make([]int16, n*2)
-			for i := range src {
-				src[i] = int16(i) ^ math.MinInt16
-			}
-			a := make([]int16, n+8)
-			b := make([]int16, n+8)
-			for i := range a {
-				a[i] = math.MaxInt16
-				b[i] = math.MaxInt16
-			}
-			k.fn(a[:n], b[:n], src)
-			for i := n; i < len(a); i++ {
-				if a[i] != math.MaxInt16 {
-					t.Errorf("deinterleave2%s wrote past end of a at [%d] = %d", k.name, i, a[i])
+			for _, n := range []int{23, 25, 31} {
+				src := make([]int16, n*2)
+				for i := range src {
+					src[i] = int16(i) ^ math.MinInt16
 				}
-				if b[i] != math.MaxInt16 {
-					t.Errorf("deinterleave2%s wrote past end of b at [%d] = %d", k.name, i, b[i])
+				a := make([]int16, n+8)
+				b := make([]int16, n+8)
+				for i := range a {
+					a[i] = math.MaxInt16
+					b[i] = math.MaxInt16
+				}
+				k.fn(a[:n], b[:n], src)
+				for i := n; i < len(a); i++ {
+					if a[i] != math.MaxInt16 {
+						t.Errorf("deinterleave2%s n=%d wrote past end of a at [%d] = %d", k.name, n, i, a[i])
+					}
+					if b[i] != math.MaxInt16 {
+						t.Errorf("deinterleave2%s n=%d wrote past end of b at [%d] = %d", k.name, n, i, b[i])
+					}
 				}
 			}
 		})


### PR DESCRIPTION
## What

`interleave2AVX2` and `deinterleave2AVX2` dropped from their 16-wide body straight to a scalar `MOVW` tail, so a remainder of 8-15 pairs cost 8-15 scalar iterations where the SSE2 sibling serves the same remainder in one 8-wide block. The dispatcher routes `len(a) >= 16` to AVX2, i.e. straight into the worse kernel at those residues. This is the interleave half of #149 (`dotAVX2` got its block in #160, `xcorr4AVX2` in #151).

## Measurement (the maintainer asked for this before assuming a win)

The interleave tails are pure load/store with no serial dependency chain, so #149 flagged the win as "not a given". Measured kernel-direct on the i7-1260P, P-core pinned, `GOMAXPROCS=1`, benchstat n=20. AVX2 vs SSE2 at the same length, negative = SSE2 faster (the sawtooth):

| n (n%16) | interleave before | deinterleave before |
|---|---|---|
| 24 (8) | -35.6% | -33.0% |
| 40 (8) | -25.6% | -14.0% |
| 47 (15) | -7.8% | -18.2% |
| 56 (8) | -13.3% | ~ |

After the block, AVX2 beats SSE2 at **every** length; the kernel itself is 30-52% faster at the residue lengths (deinterleave n=24 -52.4%). Aligned/large lengths keep their existing AVX2 win.

## How

Mirrors `dotAVX2`/`xcorr4AVX2`: one 8-wide XMM block before the 16-wide loop, tail mask `$15 -> $7`. Two differences from dot:
1. No accumulator, so no VEX upper-lane hazard and the block placement is unconstrained.
2. `deinterleave` reuses `X7` (the low lane of the gather mask) and needs no `VPERMQ`, because within one 128-bit lane `VPSHUFB` already lands a's low and b's high, so a single `VPUNPCKLQDQ`/`VPUNPCKHQDQ` pair splits them in order.

The block uses VEX forms to avoid the SSE/AVX transition penalty against the 256-bit body. Bit-exact for all n (pure data movement, no arithmetic reordering).

## Aligned-length note (deferred to #159)

Inserting the block shifts the loop's address and can straddle a 64-byte fetch line, moving aligned-length wall-time up to ~12% either way. Perf counters show this is layout, not work: at n=1000 the fixed build retires *fewer* instructions (869.9 vs 930.9/op) yet takes *more* cycles (194.5 vs 173.9). Pinning the loop with `PCALIGN` is #159's remit, measured separately.

## Test plan

- [x] Full i16 suite + AVX2/SSE2 parity (sweeps residues 8/9/15/31/1000/1023) + alloc-free pass on the i7-1260P
- [x] `NoOverwrite` sentinel tests now sweep 23/25/31, so the 8-wide-block path (n&8 set) is covered for past-end writes, not just the block-skipped n=23
- [x] `n=24` added as a committed benchstat regression guard for both ops
- [x] Pre-push gate (6 independent reviewers incl. Gemini): correctness/bounds/VEX-order/register-discipline all confirmed clean

Advances #149 (checks the interleave/deinterleave box; the i8-kernel item stays open on the #149 checklist). Do not auto-close.