### PR TITLE
f32: document and asmcheck-enforce the single-rounding / no-FMA contract (#156)

### DIFF
--- a/asmcheck_test.go
+++ b/asmcheck_test.go
@@ -292,3 +292,110 @@ func TestNoGoroutineRegisterClobber(t *testing.T) {
 			len(violations), strings.Join(violations, "\n  "))
 	}
 }
+
+// singleRoundingKernel names a kernel whose scalar reference computes
+// float32(a*b)+c as two separate roundings (the product rounds to float32 before
+// the add). Its body must emit a distinct multiply and add, never a fused
+// multiply-add: a consumer that reproduces the reference bit-for-bit (go-aac's
+// quantize path, #155) depends on the intermediate rounding. See the f32 package
+// doc and #156.
+type singleRoundingKernel struct {
+	file, fn string
+	mul, add string // the two separate mnemonics that must both appear
+}
+
+var singleRoundingKernels = []singleRoundingKernel{
+	{"f32/f32_amd64.s", "float32ToInt32ScaleClampAVX", "VMULPS", "VADDPS"},
+	{"f32/f32_arm64.s", "float32ToInt32ScaleClampNEON", "FMUL", "FADD"},
+}
+
+// asmFuncBody returns the lines of the TEXT ·fn(...) block, from its TEXT line to
+// the next TEXT line (or EOF). The header doc comment sits above the TEXT line
+// and is deliberately excluded, so a comment mentioning "VFMADD" or "FMLA" (as
+// the no-FMA kernels' own comments do) is not scanned.
+func asmFuncBody(src, fn string) ([]string, bool) {
+	lines := strings.Split(src, "\n")
+	start := -1
+	for i, l := range lines {
+		if strings.HasPrefix(strings.TrimSpace(l), "TEXT ·"+fn+"(") {
+			start = i
+			break
+		}
+	}
+	if start < 0 {
+		return nil, false
+	}
+	end := len(lines)
+	for i := start + 1; i < len(lines); i++ {
+		if strings.HasPrefix(strings.TrimSpace(lines[i]), "TEXT ·") {
+			end = i
+			break
+		}
+	}
+	return lines[start:end], true
+}
+
+// TestNoFMAContract enforces the f32 single-rounding contract (#156): the
+// listed kernels must contain a separate multiply and add and no fused
+// multiply-add. amd64 instructions are read as mnemonics; arm64 vector-float
+// ops are WORD-encoded, so each WORD is decoded through arm64asm and the decoded
+// mnemonic is checked (a WORD-encoded FMLA is caught even though the source text
+// is a hex literal).
+func TestNoFMAContract(t *testing.T) {
+	// VFMADD/VFNMADD/VFMSUB/VFNMSUB (amd64); FMADD/FMSUB/FNMADD/FNMSUB and the
+	// FMLA/FMLS vector forms (arm64). Deliberately excludes FMUL/FADD/FMAX/FMIN.
+	fmaRe := regexp.MustCompile(`^(VFN?M(ADD|SUB)|FN?M(ADD|SUB)|FML[AS])`)
+
+	for _, k := range singleRoundingKernels {
+		src, err := os.ReadFile(k.file)
+		if err != nil {
+			t.Fatalf("%s: %v", k.file, err)
+		}
+		body, ok := asmFuncBody(string(src), k.fn)
+		if !ok {
+			t.Fatalf("%s: TEXT ·%s not found (renamed? update singleRoundingKernels)", k.file, k.fn)
+		}
+
+		var mulSeen, addSeen bool
+		for _, line := range body {
+			// Resolve the effective mnemonic: the decoded op for a WORD directive,
+			// otherwise the first token of the (comment-stripped) instruction.
+			var mnem string
+			if hex, _, isWord := asmcheck.ParseWordLine(line); isWord {
+				dec, derr := asmcheck.Decode(hex)
+				if derr != nil {
+					continue // undecodable words are TestArm64WordEncodings' job
+				}
+				if f := strings.Fields(dec); len(f) > 0 {
+					mnem = strings.ToUpper(f[0])
+				}
+			} else {
+				code := line
+				if idx := strings.Index(code, "//"); idx >= 0 {
+					code = code[:idx]
+				}
+				if f := strings.Fields(code); len(f) > 0 {
+					mnem = strings.ToUpper(f[0])
+				}
+			}
+			if mnem == "" {
+				continue
+			}
+			if fmaRe.MatchString(mnem) {
+				t.Errorf("%s ·%s: forbidden fused %s in a single-rounding kernel; emit a "+
+					"separate %s then %s so the product rounds to float32 first (see #156)",
+					k.file, k.fn, mnem, k.mul, k.add)
+			}
+			switch mnem {
+			case k.mul:
+				mulSeen = true
+			case k.add:
+				addSeen = true
+			}
+		}
+		if !mulSeen || !addSeen {
+			t.Errorf("%s ·%s: the two-rounding multiply+add must be present and unfused, "+
+				"but got %s=%v %s=%v (see #156)", k.file, k.fn, k.mul, mulSeen, k.add, addSeen)
+		}
+	}
+}

