### PR TITLE
i16: PCALIGN the dotAVX2 16-wide loop to stop it straddling a fetch line (#159)

### DIFF
--- a/i16/i16_amd64.s
+++ b/i16/i16_amd64.s
@@ -423,6 +423,15 @@ dot_avx2_blocks16:
     SHRQ $4, BX                // BX = n / 16
     JZ   dot_avx2_reduce
 
+    // Pin the 29-byte 16-wide loop into a single 64-byte fetch line. Without this,
+    // whether the loop straddles a line boundary is a coin flip decided by the
+    // linker's placement of dotAVX2 (Go aligns amd64 funcs to 32, not 64), and a
+    // straddling loop measured 15-27% slower at aligned lengths (240/480/4096) on
+    // Alder Lake, with retired instructions unchanged (pure fetch/DSB effect). The
+    // ~23 NOP bytes on the n>=16 entry path are neutral even at n=16/24. Unlike the
+    // larger xcorr4 loop (uop-cache served, PCALIGN not warranted per #150), this
+    // small loop is fetch-sensitive. See #159.
+    PCALIGN $32
 dot_avx2_loop16:
     VMOVDQU (SI), Y1
     VMOVDQU (DI), Y2


### PR DESCRIPTION
## What

`dot_avx2_loop16` (i16 `dotAVX2`) is 29 bytes, so whether it fits inside one 64-byte instruction-fetch line depends entirely on where the linker places `dotAVX2`. Go aligns amd64 functions to 32 (not 64), so a straddling loop is a coin flip that any unrelated code-size change can flip. This is the measurement trap #159 documents (it confounded the #149 and #151 tail fixes twice).

`PCALIGN $32` before the loop pins it deterministically into one fetch line. In the current layout the loop straddles, so this is also a direct speedup.

## Measured (i7-1260P, P-core pinned, `cpu_core` counters, base vs PCALIGN, 20M fixed iters, min of 10)

| DotProduct | Δ cycles | Δ instructions |
| --- | --- | --- |
| n=240 (aligned) | **−21.3%** | +1.4% (NOP padding) |
| n=480 (aligned) | **−27.0%** | +0.9% |
| n=4096 (aligned) | **−15.0%** | +0.1% |
| n=16 / n=24 (short) | neutral | +2.9% |

Retired instructions barely move while cycles drop 15-27% → pure fetch/DSB-alignment, not real work. The win is guaranteed to survive code-size perturbations (that is the point: PCALIGN removes the lottery). Short-n is neutral (the ~23 NOP bytes cost nothing measurable).

## Scope

`dotAVX2` only. The larger `xcorr4` loop was already measured in #150 to be served ~99% from the uop cache (`idq.dsb_uops` identical with/without an inserted block), so PCALIGN buys it nothing. Correctness verified on the amd64 AVX2 host (PCALIGN is NOP padding; the i16 suite passes unchanged).

Closes #159
