### PR TITLE
f32: add Float32ToInt32ScaleClamp fused affine-clamp-to-int32 (NEON + AVX2) (#155)

### DIFF
--- a/README.md
+++ b/README.md
@@ -284,8 +284,13 @@ streaming DSP. These are f32-specific and have no f64 equivalent by design.
 | `Int32ToFloat32Scale(dst, src, s)` | PCM int32 to normalized float | 8x (AVX2) / 4x (NEON) |
 | `Int16ToFloat32Scale(dst, src, s)` | PCM int16 to normalized float | 8x (AVX2) / 4x (NEON) |
 | `Float32ToInt16Scale(dst, src, s)` | Normalized float to PCM int16 | 8x (AVX2) / 4x (NEON) |
+| `Float32ToInt32ScaleClamp(dst, src, s, o, lo, hi)` | Affine float to clamped int32, truncating (`int32(clamp(src*s+o, lo, hi))`) | 8x (AVX2) / 4x (NEON) |
 
 Each has an `Unsafe` variant that skips bounds reconciliation.
+
+`Float32ToInt32ScaleClamp` keeps the multiply and add as two separate float32
+roundings (never fused into an FMA), so it reproduces a scalar `float32(x*s)+o`
+reference bit-for-bit.
 
 `InterleaveN`/`DeinterleaveN` add an 8-stream AVX path (8x8 register transpose) and
 a 3-stream AVX2 path (per-stream `VPERMPS` gathers merged with `VPBLENDD`, since 3

--- a/f32/f32.go
+++ b/f32/f32.go
@@ -988,6 +988,55 @@ func Float32ToInt16ScaleUnsafe(dst []int16, src []float32, scale float32) {
 	float32ToInt16Scale(dst[:len(src)], src, scale)
 }
 
+// Float32ToInt32ScaleClamp converts float32 to int32 in one pass:
+//
+//	dst[i] = int32(clamp(src[i]*scale + offset, minV, maxV))   // truncated toward zero
+//
+// It is the int32 sibling of Float32ToInt16Scale for the float -> fixed-point
+// boundary, with caller-supplied bounds and an additive offset: the classic
+// scale, add-a-rounding-constant, clamp, then truncate idiom of fixed-point DSP
+// and affine quantization. Behavior is fully specified and identical on every
+// architecture:
+//   - the multiply and the add are two separate float32 roundings (the product
+//     rounds before offset is added); they are never contracted into an FMA;
+//   - truncation is toward zero (like a Go int32(v) cast, one LSB looser than
+//     round-to-nearest);
+//   - out-of-range values clamp to [minV, maxV] rather than wrapping;
+//   - +Inf -> maxV, -Inf -> minV, NaN -> 0.
+//
+// Callers must keep minV and maxV non-NaN and within the float32-representable
+// int32 range: minV >= -2147483648.0 and maxV <= 2147483520.0 (the largest
+// float32 not exceeding MaxInt32; float32(math.MaxInt32) rounds up to 2^31 and
+// is out of contract). Outside that range the conversion of an out-of-range
+// value is architecture-dependent (x86 yields the integer indefinite
+// 0x80000000; ARM64 saturates).
+//
+// Processes min(len(dst), len(src)) elements.
+//
+// Uses AVX on AMD64 (8x float32; the int32 output needs no saturating pack, so
+// AVX2 is not required), NEON on ARM64 (4x float32).
+func Float32ToInt32ScaleClamp(dst []int32, src []float32, scale, offset, minV, maxV float32) {
+	n := min(len(dst), len(src))
+	if n == 0 {
+		return
+	}
+	float32ToInt32ScaleClamp(dst[:n], src[:n], scale, offset, minV, maxV)
+}
+
+// Float32ToInt32ScaleClampUnsafe converts float32 to int32 without length
+// validation. This is a low-overhead variant for performance-critical code paths.
+//
+// PRECONDITIONS (caller must ensure):
+//   - len(dst) >= len(src)
+//   - len(src) > 0
+//
+// Violating these preconditions results in undefined behavior.
+// Use Float32ToInt32ScaleClamp for safe operation with automatic length handling.
+func Float32ToInt32ScaleClampUnsafe(dst []int32, src []float32, scale, offset, minV, maxV float32) {
+	// Slice dst to len(src) to ensure SIMD implementations don't write past dst
+	float32ToInt32ScaleClamp(dst[:len(src)], src, scale, offset, minV, maxV)
+}
+
 // ============================================================================
 // SPLIT-FORMAT COMPLEX OPERATIONS
 // ============================================================================

--- a/f32/f32_amd64.go
+++ b/f32/f32_amd64.go
@@ -1160,6 +1160,19 @@ func float32ToInt16Scale(dst []int16, src []float32, scale float32) {
 //go:noescape
 func float32ToInt16ScaleAVX(dst []int16, src []float32, scale float32)
 
+func float32ToInt32ScaleClamp(dst []int32, src []float32, scale, offset, minV, maxV float32) {
+	// Pure AVX (VEX.256 float ops + VCVTTPS2DQ); the int32 output needs no
+	// saturating pack, so unlike float32ToInt16Scale it does not require AVX2.
+	if cpu.X86.AVX && len(dst) >= minAVXElements {
+		float32ToInt32ScaleClampAVX(dst, src, scale, offset, minV, maxV)
+		return
+	}
+	float32ToInt32ScaleClampGo(dst, src, scale, offset, minV, maxV)
+}
+
+//go:noescape
+func float32ToInt32ScaleClampAVX(dst []int32, src []float32, scale, offset, minV, maxV float32)
+
 // ============================================================================
 // SPLIT-FORMAT COMPLEX OPERATIONS
 // ============================================================================

--- a/f32/f32_amd64.s
+++ b/f32/f32_amd64.s
@@ -4577,6 +4577,77 @@ f32toi16_done:
     VZEROUPPER
     RET
 
+// func float32ToInt32ScaleClampAVX(dst []int32, src []float32, scale, offset, minV, maxV float32)
+// dst[i] = int32(clamp(src[i]*scale + offset, minV, maxV)), truncated toward zero.
+//
+// VMULPS then VADDPS are deliberately SEPARATE (not VFMADD231PS): the product
+// rounds to float32 before offset is added, matching the two-rounding Go
+// reference bit-for-bit. Contracting them into an FMA would change the result
+// and is forbidden here (see #156). NaN -> 0: x86 MAXPS/MINPS return the bound
+// (SRC2) when the value (SRC1) is NaN, so a NaN lane would otherwise become
+// int32(minV); the self-compare mask (VCMPPS EQ, taken from v before the clamp)
+// is ANDed into the int32 result AFTER the convert to force NaN lanes to 0,
+// matching NEON's FCVTZS(NaN)=0. The clamp bounds +/-Inf to maxV/minV.
+// VCVTTPS2DQ (the truncating form) rounds toward zero to match Go's int32(v).
+// The int32 output needs no saturating pack, so this is plain AVX (no AVX2):
+// VANDPS is a bitwise AND that carries the mask across the float->int convert.
+// The 8-wide tail reprocesses the final full block with overlap, so no scalar
+// tail is needed.
+TEXT ·float32ToInt32ScaleClampAVX(SB), NOSPLIT, $0-64
+    MOVQ dst_base+0(FP), DX        // DX = dst pointer (int32 out)
+    MOVQ dst_len+8(FP), CX         // CX = length (len(dst) == len(src))
+    MOVQ src_base+24(FP), SI       // SI = src pointer (float32 in)
+
+    VBROADCASTSS scale+48(FP), Y3  // Y3 = scale  x8
+    VBROADCASTSS offset+52(FP), Y4 // Y4 = offset x8
+    VBROADCASTSS minV+56(FP), Y5   // Y5 = minV   x8
+    VBROADCASTSS maxV+60(FP), Y6   // Y6 = maxV   x8
+
+    MOVQ CX, AX
+    SHRQ $3, AX                    // len / 8
+    JZ   f32toi32_tail
+
+f32toi32_loop8:
+    VMOVUPS (SI), Y0               // 8 x float32
+    VMULPS Y3, Y0, Y0              // v = src * scale (rounds to float32)
+    VADDPS Y4, Y0, Y0             // v += offset (separate rounding; NOT an FMA)
+    VCMPPS $0, Y0, Y0, Y1        // Y1 = (v == v) ? ones : 0  (0 for NaN), from v pre-clamp
+    VMAXPS Y5, Y0, Y0           // clamp low  (>= minV; -Inf -> minV)
+    VMINPS Y6, Y0, Y0          // clamp high (<= maxV; +Inf -> maxV)
+    VCVTTPS2DQ Y0, Y0          // 8 x int32, truncate toward zero
+    VANDPS Y1, Y0, Y0         // NaN lanes -> 0 (bitwise AND on the int32 result)
+    VMOVDQU Y0, (DX)          // store 8 x int32 (32 bytes)
+    ADDQ $32, SI             // advance src by 8 x float32
+    ADDQ $32, DX            // advance dst by 8 x int32
+    DECQ AX
+    JNZ  f32toi32_loop8
+
+f32toi32_tail:
+    ANDQ $7, CX                    // remainder = len % 8
+    JZ   f32toi32_done
+
+    // Back up to the final aligned block of 8 and reprocess it (overlap). src and
+    // dst are both 4-byte elements, so both back up by (8 - rem) * 4 bytes.
+    MOVQ $8, BX
+    SUBQ CX, BX                    // BX = 8 - (len % 8)  (1..7)
+    SHLQ $2, BX                    // (8 - rem) * 4 bytes
+    SUBQ BX, SI
+    SUBQ BX, DX
+
+    VMOVUPS (SI), Y0               // final 8 x float32
+    VMULPS Y3, Y0, Y0
+    VADDPS Y4, Y0, Y0
+    VCMPPS $0, Y0, Y0, Y1
+    VMAXPS Y5, Y0, Y0
+    VMINPS Y6, Y0, Y0
+    VCVTTPS2DQ Y0, Y0
+    VANDPS Y1, Y0, Y0
+    VMOVDQU Y0, (DX)               // store final 8 x int32
+
+f32toi32_done:
+    VZEROUPPER
+    RET
+
 // ============================================================================
 // SPLIT-FORMAT COMPLEX OPERATIONS
 // ============================================================================

--- a/f32/f32_arm64.go
+++ b/f32/f32_arm64.go
@@ -780,6 +780,17 @@ func float32ToInt16Scale(dst []int16, src []float32, scale float32) {
 //go:noescape
 func float32ToInt16ScaleNEON(dst []int16, src []float32, scale float32)
 
+func float32ToInt32ScaleClamp(dst []int32, src []float32, scale, offset, minV, maxV float32) {
+	if hasNEON && len(dst) >= 4 {
+		float32ToInt32ScaleClampNEON(dst, src, scale, offset, minV, maxV)
+		return
+	}
+	float32ToInt32ScaleClampGo(dst, src, scale, offset, minV, maxV)
+}
+
+//go:noescape
+func float32ToInt32ScaleClampNEON(dst []int32, src []float32, scale, offset, minV, maxV float32)
+
 // ============================================================================
 // SPLIT-FORMAT COMPLEX OPERATIONS
 // ============================================================================

--- a/f32/f32_arm64.s
+++ b/f32/f32_arm64.s
@@ -2129,6 +2129,71 @@ f32toi16_neon_tail:
 f32toi16_neon_done:
     RET
 
+// func float32ToInt32ScaleClampNEON(dst []int32, src []float32, scale, offset, minV, maxV float32)
+// dst[i] = int32(clamp(src[i]*scale + offset, minV, maxV)), truncated toward zero.
+//
+// FMUL then FADD are deliberately SEPARATE (not FMLA): the product rounds to
+// float32 before offset is added, matching the two-rounding Go reference and the
+// AVX path bit-for-bit. NaN -> 0 falls out for free here: ARM FMAX/FMIN (not the
+// FMAXNM/FMINNM forms) PROPAGATE a NaN operand, so a NaN survives the clamp, and
+// FCVTZS maps NaN to 0. So no explicit NaN masking is needed (the AVX path needs
+// it only because x86 MINPS/MAXPS replace a NaN with the bound). The clamp bounds
+// +/-Inf to maxV/minV. FCVTZS truncates toward zero to match Go's int32(v). The
+// vector float ops (.4S) have no Go-assembler spelling, so FMUL, FADD, FMAX, FMIN
+// and FCVTZS are WORD-encoded (verified with clang -c -arch arm64 + objdump; see
+// docs/assembly-encoding.md); VDUP and VLD1/VST1 are native. The 4-wide tail
+// reprocesses the final full block with overlap.
+TEXT ·float32ToInt32ScaleClampNEON(SB), NOSPLIT, $0-64
+    MOVD dst_base+0(FP), R0        // R0 = dst pointer (int32 out)
+    MOVD dst_len+8(FP), R3         // R3 = length (len(dst) == len(src))
+    MOVD src_base+24(FP), R1       // R1 = src pointer (float32 in)
+    FMOVS scale+48(FP), F2         // F2 = scale
+    FMOVS offset+52(FP), F3        // F3 = offset
+    FMOVS minV+56(FP), F4          // F4 = minV
+    FMOVS maxV+60(FP), F5          // F5 = maxV
+
+    // Broadcast each scalar to all 4 lanes (DUP element form, native VDUP).
+    VDUP V2.S[0], V2.S4            // scale  x4
+    VDUP V3.S[0], V3.S4            // offset x4
+    VDUP V4.S[0], V4.S4            // minV   x4
+    VDUP V5.S[0], V5.S4            // maxV   x4
+
+    LSR $2, R3, R4                 // R4 = len / 4
+    CBZ R4, f32toi32_neon_tail
+
+f32toi32_neon_loop4:
+    VLD1.P 16(R1), [V0.S4]         // V0 = 4 x float32
+    WORD $0x6E22DC00              // FMUL V0.4S, V0.4S, V2.4S   (v = src * scale)
+    WORD $0x4E23D400             // FADD V0.4S, V0.4S, V3.4S   (v += offset; separate, not FMLA)
+    WORD $0x4E24F400            // FMAX V0.4S, V0.4S, V4.4S   (>= minV; -Inf -> minV, NaN propagates)
+    WORD $0x4EA5F400           // FMIN V0.4S, V0.4S, V5.4S   (<= maxV; +Inf -> maxV, NaN propagates)
+    WORD $0x4EA1B800          // FCVTZS V0.4S, V0.4S        (truncate toward zero; NaN -> 0)
+    VST1.P [V0.S4], 16(R0)    // store 4 x int32 (16 bytes)
+    SUB $1, R4
+    CBNZ R4, f32toi32_neon_loop4
+
+f32toi32_neon_tail:
+    AND $3, R3, R5                 // R5 = len % 4
+    CBZ R5, f32toi32_neon_done
+
+    // Back up to the final aligned block of 4 and reprocess it (overlap). src and
+    // dst are both 4-byte elements, so both back up by (4 - rem) * 4 bytes.
+    MOVD $4, R6
+    SUB R5, R6, R6                 // R6 = 4 - (len % 4)  (1..3)
+    LSL $2, R6, R7                 // R7 = (4 - rem) * 4 bytes
+    SUB R7, R1, R1
+    SUB R7, R0, R0
+    VLD1 (R1), [V0.S4]             // final 4 x float32
+    WORD $0x6E22DC00               // FMUL V0.4S, V0.4S, V2.4S
+    WORD $0x4E23D400               // FADD V0.4S, V0.4S, V3.4S
+    WORD $0x4E24F400               // FMAX V0.4S, V0.4S, V4.4S
+    WORD $0x4EA5F400               // FMIN V0.4S, V0.4S, V5.4S
+    WORD $0x4EA1B800               // FCVTZS V0.4S, V0.4S
+    VST1 [V0.S4], (R0)             // store final 4 x int32
+
+f32toi32_neon_done:
+    RET
+
 // ============================================================================
 // SPLIT-FORMAT COMPLEX OPERATIONS
 // ============================================================================

--- a/f32/f32_go.go
+++ b/f32/f32_go.go
@@ -750,6 +750,46 @@ func float32ToInt16ScaleGo(dst []int16, src []float32, scale float32) {
 	}
 }
 
+// float32ToInt32ScaleClampGo converts float32 to int32 in one pass:
+//
+//	v = src[i]*scale + offset, clamped to [minV, maxV], truncated toward zero.
+//
+// The multiply and the add are two SEPARATE float32 roundings, never contracted
+// into an FMA: the product rounds to float32 before offset is added. The SIMD
+// kernels emit VMULPS+VADDPS / FMUL+FADD (not VFMADD / FMLA) to match this
+// bit-for-bit, so output is identical across architectures and against this
+// reference. See #156 for the library-wide single-rounding contract.
+//
+// The float32(src[i]*scale) conversion is a mandatory rounding barrier: without
+// it the Go compiler legally fuses src*scale+offset into a single FMADDS on
+// arm64 (verified with go1.26 -gcflags=-S), which would round once and diverge
+// from both the SIMD kernels and this reference's own intent.
+//
+// NaN -> 0 (matching Float32ToInt16Scale). +Inf clamps to maxV, -Inf to minV.
+// Truncation toward zero matches Go's int32(v) and the hardware CVTTPS2DQ /
+// FCVTZS. Callers must keep minV and maxV non-NaN and within the float32-
+// representable int32 range: minV >= -2147483648.0 and maxV <= 2147483520.0
+// (the largest float32 <= MaxInt32; float32(math.MaxInt32) rounds up to 2^31 and
+// overflows). Outside that contract the conversion of an out-of-range value is
+// architecture-dependent.
+func float32ToInt32ScaleClampGo(dst []int32, src []float32, scale, offset, minV, maxV float32) {
+	for i := range src {
+		v := float32(src[i]*scale) + offset // two roundings; the conversion blocks FMA fusion
+		if v != v {                         // NaN -> 0, as on both kernels
+			dst[i] = 0
+			continue
+		}
+		// Clamp order mirrors the kernels' FMAX(minV) then FMIN(maxV).
+		if v < minV {
+			v = minV
+		}
+		if v > maxV {
+			v = maxV
+		}
+		dst[i] = int32(v) // truncate toward zero
+	}
+}
+
 // ============================================================================
 // SPLIT-FORMAT COMPLEX OPERATIONS (Pure Go)
 // ============================================================================

--- a/f32/f32_other.go
+++ b/f32/f32_other.go
@@ -71,6 +71,10 @@ func int16ToFloat32Scale(dst []float32, src []int16, s float32) { int16ToFloat32
 
 func float32ToInt16Scale(dst []int16, src []float32, s float32) { float32ToInt16ScaleGo(dst, src, s) }
 
+func float32ToInt32ScaleClamp(dst []int32, src []float32, scale, offset, minV, maxV float32) {
+	float32ToInt32ScaleClampGo(dst, src, scale, offset, minV, maxV)
+}
+
 // Split-format complex operations
 func mulComplex32(dstRe, dstIm, aRe, aIm, bRe, bIm []float32) {
 	mulComplex32Go(dstRe, dstIm, aRe, aIm, bRe, bIm)

--- a/f32/float32_to_int32_scale_clamp_test.go
+++ b/f32/float32_to_int32_scale_clamp_test.go
@@ -1,0 +1,283 @@
+package f32
+
+import (
+	"math"
+	"testing"
+)
+
+// float32ToInt32ScaleClampRef is an independent oracle for
+// Float32ToInt32ScaleClamp. It uses float64 intermediates: a float32 operand is
+// exact in float64, and each float32(...) cast rounds exactly once, so this
+// computes one float32 multiply-rounding then one float32 add-rounding (the
+// two-rounding, no-FMA contract) by a different route than the production Go
+// reference, and the float64 form cannot be compiler-fused. The NaN/clamp/
+// truncate logic matches the kernels (NaN -> 0; FMAX(minV) then FMIN(maxV); trunc
+// toward zero).
+func float32ToInt32ScaleClampRef(dst []int32, src []float32, scale, offset, minV, maxV float32) {
+	n := min(len(dst), len(src))
+	for i := range n {
+		p := float32(float64(src[i]) * float64(scale)) // product, rounded to float32
+		v := float32(float64(p) + float64(offset))     // + offset, rounded to float32
+		if v != v {                                    // NaN -> 0
+			dst[i] = 0
+			continue
+		}
+		if v < minV { // max(v, minV)
+			v = minV
+		}
+		if v > maxV { // min(v, maxV); inverted bounds (minV>maxV) yield maxV, as on the kernels
+			v = maxV
+		}
+		dst[i] = int32(v) // truncate toward zero
+	}
+}
+
+func float32Ramp32(n int) []float32 {
+	s := make([]float32, n)
+	for i := range s {
+		s[i] = float32(i%2001-1000) * 0.5
+	}
+	return s
+}
+
+func TestFloat32ToInt32ScaleClamp(t *testing.T) {
+	inf := float32(math.Inf(1))
+	nan := float32(math.NaN())
+	cases := []struct {
+		name                      string
+		src                       []float32
+		scale, offset, minV, maxV float32
+	}{
+		{"empty", nil, 2.0, 0.5, -100, 100},
+		{"single", []float32{1.5}, 2.0, 0.4, -100, 100},
+		{"four", []float32{-1, -0.5, 0.5, 1}, 3.0, 0.25, -100, 100},
+		{"eight", []float32{-2, -1, -0.25, 0, 0.25, 1, 2, 3.5}, 4.0, 0.4054, -1000, 1000},
+		{"nine", float32Ramp32(9), 7.0, 0.5, -5000, 5000},
+		{"block16", float32Ramp32(16), 7.0, 0.5, -5000, 5000},
+		{"block17", float32Ramp32(17), 7.0, 0.5, -5000, 5000},
+		{"residue_31", float32Ramp32(31), 3.0, 0.1, -2000, 2000},
+		// Clamp both ends.
+		{"clamp_both", []float32{-1e6, 1e6, -50, 50, 200, -200, 0, 0.5}, 1.0, 0.0, -100, 100},
+		// Negative truncation toward zero (scale 1, offset 0 so v == src).
+		{"trunc", []float32{-0.7, -1.5, -2.999, 2.999, 0.999, -0.001}, 1.0, 0.0, -1000, 1000},
+		// +Inf -> maxV, -Inf -> minV, NaN -> 0 (with bounds that span 0).
+		{"inf_nan_span0", []float32{inf, -inf, nan, 5, -5, nan, inf, -inf}, 1.0, 0.0, -100, 100},
+		// NaN -> 0 even when the clamp range EXCLUDES zero (distinguishes NaN->0
+		// from NaN->clamp(0); the latter would give 10 here).
+		{"nan_excl_zero", []float32{nan, 50, nan, 20}, 1.0, 0.0, 10, 100},
+		// Inverted bounds: every result is int32(maxV).
+		{"inverted", []float32{-100, 0, 100, 5}, 1.0, 0.0, 50, 10},
+		// Contract-edge bounds with huge inputs.
+		{"contract_edge", []float32{5e9, -5e9, inf, -inf, 1.5}, 1.0, 0.0, -2147483648.0, 2147483520.0},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			dst := make([]int32, len(tc.src))
+			Float32ToInt32ScaleClamp(dst, tc.src, tc.scale, tc.offset, tc.minV, tc.maxV)
+			want := make([]int32, len(tc.src))
+			float32ToInt32ScaleClampRef(want, tc.src, tc.scale, tc.offset, tc.minV, tc.maxV)
+			for i := range dst {
+				if dst[i] != want[i] {
+					t.Errorf("[%d] = %d, want %d (src=%g scale=%g offset=%g minV=%g maxV=%g)",
+						i, dst[i], want[i], tc.src[i], tc.scale, tc.offset, tc.minV, tc.maxV)
+				}
+			}
+		})
+	}
+}
+
+// TestFloat32ToInt32ScaleClampGo exercises the pure-Go fallback directly against
+// the oracle. This is the test that catches the Go compiler fusing the reference
+// itself into an FMADDS on arm64 (which would round once instead of twice).
+func TestFloat32ToInt32ScaleClampGo(t *testing.T) {
+	src := float32Ramp32(200)
+	for i := range 7 {
+		src = append(src, float32(i)+0.4054) // a few offset-boundary values
+	}
+	dst := make([]int32, len(src))
+	want := make([]int32, len(src))
+	float32ToInt32ScaleClampGo(dst, src, 4097.0, 0.4054, -1e9, 1e9)
+	float32ToInt32ScaleClampRef(want, src, 4097.0, 0.4054, -1e9, 1e9)
+	for i := range dst {
+		if dst[i] != want[i] {
+			t.Fatalf("Go[%d] = %d, want %d (src=%g)", i, dst[i], want[i], src[i])
+		}
+	}
+}
+
+// TestFloat32ToInt32ScaleClamp_NoFMA is an FMA detector. With
+// src=scale=4097 and offset=-(2^24+2^13), the true product 4097*4097 =
+// 16785409 rounds to float32 16785408 (ties-to-even), so the correct
+// two-rounding result is (16785408 + offset) = 0. A fused multiply-add keeps the
+// unrounded 16785409 and yields 1. Every dispatched path must return 0.
+func TestFloat32ToInt32ScaleClamp_NoFMA(t *testing.T) {
+	const offset = -16785408.0 // -(2^24 + 2^13)
+	src := make([]float32, 12) // > 8 so the AVX body runs, includes a residue
+	for i := range src {
+		src[i] = 4097.0
+	}
+	dst := make([]int32, len(src))
+	Float32ToInt32ScaleClamp(dst, src, 4097.0, offset, -1000, 1000)
+	for i := range dst {
+		if dst[i] != 0 {
+			t.Fatalf("[%d] = %d, want 0 (a non-zero result means the multiply and add fused into an FMA)", i, dst[i])
+		}
+	}
+}
+
+func TestFloat32ToInt32ScaleClamp_Large(t *testing.T) {
+	// Lengths cover every 8-wide AVX residue (0..7: e.g. 10->2, 11->3, 14->6) and
+	// every 4-wide NEON residue, plus multiples that skip the overlap tail.
+	for _, n := range []int{4, 5, 7, 8, 9, 10, 11, 13, 14, 15, 16, 17, 31, 32, 33, 63, 96, 1000, 4096} {
+		src := make([]float32, n)
+		for i := range src {
+			// Sweep so some values clamp at each end.
+			src[i] = float32(i%400-200) * 12.0
+		}
+		dst := make([]int32, n)
+		want := make([]int32, n)
+		Float32ToInt32ScaleClamp(dst, src, 3.0, 0.4054, -2000, 2000)
+		float32ToInt32ScaleClampGo(want, src, 3.0, 0.4054, -2000, 2000)
+		for i := range dst {
+			if dst[i] != want[i] {
+				t.Fatalf("n=%d [%d] = %d, want %d", n, i, dst[i], want[i])
+			}
+		}
+	}
+}
+
+// TestFloat32ToInt32ScaleClamp_ContractEdgeSIMD drives the max/min contract
+// bounds (2147483520 = 2^31-128, -2147483648) through the vector body at len >= 8
+// (the table's contract_edge case is 5 elements and takes the scalar path on
+// amd64), so the CVTTPS2DQ / FCVTZS of a value clamped to the extreme bound is
+// exercised on the SIMD path itself.
+func TestFloat32ToInt32ScaleClamp_ContractEdgeSIMD(t *testing.T) {
+	const maxV = 2147483520.0
+	const minV = -2147483648.0
+	inf := float32(math.Inf(1))
+	src := make([]float32, 40)
+	for i := range src {
+		switch i % 4 {
+		case 0:
+			src[i] = 1e30 // huge -> clamps to maxV
+		case 1:
+			src[i] = -1e30 // -> minV
+		case 2:
+			src[i] = inf // -> maxV
+		default:
+			src[i] = float32(i) - 20 // in-range
+		}
+	}
+	dst := make([]int32, len(src))
+	want := make([]int32, len(src))
+	Float32ToInt32ScaleClamp(dst, src, 1.0, 0.0, minV, maxV)
+	float32ToInt32ScaleClampRef(want, src, 1.0, 0.0, minV, maxV)
+	for i := range dst {
+		if dst[i] != want[i] {
+			t.Fatalf("[%d] = %d, want %d (src=%g)", i, dst[i], want[i], src[i])
+		}
+	}
+	// The clamped-to-max lanes must be exactly int32(2147483520), not the
+	// integer-indefinite 0x80000000.
+	if dst[0] != int32(maxV) {
+		t.Errorf("clamp-to-maxV lane = %d, want %d", dst[0], int32(maxV))
+	}
+}
+
+func TestFloat32ToInt32ScaleClamp_LengthMismatch(t *testing.T) {
+	// dst shorter than src: only len(dst) elements processed, src not over-read.
+	src := float32Ramp32(20)
+	dst := make([]int32, 12)
+	Float32ToInt32ScaleClamp(dst, src, 2.0, 0.5, -1000, 1000)
+	want := make([]int32, 12)
+	float32ToInt32ScaleClampRef(want, src[:12], 2.0, 0.5, -1000, 1000)
+	for i := range dst {
+		if dst[i] != want[i] {
+			t.Fatalf("[%d] = %d, want %d", i, dst[i], want[i])
+		}
+	}
+	// src shorter than dst: dst tail untouched.
+	src = float32Ramp32(10)
+	dst = make([]int32, 16)
+	for i := range dst {
+		dst[i] = -12345 // sentinel
+	}
+	Float32ToInt32ScaleClamp(dst, src, 2.0, 0.5, -1000, 1000)
+	for i := 10; i < 16; i++ {
+		if dst[i] != -12345 {
+			t.Errorf("dst[%d] = %d, want untouched sentinel -12345", i, dst[i])
+		}
+	}
+}
+
+func TestFloat32ToInt32ScaleClampUnsafe(t *testing.T) {
+	src := float32Ramp32(40)
+	dst := make([]int32, len(src))
+	safe := make([]int32, len(src))
+	Float32ToInt32ScaleClampUnsafe(dst, src, 3.0, 0.4, -1500, 1500)
+	Float32ToInt32ScaleClamp(safe, src, 3.0, 0.4, -1500, 1500)
+	for i := range dst {
+		if dst[i] != safe[i] {
+			t.Fatalf("Unsafe[%d] = %d, want %d", i, dst[i], safe[i])
+		}
+	}
+}
+
+func TestFloat32ToInt32ScaleClamp_AllocFree(t *testing.T) {
+	src := float32Ramp32(256)
+	dst := make([]int32, len(src))
+	if got := testing.AllocsPerRun(100, func() {
+		Float32ToInt32ScaleClamp(dst, src, 3.0, 0.4, -2000, 2000)
+	}); got != 0 {
+		t.Errorf("Float32ToInt32ScaleClamp allocated %v times per run, want 0", got)
+	}
+	if got := testing.AllocsPerRun(100, func() {
+		Float32ToInt32ScaleClampUnsafe(dst, src, 3.0, 0.4, -2000, 2000)
+	}); got != 0 {
+		t.Errorf("Float32ToInt32ScaleClampUnsafe allocated %v times per run, want 0", got)
+	}
+}
+
+func FuzzFloat32ToInt32ScaleClamp(f *testing.F) {
+	f.Add(uint32(0x3f800000), uint32(0x3e800000), int16(300), int16(-50), 20)
+	f.Fuzz(func(t *testing.T, scaleBits, offsetBits uint32, hi, lo int16, n int) {
+		if n < 0 {
+			n = -n
+		}
+		n %= 200
+		scale := math.Float32frombits(scaleBits)
+		offset := math.Float32frombits(offsetBits)
+		if scale != scale || offset != offset { // skip NaN scale/offset (out of contract)
+			return
+		}
+		// Keep bounds in-contract and finite. lo/hi are small ints scaled up.
+		minV := float32(lo) * 1000.0
+		maxV := float32(hi) * 1000.0
+		src := make([]float32, n)
+		for i := range src {
+			src[i] = math.Float32frombits(scaleBits*uint32(i+1) ^ offsetBits)
+		}
+		dst := make([]int32, n)
+		want := make([]int32, n)
+		Float32ToInt32ScaleClamp(dst, src, scale, offset, minV, maxV)
+		float32ToInt32ScaleClampGo(want, src, scale, offset, minV, maxV)
+		for i := range dst {
+			if dst[i] != want[i] {
+				t.Fatalf("n=%d [%d] = %d, want %d (src=%g scale=%g offset=%g minV=%g maxV=%g)",
+					n, i, dst[i], want[i], src[i], scale, offset, minV, maxV)
+			}
+		}
+	})
+}
+
+func BenchmarkFloat32ToInt32ScaleClamp(b *testing.B) {
+	src := make([]float32, 1024)
+	for i := range src {
+		src[i] = float32(i%400-200) * 8.0
+	}
+	dst := make([]int32, len(src))
+	b.SetBytes(int64(len(src)) * 8) // 4 bytes read + 4 bytes written per element
+	for b.Loop() {
+		Float32ToInt32ScaleClamp(dst, src, 3.0, 0.4054, -2000, 2000)
+	}
+}


### PR DESCRIPTION
## What

New elementwise primitive, the int32 sibling of `Float32ToInt16Scale` for the float -> fixed-point boundary with caller-supplied bounds and an additive offset:

```
dst[i] = int32(clamp(src[i]*scale + offset, minV, maxV))   // truncated toward zero
```

This is affine quantization / the scale-offset-clamp-truncate idiom of fixed-point DSP. Requested by go-aac's `quantize_bands` hot path (9.7-13.2% of encode time), rescoped by the maintainer to drop the AAC-specific sign transfer, asymmetric clamp, and no-FMA-in-the-signature parts.

## Contract (fully specified, identical on every architecture)

- **Two separate float32 roundings, never an FMA.** The kernels emit `VMULPS`+`VADDPS` / `FMUL`+`FADD` (not `VFMADD`/`FMLA`), and the Go reference writes `float32(src*scale)+offset` with an explicit conversion barrier because gc otherwise fuses it into `FMADDS` on arm64 (verified with go1.26 `-gcflags=-S`). An FMA-detector test (product `4097*4097` rounds one way fused, another unfused) guards every dispatched path.
- **Truncation toward zero** (`VCVTTPS2DQ` / `FCVTZS`) matches Go's `int32(v)`.
- **NaN -> 0** (matching `Float32ToInt16Scale`): free on NEON (`FMAX`/`FMIN` propagate NaN, `FCVTZS(NaN)=0`); on x86, `MINPS`/`MAXPS` replace a NaN with the bound, so the self-compare mask is `VANDPS`'d into the int32 result after the convert.
- **+Inf -> maxV, -Inf -> minV** via the clamp. Caller keeps `minV`/`maxV` within the float32-representable int32 range (`maxV <= 2147483520`, since `float32(MaxInt32)` rounds up to 2^31).

## Kernels

The NEON vector-float ops (`.4S`) have no Go-assembler spelling, so `FMUL`, `FADD`, `FMAX`, `FMIN`, `FCVTZS` are WORD-encoded (verified via `clang -c -arch arm64` + objdump and cross-checked by asmcheck against arm64asm); `VDUP` and `VLD1`/`VST1` are native. The AVX2 kernel is plain AVX (the int32 output needs no saturating pack, so no AVX2 requirement). Both kernels use the sibling's overlapping-tail technique. Zero allocations.

## Test plan

- [x] Bit-exact against an independent float64-emulated oracle and the Go reference on the i7-1260P (AVX) and arm64 (NEON): a length sweep through every AVX/NEON residue, clamp at both ends and inverted bounds, negative truncation, +/-Inf, NaN with bounds that exclude zero, an FMA detector, the max-contract-value on the SIMD path, and a property fuzz (4.4M execs).
- [x] Zero allocations (safe + Unsafe), builds on amd64/arm64/riscv64/wasm/386.
- [x] Pre-push gate: 6 independent reviewers (incl. Gemini) confirmed correctness, cross-arch bit-exactness, register discipline, and the WORD encodings; the two doc-accuracy findings they raised (a mis-cited contract doc, an "AVX2"->"AVX" godoc label) are fixed in this branch.

Closes #155