### PR TITLE
i8: add 16/8-wide AVX2 tail blocks to sumAbs and sad reductions (#149)

### DIFF
--- a/i8/benchmark_test.go
+++ b/i8/benchmark_test.go
@@ -212,3 +212,36 @@ func BenchmarkSAD(b *testing.B) {
 		_ = SAD(a, c)
 	}
 }
+
+// BenchmarkSumAbs_N and BenchmarkSAD_N guard the 16- and 8-wide AVX2 tail blocks
+// (#149) on the 32-wide reduction bodies: a residue of 1..31 bytes was served by
+// a serial scalar accumulator chain, so a worst-case residue of 31 cost up to 31
+// dependent adds. The fixed 4096-byte benchmarks above are all n%32==0 and cannot
+// see the sawtooth, so residue lengths must be measured explicitly. 32 is the
+// aligned sentinel (both blocks skipped); 40 is residue 8 (only the 8-wide block);
+// 48 is residue 16 (only the 16-wide block); 63 is residue 31 (both blocks plus
+// the full 7-element scalar tail, the worst case); 95 is residue 31 with more
+// 32-wide blocks; 248 is a realistic length (residue 24, both blocks).
+func BenchmarkSumAbs_N(b *testing.B) {
+	for _, n := range []int{32, 40, 48, 63, 95, 248} {
+		a := genI8(n, 1)
+		b.Run(fmt.Sprintf("%d", n), func(b *testing.B) {
+			b.SetBytes(int64(n))
+			for b.Loop() {
+				_ = SumAbs(a)
+			}
+		})
+	}
+}
+
+func BenchmarkSAD_N(b *testing.B) {
+	for _, n := range []int{32, 40, 48, 63, 95, 248} {
+		a, c := genI8(n, 1), genI8(n, 2)
+		b.Run(fmt.Sprintf("%d", n), func(b *testing.B) {
+			b.SetBytes(int64(n))
+			for b.Loop() {
+				_ = SAD(a, c)
+			}
+		})
+	}
+}

--- a/i8/i8_amd64.s
+++ b/i8/i8_amd64.s
@@ -858,6 +858,29 @@ TEXT ·sumAbsAVX2(SB), NOSPLIT, $0-28
     VPXOR Y0, Y0, Y0           // zero (PSADBW reference)
     VPXOR Y2, Y2, Y2           // u64 accumulator
 
+    // A 16-wide then an 8-wide XMM block absorb up to 24 of the 0-31 remainder
+    // bytes before the 32-wide loop, into the still-zero u64 accumulator, so the
+    // VEX.128 writes that zero Y2[255:128] are harmless (it is already zero).
+    // Legal to reorder because the sum wraps and PSADBW's u64 partials add
+    // associatively. Same shape as sumAVX2's 8-wide block (#173), scaled to the
+    // 32-wide body. Reduces the serial scalar tail from up to 31 to at most 7.
+    TESTQ $16, CX              // n % 32 >= 16?
+    JZ   sumabs_block8
+    VPABSB (SI), X1            // 16 |bytes|
+    VPSADBW X0, X1, X3         // -> 2 u64 lanes (low 128)
+    VPADDQ X3, X2, X2          // Y2[255:128] still zero after this
+    ADDQ $16, SI
+
+sumabs_block8:
+    TESTQ $8, CX               // n % 16 >= 8?
+    JZ   sumabs_blocks32
+    VMOVQ (SI), X1             // 8 bytes in low qword (upper zeroed)
+    VPABSB X1, X1
+    VPSADBW X0, X1, X3         // upper 8 bytes are 0, |0|=0 -> 1 u64 lane
+    VPADDQ X3, X2, X2
+    ADDQ $8, SI
+
+sumabs_blocks32:
     MOVQ CX, AX
     SHRQ $5, AX                // AX = n / 32
     JZ   sumabs_reduce
@@ -877,7 +900,7 @@ sumabs_reduce:
     VPADDQ X3, X2, X2          // -> total in low qword
     MOVQ X2, AX                // u64 running total
 
-    ANDQ $31, CX
+    ANDQ $7, CX                // the 16- and 8-wide blocks took n % 32 to n % 8
     JZ   sumabs_done
 
 sumabs_scalar:
@@ -911,6 +934,35 @@ TEXT ·sadAVX2(SB), NOSPLIT, $0-52
     VPSLLW $7, Y4, Y4          // 0x0101<<7 = 0x8080 per word -> 0x80 per byte
     VPXOR Y2, Y2, Y2           // u64 accumulator
 
