### PR TITLE
docs: add assembly-encoding reference (arm64 integer multiply, Plan 9 spellings) (#148)

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -206,6 +206,12 @@ Update `README.md` to include the new operation in the API table.
 - Use `VZEROUPPER` at the end of AVX functions (AMD64)
 - Test with various slice sizes to exercise all code paths
 
+Before hand-encoding a NEON instruction as a `WORD`, or reaching for an unfamiliar
+Plan 9 mnemonic, read [docs/assembly-encoding.md](docs/assembly-encoding.md): it
+lists which arm64 integer-multiply instructions the assembler rejects (so must be
+`WORD`-encoded), the amd64 spellings that differ from Intel (`PMADDWD` is
+`PMADDWL`), and how to verify a new encoding without aarch64 binutils.
+
 ## Pull Request Guidelines
 
 1. **Title**: Use a clear, descriptive title

--- a/docs/assembly-encoding.md
+++ b/docs/assembly-encoding.md
@@ -1,0 +1,89 @@
+# Assembly encoding notes
+
+Reference for the instruction-selection constraints that shape every hand-written
+kernel in this repo. These are Go-toolchain facts, not micro-architecture tuning:
+they explain *why* the integer NEON kernels are written as raw `WORD` encodings
+and why some Plan 9 mnemonics differ from their Intel names. Verified empirically
+against go1.26 (one instruction at a time in a minimal `TEXT` block); re-check on
+a toolchain bump, since the assembler's accepted set can change between releases.
+
+## ARM64: Go's assembler cannot express integer vector multiply
+
+Go's arm64 assembler rejects every integer vector multiply and multiply-accumulate
+with `unrecognized instruction`. Confirmed for, among others:
+
+```
+SMLAL, VSMLAL, VSMLAL2, VSMULL, VSMULL2, VUMULL, VMUL (int vector, .S4 and .H8),
+SQRDMULH, VSQRDMULH, SQDMULH, VSQDMULH, SRSHR, VSRSHR, VSSHR, VXTN, VXTN2,
+VABS, VSMAX, VSMIN, VSADDLP, VSADALP, VUMAXV, VSMAXV
+```
+
+The scalar `SMULL` with vector operands fails differently, with `illegal
+combination`: the general-register form exists, the vector form does not.
+
+**So NEON integer multiply-accumulate requires raw `WORD $0x...` encodings.** That
+is why `i8` and `i16` look the way they do: the widening multiply-add at the core
+of those kernels has no spelling the assembler accepts. Each `WORD` carries a
+decoded mnemonic in its trailing comment, and the test suite cross-checks every
+one against `golang.org/x/arch/arm64asm` (see the `asmcheck` package and
+`asmcheck_test.go`).
+
+### These ARE native, do not hand-encode them
+
+```
+VADD (.S4/.H8), VSHL, VADDV, VEXT, VDUP, VMOV, VEOR, VUMAX,
+VLD1/VLD1.P/VST1/VST1.P
+```
+
+`VADDV` and `VUMAX` are the two worth calling out: both look like they might need
+encoding and both do not. Reach for a `WORD` only after confirming the mnemonic is
+actually rejected.
+
+An amusing asymmetry: `go tool objdump` happily *decodes* a hand-encoded word back
+to `VSMLAL ...`. The toolchain knows the instruction on the way out but not on the
+way in.
+
+## AMD64: Plan 9 spellings that differ from Intel
+
+- **`PMADDWD` does not assemble; the SSE2 form is spelled `PMADDWL`** ("long" for
+  the 32-bit result). The VEX form keeps the Intel name, `VPMADDWD`.
+- `PADDD`/`PADDL` and `PSRLDQ`/`PSRLO` are accepted as aliases.
+- `PSHUFD`, `MOVWLSX`, `CMOVQLT` all assemble under their familiar names.
+
+## Verifying a new WORD encoding without aarch64 binutils
+
+`aarch64-linux-gnu-as` / `objdump` are not installed on every dev box. The working
+substitute:
+
+1. Write the GNU-syntax instruction in a `.s` file, assemble with
+   `clang -c -arch arm64`, disassemble with LLVM `objdump -d`. That yields the
+   authoritative encoding.
+2. Cross-check the word through the repo's own `asmcheck.Verify(hex, comment)` and
+   confirm `Status == Match`.
+
+Worth knowing about `asmcheck_test.go`: it defers any directive whose comment
+contains `.8H` to an objdump cross-check ONLY when `arm64asm` cannot decode it, and
+without objdump those are then accepted UNCHECKED. Integer `SMLAL`/`SMLAL2` with
+`.8H` operands decode fine and are checked directly, so a green run is meaningful
+for them; `SDOT` genuinely needs the objdump path. If you add a `.8H` encoding,
+confirm which side of that line it falls on rather than assuming the passing test
+covered it.
+
+To confirm quickly whether the assembler accepts a mnemonic at all, drop it into a
+one-line `TEXT` block and `GOOS=linux GOARCH=arm64 go build` (or `GOARCH=amd64`):
+an `unrecognized instruction` or `illegal combination` error is the answer.
+
+## Do not trust an LLM's Plan 9 operand-order reasoning
+
+Plan 9 reverses operand order from Intel, and reversed-convention reasoning is a
+reliable way to get a confident, wrong answer. During the #143 review an LLM rated
+a length clamp a critical out-of-bounds bug, arguing that Go's `CMPQ src, dst`
+evaluates `dst - src` so `CMPQ DX, CX` computes `CX - DX`. It is the reverse. The
+shipped sequence computed `min` correctly, and the suggested `CMOVQGT` "fix" would
+have *introduced* the out-of-bounds read it warned about. Three independent checks
+(a hardware probe returning the computed `n`, a disassembly showing
+`cmp %rdx,%rcx` + `cmovl %rcx,%rdx`, and guard-page tests where any over-read
+segfaults) all agreed the original was right.
+
+Verify operand semantics by disassembly or execution, never by recalled
+convention.


### PR DESCRIPTION
## What

Gives the hard-won assembly encoding knowledge a durable doc home (`docs/assembly-encoding.md`), linked from CONTRIBUTING.md's Assembly Guidelines. It came out of the #142/#143/#146 integer-kernel work but is not specific to it: it shapes every hand-written kernel in the repo.

Content:
- Go's arm64 assembler rejects every integer vector multiply / multiply-accumulate (`SMLAL`, `VSMULL`, `SQRDMULH`, `VMUL`, ...), which is *why* the i8/i16 NEON kernels are raw `WORD` encodings. Plus the list of NEON ops that ARE native and must not be hand-encoded (`VADDV`, `VUMAX` are the two easy to get wrong).
- The amd64 Plan 9 spellings that differ from Intel (`PMADDWD` is `PMADDWL`; the VEX form keeps `VPMADDWD`).
- How to verify a new `WORD` encoding without aarch64 binutils, and the `.8H` asmcheck deferral caveat.
- Why not to trust an LLM's Plan 9 operand-order reasoning (the #143 `CMPQ` false-positive), with the verify-by-disassembly-or-execution rule.

## Verification

Every "rejected" / "native" / "Plan 9 spelling" claim was re-checked against go1.26 by dropping each instruction into a one-line `TEXT` block and building it: `PMADDWD` -> `unrecognized instruction`, `PMADDWL`/`VPMADDWD` -> OK; `SMLAL`/`VSMULL`/`VMUL`/`SQRDMULH` -> `unrecognized instruction`; `SMULL` with vector operands -> `illegal combination`; `VADD`/`VADDV`/`VUMAX`/`VSHL` -> OK.

Docs-only, no code changes.

Closes #148