### PR TITLE
i8: replace maxAbs/minMax scalar tails with an overlapping SIMD block (#149)

### DIFF
--- a/i8/i8_amd64.s
+++ b/i8/i8_amd64.s
@@ -319,7 +319,8 @@ dot_done:
 // func minMaxAVX2(a []int8) (minVal, maxVal int8)
 // Signed byte min and max in one pass: VPMINSB/VPMAXSB fold 32-byte blocks into
 // running accumulators, a per-lane cascade reduces a 128-bit lane to a single
-// byte, and a scalar tail folds the (n mod 32) remainder. The dispatch gates
+// byte, and an overlapping final 32-byte block folds the (n mod 32) remainder
+// (idempotent, so reprocessing the overlap is exact). The dispatch gates
 // n >= 32, so at least one full block exists.
 TEXT ·minMaxAVX2(SB), NOSPLIT, $0-26
     MOVQ a_base+0(FP), SI
@@ -629,7 +630,8 @@ neg_done:
 // Per-tensor abs-max for dynamic quantization: VPABSB maps each byte to its
 // magnitude (abs(-128) -> 0x80, i.e. 128 read unsigned), VPMAXUB folds 32-byte
 // blocks into an unsigned-max accumulator, a VPMAXUB/VPSRLDQ cascade reduces a
-// 128-bit lane to one byte, and a scalar tail folds the (n mod 32) remainder.
+// 128-bit lane to one byte, and an overlapping final 32-byte block folds the
+// (n mod 32) remainder (idempotent, so reprocessing the overlap is exact).
 // The result is read zero-extended, so it lands in [0, 128].
 TEXT ·maxAbsAVX2(SB), NOSPLIT, $0-32
     MOVQ a_base+0(FP), SI

--- a/i8/i8_amd64.s
+++ b/i8/i8_amd64.s
@@ -330,7 +330,7 @@ TEXT ·minMaxAVX2(SB), NOSPLIT, $0-26
     MOVQ CX, AX
     SHRQ $5, AX                // AX = full 32-byte blocks (>=1)
     DECQ AX                    // blocks remaining after block 0
-    JZ   mm_reduce
+    JZ   mm_overlap
     LEAQ 32(SI), DI            // working ptr at block 1
 
 mm_loop:
@@ -340,6 +340,20 @@ mm_loop:
     ADDQ $32, DI
     DECQ AX
     JNZ  mm_loop
+
+mm_overlap:
+    // Absorb the (n mod 32) tail with an overlapping final 32-wide block instead
+    // of a serial scalar tail. minMaxAVX2 is dispatched only for n >= 32, so
+    // a+n-32 is in bounds; signed min/max are idempotent, so reprocessing the
+    // overlap with the last full block is bit-exact. Guarded on a nonzero residue
+    // so aligned n pays nothing.
+    TESTQ $31, CX
+    JZ   mm_reduce
+    MOVQ SI, DI                // SI is still a_base (never advanced)
+    ADDQ CX, DI                // DI = a + n
+    VMOVDQU -32(DI), Y2        // a[n-32 .. n)
+    VPMINSB Y2, Y0, Y0
+    VPMAXSB Y2, Y1, Y1
 
 mm_reduce:
     // Fold the 256-bit min accumulator to one byte.
@@ -367,31 +381,6 @@ mm_reduce:
     VPSRLDQ $1, X1, X3
     VPMAXSB X3, X1, X1
     MOVD X1, DX                // DL = running max
-
-    // scalar tail: (n mod 32) residuals at &a[fullBlocks*32]. Legacy GPRs only:
-    // DI = tail ptr (SI free after), SI = loaded byte, CX = sign-extend temp.
-    MOVQ CX, BX
-    ANDQ $31, BX
-    JZ   mm_done
-    MOVQ CX, DI
-    ANDQ $-32, DI              // fullBlocks*32 bytes
-    ADDQ SI, DI               // tail ptr
-
-mm_tail:
-    MOVBLSX (DI), SI           // r (sign-extended)
-    MOVBLSX AX, CX             // current min (sign-extend AL)
-    CMPL SI, CX
-    JGE  mm_tail_max
-    MOVB SI, AX               // r < min -> new min (low byte)
-mm_tail_max:
-    MOVBLSX DX, CX             // current max (sign-extend DL)
-    CMPL SI, CX
-    JLE  mm_tail_next
-    MOVB SI, DX               // r > max -> new max
-mm_tail_next:
-    INCQ DI
-    DECQ BX
-    JNZ  mm_tail
 
 mm_done:
     MOVB AX, minVal+24(FP)
@@ -659,6 +648,18 @@ maxabs_loop32:
     DECQ AX
     JNZ  maxabs_loop32
 
+    // Absorb the (n mod 32) tail with an overlapping final 32-wide block instead
+    // of a serial scalar tail. maxAbsAVX2 is dispatched only for n >= 32, so
+    // a+n-32 is in bounds; unsigned max is idempotent, so reprocessing the
+    // overlap with the last full block is bit-exact. Guarded on a nonzero residue
+    // so aligned n pays nothing.
+    TESTQ $31, CX
+    JZ   maxabs_reduce
+    MOVQ a_base+0(FP), DI      // reload base (SI has advanced past the last block)
+    ADDQ CX, DI                // DI = a + n
+    VPABSB -32(DI), Y1         // |a[n-32 .. n)|
+    VPMAXUB Y1, Y0, Y0
+
 maxabs_reduce:
     VEXTRACTI128 $1, Y0, X1
     VPMAXUB X1, X0, X0         // fold 32 -> 16 bytes
@@ -672,23 +673,6 @@ maxabs_reduce:
     VPMAXUB X1, X0, X0         // 1 byte
     MOVD X0, AX
     ANDQ $0xFF, AX             // running abs-max (unsigned byte) in [0, 128]
-
-    ANDQ $31, CX
-    JZ   maxabs_done
-
-maxabs_scalar:
-    MOVBLSX (SI), BX           // v (sign-extended)
-    TESTL BX, BX
-    JGE  maxabs_cmp
-    NEGL BX                    // |v|; -(-128) = 128
-maxabs_cmp:
-    CMPL BX, AX                // both in [0, 128], unsigned == signed here
-    JLE  maxabs_next
-    MOVL BX, AX                // new running max
-maxabs_next:
-    INCQ SI
-    DECQ CX
-    JNZ  maxabs_scalar
 
 maxabs_done:
     MOVQ AX, ret+24(FP)

--- a/i8/reduce_tail_bench_test.go
+++ b/i8/reduce_tail_bench_test.go
@@ -1,0 +1,38 @@
+package i8
+
+import (
+	"fmt"
+	"testing"
+)
+
+// BenchmarkMaxAbs_N and BenchmarkMinMax_N guard the overlapping-final-block tail
+// (#149) on the 32-wide MaxAbs/MinMax reductions: a residue of 1..31 bytes was
+// served by a serial compare/cmov scalar chain (up to 31 dependent steps), now
+// absorbed by one overlapping 32-wide block. The fixed 4096-byte benchmarks are
+// all n%32==0 and never run the overlap block, so residue lengths must be
+// measured explicitly. 32 is the aligned sentinel (overlap skipped, the untouched
+// control); 40/48/63/95/248 are ragged so the overlap block runs, with 63 and 95
+// at the worst-case residue 31.
+func BenchmarkMaxAbs_N(b *testing.B) {
+	for _, n := range []int{32, 40, 48, 63, 95, 248} {
+		a := genI8(n, 1)
+		b.Run(fmt.Sprintf("%d", n), func(b *testing.B) {
+			b.SetBytes(int64(n))
+			for b.Loop() {
+				_ = MaxAbs(a)
+			}
+		})
+	}
+}
+
+func BenchmarkMinMax_N(b *testing.B) {
+	for _, n := range []int{32, 40, 48, 63, 95, 248} {
+		a := genI8(n, 1)
+		b.Run(fmt.Sprintf("%d", n), func(b *testing.B) {
+			b.SetBytes(int64(n))
+			for b.Loop() {
+				_, _ = MinMax(a)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## What

`maxAbsAVX2` and `minMaxAVX2` dropped from their 32-wide body (`VPMAXUB` / `VPMINSB`+`VPMAXSB`) to a scalar tail masked `ANDQ $31`, so a remainder of 1-31 bytes cost up to 31 iterations of a serial compare / conditional-move chain. This is the #145/#149 scalar-tail sawtooth in the last two i8 reduction kernels (sumAbs/sad get the forward-block fix; sum/dot got it in #173).

## Why an overlapping block (and why it is sound here)

Because min and max are **idempotent** (reprocessing a value through min/max is a no-op), these two admit a simpler fix than the additive reductions: a single **overlapping final 32-wide block** at `a[n-32 .. n)` that absorbs the whole remainder, letting the scalar tail be deleted entirely. Both kernels dispatch to AVX2 only for `n >= 32` (`blockMinMax`), so `a+n-32` is always in bounds; reprocessing the overlap with the last full block is bit-exact. The block is guarded on a nonzero residue (`TESTQ $31`) so aligned n pays nothing.

This is the sound analogue of the overlapping block #150 explicitly flagged as **unsound for the XCorr reduction**: there the reduction is an additive sum, so an overlap would double-count. Here the reduction is min/max, so the overlap is idempotent and exact.

## Measured (i7-1260P, P-core pinned, GOMAXPROCS=1, `cpu_core/cycles`)

| kernel | length | Δ cycles | Δ instructions |
| --- | --- | --- | --- |
| MaxAbs | n=63 (residue 31) | -91% (10.6x) | -77% |
| MaxAbs | n=248 | -85% | -66% |
| MinMax | n=63 (residue 31) | -89% (9.1x) | -78% |
| MinMax | n=248 | -83% | -66% |
| MaxAbs | n=32 (aligned) | neutral (-0.05%) | +0.4% |
| MinMax | n=32 (aligned) | -4.6% (from dropping the tail) | -1% |

Instruction-backed, no regression; the aligned sentinel is neutral-to-better.

## Correctness

Verified on the amd64 AVX2 host: full i8 suite (`TestMaxAbs`, `TestMinMax`, fuzz, zero-alloc, trailing-capacity) passes, 0 failures. The scalar tails are removed, so the diff is a net simplification (-43 lines in the kernel). `BenchmarkMaxAbs_N` / `BenchmarkMinMax_N` (new file) guard the overlap at residue lengths; the existing parity/fuzz sweep already exercises the overlap at every ragged length (it has no residue-dependent branch).

Refs #149, #150, #173