--- a/f32/f32.go
+++ b/f32/f32.go
@@ -6,6 +6,20 @@
 //
 // Thread Safety: All functions are safe for concurrent use.
 // Memory: All functions are zero-allocation (no heap allocations).
+//
+// Rounding and fusion: each floating-point operation is a single IEEE-754
+// rounded instruction. The elementwise scale, offset, clamp and float-to-fixed
+// conversion primitives (for example [Scale], [AddScalar], [ClampScale],
+// [Float32ToInt32ScaleClamp] and the Int*ToFloat32Scale family) never contract a
+// multiply and a following add into a fused multiply-add: a consumer that
+// reproduces a scalar reference bit-for-bit depends on the product rounding to
+// float32 before the add. Where fusion is wanted, use [FMA] or the AXPY
+// [AddScaled], whose names say so. Reductions and math functions such as
+// [DotProduct] and the exp/log family do use FMA, where a single fused rounding
+// is correct and no such reference exists. The no-fuse contract is
+// asmcheck-enforced for the primitives that actually perform a multiply followed
+// by an add (see TestNoFMAContract in the module root); a future optimization
+// that fuses one of them fails that test rather than silently changing bits.
 package f32
 
 import "math"


### PR DESCRIPTION
## What

Codifies the single-rounding / no-FMA contract that #155 relies on, so a future optimization cannot silently fuse a multiply and add and change a bit-exact consumer's output.

## Documentation (f32 package doc)

Each floating-point operation is a single IEEE-754 rounded instruction. The elementwise scale/offset/clamp/convert primitives (`Scale`, `AddScalar`, `ClampScale`, `Float32ToInt32ScaleClamp`, the `Int*ToFloat32Scale` family) never contract a multiply and a following add into an FMA, because a consumer reproducing a scalar reference bit-for-bit depends on the product rounding to float32 before the add. `FMA` and the AXPY `AddScaled` are the explicit fused ops (their names say so).

The contract is deliberately narrow, not package-wide: reductions and math functions (`DotProduct`, the exp/log family) legitimately use FMA, where a single fused rounding is correct and no such scalar reference exists. (Verified while writing the doc: `DotProduct` and exp/log emit `VFMADD`; `Sqrt` is a plain `VSQRTPS` and `ClampScale` is a separate `VSUBPS`+`VMULPS`, both single-rounded.)

## Enforcement (`TestNoFMAContract`, module root)

For each kernel whose reference does `float32(a*b)+c` as two roundings (currently `Float32ToInt32ScaleClamp`'s AVX and NEON kernels), the test extracts the `TEXT` body and asserts a separate multiply and add are present and no fused multiply-add is. amd64 ops are read as mnemonics; the arm64 vector-float ops are WORD-encoded, so each WORD is decoded through `arm64asm` and the decoded mnemonic checked, catching a WORD-encoded `FMLA` even though the source is a hex literal. The list is extensible.

## Test plan

- [x] `TestNoFMAContract` passes on the real kernels.
- [x] Negative proof: replacing the AVX `VADDPS` with `VFMADD231PS` fails with `forbidden fused VFMADD231PS`; replacing the NEON `FMUL` WORD with an `FMLA` WORD fails with `forbidden fused FMLA`. Both reverted.
- [x] `go build/vet ./...`, gofmt, full asmcheck + f32 suites pass.

The NaN behaviour of `MinIdx`/`MaxIdx` (the other #156 item) is already documented on those functions, so no change there.

Closes #156