+    // A 16-wide then an 8-wide XMM block absorb up to 24 of the 0-31 remainder
+    // bytes before the 32-wide loop, into the still-zero u64 accumulator, so the
+    // VEX.128 writes that zero Y2[255:128] are harmless (it is already zero).
+    // Legal to reorder because the sum wraps and PSADBW's u64 partials add
+    // associatively. Reduces the serial scalar tail from up to 31 to at most 7.
+    TESTQ $16, CX
+    JZ   sad_block8
+    VMOVDQU (SI), X0
+    VMOVDQU (DI), X1
+    VPXOR X4, X0, X0           // a+128 (X4 low 128 = 0x80 bytes)
+    VPXOR X4, X1, X1           // b+128
+    VPSADBW X1, X0, X3         // sum|a-b| over 16 bytes -> 2 u64 lanes
+    VPADDQ X3, X2, X2          // Y2[255:128] still zero after this
+    ADDQ $16, SI
+    ADDQ $16, DI
+
+sad_block8:
+    TESTQ $8, CX
+    JZ   sad_blocks32
+    VMOVQ (SI), X0             // 8 bytes, upper zeroed
+    VMOVQ (DI), X1
+    VPXOR X4, X0, X0           // upper 8 bytes become 0x80 for BOTH a and b
+    VPXOR X4, X1, X1
+    VPSADBW X1, X0, X3         // upper 8: |0x80-0x80| = 0 -> contributes 0
+    VPADDQ X3, X2, X2
+    ADDQ $8, SI
+    ADDQ $8, DI
+
+sad_blocks32:
     MOVQ CX, AX
     SHRQ $5, AX
     JZ   sad_reduce
@@ -934,7 +986,7 @@ sad_reduce:
     VPADDQ X3, X2, X2
     MOVQ X2, AX                // u64 running total
 
-    ANDQ $31, CX
+    ANDQ $7, CX                // the 16- and 8-wide blocks took n % 32 to n % 8
     JZ   sad_done
 
 sad_scalar:

--- a/i8/i8_test.go
+++ b/i8/i8_test.go
@@ -22,7 +22,10 @@ func genI8(n int, seed uint32) []int8 {
 // dispatch threshold (16) with n%16 == 8 and 9, exercising the 8-wide AVX2 tail
 // block in Sum/DotProduct with a zero and a one-element scalar remainder (#149);
 // 31/63/255 give it a full 7-element scalar remainder, 1000 a zero one.
-var lengths = []int{0, 1, 2, 3, 7, 8, 15, 16, 17, 24, 25, 31, 32, 33, 63, 64, 65, 100, 255, 256, 257, 1000, 1024, 1031}
+// 48 and 55 have n%32 == 16 and 23, isolating the 16-wide-only tail block (8-wide
+// skipped) in the 32-wide SumAbs/SAD reductions, with a zero and a full 7-element
+// scalar remainder respectively (#149); 63/95/255 drive both blocks together.
+var lengths = []int{0, 1, 2, 3, 7, 8, 15, 16, 17, 24, 25, 31, 32, 33, 48, 55, 63, 64, 65, 100, 255, 256, 257, 1000, 1024, 1031}
 
 func TestAddSaturate(t *testing.T) {
 	// Literal saturation cases validate the reference independently of the SIMD path.


### PR DESCRIPTION
## What

`sumAbsAVX2` and `sadAVX2` dropped from their 32-wide `VPSADBW` body straight to a scalar tail masked `ANDQ $31`, so a remainder of 1-31 bytes cost up to 31 iterations of a serial `ADDQ` accumulator chain. This is the #145/#149 scalar-tail sawtooth. The `sum`/`dot` reductions already got the fix in #173; these two did not.

This adds a 16-wide then an 8-wide XMM block before the 32-wide loop, folding into the still-zero u64 accumulator (the VEX.128 upper-lane zeroing is harmless while `Y2` is still zero). That narrows the tail mask to `ANDQ $7`, the same shape as `sumAVX2`'s 8-wide block scaled to the 32-wide body.

## Correctness

Bit-exact: `PSADBW`'s u64 partials add associatively and the sum wraps to int32, so reordering the remainder ahead of the body cannot change the result. The block consumption is exact for all n: `(n&16) + (n&8) + 32*(n>>5) + (n&7) == n`, and `SHRQ $5` on the unmodified n still yields the right 32-block count. Reads never pass `a[n]` (the kernel only dispatches for `n >= 32`, and the widest read is unchanged at 32 bytes).

Verified on the amd64 AVX2 host (`TestSumAbs`, `TestSAD`, fuzzer, 0 failures). Parity lengths 48 and 55 were added so the isolated 16-wide-only tail block (`n%32` in 16..23, 8-wide skipped) gets deterministic coverage for both kernels.

## Measured (i7-1260P, P-core pinned, GOMAXPROCS=1, `cpu_core/cycles`)

| kernel | length | Δ cycles |
| --- | --- | --- |
| SumAbs | n=63 (residue 31) | -81% |
| SumAbs | n=248 | -79% |
| SAD | n=63 (residue 31) | -61% |
| SAD | n=248 | -58% |
| both | n=32 (aligned sentinel) | neutral (-0.2% / +1.3%) |

`BenchmarkSumAbs_N` / `BenchmarkSAD_N` at residue lengths {32,40,48,63,95,248} exercise and guard the sawtooth (the existing n=4096 benchmarks are a multiple of 32 and never run the tail).

## Follow-up (pre-existing, not in this PR)

The reduction kernels have no dedicated read-side poison/over-read test; correctness rests on the parity sweep plus the fuzzer. This change does not widen the max read, so it is not newly critical, but a poison test with slack >= the widest vector block would be a more robust guard for all reductions.

Refs #149, #173, #145


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Performance Improvements**
  * Improved processing efficiency for certain input lengths when calculating absolute sums and differences.
  * Reduced remaining scalar processing for non-standard input sizes.

* **Bug Fixes**
  * Improved handling of vectorized operations for inputs that are not multiples of the processing block size.

* **Tests**
  * Added coverage for additional input lengths and benchmark scenarios to validate remainder handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->