### PR TITLE
i16: fold XCorr AVX2 lag reduction with VPHADDD on the no-tail path (#150 item 3)

### DIFF
--- a/i16/i16_amd64.s
+++ b/i16/i16_amd64.s
@@ -717,7 +717,50 @@ xcorr4_avx2_loop16:
     DECQ AX
     JNZ  xcorr4_avx2_loop16
 
+// Horizontal fold (#150 item 3). Each Yn holds eight int32 partials for lag n
+// across two 128-bit lanes. The two exit paths need the four lag sums in
+// different places, so each folds the cheapest way for its need.
+//
+// No scalar tail (n%4 == 0, the aligned lengths the fixed-point callers use):
+// VEXTRACTI128+VPADDD collapses each lag's high lane into its low, then a
+// three-node VPHADDD tree reduces all four lags at once. VPHADDD Xb, Xa, Xd sets
+// Xd = [a0+a1, a2+a3, b0+b1, b2+b3] with plain wrapping 32-bit adds (it never
+// saturates, unlike VPHADDSW), so it preserves the wrapping-add contract XCorr
+// documents to callers. The final VPHADDD lands the four sums as contiguous
+// int32 in lane order 0,1,2,3, stored with one 16-byte VMOVDQU. Bit-exact only
+// because wrapping int32 addition is associative and commutative: this regroups
+// each lag's four partials as (n0+n1)+(n2+n3). Kernel-direct measurement shows
+// -2% to -7% cycles versus the per-lag fold here, backed by a matching drop in
+// retired instructions (the raw aligned-length cycle delta alone is muddied by
+// the code-layout lottery of #159, so the instruction count is the load-bearing
+// evidence).
+//
+// Scalar tail present (n%4 != 0): the tail loop accumulates into R8-R11, so the
+// four sums have to reach GP registers. Extracting them out of a VPHADDD result
+// costs a VPEXTRD per lag whose latency exceeds the shuffles the tree saved
+// (measured +5% at small n), so this path keeps the original per-lag fold that
+// lands each sum straight in a register with MOVQ. It is byte-for-byte the
+// pre-#150 fold; only the no-tail path above is new. ANDQ runs first so the
+// aligned path pays no VPEXTRD and the tail path pays no VPHADDD.
 xcorr4_avx2_fold:
+    ANDQ $3, CX                // $3 not $7: the 8- and 4-wide blocks took those bits
+    JNZ  xcorr4_avx2_fold_tail
+    VEXTRACTI128 $1, Y4, X0
+    VPADDD X0, X4, X4          // X4 = four int32 partials for lag 0
+    VEXTRACTI128 $1, Y5, X0
+    VPADDD X0, X5, X5          // X5 = lag 1 partials
+    VEXTRACTI128 $1, Y6, X0
+    VPADDD X0, X6, X6          // X6 = lag 2 partials
+    VEXTRACTI128 $1, Y7, X0
+    VPADDD X0, X7, X7          // X7 = lag 3 partials
+    VPHADDD X5, X4, X4         // X4 = [lag0(0+1), lag0(2+3), lag1(0+1), lag1(2+3)]
+    VPHADDD X7, X6, X6         // X6 = [lag2(0+1), lag2(2+3), lag3(0+1), lag3(2+3)]
+    VPHADDD X6, X4, X4         // X4 = [sumLag0, sumLag1, sumLag2, sumLag3]
+    VMOVDQU X4, (DI)           // no scalar tail: store all four lag sums at once
+    VZEROUPPER
+    RET
+
+xcorr4_avx2_fold_tail:
     VEXTRACTI128 $1, Y4, X0
     VPADDD X0, X4, X4
     VPSHUFD $0x4E, X4, X0
@@ -746,9 +789,6 @@ xcorr4_avx2_fold:
     VPSHUFD $0xB1, X7, X0
     VPADDD X0, X7, X7
     MOVQ X7, R11               // lag 3
-
-    ANDQ $3, CX                // $3 not $7: the 8- and 4-wide blocks took those bits
-    JZ   xcorr4_avx2_store
 
 xcorr4_avx2_scalar:
     MOVWLSX (SI), AX           // x[j], sign-extended
@@ -903,7 +943,34 @@ xcorrvnni_loop16:
     DECQ AX
     JNZ  xcorrvnni_loop16
 
+// Horizontal fold (#150 item 3), identical to xcorr4AVX2's dual-path fold above:
+// the no-tail path (n%4 == 0) uses the three-node VPHADDD tree plus a single
+// 16-byte VMOVDQU store, and the scalar-tail path (n%4 != 0) keeps the original
+// per-lag VEXTRACTI128/VPSHUFD fold that lands each sum straight in R8-R11. See
+// the xcorr4_avx2_fold comment for the full rationale: VPHADDD operand order and
+// the [sumLag0..3] lane layout, the wrapping-add bit-exactness of regrouping the
+// partials, and why the tail path avoids VPEXTRD (its latency exceeds the
+// shuffles the tree saves, measured +5% at small n). ANDQ runs first so the
+// aligned path pays no VPEXTRD and the tail path pays no VPHADDD.
 xcorrvnni_fold:
+    ANDQ $3, CX                // $3 not $7: the 8- and 4-wide blocks took those bits
+    JNZ  xcorrvnni_fold_tail
+    VEXTRACTI128 $1, Y4, X0
+    VPADDD X0, X4, X4          // X4 = four int32 partials for lag 0
+    VEXTRACTI128 $1, Y5, X0
+    VPADDD X0, X5, X5          // X5 = lag 1 partials
+    VEXTRACTI128 $1, Y6, X0
+    VPADDD X0, X6, X6          // X6 = lag 2 partials
+    VEXTRACTI128 $1, Y7, X0
+    VPADDD X0, X7, X7          // X7 = lag 3 partials
+    VPHADDD X5, X4, X4         // X4 = [lag0(0+1), lag0(2+3), lag1(0+1), lag1(2+3)]
+    VPHADDD X7, X6, X6         // X6 = [lag2(0+1), lag2(2+3), lag3(0+1), lag3(2+3)]
+    VPHADDD X6, X4, X4         // X4 = [sumLag0, sumLag1, sumLag2, sumLag3]
+    VMOVDQU X4, (DI)           // no scalar tail: store all four lag sums at once
+    VZEROUPPER
+    RET
+
+xcorrvnni_fold_tail:
     VEXTRACTI128 $1, Y4, X0
     VPADDD X0, X4, X4
     VPSHUFD $0x4E, X4, X0
@@ -932,9 +999,6 @@ xcorrvnni_fold:
     VPSHUFD $0xB1, X7, X0
     VPADDD X0, X7, X7
     MOVQ X7, R11               // lag 3
-
-    ANDQ $3, CX                // $3 not $7: the 8- and 4-wide blocks took those bits
-    JZ   xcorrvnni_store
 
 xcorrvnni_scalar:
     MOVWLSX (SI), AX           // x[j], sign-extended


### PR DESCRIPTION
## What

`xcorr4AVX2` and `xcorr4AVXVNNI` reduced their four YMM lag accumulators to four int32 lag sums with a 28-instruction per-lag fold (`VEXTRACTI128` + two `VPSHUFD`/`VPADDD` pairs + `MOVQ` per lag). For the common `n%4 == 0` case, where no scalar tail follows, the four sums can be folded together and stored in one shot.

This is #150 item 3. On the no-tail path, the fold is now a three-node `VPHADDD` tree that lands the four lag sums as contiguous int32 in lane order 0..3 in `X4`, stored with a single 16-byte `VMOVDQU`. `VPHADDD` does plain wrapping 32-bit adds (it never saturates, unlike `VPHADDSW`), so it preserves the wrapping-add contract `XCorr` documents to callers; bit-exact because wrapping int32 addition is associative.

## Non-regressing by construction

The scalar-tail path (`n%4 != 0`) keeps the original per-lag fold. Its sums have to reach `R8-R11` for the tail loop, and extracting them out of a `VPHADDD` result costs a `VPEXTRD` per lag whose latency exceeds the shuffles the tree saved (an all-paths `VPHADDD` fold measured **+5%** at small ragged n). Branching on the tail count first means the aligned path pays no `VPEXTRD` and the ragged path pays no `VPHADDD`, so the ragged path is byte-for-byte the pre-#150 fold.

## Measured (i7-1260P, P-core pinned, GOMAXPROCS=1, `cpu_core/cycles`, vs the per-lag fold)

| XCorr shape | path | Δ cycles | Δ instructions |
| --- | --- | --- | --- |
| n=240, n=248, n=480 | no-tail (n%4==0) | -3% to -6% | -4% to -6.6% |
| n=247, n=25 | scalar-tail (n%4!=0) | noise (±1%) | ±0.0% (identical) |

The tail path retires instruction-identical counts to base, so there is no regression on ragged lengths; the aligned lengths the fixed-point callers use get a clean, instruction-backed win.

## Correctness

Verified on the amd64 AVX2 **and** AVX-VNNI host: `TestXCorr4AMD64_ParityWithGo`, `MinInt16`, `ShortWindowIsBounded`, `LongWindowIsClamped`, and `FuzzI16XCorr` seeds all pass on both the AVX2 and AVXVNNI kernels, 0 failures. Both the single-store no-tail path and the per-lag tail path are exercised by the length sweep.

Refs #150, #159
