### PR TITLE
i8: replace toI16/toI32 conversion scalar tails with an overlapping block (#149)

### DIFF
--- a/i8/conv_tail_bench_test.go
+++ b/i8/conv_tail_bench_test.go
@@ -1,0 +1,32 @@
+package i8
+
+import (
+	"fmt"
+	"testing"
+)
+
+func BenchmarkToInt16_N(b *testing.B) {
+	for _, n := range []int{16, 31, 240, 255} {
+		src := genI8(n, 1)
+		dst := make([]int16, n)
+		b.Run(fmt.Sprintf("%d", n), func(b *testing.B) {
+			b.SetBytes(int64(n))
+			for b.Loop() {
+				ToInt16(dst, src)
+			}
+		})
+	}
+}
+
+func BenchmarkToInt32_N(b *testing.B) {
+	for _, n := range []int{8, 15, 240, 255} {
+		src := genI8(n, 1)
+		dst := make([]int32, n)
+		b.Run(fmt.Sprintf("%d", n), func(b *testing.B) {
+			b.SetBytes(int64(n))
+			for b.Loop() {
+				ToInt32(dst, src)
+			}
+		})
+	}
+}

--- a/i8/i8_amd64.s
+++ b/i8/i8_amd64.s
@@ -184,17 +184,22 @@ toi16_loop16:
     DECQ AX
     JNZ  toi16_loop16
 
+    // Overlapping final 16-wide block absorbs the (n mod 16) tail instead of a
+    // scalar loop. toI16AVX2 is dispatched only for n >= 16, so src[n-16 .. n) is
+    // in bounds; re-writing the overlap with the same widened int16 values is
+    // idempotent, and src (int8) and dst (int16) are distinct slices that cannot
+    // alias. Guarded on a nonzero residue so aligned n pays nothing.
 toi16_remainder:
-    ANDQ $15, CX
+    TESTQ $15, CX
     JZ   toi16_done
-
-toi16_scalar:
-    MOVBLSX (SI), AX
-    MOVW AX, (DX)
-    INCQ SI
-    ADDQ $2, DX
-    DECQ CX
-    JNZ  toi16_scalar
+    MOVQ src_base+24(FP), SI   // reload src base (SI advanced past the last block)
+    ADDQ CX, SI
+    SUBQ $16, SI               // SI = &src[n-16]
+    VPMOVSXBW (SI), Y0         // src[n-16 .. n) -> 16 int16
+    MOVQ dst_base+0(FP), DX    // reload dst base
+    LEAQ (DX)(CX*2), DX        // DX = dst + 2*n
+    SUBQ $32, DX               // DX = &dst[n-16]
+    VMOVDQU Y0, (DX)
 
 toi16_done:
     VZEROUPPER
@@ -219,17 +224,21 @@ toi32_loop8:
     DECQ AX
     JNZ  toi32_loop8
 
+    // Overlapping final 8-wide block absorbs the (n mod 8) tail (same idempotent
+    // widening-overlap argument as toI16; dispatched only for n >= 8). A short
+    // non-branchy widening tail, so the win is modest, but it drops the scalar
+    // loop and keeps the kernel uniform with toI16.
 toi32_remainder:
-    ANDQ $7, CX
+    TESTQ $7, CX
     JZ   toi32_done
-
-toi32_scalar:
-    MOVBLSX (SI), AX
-    MOVL AX, (DX)
-    INCQ SI
-    ADDQ $4, DX
-    DECQ CX
-    JNZ  toi32_scalar
+    MOVQ src_base+24(FP), SI   // reload src base
+    ADDQ CX, SI
+    SUBQ $8, SI                // SI = &src[n-8]
+    VPMOVSXBD (SI), Y0         // src[n-8 .. n) -> 8 int32
+    MOVQ dst_base+0(FP), DX    // reload dst base
+    LEAQ (DX)(CX*4), DX        // DX = dst + 4*n
+    SUBQ $32, DX               // DX = &dst[n-8]
+    VMOVDQU Y0, (DX)
 
 toi32_done:
     VZEROUPPER


### PR DESCRIPTION
## What

`ToInt16` and `ToInt32` widen int8 -> int16 / int32 with `VPMOVSXBW` / `VPMOVSXBD` over 16- and 8-wide blocks, then a scalar tail (`MOVBLSX` + widening store) for the (n mod block) remainder. The tail is not branchy, but toI16's up to 15 serial load/store iterations still cost ~6-7 ns, making ragged lengths **2.2-3.4x slower** than aligned (n=31 was 9.1 ns vs 2.7 ns at n=16).

This absorbs the tail with an **overlapping final block** (16-wide for toI16, 8-wide for toI32): if `n mod block != 0`, widen `src[n-block .. n)` and store to `dst[n-block .. n)`.

## Why it is safe

`src` (int8) and `dst` (int16/int32) are distinct slices that **cannot alias**, so re-writing the overlap with the same widened values is idempotent. Both kernels dispatch only for `n >= block` (`blockWiden16`/`blockWiden32`), so `src[n-block]` is in bounds. The block is guarded on a nonzero residue so aligned n pays nothing (perf-verified identical to base at n=16, within 0.2% on both cycles and instructions).

## Measured (i7-1260P, P-core pinned, `cpu_core` counters)

| kernel | length | result |
| --- | --- | --- |
| ToInt16 | n=255 (residue 15) | **-55% cycles (2.2x), -34% instructions** |
| ToInt16 | n=31 (residue 15) | ~3x |
| ToInt16 | n=16 (aligned) | neutral (within 0.2%) |
| ToInt32 | n=255 (residue 7) | ~1.1x (short non-branchy tail, modest) |
| ToInt32 | n=15 | ~1.3x |

toI16 is the real win; toI32's tail is short (max 7) so its gain is modest, but the same overlap drops its scalar loop and keeps the two kernels uniform.

## Correctness

Verified on the amd64 AVX2 host: full i8 suite passes, 0 failures. `TestToInt16`/`TestToInt32` sweep ragged lengths through the shared `lengths` table, and the overlap has no residue-dependent branch, so a single ragged length exercises it. `BenchmarkToInt16_N`/`BenchmarkToInt32_N` guard the sawtooth.

This completes the i8 kernels for #149 (reductions #173/#174/#176, element-wise #177, conversions here).

Refs #149


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Performance**
  - Improved AVX2-accelerated conversion of 8-bit signed values to 16-bit and 32-bit integers, especially for inputs whose lengths are not exact vector-size multiples.
  - Reduced scalar tail processing, improving conversion efficiency across a wider range of input sizes.

- **Tests**
  - Added benchmarks covering conversion performance across multiple input sizes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->