### PR TITLE
i16: add a 4-wide AVX2 remainder block to xcorr4AVX2 (#150 item 2)

### DIFF
--- a/i16/benchmark_test.go
+++ b/i16/benchmark_test.go
@@ -145,10 +145,17 @@ func BenchmarkXCorr_248x64(b *testing.B) { benchmarkXCorr(b, 248, 64, XCorr) }
 func BenchmarkXCorr_240x61(b *testing.B) { benchmarkXCorr(b, 240, 61, XCorr) }
 func BenchmarkXCorr_248x61(b *testing.B) { benchmarkXCorr(b, 248, 61, XCorr) }
 
+// x=247 leaves len(x) % 8 == 7: the 4-wide AVX2 block (#150) absorbs 4 of those
+// 7 tail elements, leaving 3 scalar. It is the regression guard for that block;
+// 248 above is the aligned control, and before the block x=247 carried a
+// period-8 sawtooth (n=255 vs n=256 measured 1.40x on the i7-1260P).
+func BenchmarkXCorr_247x64(b *testing.B) { benchmarkXCorr(b, 247, 64, XCorr) }
+
 func BenchmarkXCorrGo_25x64(b *testing.B)  { benchmarkXCorr(b, 25, 64, xcorrGo) }
 func BenchmarkXCorrGo_248x64(b *testing.B) { benchmarkXCorr(b, 248, 64, xcorrGo) }
 func BenchmarkXCorrGo_240x61(b *testing.B) { benchmarkXCorr(b, 240, 61, xcorrGo) }
 func BenchmarkXCorrGo_248x61(b *testing.B) { benchmarkXCorr(b, 248, 61, xcorrGo) }
+func BenchmarkXCorrGo_247x64(b *testing.B) { benchmarkXCorr(b, 247, 64, xcorrGo) }
 
 func BenchmarkXCorrGo_240x4(b *testing.B)   { benchmarkXCorr(b, 240, 4, xcorrGo) }
 func BenchmarkXCorrGo_240x64(b *testing.B)  { benchmarkXCorr(b, 240, 64, xcorrGo) }

--- a/i16/i16_amd64.s
+++ b/i16/i16_amd64.s
@@ -581,10 +581,12 @@ xcorr4_sse2_store:
 // As xcorr4SSE2 at twice the width, plus an 8-wide tier SSE2 has no need for;
 // VPMADDWD's three-operand form also spares the reload-into-destination dance.
 //
-// An 8-wide XMM block runs BEFORE the 16-wide loop, so a remainder of 8-15
-// elements costs one vector block plus at most 7 scalar iterations rather than
-// 8-15 scalar iterations across four lags. Without it AVX2 lost to SSE2 across
-// half the len(x) domain, which is exactly where the dispatcher prefers it; see
+// An 8-wide XMM block, then a 4-wide one (#150), run BEFORE the 16-wide loop, so
+// a remainder of 8-15 elements costs one or two vector blocks plus at most 3
+// scalar iterations rather than 8-15 scalar iterations across four lags (the
+// 4-wide block is detailed at its own site below). Without the 8-wide block AVX2
+// lost to SSE2 across half the len(x) domain, which is exactly where the
+// dispatcher prefers it; see
 // #145 for the measurements. A narrow tier below the wide body is the usual
 // shape here (f32/f32_amd64.s dot32_loop8_check, f64/f64_amd64.s var_avx_loop4),
 // but both of those put it after the body, and get it for free from their
@@ -639,7 +641,7 @@ xcorr4_avx2_empty:
 
 xcorr4_avx2_blocks:
     TESTQ $8, CX               // n % 16 >= 8? one XMM block absorbs the 8
-    JZ   xcorr4_avx2_blocks16
+    JZ   xcorr4_avx2_block4    // skip the 8-wide block but still try the 4-wide one
 
     VMOVDQU (SI), X0           // x[0..8), reused by all four lags
     VMOVDQU (BX), X1           // lag 0
@@ -657,9 +659,40 @@ xcorr4_avx2_blocks:
     ADDQ $16, SI               // 8 int16 consumed from x
     ADDQ $16, BX               // y slides by the same 8, lag offsets unchanged
 
-    // The block count is computed AFTER the 8-wide block, not before, so SHRQ's
-    // own ZF still drives the branch below; computing it first would need a
-    // separate TESTQ AX, AX.
+    // A 4-wide XMM block below the 8-wide one, absorbing another 4 of the 0-7
+    // scalar-tail elements. The scalar tail costs ~2.7 cyc/element versus ~0.19
+    // for a vectorized one (#150), so a 4-wide block is worth its ~1.5 cycles.
+    // It uses 64-bit VMOVQ loads: x[0..4) and each lag's y[0..4) land in the low
+    // half of the register with the upper half zeroed, so VPMADDWD yields two
+    // int32 partial sums (and two zero lanes) that VPADDD folds into the low lane
+    // of each accumulator. Like the 8-wide block it must run BEFORE any 256-bit
+    // accumulation: its VEX.128 VPADDD writes zero the upper lane, which is still
+    // zero here, and the 16-wide loop then accumulates on top with VEX.256. The
+    // reordering is bit-exact only because the wrapping int32 add is associative
+    // (the property XCorr's doc guarantees), the same basis as the 8-wide block.
+xcorr4_avx2_block4:
+    TESTQ $4, CX               // n % 8 >= 4? one 4-wide XMM block absorbs the 4
+    JZ   xcorr4_avx2_blocks16
+    VMOVQ (SI), X0             // x[0..4) in the low 64 bits (upper zeroed)
+    VMOVQ (BX), X1             // lag 0: y[0..4)
+    VPMADDWD X0, X1, X1        // 2 int32 partial sums (+ 2 zero lanes)
+    VPADDD X1, X4, X4          // VEX-128 zeroes Y4[255:128]; it is still zero
+    VMOVQ 2(BX), X1            // lag 1
+    VPMADDWD X0, X1, X1
+    VPADDD X1, X5, X5
+    VMOVQ 4(BX), X1            // lag 2
+    VPMADDWD X0, X1, X1
+    VPADDD X1, X6, X6
+    VMOVQ 6(BX), X1            // lag 3
+    VPMADDWD X0, X1, X1
+    VPADDD X1, X7, X7
+    ADDQ $8, SI                // 4 int16 consumed from x
+    ADDQ $8, BX                // y slides by the same 4, lag offsets unchanged
+
+    // The block count is computed AFTER the 8- and 4-wide blocks, not before, so
+    // SHRQ's own ZF still drives the branch below; computing it first would need
+    // a separate TESTQ AX, AX. CX keeps the full n: the 8 and 4 the blocks
+    // consumed are exactly the ones n/16 already excludes.
 xcorr4_avx2_blocks16:
     MOVQ CX, AX
     SHRQ $4, AX                // AX = n / 16, the 16-wide block count
@@ -714,7 +747,7 @@ xcorr4_avx2_fold:
     VPADDD X0, X7, X7
     MOVQ X7, R11               // lag 3
 
-    ANDQ $7, CX                // not $15: the 8-wide block above took that bit
+    ANDQ $3, CX                // $3 not $7: the 8- and 4-wide blocks took those bits
     JZ   xcorr4_avx2_store
 
 xcorr4_avx2_scalar:

--- a/i16/xcorr_test.go
+++ b/i16/xcorr_test.go
@@ -52,7 +52,11 @@ func equalI32(t *testing.T, what string, got, want []int32) {
 // counts deliberately straddle the 4-lag block boundary in both directions, and
 // the x lengths straddle the 8- and 16-wide kernel bodies plus their tails.
 func TestXCorr_MatchesDotProductAtEveryLag(t *testing.T) {
-	for _, xn := range []int{1, 2, 3, 7, 8, 9, 11, 15, 16, 17, 23, 24, 31, 32, 33, 64, 240} {
+	// 12/13/14 run BOTH the 8- and 4-wide AVX2 blocks (n%16 in 12..15) with a
+	// 0/1/2-element scalar tail; 20/21/22 run the 4-wide block only (n%8 in 4..6)
+	// plus a 16-wide iteration. Together with 7/15/23/31 (residue 7) they cover
+	// every 4-wide-block residue combination (#150).
+	for _, xn := range []int{1, 2, 3, 7, 8, 9, 11, 12, 13, 14, 15, 16, 17, 20, 21, 22, 23, 24, 31, 32, 33, 64, 240} {
 		for _, lags := range []int{1, 2, 3, 4, 5, 6, 7, 8, 9, 12, 13, 16, 17, 61} {
 			x := genI16(xn, 91)
 			y := genI16(xn+lags-1, 92)


### PR DESCRIPTION
## What

`xcorr4AVX2` dropped from its 8-wide XMM block (#151) straight to a 0-7 element scalar tail. That tail is expensive across four lags: ~2.7 cyc/element vs ~0.19 for a vectorized one on the i7-1260P, leaving a residual period-8 sawtooth (item 2 of #150).

A `TESTQ $4`-guarded 4-wide block below the 8-wide one absorbs 4 of the 7 tail elements. It uses 64-bit `VMOVQ` loads so `x[0..4)` and each lag's `y[0..4)` land in the low half with the upper half zeroed; `VPMADDWD` then yields two int32 partial sums (and two zero lanes) that `VPADDD` folds into the low lane of each lag accumulator, which the fold sums back in. Like the 8-wide block it must run **before** any 256-bit accumulation (its VEX.128 writes zero the upper lane), and the reordering is bit-exact only because the wrapping int32 add is associative, the property XCorr documents. Tail mask `$7` -> `$3`.

The 8-wide block's skip now targets the 4-wide check rather than the 16-wide loop, so a length that skips the 8-wide block (`n%16 < 8`) still runs the 4-wide one.

## Measured (i7-1260P, P-core pinned, GOMAXPROCS=1, benchstat n=30)

| length | vs base |
|---|---|
| XCorr 247x64 (`len(x)%8==7`) | **-13.5%** |
| 240x64 / 248x64 (aligned) | ~ (no change) |
| 480x64 (aligned) | -2.3% |
| geomean | **-4.2%** |

`idq.dsb_uops` is unchanged (5800 vs 5809), so the aligned 16-wide loop is untouched (no uop-cache eviction); an early +23% reading at 248x64 was measurement noise (gone at n=30, p=0.19).

## Test plan

- [x] Bit-exact parity on the real i7-1260P at every 4-wide residue; sweep extended to 12/13/14 (both blocks + short tail) and 20/21/22 (4-wide only). `TestXCorr4AMD64_ShortWindowIsBounded` pins the y-over-read boundary.
- [x] `n=247` added as a benchstat regression guard.
- [x] Gate: Agent 2 (correctness, hand-decoded the VEX bytes) and Gemini both confirm consumption == n, no over-read, VMOVQ upper-lane zeroing, VEX.128 ordering, operand order, and bit-exactness.

Items 1 (AVX-VNNI `VPDPWSSD` tier) and 3 (`VPHADDD` fold) of #150 remain; filing this as a focused increment.

Refs #150, #151, #145