### PR TITLE
i8: shrink the element-wise AVX2 scalar tails with forward 16/8-wide blocks (#149)

### DIFF
--- a/i8/elementwise_residue_test.go
+++ b/i8/elementwise_residue_test.go
@@ -9,7 +9,7 @@ import "testing"
 //
 //	40  -> residue  8  (0b01000): 8-wide block only, empty scalar tail
 //	48  -> residue 16  (0b10000): 16-wide block only, empty scalar tail
-//	55  -> residue 23  (0b10111): 16-wide + 8-wide blocks + 7-element scalar tail
+//	55  -> residue 23  (0b10111): 16-wide block only (bit3=0), 7-element scalar tail
 //	63  -> residue 31  (0b11111): 16-wide + 8-wide blocks + 7-element scalar tail
 //
 // n=48 in particular is the only case that runs the 16-wide block with the
@@ -81,28 +81,31 @@ func TestElementwiseResiduePreBlocks(t *testing.T) {
 // the pre-blocks read each input byte then write its output before advancing, so
 // dst==a aliasing must produce the same result as the out-of-place call even for
 // the non-idempotent ops. An overlapping/backward block would double-transform
-// bytes it re-read from dst; a forward block does not. n=55 is ragged (residue
-// 23), so both the 16-wide and 8-wide in-place blocks run.
+// bytes it re-read from dst; a forward block does not. n=55 (residue 23) runs the
+// 16-wide block in place; n=63 (residue 31) runs both the 16-wide and 8-wide
+// blocks (plus a 7-element scalar tail) in place, so the two lengths together
+// cover both forward pre-blocks with aliased dst.
 func TestElementwiseInPlaceForwardBlocks(t *testing.T) {
-	const n = 55
-	a := genI8(n, 1)
-	b := genI8(n, 2)
+	for _, n := range []int{55, 63} {
+		a := genI8(n, 1)
+		b := genI8(n, 2)
 
-	// Abs in place: dst == a.
-	{
-		want := make([]int8, n)
-		Abs(want, a) // out-of-place reference
-		inplace := append([]int8(nil), a...)
-		Abs(inplace, inplace)
-		assertI8Eq(t, "Abs in-place", n, inplace, want)
-	}
+		// Abs in place: dst == a.
+		{
+			want := make([]int8, n)
+			Abs(want, a) // out-of-place reference
+			inplace := append([]int8(nil), a...)
+			Abs(inplace, inplace)
+			assertI8Eq(t, "Abs in-place", n, inplace, want)
+		}
 
-	// AddSaturate in place: dst == a (first input aliases output).
-	{
-		want := make([]int8, n)
-		AddSaturate(want, a, b)
-		inplace := append([]int8(nil), a...)
-		AddSaturate(inplace, inplace, b)
-		assertI8Eq(t, "AddSaturate in-place", n, inplace, want)
+		// AddSaturate in place: dst == a (first input aliases output).
+		{
+			want := make([]int8, n)
+			AddSaturate(want, a, b)
+			inplace := append([]int8(nil), a...)
+			AddSaturate(inplace, inplace, b)
+			assertI8Eq(t, "AddSaturate in-place", n, inplace, want)
+		}
 	}
 }

--- a/i8/elementwise_residue_test.go
+++ b/i8/elementwise_residue_test.go
@@ -1,0 +1,108 @@
+package i8
+
+import "testing"
+
+// residueLengths isolate the 16-wide and 8-wide AVX2 pre-blocks (#149) that the
+// shared `lengths` sweep does not pin down on its own. Each is past the
+// blockSat32 (32) dispatch threshold so the SIMD path runs, and the residue
+// n%32 selects which pre-blocks fire:
+//
+//	40  -> residue  8  (0b01000): 8-wide block only, empty scalar tail
+//	48  -> residue 16  (0b10000): 16-wide block only, empty scalar tail
+//	55  -> residue 23  (0b10111): 16-wide + 8-wide blocks + 7-element scalar tail
+//	63  -> residue 31  (0b11111): 16-wide + 8-wide blocks + 7-element scalar tail
+//
+// n=48 in particular is the only case that runs the 16-wide block with the
+// 8-wide block skipped, which the shared table's residue-8/9 entries never hit.
+var residueLengths = []int{40, 48, 55, 63}
+
+// TestElementwiseResiduePreBlocks checks every element-wise op against its Go
+// reference at the residue lengths that isolate the new SIMD pre-blocks. A bug in
+// a pre-block (wrong op, operand order, or pointer advance) shows up here as a
+// mismatch at exactly the bytes the block wrote.
+func TestElementwiseResiduePreBlocks(t *testing.T) {
+	for _, n := range residueLengths {
+		a, b := genI8(n, 1), genI8(n, 2)
+		got := make([]int8, n)
+		want := make([]int8, n)
+
+		// dst, a: single input ops.
+		Abs(got, a)
+		absGo(want, a)
+		assertI8Eq(t, "Abs", n, got, want)
+
+		Neg(got, a)
+		negGo(want, a)
+		assertI8Eq(t, "Neg", n, got, want)
+
+		// dst, a, b: two-input ops.
+		AddSaturate(got, a, b)
+		addSatGo(want, a, b)
+		assertI8Eq(t, "AddSaturate", n, got, want)
+
+		SubSaturate(got, a, b)
+		subSatGo(want, a, b)
+		assertI8Eq(t, "SubSaturate", n, got, want)
+
+		Min(got, a, b)
+		minGo(want, a, b)
+		assertI8Eq(t, "Min", n, got, want)
+
+		Max(got, a, b)
+		maxGo(want, a, b)
+		assertI8Eq(t, "Max", n, got, want)
+
+		AbsDiff(got, a, b)
+		absDiffGo(want, a, b)
+		assertI8Eq(t, "AbsDiff", n, got, want)
+
+		// dst, src, lo, hi: clamp, both lo<hi and lo>hi (max-then-min ordering).
+		for _, lohi := range []struct{ lo, hi int8 }{{-40, 90}, {50, -50}} {
+			Clamp(got, a, lohi.lo, lohi.hi)
+			clampGo(want, a, lohi.lo, lohi.hi)
+			assertI8Eq(t, "Clamp", n, got, want)
+		}
+
+		// dst, a, s: scalar-broadcast ops. Exercise a positive and a negative s so
+		// both saturation directions run through the reused sVec X-half.
+		for _, s := range []int8{37, -100} {
+			AddScalarSaturate(got, a, s)
+			addScalarSatGo(want, a, s)
+			assertI8Eq(t, "AddScalarSaturate", n, got, want)
+
+			SubScalarSaturate(got, a, s)
+			subScalarSatGo(want, a, s)
+			assertI8Eq(t, "SubScalarSaturate", n, got, want)
+		}
+	}
+}
+
+// TestElementwiseInPlaceForwardBlocks guards the forward-block in-place safety:
+// the pre-blocks read each input byte then write its output before advancing, so
+// dst==a aliasing must produce the same result as the out-of-place call even for
+// the non-idempotent ops. An overlapping/backward block would double-transform
+// bytes it re-read from dst; a forward block does not. n=55 is ragged (residue
+// 23), so both the 16-wide and 8-wide in-place blocks run.
+func TestElementwiseInPlaceForwardBlocks(t *testing.T) {
+	const n = 55
+	a := genI8(n, 1)
+	b := genI8(n, 2)
+
+	// Abs in place: dst == a.
+	{
+		want := make([]int8, n)
+		Abs(want, a) // out-of-place reference
+		inplace := append([]int8(nil), a...)
+		Abs(inplace, inplace)
+		assertI8Eq(t, "Abs in-place", n, inplace, want)
+	}
+
+	// AddSaturate in place: dst == a (first input aliases output).
+	{
+		want := make([]int8, n)
+		AddSaturate(want, a, b)
+		inplace := append([]int8(nil), a...)
+		AddSaturate(inplace, inplace, b)
+		assertI8Eq(t, "AddSaturate in-place", n, inplace, want)
+	}
+}

--- a/i8/elementwise_tail_bench_test.go
+++ b/i8/elementwise_tail_bench_test.go
@@ -1,0 +1,145 @@
+package i8
+
+import (
+	"fmt"
+	"testing"
+)
+
+// tailBenchLengths exercises the 16-wide and 8-wide AVX2 pre-blocks (#149) added
+// to the element-wise kernels. Each length is past the blockSat32 (32) dispatch
+// threshold so the SIMD path runs, and the residue n%32 sweeps the pre-block
+// combinations: 32 is aligned (both blocks skipped, empty scalar tail); 40 is
+// residue 8 (8-wide block only); 48 is residue 16 (16-wide block only); 63 is
+// residue 31 (16+8 blocks plus a full 7-element scalar tail); 95 is residue 31
+// with more full 32-blocks; 248 is residue 24 (16+8 blocks, empty scalar tail).
+var tailBenchLengths = []int{32, 40, 48, 63, 95, 248}
+
+func BenchmarkAbs_N(b *testing.B) {
+	for _, n := range tailBenchLengths {
+		a := genI8(n, 1)
+		dst := make([]int8, n)
+		b.Run(fmt.Sprintf("%d", n), func(b *testing.B) {
+			b.SetBytes(int64(n))
+			for b.Loop() {
+				Abs(dst, a)
+			}
+		})
+	}
+}
+
+func BenchmarkNeg_N(b *testing.B) {
+	for _, n := range tailBenchLengths {
+		a := genI8(n, 1)
+		dst := make([]int8, n)
+		b.Run(fmt.Sprintf("%d", n), func(b *testing.B) {
+			b.SetBytes(int64(n))
+			for b.Loop() {
+				Neg(dst, a)
+			}
+		})
+	}
+}
+
+func BenchmarkAddSaturate_N(b *testing.B) {
+	for _, n := range tailBenchLengths {
+		a, c := genI8(n, 1), genI8(n, 2)
+		dst := make([]int8, n)
+		b.Run(fmt.Sprintf("%d", n), func(b *testing.B) {
+			b.SetBytes(int64(n))
+			for b.Loop() {
+				AddSaturate(dst, a, c)
+			}
+		})
+	}
+}
+
+func BenchmarkSubSaturate_N(b *testing.B) {
+	for _, n := range tailBenchLengths {
+		a, c := genI8(n, 1), genI8(n, 2)
+		dst := make([]int8, n)
+		b.Run(fmt.Sprintf("%d", n), func(b *testing.B) {
+			b.SetBytes(int64(n))
+			for b.Loop() {
+				SubSaturate(dst, a, c)
+			}
+		})
+	}
+}
+
+func BenchmarkMin_N(b *testing.B) {
+	for _, n := range tailBenchLengths {
+		a, c := genI8(n, 1), genI8(n, 2)
+		dst := make([]int8, n)
+		b.Run(fmt.Sprintf("%d", n), func(b *testing.B) {
+			b.SetBytes(int64(n))
+			for b.Loop() {
+				Min(dst, a, c)
+			}
+		})
+	}
+}
+
+func BenchmarkMax_N(b *testing.B) {
+	for _, n := range tailBenchLengths {
+		a, c := genI8(n, 1), genI8(n, 2)
+		dst := make([]int8, n)
+		b.Run(fmt.Sprintf("%d", n), func(b *testing.B) {
+			b.SetBytes(int64(n))
+			for b.Loop() {
+				Max(dst, a, c)
+			}
+		})
+	}
+}
+
+func BenchmarkClamp_N(b *testing.B) {
+	for _, n := range tailBenchLengths {
+		src := genI8(n, 1)
+		dst := make([]int8, n)
+		b.Run(fmt.Sprintf("%d", n), func(b *testing.B) {
+			b.SetBytes(int64(n))
+			for b.Loop() {
+				Clamp(dst, src, -64, 64)
+			}
+		})
+	}
+}
+
+func BenchmarkAbsDiff_N(b *testing.B) {
+	for _, n := range tailBenchLengths {
+		a, c := genI8(n, 1), genI8(n, 2)
+		dst := make([]int8, n)
+		b.Run(fmt.Sprintf("%d", n), func(b *testing.B) {
+			b.SetBytes(int64(n))
+			for b.Loop() {
+				AbsDiff(dst, a, c)
+			}
+		})
+	}
+}
+
+func BenchmarkAddScalarSaturate_N(b *testing.B) {
+	for _, n := range tailBenchLengths {
+		a := genI8(n, 1)
+		dst := make([]int8, n)
+		b.Run(fmt.Sprintf("%d", n), func(b *testing.B) {
+			b.SetBytes(int64(n))
+			for b.Loop() {
+				AddScalarSaturate(dst, a, 37)
+			}
+		})
+	}
+}
+
+func BenchmarkSubScalarSaturate_N(b *testing.B) {
+	for _, n := range tailBenchLengths {
+		a := genI8(n, 1)
+		dst := make([]int8, n)
+		b.Run(fmt.Sprintf("%d", n), func(b *testing.B) {
+			b.SetBytes(int64(n))
+			for b.Loop() {
+				SubScalarSaturate(dst, a, 37)
+			}
+		})
+	}
+}

--- a/i8/i8_amd64.s
+++ b/i8/i8_amd64.s
@@ -26,6 +26,31 @@ TEXT ·addSatAVX2(SB), NOSPLIT, $0-72
     MOVQ a_base+24(FP), SI
     MOVQ b_base+48(FP), DI
 
+    // A 16-wide then an 8-wide XMM block absorb up to 24 of the 0-31 remainder
+    // bytes before the 32-wide loop, shrinking the branchy scalar tail from up to
+    // 31 elements to at most 7. FORWARD blocks (not overlapping): each input byte
+    // is read then its output written exactly once, so in-place dst==a (or dst==b)
+    // stays correct for this non-idempotent op. Both input pointers advance.
+    TESTQ $16, CX
+    JZ   addsat_block8
+    VMOVDQU (SI), X0
+    VMOVDQU (DI), X1
+    VPADDSB X1, X0, X2         // saturating(a + b)
+    VMOVDQU X2, (DX)
+    ADDQ $16, SI
+    ADDQ $16, DI
+    ADDQ $16, DX
+addsat_block8:
+    TESTQ $8, CX
+    JZ   addsat_blocks32
+    VMOVQ (SI), X0             // 8 bytes (upper zeroed)
+    VMOVQ (DI), X1
+    VPADDSB X1, X0, X2         // low 8 = a+b; upper 8 = 0+0 = 0, never stored
+    VMOVQ X2, (DX)             // store 8 bytes
+    ADDQ $8, SI
+    ADDQ $8, DI
+    ADDQ $8, DX
+addsat_blocks32:
     MOVQ CX, AX
     SHRQ $5, AX                // AX = n / 32
     JZ   addsat_remainder
@@ -42,7 +67,7 @@ addsat_loop32:
     JNZ  addsat_loop32
 
 addsat_remainder:
-    ANDQ $31, CX
+    ANDQ $7, CX                // the 16- and 8-wide blocks took n % 32 to n % 8
     JZ   addsat_done
 
 addsat_scalar:
@@ -75,6 +100,29 @@ TEXT ·subSatAVX2(SB), NOSPLIT, $0-72
     MOVQ a_base+24(FP), SI
     MOVQ b_base+48(FP), DI
 
+    // 16-wide then 8-wide forward XMM pre-block; shrinks the branchy scalar tail
+    // from up to 31 elements to at most 7. Each input byte is read then written
+    // once, so in-place dst==a/dst==b stays correct. Both input pointers advance.
+    TESTQ $16, CX
+    JZ   subsat_block8
+    VMOVDQU (SI), X0
+    VMOVDQU (DI), X1
+    VPSUBSB X1, X0, X2         // saturating(a - b)
+    VMOVDQU X2, (DX)
+    ADDQ $16, SI
+    ADDQ $16, DI
+    ADDQ $16, DX
+subsat_block8:
+    TESTQ $8, CX
+    JZ   subsat_blocks32
+    VMOVQ (SI), X0             // 8 bytes (upper zeroed)
+    VMOVQ (DI), X1
+    VPSUBSB X1, X0, X2         // low 8 = a-b; upper 8 = 0-0 = 0, never stored
+    VMOVQ X2, (DX)             // store 8 bytes
+    ADDQ $8, SI
+    ADDQ $8, DI
+    ADDQ $8, DX
+subsat_blocks32:
     MOVQ CX, AX
     SHRQ $5, AX
     JZ   subsat_remainder
@@ -91,7 +139,7 @@ subsat_loop32:
     JNZ  subsat_loop32
 
 subsat_remainder:
-    ANDQ $31, CX
+    ANDQ $7, CX                // the 16- and 8-wide blocks took n % 32 to n % 8
     JZ   subsat_done
 
 subsat_scalar:
@@ -398,6 +446,29 @@ TEXT ·minAVX2(SB), NOSPLIT, $0-72
     MOVQ a_base+24(FP), SI
     MOVQ b_base+48(FP), DI
 
+    // 16-wide then 8-wide forward XMM pre-block; shrinks the branchy scalar tail
+    // from up to 31 elements to at most 7. Each input byte is read then written
+    // once, so in-place dst==a/dst==b stays correct. Both input pointers advance.
+    TESTQ $16, CX
+    JZ   min_block8
+    VMOVDQU (SI), X0
+    VMOVDQU (DI), X1
+    VPMINSB X1, X0, X2         // min(a, b)
+    VMOVDQU X2, (DX)
+    ADDQ $16, SI
+    ADDQ $16, DI
+    ADDQ $16, DX
+min_block8:
+    TESTQ $8, CX
+    JZ   min_blocks32
+    VMOVQ (SI), X0             // 8 bytes (upper zeroed)
+    VMOVQ (DI), X1
+    VPMINSB X1, X0, X2         // low 8 = min(a,b); upper 8 = min(0,0) = 0, unstored
+    VMOVQ X2, (DX)             // store 8 bytes
+    ADDQ $8, SI
+    ADDQ $8, DI
+    ADDQ $8, DX
+min_blocks32:
     MOVQ CX, AX
     SHRQ $5, AX                // AX = n / 32
     JZ   min_remainder
@@ -414,7 +485,7 @@ min_loop32:
     JNZ  min_loop32
 
 min_remainder:
-    ANDQ $31, CX
+    ANDQ $7, CX                // the 16- and 8-wide blocks took n % 32 to n % 8
     JZ   min_done
 
 min_scalar:
@@ -444,6 +515,29 @@ TEXT ·maxAVX2(SB), NOSPLIT, $0-72
     MOVQ a_base+24(FP), SI
     MOVQ b_base+48(FP), DI
 
+    // 16-wide then 8-wide forward XMM pre-block; shrinks the branchy scalar tail
+    // from up to 31 elements to at most 7. Each input byte is read then written
+    // once, so in-place dst==a/dst==b stays correct. Both input pointers advance.
+    TESTQ $16, CX
+    JZ   max_block8
+    VMOVDQU (SI), X0
+    VMOVDQU (DI), X1
+    VPMAXSB X1, X0, X2         // max(a, b)
+    VMOVDQU X2, (DX)
+    ADDQ $16, SI
+    ADDQ $16, DI
+    ADDQ $16, DX
+max_block8:
+    TESTQ $8, CX
+    JZ   max_blocks32
+    VMOVQ (SI), X0             // 8 bytes (upper zeroed)
+    VMOVQ (DI), X1
+    VPMAXSB X1, X0, X2         // low 8 = max(a,b); upper 8 = max(0,0) = 0, unstored
+    VMOVQ X2, (DX)             // store 8 bytes
+    ADDQ $8, SI
+    ADDQ $8, DI
+    ADDQ $8, DX
+max_blocks32:
     MOVQ CX, AX
     SHRQ $5, AX
     JZ   max_remainder
@@ -460,7 +554,7 @@ max_loop32:
     JNZ  max_loop32
 
 max_remainder:
-    ANDQ $31, CX
+    ANDQ $7, CX                // the 16- and 8-wide blocks took n % 32 to n % 8
     JZ   max_done
 
 max_scalar:
@@ -492,6 +586,28 @@ TEXT ·clampAVX2(SB), NOSPLIT, $0-50
     VPBROADCASTB lo+48(FP), Y3 // loVec: lo in all 32 lanes
     VPBROADCASTB hi+49(FP), Y4 // hiVec
 
+    // 16-wide then 8-wide forward XMM pre-block; shrinks the branchy scalar tail
+    // from up to 31 elements to at most 7. Each src byte is read then written
+    // once, so in-place dst==src stays correct. loVec/hiVec are read-only, so the
+    // pre-block reuses their X-halves (X3, X4).
+    TESTQ $16, CX
+    JZ   clamp_block8
+    VMOVDQU (SI), X0
+    VPMAXSB X3, X0, X0         // max(src, lo)
+    VPMINSB X4, X0, X2         // min(., hi)
+    VMOVDQU X2, (DX)
+    ADDQ $16, SI
+    ADDQ $16, DX
+clamp_block8:
+    TESTQ $8, CX
+    JZ   clamp_blocks32
+    VMOVQ (SI), X0             // 8 bytes (upper zeroed)
+    VPMAXSB X3, X0, X0         // upper 8 = clamp(0) garbage, never stored
+    VPMINSB X4, X0, X2
+    VMOVQ X2, (DX)             // store 8 bytes
+    ADDQ $8, SI
+    ADDQ $8, DX
+clamp_blocks32:
     MOVQ CX, AX
     SHRQ $5, AX
     JZ   clamp_remainder
@@ -507,7 +623,7 @@ clamp_loop32:
     JNZ  clamp_loop32
 
 clamp_remainder:
-    ANDQ $31, CX
+    ANDQ $7, CX                // the 16- and 8-wide blocks took n % 32 to n % 8
     JZ   clamp_done
     MOVBLSX lo+48(FP), DI      // lo (sign-extended)
     MOVBLSX hi+49(FP), R8      // hi
@@ -543,6 +659,30 @@ TEXT ·absAVX2(SB), NOSPLIT, $0-48
 
     VPXOR Y3, Y3, Y3           // zero
 
+    // A 16-wide then an 8-wide XMM block absorb up to 24 of the 0-31 remainder
+    // bytes before the 32-wide loop, shrinking the branchy scalar tail from up to
+    // 31 elements to at most 7. FORWARD blocks (not overlapping): each byte is
+    // read then written exactly once, so in-place dst==a stays correct. The
+    // scalar tail's sign branch mispredicts on random data (~3.6 cyc/element), so
+    // moving 24 of those onto branchless SIMD is the win.
+    TESTQ $16, CX
+    JZ   abs_block8
+    VMOVDQU (SI), X0
+    VPSUBSB X0, X3, X1
+    VPMAXSB X1, X0, X2
+    VMOVDQU X2, (DX)
+    ADDQ $16, SI
+    ADDQ $16, DX
+abs_block8:
+    TESTQ $8, CX
+    JZ   abs_blocks32
+    VMOVQ (SI), X0             // 8 bytes (upper zeroed)
+    VPSUBSB X0, X3, X1
+    VPMAXSB X1, X0, X2         // |a| for the low 8; upper 8 are |0|=0
+    VMOVQ X2, (DX)             // store 8 bytes
+    ADDQ $8, SI
+    ADDQ $8, DX
+abs_blocks32:
     MOVQ CX, AX
     SHRQ $5, AX
     JZ   abs_remainder
@@ -558,7 +698,7 @@ abs_loop32:
     JNZ  abs_loop32
 
 abs_remainder:
-    ANDQ $31, CX
+    ANDQ $7, CX                // the 16- and 8-wide blocks took n % 32 to n % 8
     JZ   abs_done
 
 abs_scalar:
@@ -592,6 +732,27 @@ TEXT ·negAVX2(SB), NOSPLIT, $0-48
 
     VPXOR Y3, Y3, Y3           // zero
 
+    // A 16-wide then an 8-wide XMM block absorb up to 24 of the 0-31 remainder
+    // bytes before the 32-wide loop, shrinking the branchy scalar tail from up to
+    // 31 elements to at most 7. FORWARD blocks (not overlapping): each byte is
+    // read then written exactly once, so in-place dst==a stays correct even for
+    // this non-idempotent op. Same template as absAVX2.
+    TESTQ $16, CX
+    JZ   neg_block8
+    VMOVDQU (SI), X0
+    VPSUBSB X0, X3, X2         // saturating(0 - a)
+    VMOVDQU X2, (DX)
+    ADDQ $16, SI
+    ADDQ $16, DX
+neg_block8:
+    TESTQ $8, CX
+    JZ   neg_blocks32
+    VMOVQ (SI), X0             // 8 bytes (upper zeroed)
+    VPSUBSB X0, X3, X2         // low 8 = -a; upper 8 = -0 = 0, never stored
+    VMOVQ X2, (DX)             // store 8 bytes
+    ADDQ $8, SI
+    ADDQ $8, DX
+neg_blocks32:
     MOVQ CX, AX
     SHRQ $5, AX
     JZ   neg_remainder
@@ -606,7 +767,7 @@ neg_loop32:
     JNZ  neg_loop32
 
 neg_remainder:
-    ANDQ $31, CX
+    ANDQ $7, CX                // the 16- and 8-wide blocks took n % 32 to n % 8
     JZ   neg_done
 
 neg_scalar:
@@ -692,6 +853,33 @@ TEXT ·absDiffAVX2(SB), NOSPLIT, $0-72
     MOVQ a_base+24(FP), SI
     MOVQ b_base+48(FP), DI
 
+    // 16-wide then 8-wide forward XMM pre-block; shrinks the branchy scalar tail
+    // from up to 31 elements to at most 7. Each input byte is read then written
+    // once, so in-place dst==a/dst==b stays correct. Both input pointers advance.
+    TESTQ $16, CX
+    JZ   absdiff_block8
+    VMOVDQU (SI), X0           // a
+    VMOVDQU (DI), X1           // b
+    VPSUBSB X1, X0, X2         // saturating(a - b)
+    VPSUBSB X0, X1, X3         // saturating(b - a)
+    VPMAXSB X3, X2, X4         // |a - b| clamped to [0, 127]
+    VMOVDQU X4, (DX)
+    ADDQ $16, SI
+    ADDQ $16, DI
+    ADDQ $16, DX
+absdiff_block8:
+    TESTQ $8, CX
+    JZ   absdiff_blocks32
+    VMOVQ (SI), X0             // 8 bytes (upper zeroed)
+    VMOVQ (DI), X1
+    VPSUBSB X1, X0, X2         // low 8 = a-b; upper 8 = 0-0 = 0
+    VPSUBSB X0, X1, X3         // upper 8 = 0
+    VPMAXSB X3, X2, X4         // upper 8 = |0| = 0, never stored
+    VMOVQ X4, (DX)             // store 8 bytes
+    ADDQ $8, SI
+    ADDQ $8, DI
+    ADDQ $8, DX
+absdiff_blocks32:
     MOVQ CX, AX
     SHRQ $5, AX
     JZ   absdiff_remainder
@@ -710,7 +898,7 @@ absdiff_loop32:
     JNZ  absdiff_loop32
 
 absdiff_remainder:
-    ANDQ $31, CX
+    ANDQ $7, CX                // the 16- and 8-wide blocks took n % 32 to n % 8
     JZ   absdiff_done
 
 absdiff_scalar:
@@ -745,6 +933,26 @@ TEXT ·addScalarSatAVX2(SB), NOSPLIT, $0-49
     MOVQ a_base+24(FP), SI
     VPBROADCASTB s+48(FP), Y1  // s in all 32 lanes
 
+    // 16-wide then 8-wide forward XMM pre-block; shrinks the branchy scalar tail
+    // from up to 31 elements to at most 7. Each input byte is read then written
+    // once, so in-place dst==a stays correct. sVec is read-only, so the pre-block
+    // reuses its X-half (X1).
+    TESTQ $16, CX
+    JZ   addscalar_block8
+    VMOVDQU (SI), X0
+    VPADDSB X1, X0, X2         // saturating(a + s)
+    VMOVDQU X2, (DX)
+    ADDQ $16, SI
+    ADDQ $16, DX
+addscalar_block8:
+    TESTQ $8, CX
+    JZ   addscalar_blocks32
+    VMOVQ (SI), X0             // 8 bytes (upper zeroed)
+    VPADDSB X1, X0, X2         // upper 8 = 0+s garbage, never stored
+    VMOVQ X2, (DX)             // store 8 bytes
+    ADDQ $8, SI
+    ADDQ $8, DX
+addscalar_blocks32:
     MOVQ CX, AX
     SHRQ $5, AX
     JZ   addscalar_remainder
@@ -759,7 +967,7 @@ addscalar_loop32:
     JNZ  addscalar_loop32
 
 addscalar_remainder:
-    ANDQ $31, CX
+    ANDQ $7, CX                // the 16- and 8-wide blocks took n % 32 to n % 8
     JZ   addscalar_done
     MOVBLSX s+48(FP), DI       // s (sign-extended)
 
@@ -793,6 +1001,26 @@ TEXT ·subScalarSatAVX2(SB), NOSPLIT, $0-49
     MOVQ a_base+24(FP), SI
     VPBROADCASTB s+48(FP), Y1  // s in all 32 lanes
 
+    // 16-wide then 8-wide forward XMM pre-block; shrinks the branchy scalar tail
+    // from up to 31 elements to at most 7. Each input byte is read then written
+    // once, so in-place dst==a stays correct. sVec is read-only, so the pre-block
+    // reuses its X-half (X1).
+    TESTQ $16, CX
+    JZ   subscalar_block8
+    VMOVDQU (SI), X0
+    VPSUBSB X1, X0, X2         // saturating(a - s)
+    VMOVDQU X2, (DX)
+    ADDQ $16, SI
+    ADDQ $16, DX
+subscalar_block8:
+    TESTQ $8, CX
+    JZ   subscalar_blocks32
+    VMOVQ (SI), X0             // 8 bytes (upper zeroed)
+    VPSUBSB X1, X0, X2         // upper 8 = 0-s garbage, never stored
+    VMOVQ X2, (DX)             // store 8 bytes
+    ADDQ $8, SI
+    ADDQ $8, DX
+subscalar_blocks32:
     MOVQ CX, AX
     SHRQ $5, AX
     JZ   subscalar_remainder
@@ -807,7 +1035,7 @@ subscalar_loop32:
     JNZ  subscalar_loop32
 
 subscalar_remainder:
-    ANDQ $31, CX
+    ANDQ $7, CX                // the 16- and 8-wide blocks took n % 32 to n % 8
     JZ   subscalar_done
     MOVBLSX s+48(FP), DI       // s (sign-extended)
 


### PR DESCRIPTION
## What

The 10 element-wise i8 AVX2 kernels (`abs`, `neg`, `addSat`, `subSat`, `min`, `max`, `clamp`, `absDiff`, `addScalarSat`, `subScalarSat`) dropped from their 32-wide body to a scalar tail masked `ANDQ $31`. That tail is expensive: it has a **data-dependent branch** (the sign test / saturation clamp) that mispredicts on random data (~3.6 cyc/element), so a remainder of 1-31 bytes ran ~10-13x slower than an aligned length (Abs n=63 was 33 ns vs 2.6 ns at n=32).

This adds a forward 16-wide then 8-wide XMM pre-block before the 32-wide loop and narrows the tail mask to `ANDQ $7`, moving up to 24 of the mispredicting scalar iterations onto branchless SIMD.

## Why forward blocks (not an overlapping block)

The README documents in-place use (`i8.Abs(left, left)`). **Forward** blocks read each input byte then write its output exactly once, so in-place `dst==a` stays correct even for the non-idempotent ops. An overlapping final block (as used for the idempotent min/max reductions in #176) would re-read already-written output and double-transform them. A `TestElementwiseInPlaceForwardBlocks` test guards this.

## Measured (i7-1260P, P-core pinned, GOMAXPROCS=1), fix vs base

| kernel | n=63 (residue 31) | n=248 (residue 24) |
| --- | --- | --- |
| Abs | 5.1x | 6.1x |
| AddSaturate | 3.1x | 4.0x |
| AbsDiff | 2.9x | 3.4x |

Neg, Min, Max, Clamp, and the scalar-saturate ops fall in the same 3-6x band. Aligned n=32 stays neutral. The residue mod 8 (0-7) still runs the branchy scalar tail, so the win is largest when the residue is a multiple of 8 (n=248 fully absorbs its tail).

## Correctness

Verified on the amd64 AVX2 host: full i8 suite passes, 0 failures. New tests (no touching the shared `lengths` table, to stay conflict-free):
- `TestElementwiseResiduePreBlocks` at residues {40, 48, 55, 63} (8-only, 16-only, and 16+8+tail combos; n=48 isolates the 16-wide-only block the shared sweep never hits) compares every op against its Go reference.
- `TestElementwiseInPlaceForwardBlocks` at n=55 checks `Abs(x,x)` and `AddSaturate(x,x,b)` match the out-of-place result.
- `BenchmarkXxx_N` residue benchmarks guard the sawtooth.

This completes the i8 element-wise kernels for #149 (the four reduction kernels landed in #173/#174/#176).

Refs #149
