### PR TITLE
i16: add an AVX-VNNI VPDPWSSD tier to XCorr (#150 item 1)

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,7 +100,8 @@ program start. Each token clears its own flag plus everything that depends on it
 | Token       | Clears                                    |
 | ----------- | ----------------------------------------- |
 | `avx512`    | AVX512F, AVX512VL                         |
-| `avx2`      | AVX2 (and the `avx512` set)               |
+| `avxvnni`   | AVXVNNI only                              |
+| `avx2`      | AVX2, AVXVNNI (and the `avx512` set)      |
 | `avx`       | AVX, FMA, F16C (and the `avx2` set)       |
 | `fma`       | FMA only                                  |
 | `sse42`     | SSE42 (and the `avx` set)                 |
@@ -108,15 +109,20 @@ program start. Each token clears its own flag plus everything that depends on it
 | `ssse3`     | SSSE3 (and the `sse41` set)               |
 | `sse3`      | SSE3 (and the `ssse3` set)                |
 | `pclmulqdq` | PCLMULQDQ only                            |
-| `neon`      | NEON, FP16, SVE, SVE2, PMULL              |
+| `neon`      | NEON, FP16, SVE, SVE2, PMULL, DOTPROD     |
 | `fp16`      | FP16 only                                 |
 | `sve`       | SVE, SVE2                                 |
 | `pmull`     | PMULL only                                |
+| `dotprod`   | DOTPROD only                              |
 | `all`       | every flag (forces the pure-Go path)      |
 
 F16C is VEX-encoded and only detected alongside AVX, so it clears with the `avx`
 cascade (and therefore with every `sse*` token and `all`); `avx2`, `fma`, and
-`avx512` sit above AVX and leave F16C set.
+`avx512` sit above AVX and leave F16C set. AVX-VNNI (the VEX-encoded `VPDPWSSD`
+tier `i16.XCorr` uses) is detected only alongside AVX2 and its dispatch sits
+above it, so `avx2` and every token that cascades through it also clear AVXVNNI,
+while the `avxvnni` token clears only that tier (handy for A/B'ing the VNNI
+`XCorr` kernel against the plain AVX2 one on one machine).
 
 Unknown tokens are ignored (the library never panics or writes to stderr on env
 input). `cpu.Info()` reflects the cleared flags.
@@ -621,7 +627,7 @@ The interleave kernels are pure 16-bit-lane movement (AVX2/SSE2 word unpacks plu
 
 `DotProduct` is the opposite case: the bit pattern is the whole point. It widens each product to int32 and accumulates with **two's-complement wraparound, never saturation**, and that is a guarantee callers may rely on. Wrapping addition is associative and commutative modulo 2^32, so any lane grouping and any horizontal reduction order is bit-identical to the scalar loop, including on operands engineered to overflow; a saturating accumulator is not associative and could not be vectorized without changing results. Fixed-point codecs (Opus/CELT, FLAC LPC) use integer arithmetic precisely because it is exactly reproducible, so this property is the feature. The kernels are `PMADDWD` (SSE2, hence always present on the `GOAMD64=v1` baseline) with an AVX2 tier at twice the width, and `SMLAL`/`SMLAL2` on NEON. All kernels are zero-allocation.
 
-`XCorr` is the same arithmetic evaluated at every lag, and `dst[k]` is defined to equal `DotProduct(x, y[k:k+len(x)])` exactly. The win over calling `DotProduct` in a loop is that it loads `x` once and multiply-accumulates it against four overlapping `y` windows at a time (the libopus `xcorr_kernel` shape), rather than re-reading `x` for every lag. Only lags whose full window fits in `y` are computed, and `dst` beyond that is left untouched rather than zeroed.
+`XCorr` is the same arithmetic evaluated at every lag, and `dst[k]` is defined to equal `DotProduct(x, y[k:k+len(x)])` exactly. The win over calling `DotProduct` in a loop is that it loads `x` once and multiply-accumulates it against four overlapping `y` windows at a time (the libopus `xcorr_kernel` shape), rather than re-reading `x` for every lag. Only lags whose full window fits in `y` are computed, and `dst` beyond that is left untouched rather than zeroed. On CPUs with AVX-VNNI (Intel Alder Lake and later, AMD Zen 4 and later) a fourth dispatch tier fuses each `VPMADDWD`+`VPADDD` in the 16-wide loop into one `VPDPWSSD`, which is bit-identical because it accumulates with the same wrapping dword add; it is selected above the plain AVX2 tier and can be masked back to AVX2 with `SIMD_DISABLE=avxvnni`.
 
 `Abs`, `MaxAbs` and `MulQ15` are the fixed-point envelope/gain trio. `Abs` wraps rather than saturates (`abs(-32768) = -32768`, the opposite of `i8.Abs`), `MaxAbs` returns an `int` because `|-32768| = 32768` does not fit int16 (libopus `celt_maxabs16`), and `MulQ15` is the *rounding* Q15 multiply (`MULT16_16_P15`): `dst[i] = int16((a[i]*b[i] + 1<<14) >> 15)` with the single out-of-range product `(-32768)^2` wrapping to `-32768`. All three are bit-exact against their pure-Go references for every input. On amd64 these three are AVX2-or-Go (no SSE2 tier, matching `i8` and the `i32` arithmetic); on ARM64 they run NEON (`MulQ15` via `SMULL`/`SRSHR`/`XTN`, since the single-instruction `SQRDMULH` saturates the `(-32768)^2` case and would break the wrap guarantee).
 
@@ -979,7 +985,7 @@ each package's `*_amd64.go` dispatch):
 | `f64`   | SSE2                    | AVX (no FMA), AVX+FMA, AVX-512 | pure Go (baseline guarantees SSE2) |
 | `c128`  | SSE2                    | AVX (no FMA), AVX+FMA, AVX-512 | pure Go (baseline guarantees SSE2) |
 | `c64`   | SSE4.1 (BLENDPS)        | AVX+FMA, AVX-512        | pure Go |
-| `i16`   | SSE2 (interleave, dot, xcorr); AVX2 (Abs, MulQ15, MaxAbs) | AVX2 | pure Go (baseline guarantees SSE2 for the SSE2-tier ops) |
+| `i16`   | SSE2 (interleave, dot, xcorr); AVX2 (Abs, MulQ15, MaxAbs) | AVX2; AVX-VNNI (xcorr) | pure Go (baseline guarantees SSE2 for the SSE2-tier ops) |
 | `i32`   | AVX (interleave), AVX2 (arithmetic) | -           | pure Go |
 | `i8`    | AVX2                    | -                       | pure Go |
 | `f16`   | F16C (slice conversions only) | -                 | pure Go (all f16 compute is pure Go on amd64) |

--- a/cpu/cpu.go
+++ b/cpu/cpu.go
@@ -14,6 +14,7 @@ type Features struct {
 	SSE42     bool
 	AVX       bool
 	AVX2      bool
+	AVXVNNI   bool // AVX-VNNI (VEX-encoded VPDPWSSD/VPDPBUSD); Alder Lake+ and Zen 4+
 	AVX512F   bool
 	AVX512VL  bool
 	FMA       bool
@@ -43,6 +44,14 @@ func HasAVX() bool { return X86.AVX }
 
 // HasAVX2 returns true if AVX2 is available.
 func HasAVX2() bool { return X86.AVX2 }
+
+// HasAVXVNNI returns true if the VEX-encoded AVX-VNNI instructions
+// (VPDPWSSD / VPDPBUSD and their saturating variants) are available. They fuse
+// the widen-multiply-accumulate that int16/int8 dot products otherwise spell as
+// a VPMADDWD/VPMADDUBSW plus a separate VPADDD. Shipped on Intel Alder Lake and
+// later and on AMD Zen 4 and later, in VEX form so both hybrid core types carry
+// it. Detection gates on AVX2 (the VEX form runs on YMM state).
+func HasAVXVNNI() bool { return X86.AVXVNNI }
 
 // HasFMA returns true if FMA is available.
 func HasFMA() bool { return X86.FMA }
@@ -89,8 +98,9 @@ func Info() string {
 // Recognized tokens:
 //
 //	avx512     AVX512F, AVX512VL
-//	avx2       AVX2 and the avx512 set
-//	avx        AVX, FMA and the avx2 set
+//	avxvnni    AVXVNNI only
+//	avx2       AVX2, AVXVNNI and the avx512 set
+//	avx        AVX, FMA, F16C and the avx2 set
 //	fma        FMA only
 //	sse42      SSE42 and the avx set
 //	sse41      SSE41 and the sse42 set
@@ -113,6 +123,8 @@ func applyDisable(f *Features, spec string) {
 			// Empty token (e.g. trailing comma): ignore.
 		case "avx512":
 			clearAVX512(f)
+		case "avxvnni":
+			f.AVXVNNI = false
 		case "avx2":
 			clearAVX2(f)
 		case "avx":
@@ -158,6 +170,9 @@ func clearAVX512(f *Features) {
 
 func clearAVX2(f *Features) {
 	f.AVX2 = false
+	// AVX-VNNI (VEX form) runs on YMM state and its dispatch tier sits above
+	// AVX2, so dropping AVX2 must drop it too, like the avx512 set below.
+	f.AVXVNNI = false
 	clearAVX512(f)
 }
 

--- a/cpu/cpu_amd64.go
+++ b/cpu/cpu_amd64.go
@@ -32,13 +32,31 @@ func init() {
 	_, _, ecx, _ := cpuid(1, 0)
 	X86.F16C = X86.AVX && ecx&cpuidF16CBit != 0
 
+	// AVX-VNNI (VEX-encoded VPDPWSSD etc.) is not exposed by golang.org/x/sys/cpu
+	// either, so read it directly from CPUID leaf 7 sub-leaf 1, EAX bit 4. Gate on
+	// AVX2: the VEX form operates on YMM state, so it needs the same
+	// OSXSAVE/XGETBV OS support that AVX2 detection already establishes, and the
+	// kernel that consumes it is an AVX2 kernel.
+	eaxVNNI, _, _, _ := cpuid(cpuidExtdFeatureLeaf, cpuidExtdFeatureSubleaf1)
+	X86.AVXVNNI = X86.AVX2 && eaxVNNI&cpuidAVXVNNIBit != 0
+
 	// Honor SIMD_DISABLE last, so the env var can mask any detected feature
-	// (including F16C via the "all" token).
+	// (including F16C and AVXVNNI via the "all" token).
 	applyDisable(&X86, os.Getenv("SIMD_DISABLE"))
 }
 
 // cpuidF16CBit is CPUID leaf 1 ECX bit 29, set when F16C is supported.
 const cpuidF16CBit = 1 << 29
+
+// CPUID leaf 7 sub-leaf 1 addresses the structured extended feature flags whose
+// EAX reports AVX-VNNI; cpuidAVXVNNIBit is that EAX's bit 4, set when the
+// VEX-encoded AVX-VNNI instructions are supported. Named rather than inlined so
+// the leaf/sub-leaf selectors read as identifiers, not magic numbers.
+const (
+	cpuidExtdFeatureLeaf     = 7
+	cpuidExtdFeatureSubleaf1 = 1
+	cpuidAVXVNNIBit          = 1 << 4
+)
 
 // cpuid is the raw CPUID wrapper implemented in cpuid_amd64.s.
 //

--- a/cpu/cpu_test.go
+++ b/cpu/cpu_test.go
@@ -19,6 +19,12 @@ func TestHasAVX2(_ *testing.T) {
 	_ = got
 }
 
+// TestHasAVXVNNI tests the HasAVXVNNI function
+func TestHasAVXVNNI(_ *testing.T) {
+	got := HasAVXVNNI()
+	_ = got
+}
+
 // TestHasFMA tests the HasFMA function
 func TestHasFMA(_ *testing.T) {
 	got := HasFMA()
@@ -92,6 +98,7 @@ func TestFeatures(_ *testing.T) {
 	_ = X86.SSE42
 	_ = X86.AVX
 	_ = X86.AVX2
+	_ = X86.AVXVNNI
 	_ = X86.AVX512F
 	_ = X86.AVX512VL
 	_ = X86.FMA

--- a/cpu/disable_test.go
+++ b/cpu/disable_test.go
@@ -45,16 +45,20 @@ func TestApplyDisable(t *testing.T) {
 	}{
 		{"", nil},
 		{"avx512", []string{"AVX512F", "AVX512VL"}},
-		{"avx2", []string{"AVX2", "AVX512F", "AVX512VL"}},
+		// AVXVNNI is VEX-encoded and its dispatch tier sits above AVX2, so clearing
+		// AVX2 (and every token that cascades through clearAVX2) must also clear it.
+		// The avxvnni token itself clears only AVXVNNI.
+		{"avxvnni", []string{"AVXVNNI"}},
+		{"avx2", []string{"AVX2", "AVX512F", "AVX512VL", "AVXVNNI"}},
 		// F16C is VEX-encoded and gated on AVX, so the avx cascade (and every SSE
 		// token that cascades through clearAVX) must also clear F16C. avx2/fma/avx512
 		// sit above AVX and correctly leave it set.
-		{"avx", []string{"AVX", "AVX2", "AVX512F", "AVX512VL", "F16C", "FMA"}},
+		{"avx", []string{"AVX", "AVX2", "AVX512F", "AVX512VL", "AVXVNNI", "F16C", "FMA"}},
 		{"fma", []string{"FMA"}},
-		{"sse42", []string{"AVX", "AVX2", "AVX512F", "AVX512VL", "F16C", "FMA", "SSE42"}},
-		{"sse41", []string{"AVX", "AVX2", "AVX512F", "AVX512VL", "F16C", "FMA", "SSE41", "SSE42"}},
-		{"ssse3", []string{"AVX", "AVX2", "AVX512F", "AVX512VL", "F16C", "FMA", "SSE41", "SSE42", "SSSE3"}},
-		{"sse3", []string{"AVX", "AVX2", "AVX512F", "AVX512VL", "F16C", "FMA", "SSE3", "SSE41", "SSE42", "SSSE3"}},
+		{"sse42", []string{"AVX", "AVX2", "AVX512F", "AVX512VL", "AVXVNNI", "F16C", "FMA", "SSE42"}},
+		{"sse41", []string{"AVX", "AVX2", "AVX512F", "AVX512VL", "AVXVNNI", "F16C", "FMA", "SSE41", "SSE42"}},
+		{"ssse3", []string{"AVX", "AVX2", "AVX512F", "AVX512VL", "AVXVNNI", "F16C", "FMA", "SSE41", "SSE42", "SSSE3"}},
+		{"sse3", []string{"AVX", "AVX2", "AVX512F", "AVX512VL", "AVXVNNI", "F16C", "FMA", "SSE3", "SSE41", "SSE42", "SSSE3"}},
 		{"pclmulqdq", []string{"PCLMULQDQ"}},
 		{"neon", []string{"DOTPROD", "FP16", "NEON", "PMULL", "SVE", "SVE2"}},
 		{"fp16", []string{"FP16"}},
@@ -64,7 +68,7 @@ func TestApplyDisable(t *testing.T) {
 		// Case-insensitivity and surrounding whitespace.
 		{"AVX512", []string{"AVX512F", "AVX512VL"}},
 		{"  avx512  ", []string{"AVX512F", "AVX512VL"}},
-		{"Avx2", []string{"AVX2", "AVX512F", "AVX512VL"}},
+		{"Avx2", []string{"AVX2", "AVX512F", "AVX512VL", "AVXVNNI"}},
 		// Unknown tokens are ignored.
 		{"foobar", nil},
 		{"avx512,foobar", []string{"AVX512F", "AVX512VL"}},

--- a/cpu/example_test.go
+++ b/cpu/example_test.go
@@ -7,7 +7,7 @@ import (
 )
 
 func ExampleInfo() {
-	// Returns a string like "AMD64 AVX2+FMA" or "ARM64 NEON"
+	// Returns a string like "AMD64 AVX+FMA" or "ARM64 NEON"
 	info := cpu.Info()
 	fmt.Printf("CPU supports: %s\n", info)
 }

--- a/i16/i16_amd64.go
+++ b/i16/i16_amd64.go
@@ -13,9 +13,10 @@ const (
 	minSSE2Elements = 8
 )
 
-// Dispatch priority mirrors f32/f64: AVX2 > SSE2 > Go. The kernels gate on the
-// CPU feature explicitly (rather than relying on length alone) so the package is
-// correct on every amd64 baseline.
+// Dispatch priority mirrors f32/f64: AVX2 > SSE2 > Go, with XCorr adding an
+// AVX-VNNI tier above AVX2 (see xcorrI16). The kernels gate on the CPU feature
+// explicitly (rather than relying on length alone) so the package is correct on
+// every amd64 baseline.
 //
 // SSE2 is part of the amd64 baseline, so for the ops that ship an SSE2 tier
 // (interleave, dot, xcorr) the pure-Go fallback is effectively a non-amd64
@@ -23,8 +24,9 @@ const (
 // MaxAbs) are AVX2-or-Go, so on a pre-AVX2 amd64 host their Go reference is a
 // live, reachable path rather than a formality.
 var (
-	hasAVX2 = cpu.X86.AVX2
-	hasSSE2 = cpu.X86.SSE2
+	hasAVXVNNI = cpu.X86.AVXVNNI
+	hasAVX2    = cpu.X86.AVX2
+	hasSSE2    = cpu.X86.SSE2
 )
 
 // Dot dispatch thresholds. They are independent literals rather than aliases of
@@ -57,6 +59,11 @@ const (
 const (
 	minSSE2XCorr = 8
 	minAVX2XCorr = 16
+	// The AVX-VNNI kernel shares xcorr4AVX2's structure below the 16-wide loop
+	// (identical 8- and 4-wide blocks, identical fold), so it carries the same
+	// fold overhead and the same break-even against SSE2: its cut is 16 too, an
+	// independent literal per the dot precedent above rather than an alias.
+	minAVXVNNIXCorr = 16
 )
 
 // The two block loops below are identical except for the kernel they call, and
@@ -68,6 +75,10 @@ func xcorrI16(dst []int32, x, y []int16) {
 	m := xcorrLags(dst, x, y)
 	k := 0
 	switch {
+	case hasAVXVNNI && len(x) >= minAVXVNNIXCorr:
+		for ; k+xcorrLagBlock <= m; k += xcorrLagBlock {
+			xcorr4AVXVNNI(dst[k:k+xcorrLagBlock], x, xcorrWindow(x, y, k))
+		}
 	case hasAVX2 && len(x) >= minAVX2XCorr:
 		for ; k+xcorrLagBlock <= m; k += xcorrLagBlock {
 			xcorr4AVX2(dst[k:k+xcorrLagBlock], x, xcorrWindow(x, y, k))
@@ -166,6 +177,9 @@ func absAVX2(dst, a []int16)
 
 //go:noescape
 func maxAbsAVX2(a []int16) int
+
+//go:noescape
+func xcorr4AVXVNNI(dst []int32, x, y []int16)
 
 //go:noescape
 func xcorr4AVX2(dst []int32, x, y []int16)

--- a/i16/i16_amd64.s
+++ b/i16/i16_amd64.s
@@ -777,6 +777,192 @@ xcorr4_avx2_store:
     VZEROUPPER
     RET
 
+// func xcorr4AVXVNNI(dst []int32, x, y []int16)
+// xcorr4AVX2 with the 16-wide loop's four VPMADDWD+VPADDD pairs (madd the 16-bit
+// lane pairs to int32, then accumulate) each fused into one VPDPWSSD (#150 item
+// 1). VPDPWSSD acc, a, b computes acc += VPMADDWD(a, b) with the same WRAPPING
+// dword accumulation, so it is bit-identical to the pair it replaces and
+// preserves the wrapping contract XCorr documents to callers. (VPDPWSSDS, the
+// saturating sibling, must never be used here.) Fusing the loop's 8 vector-ALU
+// ops to 4, all on p0/p1, drops the 16-wide body's port floor from 3 to 2
+// cyc/block. That floor is not realized: fusion moves the whole
+// multiply-accumulate onto each lag's loop-carried accumulator chain (in
+// xcorr4AVX2 the VPMADDWD fed VPADDD from loads, off the chain), so with one
+// accumulator per lag the 4-way ILP keeps the ports busy but cannot shorten any
+// single chain, and the realized loop rate is set by VPDPWSSD's accumulator
+// latency, ~2.5 cyc/block measured on the i7-1260P (Alder Lake), not the 2-cyc
+// floor. The net XCorr win is a modest ~2-7% per length (~2.3% geomean), with
+// the aligned-length tails muddied by the code-layout lottery of #159; see #150
+// for the port model. Requires AVX-VNNI in VEX form (cpu.X86.AVXVNNI), which the
+// dispatcher checks above AVX2.
+//
+// Only the 16-wide loop is fused. The 8- and 4-wide remainder blocks run at most
+// once per call, so VNNI would save them nothing measurable; they are the exact
+// VPMADDWD+VPADDD blocks xcorr4AVX2 carries, including the reason they run BEFORE
+// the 256-bit loop (their VEX.128 writes zero Y4-Y7's upper lanes while those are
+// still the freshly-VPXOR'd zero, so the VEX.256 loop then accumulates on top
+// preserving the low lane). The reordering is bit-exact only because the int32
+// accumulation wraps, hence is associative; the fold and scalar tail are
+// unchanged. See xcorr4AVX2 above for the full argument.
+//
+// VPDPWSSD is HAND-ENCODED below. The Go assembler (go1.26) knows only the EVEX
+// form of this mnemonic: avx_optabs.go lists AVPDPWSSD with evex128/256/512 and
+// no vex form, so `VPDPWSSD Y0, Y1, Y4` assembles to EVEX.256 (62-prefixed), the
+// AVX-512-VNNI encoding, which #UDs on AVX-VNNI-only parts such as Alder Lake
+// where AVX-512 is fused off (confirmed: it SIGILLs on the i7-1260P). The BYTE
+// directives emit the VEX form instead, VEX.256.66.0F38.W0 52 /r:
+//   C4 E2 75 52 modrm   x in Y0 (ModRM.rm=0), y in Y1 (VEX.vvvv=~1=1110), L=1
+//                       (256), pp=01 (66); modrm = 0xC0 | reg<<3, reg = dst YMM.
+// So Y4->0xE0, Y5->0xE8, Y6->0xF0, Y7->0xF8. This is the same hand-encoding
+// discipline the arm64 NEON kernels use (WORD there, BYTE here); asmcheck only
+// cross-checks arm64 words, so the encoding's runtime gate is the host
+// ParityWithGo test, which executes the kernel (a wrong byte SIGILLs or missums).
+TEXT ·xcorr4AVXVNNI(SB), NOSPLIT, $0-72
+    MOVQ dst_base+0(FP), DI
+    MOVQ x_base+24(FP), SI
+    MOVQ x_len+32(FP), CX
+    MOVQ y_base+48(FP), BX
+    MOVQ y_len+56(FP), DX
+
+    VPXOR Y4, Y4, Y4           // lag 0 accumulator
+    VPXOR Y5, Y5, Y5           // lag 1
+    VPXOR Y6, Y6, Y6           // lag 2
+    VPXOR Y7, Y7, Y7           // lag 3
+
+    SUBQ $3, DX                // DX = len(y) - 3
+    JLE  xcorrvnni_empty
+    CMPQ DX, CX
+    CMOVQLT DX, CX             // CX = n = min(len(x), len(y)-3)
+    JMP  xcorrvnni_blocks
+
+xcorrvnni_empty:
+    XORQ CX, CX
+
+xcorrvnni_blocks:
+    TESTQ $8, CX               // n % 16 >= 8? one XMM block absorbs the 8
+    JZ   xcorrvnni_block4
+
+    VMOVDQU (SI), X0           // x[0..8), reused by all four lags
+    VMOVDQU (BX), X1           // lag 0
+    VPMADDWD X0, X1, X1
+    VPADDD X1, X4, X4          // VEX-128 zeroes Y4[255:128]; it is still zero
+    VMOVDQU 2(BX), X1          // lag 1
+    VPMADDWD X0, X1, X1
+    VPADDD X1, X5, X5
+    VMOVDQU 4(BX), X1          // lag 2
+    VPMADDWD X0, X1, X1
+    VPADDD X1, X6, X6
+    VMOVDQU 6(BX), X1          // lag 3
+    VPMADDWD X0, X1, X1
+    VPADDD X1, X7, X7
+    ADDQ $16, SI               // 8 int16 consumed from x
+    ADDQ $16, BX               // y slides by the same 8, lag offsets unchanged
+
+    // A 4-wide XMM block below the 8-wide one, identical to xcorr4AVX2's. VMOVQ
+    // loads put x[0..4) and each lag's y[0..4) in the low 64 bits with the upper
+    // zeroed, so VPMADDWD yields two int32 partial sums (and two zero lanes) that
+    // VPADDD folds into the accumulator's low lane. Same pre-body ordering and
+    // wrapping-associativity basis as the 8-wide block. Left as plain AVX2: it
+    // runs at most once, so fusing it to VPDPWSSD would save nothing measurable.
+xcorrvnni_block4:
+    TESTQ $4, CX               // n % 8 >= 4? one 4-wide XMM block absorbs the 4
+    JZ   xcorrvnni_blocks16
+    VMOVQ (SI), X0             // x[0..4) in the low 64 bits (upper zeroed)
+    VMOVQ (BX), X1             // lag 0: y[0..4)
+    VPMADDWD X0, X1, X1        // 2 int32 partial sums (+ 2 zero lanes)
+    VPADDD X1, X4, X4          // VEX-128 zeroes Y4[255:128]; it is still zero
+    VMOVQ 2(BX), X1            // lag 1
+    VPMADDWD X0, X1, X1
+    VPADDD X1, X5, X5
+    VMOVQ 4(BX), X1            // lag 2
+    VPMADDWD X0, X1, X1
+    VPADDD X1, X6, X6
+    VMOVQ 6(BX), X1            // lag 3
+    VPMADDWD X0, X1, X1
+    VPADDD X1, X7, X7
+    ADDQ $8, SI                // 4 int16 consumed from x
+    ADDQ $8, BX                // y slides by the same 4, lag offsets unchanged
+
+xcorrvnni_blocks16:
+    MOVQ CX, AX
+    SHRQ $4, AX                // AX = n / 16, the 16-wide block count
+    JZ   xcorrvnni_fold
+
+xcorrvnni_loop16:
+    VMOVDQU (SI), Y0           // x[j..j+16), reused by all four lags
+    VMOVDQU (BX), Y1           // lag 0
+    BYTE $0xC4; BYTE $0xE2; BYTE $0x75; BYTE $0x52; BYTE $0xE0  // VPDPWSSD Y0, Y1, Y4 (Y4 += madd(Y1, Y0))
+    VMOVDQU 2(BX), Y1          // lag 1
+    BYTE $0xC4; BYTE $0xE2; BYTE $0x75; BYTE $0x52; BYTE $0xE8  // VPDPWSSD Y0, Y1, Y5
+    VMOVDQU 4(BX), Y1          // lag 2
+    BYTE $0xC4; BYTE $0xE2; BYTE $0x75; BYTE $0x52; BYTE $0xF0  // VPDPWSSD Y0, Y1, Y6
+    VMOVDQU 6(BX), Y1          // lag 3
+    BYTE $0xC4; BYTE $0xE2; BYTE $0x75; BYTE $0x52; BYTE $0xF8  // VPDPWSSD Y0, Y1, Y7
+    ADDQ $32, SI
+    ADDQ $32, BX
+    DECQ AX
+    JNZ  xcorrvnni_loop16
+
+xcorrvnni_fold:
+    VEXTRACTI128 $1, Y4, X0
+    VPADDD X0, X4, X4
+    VPSHUFD $0x4E, X4, X0
+    VPADDD X0, X4, X4
+    VPSHUFD $0xB1, X4, X0
+    VPADDD X0, X4, X4
+    MOVQ X4, R8                // lag 0 partial sum
+    VEXTRACTI128 $1, Y5, X0
+    VPADDD X0, X5, X5
+    VPSHUFD $0x4E, X5, X0
+    VPADDD X0, X5, X5
+    VPSHUFD $0xB1, X5, X0
+    VPADDD X0, X5, X5
+    MOVQ X5, R9                // lag 1
+    VEXTRACTI128 $1, Y6, X0
+    VPADDD X0, X6, X6
+    VPSHUFD $0x4E, X6, X0
+    VPADDD X0, X6, X6
+    VPSHUFD $0xB1, X6, X0
+    VPADDD X0, X6, X6
+    MOVQ X6, R10               // lag 2
+    VEXTRACTI128 $1, Y7, X0
+    VPADDD X0, X7, X7
+    VPSHUFD $0x4E, X7, X0
+    VPADDD X0, X7, X7
+    VPSHUFD $0xB1, X7, X0
+    VPADDD X0, X7, X7
+    MOVQ X7, R11               // lag 3
+
+    ANDQ $3, CX                // $3 not $7: the 8- and 4-wide blocks took those bits
+    JZ   xcorrvnni_store
+
+xcorrvnni_scalar:
+    MOVWLSX (SI), AX           // x[j], sign-extended
+    MOVWLSX (BX), DX
+    IMULL AX, DX
+    ADDL DX, R8
+    MOVWLSX 2(BX), DX
+    IMULL AX, DX
+    ADDL DX, R9
+    MOVWLSX 4(BX), DX
+    IMULL AX, DX
+    ADDL DX, R10
+    MOVWLSX 6(BX), DX
+    IMULL AX, DX
+    ADDL DX, R11
+    ADDQ $2, SI
+    ADDQ $2, BX
+    DECQ CX
+    JNZ  xcorrvnni_scalar
+
+xcorrvnni_store:
+    MOVL R8, 0(DI)
+    MOVL R9, 4(DI)
+    MOVL R10, 8(DI)
+    MOVL R11, 12(DI)
+    VZEROUPPER
+    RET
+
 // Tier-3 element-wise and reduction kernels (AVX2).
 //
 // All three receive pre-clamped slices from the public API, so unlike the dot

--- a/i16/i16_amd64_test.go
+++ b/i16/i16_amd64_test.go
@@ -285,6 +285,7 @@ type xcorr4Kernel struct {
 
 func xcorr4Kernels() []xcorr4Kernel {
 	return []xcorr4Kernel{
+		{"AVXVNNI", cpu.X86.AVXVNNI, xcorr4AVXVNNI},
 		{"AVX2", cpu.X86.AVX2, xcorr4AVX2},
 		{"SSE2", cpu.X86.SSE2, xcorr4SSE2},
 	}
@@ -328,6 +329,42 @@ func TestXCorr4AMD64_ParityWithGo(t *testing.T) {
 				for lag := range xcorrLagBlock {
 					if got, want := dst[lag], dotOracle(x, y[lag:]); got != want {
 						t.Errorf("xcorr4%s xn=%d: dst[%d] = %d, want %d", k.name, xn, lag, got, want)
+					}
+				}
+			}
+		})
+	}
+}
+
+// TestXCorr4AMD64_MinInt16 pins the wrapping accumulation across all tiers,
+// which is the property that makes XCorr vectorizable and is exactly what the
+// AVX-VNNI kernel's VPDPWSSD must honor (VPDPWSSDS, the saturating sibling, is
+// forbidden here). With x and y all MinInt16, every 16-bit pair product is
+// (-32768)*(-32768) = 2^30, and a sum of them must wrap mod 2^32 to match the
+// scalar oracle rather than saturate. Swept 1..64 so the count is not always a
+// multiple of the block widths, per the miscount-blindness note on the
+// all-MinInt16 pattern; the pseudo-random ParityWithGo sweep is what catches a
+// dropped block, this catches a saturating substitute.
+func TestXCorr4AMD64_MinInt16(t *testing.T) {
+	for _, k := range xcorr4Kernels() {
+		t.Run(k.name, func(t *testing.T) {
+			if !k.available {
+				t.Skipf("%s not available", k.name)
+			}
+			for xn := 1; xn <= 64; xn++ {
+				x := make([]int16, xn)
+				y := make([]int16, xn+3)
+				for i := range x {
+					x[i] = math.MinInt16
+				}
+				for i := range y {
+					y[i] = math.MinInt16
+				}
+				dst := make([]int32, xcorrLagBlock)
+				k.fn(dst, x, y)
+				for lag := range xcorrLagBlock {
+					if got, want := dst[lag], dotOracle(x, y[lag:]); got != want {
+						t.Errorf("xcorr4%s all-MinInt16 xn=%d: dst[%d] = %d, want %d", k.name, xn, lag, got, want)
 					}
 				}
 			}
@@ -388,14 +425,23 @@ func TestXCorrDispatch_ReachesSIMD(t *testing.T) {
 	if hasAVX2 != cpu.X86.AVX2 {
 		t.Fatalf("hasAVX2 = %v but cpu.X86.AVX2 = %v: dispatch flag is not wired to CPU detection", hasAVX2, cpu.X86.AVX2)
 	}
+	if hasAVXVNNI != cpu.X86.AVXVNNI {
+		t.Fatalf("hasAVXVNNI = %v but cpu.X86.AVXVNNI = %v: dispatch flag is not wired to CPU detection", hasAVXVNNI, cpu.X86.AVXVNNI)
+	}
+	// AVX-VNNI sits above AVX2 in the switch, so it can never be selected while
+	// AVX2 is absent: the VEX form runs on YMM state that AVX2 detection gates on.
+	if hasAVXVNNI && !hasAVX2 {
+		t.Fatal("hasAVXVNNI is true but hasAVX2 is false: the AVX-VNNI tier would dispatch on a CPU its accumulators cannot run on")
+	}
 	if !hasSSE2 {
 		t.Fatal("hasSSE2 is false on amd64: PMADDWD is SSE2 baseline, so XCorr should never fall back to Go here")
 	}
 	// One vector block each, matching the kernel bodies. A bound of 2x the
-	// block would be a tautology against the real values (8 and 16).
-	if minSSE2XCorr > 8 || minAVX2XCorr > 16 {
-		t.Fatalf("XCorr thresholds too high (SSE2 %d, AVX2 %d): would not vectorize at the x lengths it was written for",
-			minSSE2XCorr, minAVX2XCorr)
+	// block would be a tautology against the real values (8 and 16). The VNNI
+	// tier shares the AVX2 body's 16-wide block, so it carries the same cut.
+	if minSSE2XCorr > 8 || minAVX2XCorr > 16 || minAVXVNNIXCorr > 16 {
+		t.Fatalf("XCorr thresholds too high (SSE2 %d, AVX2 %d, AVXVNNI %d): would not vectorize at the x lengths it was written for",
+			minSSE2XCorr, minAVX2XCorr, minAVXVNNIXCorr)
 	}
 }
 
@@ -613,4 +659,58 @@ func TestXCorr4AMD64_LongWindowIsClamped(t *testing.T) {
 			}
 		})
 	}
+}
+
+// benchmarkXCorr4Kernel drives one 4-lag kernel directly, a single block of 4
+// lags, so the AVX-VNNI body can be A/B'd against the AVX2 body with nothing
+// else on the clock: no dispatcher, no remainder-lag loop, and the same call
+// site for both tiers. xn sets len(x); y is len(x)+3, the exact window the
+// dispatcher passes. Compare BenchmarkXCorr4AVX2_N against
+// BenchmarkXCorr4AVXVNNI_N at the same N through benchstat. The VNNI win is on
+// the 16-wide loop (VPDPWSSD halves its vector-ALU ops), so it grows with N; at
+// N=16 the fold and call overhead dominate and the two run close.
+//
+// Kernel-direct comparison is deliberate: it holds the surrounding layout fixed,
+// which is the confound #159 records for aligned lengths. It is not a substitute
+// for the SIMD_DISABLE=avxvnni A/B on the public XCorr benchmarks, which is what
+// measures what a caller actually sees.
+func benchmarkXCorr4Kernel(b *testing.B, xn int, avail bool, fn func(dst []int32, x, y []int16)) {
+	b.Helper()
+	if !avail {
+		b.Skip("kernel not available")
+	}
+	x := make([]int16, xn)
+	y := make([]int16, xn+3)
+	for i := range x {
+		x[i] = int16(i*7 - 3000)
+	}
+	for i := range y {
+		y[i] = int16(i*-5 + 2000)
+	}
+	dst := make([]int32, xcorrLagBlock)
+	b.SetBytes(int64(xn+len(y)) * 2)
+	for b.Loop() {
+		fn(dst, x, y)
+	}
+}
+
+func BenchmarkXCorr4AVX2_16(b *testing.B)  { benchmarkXCorr4Kernel(b, 16, cpu.X86.AVX2, xcorr4AVX2) }
+func BenchmarkXCorr4AVX2_240(b *testing.B) { benchmarkXCorr4Kernel(b, 240, cpu.X86.AVX2, xcorr4AVX2) }
+func BenchmarkXCorr4AVX2_480(b *testing.B) { benchmarkXCorr4Kernel(b, 480, cpu.X86.AVX2, xcorr4AVX2) }
+func BenchmarkXCorr4AVX2_247(b *testing.B) { benchmarkXCorr4Kernel(b, 247, cpu.X86.AVX2, xcorr4AVX2) }
+
+func BenchmarkXCorr4AVXVNNI_16(b *testing.B) {
+	benchmarkXCorr4Kernel(b, 16, cpu.X86.AVXVNNI, xcorr4AVXVNNI)
+}
+
+func BenchmarkXCorr4AVXVNNI_240(b *testing.B) {
+	benchmarkXCorr4Kernel(b, 240, cpu.X86.AVXVNNI, xcorr4AVXVNNI)
+}
+
+func BenchmarkXCorr4AVXVNNI_480(b *testing.B) {
+	benchmarkXCorr4Kernel(b, 480, cpu.X86.AVXVNNI, xcorr4AVXVNNI)
+}
+
+func BenchmarkXCorr4AVXVNNI_247(b *testing.B) {
+	benchmarkXCorr4Kernel(b, 247, cpu.X86.AVXVNNI, xcorr4AVXVNNI)
 }


### PR DESCRIPTION
Closes the highest-ROI item of #150: a fourth `i16.XCorr` dispatch tier that fuses the 16-wide loop's four `VPMADDWD`+`VPADDD` pairs into four `VPDPWSSD` (AVX-VNNI). Selected above AVX2 on CPUs that have AVX-VNNI in VEX form (Intel Alder Lake and later, AMD Zen 4 and later).

## Why it's bit-identical

`VPDPWSSD` computes `acc += VPMADDWD(a, b)` with the same wrapping int32 accumulation, so it drops in for the pair with no change to `XCorr`'s documented wrapping contract. It is `VPDPWSSD` (opcode `0x52`), never the saturating `VPDPWSSDS` (`0x53`). The kernel joins the shared `xcorr4Kernels()` table, inheriting the existing ParityWithGo / ShortWindowIsBounded / LongWindowIsClamped coverage, and a new all-MinInt16 test pins the wrap-not-saturate contract across every tier (a saturating substitute makes it fail).

## The encoding gotcha (why hand-encoded bytes)

The `VPDPWSSD` mnemonic assembles natively in go1.26, but only to its **EVEX** (AVX-512-VNNI) form: the assembler's optab (`avx_optabs.go`) registers `AVPDPWSSD` with `evex128/256/512` and no VEX form. On an AVX-VNNI-only part like Alder Lake (AVX-512 fused off) that EVEX encoding is illegal and `SIGILL`s. So the four loop instructions are hand-encoded as the VEX form via `BYTE` directives (`C4 E2 75 52 {E0,E8,F0,F8}`), the amd64 analogue of this repo's arm64 `WORD` hand-encoding. Only the 16-wide loop is fused; the run-once 8-/4-wide remainder blocks, the fold, and the scalar tail stay byte-identical to `xcorr4AVX2`.

## Detection and disabling

`cpu.X86.AVXVNNI` reads CPUID leaf 7 sub-leaf 1 EAX bit 4, gated on AVX2 (the VEX form runs on YMM state). A new `SIMD_DISABLE=avxvnni` token masks just this tier (handy for A/B against AVX2 on one machine), and it also cascades out with `avx2`/`avx`/`sse*` since it sits above AVX2 in dispatch. `HasAVXVNNI()` is added alongside the other feature helpers.

## Performance

Measured on an i7-1260P (P-core pinned, `GOMAXPROCS=1`, benchstat n=10). The win is real but modest: the fused loop's port floor drops from 3 to 2 cyc/block, but fusion moves the multiply-accumulate onto each lag's loop-carried accumulator chain, so with one accumulator per lag the realized rate is bound by `VPDPWSSD`'s accumulator latency (~2.5 cyc/block here), not the 2-cyc floor.

| Benchmark | AVX2 | AVX-VNNI | delta |
| --- | --- | --- | --- |
| XCorr_248x64 | 256.6n | 239.4n | -6.7% |
| XCorr_240x61 | 234.2n | 220.6n | -5.8% |
| XCorr_240x4 | 16.89n | 15.94n | -5.7% |
| XCorr_240x288 | 1027n | 972n | -5.4% |
| geomean (public op) | 206.8n | 202.0n | **-2.3%** |

A few short/edge lengths (25x64, 248x61, 480x64) show small `+2-4%` moves that are the aligned-length code-layout lottery tracked in #159 (the new loop is a different byte size than the AVX2 one, so its fetch-line straddle differs); the sign flips at fixed x-length depending only on lag count, which a real regression cannot do. Per #150 this file already measured `PCALIGN` as unwarranted, so the layout sensitivity is documented rather than papered over.

## Validation

Verified on the i7-1260P (has `avx_vnni`): all four `xcorr4AVXVNNI` subtests pass (parity, MinInt16 wrap, short-window, long-window clamp), and GNU objdump confirms the four loop ops decode as `{vex} vpdpwssd %ymm0,%ymm1,%ymm{4,5,6,7}` with zero EVEX and zero `(bad)`. Builds and vets clean on amd64 and arm64.

Bonus: corrected three pre-existing doc nits found during review (the README `neon` SIMD_DISABLE row was missing `DOTPROD`, the `applyDisable` doc comment's `avx` line omitted F16C, and `ExampleInfo`'s comment said `AVX2+FMA` where `cpu.Info()` returns `AVX+FMA`).

Refs #150, #159