### PR TITLE
f32: lift MinIdxOfSumRows remainder rows onto SIMD via an overlapping block (#161 item 1)

### DIFF
--- a/f32/f32_amd64.go
+++ b/f32/f32_amd64.go
@@ -325,29 +325,62 @@ func maxIdx32(a []float32) int {
 // composes any remainder rows with the scalar path. Non-unit slides and a
 // missing AVX2 stay on the Go reference. All paths are bit-identical (see
 // minIdxOfSumRows8AVX2). SSE2-only hosts take the Go path deliberately.
+// Row-block widths for the MinIdxOfSumRows AVX2 dispatcher: minIdxOfSumRows8AVX2
+// covers 8 rows per call, minIdxOfSumRows4AVX2 covers 4. The dispatcher blocks by
+// these widths and covers any remainder with one overlapping block of the same
+// width, so they double as the minimum m each block can serve.
+const (
+	minIdxRows8 = 8
+	minIdxRows4 = 4
+)
+
 func minIdxOfSumRows32(vals []float32, idxs []int32, a, k []float32, base, slide int) {
 	if cpu.X86.AVX2 && (slide == 1 || slide == -1) {
 		r := 0
-		for ; r+8 <= len(vals); r += 8 {
+		for ; r+minIdxRows8 <= len(vals); r += minIdxRows8 {
 			off := base + r*slide
 			if slide == 1 {
-				minIdxOfSumRows8AVX2(vals[r:r+8], idxs[r:r+8], a, k[off:], 0)
+				minIdxOfSumRows8AVX2(vals[r:r+minIdxRows8], idxs[r:r+minIdxRows8], a, k[off:], 0)
 			} else {
-				minIdxOfSumRows8AVX2(vals[r:r+8], idxs[r:r+8], a, k[off-7:], 1)
+				minIdxOfSumRows8AVX2(vals[r:r+minIdxRows8], idxs[r:r+minIdxRows8], a, k[off-7:], 1)
 			}
 		}
-		if r+4 <= len(vals) {
+		if r+minIdxRows4 <= len(vals) {
 			off := base + r*slide
 			if slide == 1 {
-				minIdxOfSumRows4AVX2(vals[r:r+4], idxs[r:r+4], a, k[off:], 0)
+				minIdxOfSumRows4AVX2(vals[r:r+minIdxRows4], idxs[r:r+minIdxRows4], a, k[off:], 0)
 			} else {
-				minIdxOfSumRows4AVX2(vals[r:r+4], idxs[r:r+4], a, k[off-3:], 1)
+				minIdxOfSumRows4AVX2(vals[r:r+minIdxRows4], idxs[r:r+minIdxRows4], a, k[off-3:], 1)
 			}
-			r += 4
+			r += minIdxRows4
 		}
-		// Leftover rows (fewer than a 4-wide block) compose with the scalar
-		// reference, keeping the tie-break/NaN/rounding contract in one place.
-		minIdxOfSumRowsGo(vals[r:], idxs[r:], a, k, base+r*slide, slide)
+		// The 0-3 leftover rows (leftover == m mod 4 after the 8- and 4-wide
+		// blocks) go through SIMD via one overlapping 4-wide block ONLY when there
+		// are at least 2 of them. The 4-wide block's cost is dominated by its fixed
+		// column loop and per-row argmin reduction, not by how many rows it
+		// recomputes, so it costs about one scalar row regardless; it therefore
+		// only pays off when it replaces 2 or 3 scalar rows. A single leftover row
+		// is cheaper computed scalar: #161 measured a +10% regression at 17x17
+		// (= 2*8+1, so exactly 1 leftover row) when a lone remainder row was
+		// covered by a full block, and narrowing the block from 8- to 4-wide did
+		// not move it. Recomputing is bit-identical (each row is independent and
+		// the kernel is pure) and the wrapper already range-validated every row's
+		// window, so the overlap reads stay in bounds. A single leftover row, or
+		// m<4 (no wide-enough block), stays scalar; a leftover of 0 leaves r == m
+		// and skips this block entirely. Same rule as the NEON dispatcher.
+		if r < len(vals) {
+			m := len(vals)
+			if m >= minIdxRows4 && m-r >= 2 {
+				off := base + (m-minIdxRows4)*slide
+				if slide == 1 {
+					minIdxOfSumRows4AVX2(vals[m-minIdxRows4:], idxs[m-minIdxRows4:], a, k[off:], 0)
+				} else {
+					minIdxOfSumRows4AVX2(vals[m-minIdxRows4:], idxs[m-minIdxRows4:], a, k[off-3:], 1)
+				}
+			} else {
+				minIdxOfSumRowsGo(vals[r:], idxs[r:], a, k, base+r*slide, slide)
+			}
+		}
 		return
 	}
 	minIdxOfSumRowsGo(vals, idxs, a, k, base, slide)

--- a/f32/f32_arm64.go
+++ b/f32/f32_arm64.go
@@ -555,20 +555,44 @@ func maxIdx32(a []float32) int {
 // the NEON block kernel, four rows per lane-per-row block, and composes any
 // remainder rows with the scalar path. Non-unit slides and a missing NEON stay
 // on the Go reference. All paths are bit-identical (see minIdxOfSumRows4NEON).
+// minIdxRowsNEON is the row-block width of minIdxOfSumRows4NEON (4 rows per
+// call); it doubles as the minimum m the overlapping remainder block can serve.
+const minIdxRowsNEON = 4
+
 func minIdxOfSumRows32(vals []float32, idxs []int32, a, k []float32, base, slide int) {
 	if hasNEON && (slide == 1 || slide == -1) {
 		r := 0
-		for ; r+4 <= len(vals); r += 4 {
+		for ; r+minIdxRowsNEON <= len(vals); r += minIdxRowsNEON {
 			off := base + r*slide
 			if slide == 1 {
-				minIdxOfSumRows4NEON(vals[r:r+4], idxs[r:r+4], a, k[off:], 0)
+				minIdxOfSumRows4NEON(vals[r:r+minIdxRowsNEON], idxs[r:r+minIdxRowsNEON], a, k[off:], 0)
 			} else {
-				minIdxOfSumRows4NEON(vals[r:r+4], idxs[r:r+4], a, k[off-3:], 1)
+				minIdxOfSumRows4NEON(vals[r:r+minIdxRowsNEON], idxs[r:r+minIdxRowsNEON], a, k[off-3:], 1)
 			}
 		}
-		// Leftover rows (fewer than a 4-wide block) compose with the scalar
-		// reference, keeping the tie-break/NaN/rounding contract in one place.
-		minIdxOfSumRowsGo(vals[r:], idxs[r:], a, k, base+r*slide, slide)
+		// The 0-3 leftover rows go through SIMD via one overlapping 4-wide block
+		// ONLY when there are at least 2 of them. The block's cost is dominated by
+		// its fixed column loop and per-row argmin reduction, not the row count, so
+		// it only pays off replacing 2 or 3 scalar rows; a single leftover row is
+		// cheaper scalar (see the AVX2 dispatcher, where covering a lone remainder
+		// row with a block measured +10% at 17x17). Recomputing is bit-identical
+		// (each row is independent and the kernel is pure) and the wrapper already
+		// range-validated every row's window, so the overlap reads stay in bounds.
+		// A single leftover row, or m<4 (no wide-enough block), stays scalar; a
+		// leftover of 0 leaves r == m and skips this block entirely.
+		if r < len(vals) {
+			m := len(vals)
+			if m >= minIdxRowsNEON && m-r >= 2 {
+				off := base + (m-minIdxRowsNEON)*slide
+				if slide == 1 {
+					minIdxOfSumRows4NEON(vals[m-minIdxRowsNEON:], idxs[m-minIdxRowsNEON:], a, k[off:], 0)
+				} else {
+					minIdxOfSumRows4NEON(vals[m-minIdxRowsNEON:], idxs[m-minIdxRowsNEON:], a, k[off-3:], 1)
+				}
+			} else {
+				minIdxOfSumRowsGo(vals[r:], idxs[r:], a, k, base+r*slide, slide)
+			}
+		}
 		return
 	}
 	minIdxOfSumRowsGo(vals, idxs, a, k, base, slide)


### PR DESCRIPTION
Implements the highest-ROI item of #161. `MinIdxOfSumRows` blocks rows in fixed widths (AVX2 8 then 4, NEON 4) and used to hand the 0-3 leftover rows to the scalar reference. At the ragged shapes that motivate the op, that tail is a large fraction (m=11 leaves 3 of 11 rows scalar, which is the most plausible reason the small shapes sat well below the width-aligned ones). This lifts the leftover onto SIMD.

## How

Each row's argmin is independent and the kernel is pure, so a final **overlapping** SIMD block that recomputes the last 4 rows is bit-identical, and it covers the leftover with no correctness cost. The wrapper already range-validates every processed row's `k` window before dispatch, so the overlapping reads stay in bounds (the overlap only ever touches rows `m-4 .. m-1`, all already validated).

## Why leftover >= 2, not always

The overlap runs only when the leftover is 2 or 3 rows. A 4-wide block's cost is dominated by its fixed column loop and per-row argmin reduction, **not** by how many rows it recomputes, so it costs about one scalar row regardless and only pays off replacing 2 or 3 of them. A single leftover row is cheaper computed scalar. This was measured, not assumed: covering a lone remainder row with a block regressed 17x17 (`= 2*8+1`, exactly 1 leftover row) by +10% on the i7-1260P, and narrowing the block from 8-wide to 4-wide did not move it. Gating on `leftover >= 2` removes the regression (now within layout noise) while keeping every ragged win. `m < 4` has no wide-enough block and stays scalar.

## Performance

Measured P-core pinned, `GOMAXPROCS=1`, benchstat, drift-immune interleaved A/B (this branch vs main):

| shape (leftover) | i7-1260P AVX2 | Cortex-A76 NEON |
| --- | --- | --- |
| 11x11 (3) | -32% | 3.0x over Go ref |
| 11x14 (3) | -29% | 3.7x over Go ref |
| 14x14 (2) | -5.7% | ~3.6x over Go ref |
| 14x17 (2) | -5.1% | win |
| 17x17 (1) | neutral (was +10% pre-gate) | neutral |
| slide +1/-1 | -7% / -7% | win |
| 32x32, 96x17, 96x96 (aligned) | neutral | neutral |
| geomean | **-9.44%** | ragged wins, aligned neutral |

Width-aligned shapes are neutral because the overlap never runs there.

## Correctness

Parity is bit-exact vs a per-row Go oracle (and the batched reference) across the full shape sweep `{1..9,11,14,17,31,32,33,96}` for both slide +1 and -1, on both the i7-1260P (AVX2) and the rpi5 Cortex-A76 (NEON). The over-read poison, panic, signed-zero/subnormal, and fuzz suites all pass; 0 allocs/op. The new leftover-2/3 path is genuinely exercised by the parity matrix (rows 6, 7, 11, 14).

Row-block widths are named constants (`minIdxRows8`/`minIdxRows4` on amd64, `minIdxRowsNEON` on arm64), used throughout both dispatchers.

Relates to #161 (items 2-4 remain). Refs #159 (aligned-length layout noise).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Performance**
  - Improved optimized processing for sliding-window calculations on supported x86 and ARM64 hardware.
  - Reduced scalar fallback work for small remaining row groups by using vectorized processing where safe.
  - Preserved existing behavior for unsupported hardware, other slide values, tie-breaking, NaN handling, and rounding.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->