### PR TITLE
i8: add an 8-wide AVX2 tail block to the sum and dot reduction kernels (#149)

### DIFF
--- a/i8/benchmark_test.go
+++ b/i8/benchmark_test.go
@@ -1,6 +1,9 @@
 package i8
 
-import "testing"
+import (
+	"fmt"
+	"testing"
+)
 
 const benchN = 4096
 
@@ -59,6 +62,38 @@ func BenchmarkDotProduct(b *testing.B) {
 	b.ResetTimer()
 	for b.Loop() {
 		_ = DotProduct(a, c)
+	}
+}
+
+// BenchmarkSum_N and BenchmarkDotProduct_N guard the 8-wide AVX2 tail block
+// (#149): n%16 in 8..15 exercises the block, aligned n (16, 32) does not. The
+// fixed 4096-byte benchmarks above are all n%16==0 and cannot see the tail
+// sawtooth, so residue lengths (24, 40, 248) must be measured explicitly; n=16
+// is the aligned sentinel where the block never runs.
+func BenchmarkSum_N(b *testing.B) {
+	// 16 is the aligned sentinel (block skipped); 24/40/248 are residue 8 (block,
+	// empty scalar tail); 31 is residue 15 (block plus the full 7-element scalar
+	// tail), so the guard times the block in isolation and alongside a tail.
+	for _, n := range []int{16, 24, 31, 40, 248} {
+		a := genI8(n, 1)
+		b.Run(fmt.Sprintf("%d", n), func(b *testing.B) {
+			b.SetBytes(int64(n))
+			for b.Loop() {
+				_ = Sum(a)
+			}
+		})
+	}
+}
+
+func BenchmarkDotProduct_N(b *testing.B) {
+	for _, n := range []int{16, 24, 31, 40, 248} {
+		a, c := genI8(n, 1), genI8(n, 2)
+		b.Run(fmt.Sprintf("%d", n), func(b *testing.B) {
+			b.SetBytes(int64(n))
+			for b.Loop() {
+				_ = DotProduct(a, c)
+			}
+		})
 	}
 }
 

--- a/i8/i8_amd64.s
+++ b/i8/i8_amd64.s
@@ -200,6 +200,19 @@ TEXT ·sumAVX2(SB), NOSPLIT, $0-28
     VPXOR Y5, Y5, Y5
     VPSUBW Y4, Y5, Y3          // Y3 = 0 - (-1) = +1 per int16 lane
 
+    // An 8-wide XMM block absorbs 8 of the 0-15 remainder bytes before the
+    // 16-wide loop, into the still-zero accumulator, so the VEX.128 write that
+    // zeroes Y2[255:128] is harmless. Legal to reorder because the int32 sum
+    // wraps (associative). Without it a residue of 8-15 falls entirely to the
+    // serial scalar tail. Same shape as i16 dotAVX2 (#160).
+    TESTQ $8, CX               // n % 16 >= 8?
+    JZ   sum_blocks16
+    VPMOVSXBW (SI), X0         // 8 int16
+    VPMADDWD X3, X0, X1        // pairwise (x*1 + x*1) -> 4 int32
+    VPADDD X1, X2, X2          // Y2[255:128] still zero after this
+    ADDQ $8, SI
+
+sum_blocks16:
     MOVQ CX, AX
     SHRQ $4, AX                // AX = n / 16
     JZ   sum_reduce
@@ -221,7 +234,7 @@ sum_reduce:
     VPADDD X3, X2, X2
     MOVQ X2, AX                // low int32 = vector total (in EAX)
 
-    ANDQ $15, CX
+    ANDQ $7, CX                // the 8-wide block took n % 16 down to n % 8
     JZ   sum_done
 
 sum_scalar:
@@ -239,7 +252,9 @@ sum_done:
 // func dotAVX2(a, b []int8) int32
 // Widens 16 bytes/iter of each operand to int16 (VPMOVSXBW) and reduces the
 // products to int32 with VPMADDWD, accumulating in Y2; a horizontal add folds
-// the lanes and a scalar tail adds the remaining products.
+// the lanes and a scalar tail adds the remaining products. An 8-wide XMM block
+// before the loop absorbs 8 of the 0-15 remainder bytes so a residue of 8-15
+// does not fall entirely to the serial scalar tail (see i16 dotAVX2, #160).
 TEXT ·dotAVX2(SB), NOSPLIT, $0-52
     MOVQ a_base+0(FP), SI
     MOVQ a_len+8(FP), CX
@@ -247,6 +262,19 @@ TEXT ·dotAVX2(SB), NOSPLIT, $0-52
 
     VPXOR Y2, Y2, Y2           // int32 accumulator = 0
 
+    // 8-wide XMM block into the still-zero accumulator (the VEX.128 write that
+    // zeroes Y2[255:128] is harmless). Legal to reorder because the int32
+    // accumulation wraps (associative).
+    TESTQ $8, CX               // n % 16 >= 8?
+    JZ   dot_blocks16
+    VPMOVSXBW (SI), X0         // a -> 8 int16
+    VPMOVSXBW (DI), X1         // b -> 8 int16
+    VPMADDWD X1, X0, X4        // 4 int32 products
+    VPADDD X4, X2, X2          // Y2[255:128] still zero after this
+    ADDQ $8, SI
+    ADDQ $8, DI
+
+dot_blocks16:
     MOVQ CX, AX
     SHRQ $4, AX                // AX = n / 16
     JZ   dot_reduce
@@ -270,7 +298,7 @@ dot_reduce:
     VPADDD X3, X2, X2
     MOVQ X2, AX                // EAX = vector total
 
-    ANDQ $15, CX
+    ANDQ $7, CX                // the 8-wide block took n % 16 down to n % 8
     JZ   dot_done
 
 dot_scalar:

--- a/i8/i8_test.go
+++ b/i8/i8_test.go
@@ -18,8 +18,11 @@ func genI8(n int, seed uint32) []int8 {
 }
 
 // lengths sweeps sub-threshold, single-block, multi-block, and ragged-tail sizes
-// for both 16- and 32-byte vector kernels.
-var lengths = []int{0, 1, 2, 3, 7, 8, 15, 16, 17, 31, 32, 33, 63, 64, 65, 100, 255, 256, 257, 1000, 1024, 1031}
+// for both 16- and 32-byte vector kernels. 24 and 25 sit just past the reduce
+// dispatch threshold (16) with n%16 == 8 and 9, exercising the 8-wide AVX2 tail
+// block in Sum/DotProduct with a zero and a one-element scalar remainder (#149);
+// 31/63/255 give it a full 7-element scalar remainder, 1000 a zero one.
+var lengths = []int{0, 1, 2, 3, 7, 8, 15, 16, 17, 24, 25, 31, 32, 33, 63, 64, 65, 100, 255, 256, 257, 1000, 1024, 1031}
 
 func TestAddSaturate(t *testing.T) {
 	// Literal saturation cases validate the reference independently of the SIMD path.


### PR DESCRIPTION
## Summary

The i8 `Sum` and `DotProduct` AVX2 kernels widen 16 bytes/iter (`VPMOVSXBW` -> `VPMADDWD` -> `VPADDD` into Y2) then drop to a serial scalar tail for the 0-15 remainder bytes, so a residue of 8-15 paid up to 15 iterations of a `load -> (multiply) -> add` dependency chain. This adds one 8-wide XMM block before the 16-wide loop, into the freshly-zeroed accumulator (so the VEX.128 write that zeroes `Y2[255:128]` is harmless), and shrinks the tail mask `ANDQ $15` -> `ANDQ $7`. Same shape as the merged i16 `dotAVX2` fix (#160); the reorder is legal because the int32 accumulation wraps (associative) and there is no saturation.

## Related Issues

Relates to #149. This covers the two reduction kernels; the remaining i8 element-wise and conversion AVX2 kernels (32-wide bodies, `ANDQ $31` tails, load/store tails with no serial dependency) are a separate benchmark-gated batch.

## Test Plan

Measured on the i7-1260P (P-core pinned, `GOMAXPROCS=1`, interleaved base/new, benchstat n=20):

| shape | Sum | DotProduct |
| --- | --- | --- |
| n=16 (aligned sentinel, block skipped) | ~0% (p=0.86) | ~0% (p=0.62) |
| n=24 (residue 8) | -23.2% | -35.4% |
| n=40 (residue 8) | -28.1% | -35.4% |
| n=248 (residue 8) | -35.6% | -10.6% |

Geomean over the eight measured shapes: -22.4%. The aligned sentinels being neutral rules out the #159/#149 code-layout confound (the shared address-shifted loop did not move), so the residue-length wins are the tail fix, not alignment.

- [x] `go build`, `go vet`, `gofmt`, `golangci-lint` clean on the changed files
- [x] Correctness: full i8 suite bit-exact on the amd64 host (real AVX2 path and the `SIMD_DISABLE=avx2` pure-Go fallback) at block-exercising residue lengths (24, 25, 31, 63, 255, 1000), and on arm64
- [x] The parity sweep in `i8_test.go` gains n=24 (block, empty tail) and n=25 (block + 1 scalar), complementing the pre-existing n=31/63/255 (block + 7 scalar) and n=1000 (block only)
- [x] New `BenchmarkSum_N` / `BenchmarkDotProduct_N` guard the tail at residue lengths (the fixed 4096-byte benchmarks are all n%16==0 and never ran the tail)