### PR TITLE
f32: document Sqrt as IEEE-754 correctly-rounded and add fused AbsPow34 (#183)

### DIFF
--- a/f32/abspow34_amd64_test.go
+++ b/f32/abspow34_amd64_test.go
@@ -1,0 +1,84 @@
+//go:build amd64
+
+package f32
+
+import (
+	"testing"
+
+	"github.com/tphakala/simd/cpu"
+)
+
+func TestAbsPow34AVX_ParityWithGo(t *testing.T) {
+	if !cpu.X86.AVX {
+		t.Skip("AVX not available")
+	}
+	checkAbsPow34Kernel(t, "absPow34AVX", absPow34AVX)
+}
+
+func TestAbsPow34SSE_ParityWithGo(t *testing.T) {
+	if !cpu.X86.SSE2 {
+		t.Skip("SSE2 not available")
+	}
+	checkAbsPow34Kernel(t, "absPow34SSE", absPow34SSE)
+}
+
+// TestAbsPow34Kernels_AllocFree asserts the kernels run allocation-free at the
+// kernel boundary, mirroring the public-API alloc test.
+func TestAbsPow34Kernels_AllocFree(t *testing.T) {
+	const n = 1024
+	src := make([]float32, n)
+	dst := make([]float32, n)
+	kernels := []struct {
+		name string
+		fn   func()
+		skip bool
+	}{
+		{"absPow34AVX", func() { absPow34AVX(dst, src) }, !cpu.X86.AVX},
+		{"absPow34SSE", func() { absPow34SSE(dst, src) }, !cpu.X86.SSE2},
+	}
+	for _, k := range kernels {
+		if k.skip {
+			continue
+		}
+		if got := testing.AllocsPerRun(100, k.fn); got != 0 {
+			t.Errorf("%s allocated %v times per run, want 0", k.name, got)
+		}
+	}
+}
+
+// TestAbsPow34Dispatch_amd64 runs the public AbsPow34 against the exact kernel the
+// direct-branch dispatcher (absPow34_32) should select for the detected CPU
+// features, over lengths that straddle the block boundaries. Because AVX, SSE, and
+// the Go fallback are bit-identical by design, this output comparison confirms the
+// dispatched path returns correct bits but cannot by itself prove WHICH kernel ran
+// (a silent Go fallback would produce the same bits); that the SIMD branch is
+// actually taken is confirmed by coverage instrumentation on a host that has the
+// feature. It is white-box (reads the cpu flags the dispatcher reads) and must not
+// call t.Parallel().
+func TestAbsPow34Dispatch_amd64(t *testing.T) {
+	in := tiledAbsPow34Inputs(64)
+
+	var want func(dst, src []float32)
+	switch {
+	case cpu.X86.AVX:
+		want = absPow34AVX
+	case cpu.X86.SSE2:
+		want = absPow34SSE
+	default:
+		want = absPow34Go
+	}
+
+	for _, n := range []int{1, 4, 7, 8, 15, 16, 33, len(in)} {
+		src := in[:n]
+		gotDispatch := make([]float32, n)
+		gotKernel := make([]float32, n)
+		AbsPow34(gotDispatch, src)
+		want(gotKernel, src)
+		for i := range gotDispatch {
+			if !bitsEqF32(gotDispatch[i], gotKernel[i]) {
+				t.Fatalf("n=%d: AbsPow34 dispatched to a different kernel than expected at lane %d: got %v want %v",
+					n, i, gotDispatch[i], gotKernel[i])
+			}
+		}
+	}
+}

--- a/f32/abspow34_arm64_test.go
+++ b/f32/abspow34_arm64_test.go
@@ -1,0 +1,62 @@
+//go:build arm64
+
+package f32
+
+import (
+	"testing"
+
+	"github.com/tphakala/simd/cpu"
+)
+
+// TestAbsPow34NEON_ParityWithGo drives the hand-encoded NEON kernel directly over
+// every prefix length, catching a wrong WORD, a mishandled 4-element remainder, a
+// dropped scalar tail, or a lane error that SIMD-vs-SIMD agreement would miss.
+// Each result must be bit-identical to absPow34Go, including the +Inf/0
+// saturation lanes and NaN (compared NaN-equal).
+func TestAbsPow34NEON_ParityWithGo(t *testing.T) {
+	if !hasNEON {
+		t.Skip("NEON required")
+	}
+	checkAbsPow34Kernel(t, "absPow34NEON", absPow34NEON)
+}
+
+// TestAbsPow34NEON_AllocFree asserts the kernel runs allocation-free at the
+// kernel boundary.
+func TestAbsPow34NEON_AllocFree(t *testing.T) {
+	if !hasNEON {
+		t.Skip("NEON required")
+	}
+	const n = 1024
+	src := make([]float32, n)
+	dst := make([]float32, n)
+	if got := testing.AllocsPerRun(100, func() { absPow34NEON(dst, src) }); got != 0 {
+		t.Errorf("absPow34NEON allocated %v times per run, want 0", got)
+	}
+}
+
+// TestAbsPow34Dispatch_arm64 pins the dispatch inputs absPow34_32 reads: hasNEON
+// must reflect CPU detection so a mis-wired flag cannot silently strand every
+// call on the Go path. It is white-box (reads package-level state) and must not
+// call t.Parallel(). The NEON length threshold matches sqrt32's (>= 4), verified
+// by driving one below-threshold and one at-threshold length through the public
+// AbsPow34 and confirming both match the reference.
+func TestAbsPow34Dispatch_arm64(t *testing.T) {
+	if hasNEON != cpu.ARM64.NEON {
+		t.Fatalf("hasNEON = %v but cpu.ARM64.NEON = %v: dispatch flag is not wired to CPU detection", hasNEON, cpu.ARM64.NEON)
+	}
+	for _, n := range []int{3, 4} { // below the >=4 NEON threshold and at it
+		src := make([]float32, n)
+		for i := range src {
+			src[i] = float32(i)*2.5 - 1
+		}
+		got := make([]float32, n)
+		want := make([]float32, n)
+		AbsPow34(got, src)
+		absPow34Go(want, src)
+		for i := range got {
+			if !bitsEqF32(got[i], want[i]) {
+				t.Fatalf("AbsPow34 n=%d: dst[%d] = %v, want %v", n, i, got[i], want[i])
+			}
+		}
+	}
+}

--- a/f32/abspow34_test.go
+++ b/f32/abspow34_test.go
@@ -1,0 +1,328 @@
+package f32
+
+import (
+	"math"
+	"math/rand"
+	"testing"
+)
+
+// Tests for AbsPow34: dst[i] = |src[i]|^(3/4) = sqrt(|x| * sqrt(|x|)). The
+// contract is bit-exactness to the fused C form sqrtf(a*sqrtf(a)) on every
+// backend, INCLUDING the intermediate float32 overflow to +Inf (|x| >~ 2^85.33)
+// and underflow to 0 (tiny |x|). The oracle reproduces that intermediate: it uses
+// an independent big.Float for both square roots but a genuine float32 multiply
+// in between, so it validates both the correct rounding of each sqrt and the
+// saturation contract. See the AbsPow34 doc comment.
+
+// absPow34Oracle is the independent reference. a = |x| (float32); s = correctly-
+// rounded sqrt(a) via big.Float; p = a*s as a real float32 product (may overflow
+// to +Inf or underflow to 0); result = correctly-rounded sqrt(p) via big.Float.
+// bigSqrtToF32 lives in sqrt_rounding_test.go.
+func absPow34Oracle(x float32) float32 {
+	if x != x { // NaN in -> NaN out (payload not asserted)
+		return float32(math.NaN())
+	}
+	a := float32(math.Abs(float64(x)))
+	if math.IsInf(float64(a), 1) {
+		return float32(math.Inf(1)) // |+-Inf|^0.75 = +Inf
+	}
+	if a == 0 {
+		return 0
+	}
+	s := bigSqrtToF32(a)
+	p := a * s // genuine float32 product: overflows to +Inf / underflows to 0
+	switch {
+	case math.IsInf(float64(p), 1):
+		return float32(math.Inf(1))
+	case p == 0:
+		return 0
+	default:
+		return bigSqrtToF32(p)
+	}
+}
+
+// absPow34SweepInputs gathers the design sweep: specials and signed zeros, the
+// float32 extremes, subnormals (which all underflow the intermediate to 0), a
+// dense band around 1.0, fine grids straddling the 2^85.33 overflow and the
+// 2^-99.33 underflow thresholds (both signs), and random draws across the whole
+// range.
+func absPow34SweepInputs(short bool) []float32 {
+	in := make([]float32, 0, 1<<16)
+
+	in = append(in,
+		0, float32(math.Copysign(0, -1)),
+		float32(math.Inf(1)), float32(math.Inf(-1)),
+		float32(math.NaN()),
+		math.MaxFloat32, -math.MaxFloat32,
+		math.SmallestNonzeroFloat32, -math.SmallestNonzeroFloat32,
+		1, -1, 16, 81, 256, -256,
+	)
+
+	// Subnormals (and negatives): every one underflows the a^1.5 intermediate.
+	for bits := uint32(1); bits <= 8192; bits++ {
+		v := math.Float32frombits(bits)
+		in = append(in, v, -v)
+	}
+
+	// Dense band around 1.0.
+	oneBits := math.Float32bits(1.0)
+	band := uint32(1 << 14)
+	if short {
+		band = 1 << 10
+	}
+	for d := uint32(1); d <= band; d++ {
+		lo := math.Float32frombits(oneBits - d)
+		hi := math.Float32frombits(oneBits + d)
+		in = append(in, lo, -lo, hi, -hi)
+	}
+
+	// Fine grids straddling the overflow boundary (a^1.5 overflows near
+	// a = 2^85.33) and the underflow boundary (a^1.5 underflows near a = 2^-99.33);
+	// -85 is included as the design calls for symmetric sampling.
+	for _, e := range []int{83, 84, 85, 86, 87, 88, -84, -85, -86, -98, -99, -100, -101} {
+		base := math.Ldexp(1, e)
+		for f := range 1024 {
+			v := float32(base * (1.0 + float64(f)/1024.0))
+			in = append(in, v, -v)
+		}
+	}
+
+	rng := rand.New(rand.NewSource(0xAB0F34)) //nolint:gosec // deterministic test vectors
+	randCount := 200000
+	if short {
+		randCount = 5000
+	}
+	for range randCount {
+		x := math.Float32frombits(rng.Uint32()) // any bit pattern, both signs
+		in = append(in, x)
+	}
+
+	return in
+}
+
+// absPow34InterestingInputs is a compact set of values that stress the AbsPow34
+// contract: signed zeros, infinities, NaN, the float32 extremes, the intermediate
+// overflow (2^85+) and underflow (2^-100) regions, subnormals, and ordinary
+// magnitudes of both signs. The direct-kernel parity tests tile this to a length
+// that bears a scalar tail and compare each kernel bit-for-bit to absPow34Go.
+func absPow34InterestingInputs() []float32 {
+	return []float32{
+		0, float32(math.Copysign(0, -1)),
+		float32(math.Inf(1)), float32(math.Inf(-1)), float32(math.NaN()),
+		math.MaxFloat32, -math.MaxFloat32,
+		math.SmallestNonzeroFloat32, -math.SmallestNonzeroFloat32,
+		math.Float32frombits(3), math.Float32frombits(100), // subnormals
+		1, -1, 2, 0.5, 4, 9, 16, 81, 256, -256, 1000.5, -0.25,
+		float32(math.Ldexp(1, 85)), float32(math.Ldexp(1.5, 85)), // overflow region
+		float32(math.Ldexp(1, 86)), -float32(math.Ldexp(1, 86)),
+		float32(math.Ldexp(1, -100)), float32(math.Ldexp(1, -99)), // underflow region
+		float32(math.Ldexp(1, 42)), -float32(math.Ldexp(1, 42)),
+	}
+}
+
+// tiledAbsPow34Inputs repeats the interesting-value set until it is at least
+// minLen long, so a prefix at every length exercises the vector body and every
+// scalar-tail remainder of the 8-wide AVX, 4-wide SSE, and 4-wide NEON kernels.
+func tiledAbsPow34Inputs(minLen int) []float32 {
+	base := absPow34InterestingInputs()
+	out := make([]float32, 0, minLen+len(base))
+	for len(out) < minLen {
+		out = append(out, base...)
+	}
+	return out
+}
+
+// checkAbsPow34Kernel drives kern directly over every prefix length so a
+// threshold change in the dispatcher can never quietly reduce this to a test of
+// the Go reference against itself. Each result must be bit-identical to
+// absPow34Go, including the +Inf/0 saturation lanes and NaN (NaN treated equal).
+func checkAbsPow34Kernel(t *testing.T, name string, kern func(dst, src []float32)) {
+	t.Helper()
+	in := tiledAbsPow34Inputs(64)
+	for n := 1; n <= len(in); n++ {
+		src := in[:n]
+		got := make([]float32, n)
+		want := make([]float32, n)
+		kern(got, src)
+		absPow34Go(want, src)
+		for i := range got {
+			if !bitsEqF32(got[i], want[i]) {
+				t.Fatalf("%s n=%d: dst[%d] = %v [%#08x], want %v [%#08x] (src=%v)",
+					name, n, i, got[i], math.Float32bits(got[i]),
+					want[i], math.Float32bits(want[i]), src[i])
+			}
+		}
+	}
+}
+
+// TestAbsPow34 checks the dispatched AbsPow34 and the pure-Go absPow34Go against
+// the big.Float oracle bit-for-bit, and against each other. The full slice
+// exercises the SIMD vector body; a one-element shift moves different values into
+// the SIMD scalar tail.
+func TestAbsPow34(t *testing.T) {
+	in := absPow34SweepInputs(testing.Short())
+	t.Logf("sweep size: %d inputs", len(in))
+
+	check := func(name string, got, src []float32) {
+		for i := range got {
+			want := absPow34Oracle(src[i])
+			if !bitsEqF32(got[i], want) {
+				t.Fatalf("%s: AbsPow34(%v [%#08x]) = %v [%#08x], want %v [%#08x]",
+					name, src[i], math.Float32bits(src[i]),
+					got[i], math.Float32bits(got[i]),
+					want, math.Float32bits(want))
+			}
+		}
+	}
+
+	dst := make([]float32, len(in))
+	AbsPow34(dst, in)
+	check("AbsPow34(full)", dst, in)
+
+	ref := make([]float32, len(in))
+	absPow34Go(ref, in)
+	check("absPow34Go(full)", ref, in)
+
+	if len(in) > 1 {
+		src := in[1:]
+		d2 := make([]float32, len(src))
+		AbsPow34(d2, src)
+		check("AbsPow34(shift1)", d2, src)
+	}
+}
+
+// TestAbsPow34_AllocFree pins the zero-allocation contract; buffers are declared
+// inside the measured closure so only genuine per-call heap traffic counts.
+func TestAbsPow34_AllocFree(t *testing.T) {
+	if n := testing.AllocsPerRun(50, func() {
+		var src, dst [1000]float32
+		AbsPow34(dst[:], src[:])
+	}); n != 0 {
+		t.Errorf("AbsPow34 forces %v caller allocations per run, want 0", n)
+	}
+}
+
+// TestAbsPow34_TailUntouched plants sentinels past n=11 (one 8-wide AVX block +
+// 3 tail, two 4-wide NEON blocks + 3 tail) so both vector bodies run and both
+// scalar tails must stop exactly at n.
+func TestAbsPow34_TailUntouched(t *testing.T) {
+	const n = 11
+	src := make([]float32, n)
+	for i := range src {
+		src[i] = float32(i) + 0.5
+	}
+	dst := make([]float32, n+8)
+	for i := range dst {
+		dst[i] = float32(math.NaN()) // sentinel: any write shows up as a non-NaN
+	}
+	sentinelBits := math.Float32bits(dst[0])
+	AbsPow34(dst[:n], src)
+	for i := n; i < len(dst); i++ {
+		if math.Float32bits(dst[i]) != sentinelBits {
+			t.Errorf("AbsPow34 wrote past end at dst[%d] = %v", i, dst[i])
+		}
+	}
+}
+
+// TestAbsPow34_Clamp covers mismatched lengths in both directions, the empty
+// no-op, and nil operands.
+func TestAbsPow34_Clamp(t *testing.T) {
+	src := make([]float32, 40)
+	for i := range src {
+		src[i] = float32(i) * 1.5
+	}
+
+	short := make([]float32, 25)
+	AbsPow34(short, src) // dst shorter: n = 25
+	for i := range short {
+		if want := absPow34Oracle(src[i]); !bitsEqF32(short[i], want) {
+			t.Fatalf("AbsPow34 short dst: dst[%d] = %v, want %v", i, short[i], want)
+		}
+	}
+
+	long := make([]float32, 40)
+	for i := range long {
+		long[i] = -7 // sentinel
+	}
+	AbsPow34(long, src[:25]) // src shorter: long[25:] untouched
+	for i := 25; i < len(long); i++ {
+		if long[i] != -7 {
+			t.Fatalf("AbsPow34 wrote past clamp at dst[%d] = %v", i, long[i])
+		}
+	}
+
+	AbsPow34(nil, nil)
+	one := []float32{42}
+	AbsPow34(one, nil)
+	if one[0] != 42 {
+		t.Errorf("AbsPow34 wrote on empty input: %v", one)
+	}
+}
+
+// TestAbsPow34_Aliasing verifies the documented in-place safety: AbsPow34(x, x)
+// equals the out-of-place result, since each output depends only on its own
+// input element.
+func TestAbsPow34_Aliasing(t *testing.T) {
+	for _, n := range []int{1, 3, 4, 7, 8, 9, 15, 16, 17, 33, 64} {
+		src := make([]float32, n)
+		for i := range src {
+			src[i] = float32(i)*0.75 - 3
+		}
+		want := make([]float32, n)
+		AbsPow34(want, src)
+
+		AbsPow34(src, src) // in place
+		for i := range src {
+			if !bitsEqF32(src[i], want[i]) {
+				t.Fatalf("AbsPow34 in-place n=%d: dst[%d] = %v, want %v", n, i, src[i], want[i])
+			}
+		}
+	}
+}
+
+// TestAbsPow34_UnalignedOperands sweeps all eight element offsets, holding dst
+// and src at different offsets so neither is reliably 16- or 32-byte aligned; an
+// aligned-load or aligned-store substitution cannot survive the suite.
+func TestAbsPow34_UnalignedOperands(t *testing.T) {
+	const span = 320
+	base := make([]float32, span)
+	for i := range base {
+		base[i] = float32(i)*0.5 - 40
+	}
+	backing := make([]float32, span)
+	for _, n := range []int{4, 5, 7, 8, 9, 11, 17, 25, 33, 64, 240} {
+		for off := range 8 {
+			src := base[off+1 : off+1+n]
+			dst := backing[off+3 : off+3+n]
+			AbsPow34(dst, src)
+			for i := range n {
+				if want := absPow34Oracle(src[i]); !bitsEqF32(dst[i], want) {
+					t.Fatalf("AbsPow34 unaligned n=%d off=%d: dst[%d] = %v, want %v", n, off, i, dst[i], want)
+				}
+			}
+		}
+	}
+}
+
+// FuzzAbsPow34 differentially fuzzes the dispatched AbsPow34 against absPow34Go
+// over arbitrary bit patterns (organically producing NaN, Inf, and subnormals).
+// The two are bit-identical by construction, so any lane may be compared exactly
+// (NaN treated as equal to NaN).
+func FuzzAbsPow34(f *testing.F) {
+	addByteLenSeeds(f)
+	f.Fuzz(func(t *testing.T, raw []byte) {
+		src := f32sBits(raw)
+		got := make([]float32, len(src))
+		want := make([]float32, len(src))
+		AbsPow34(got, src)
+		absPow34Go(want, src)
+		for i := range got {
+			if !bitsEqF32(got[i], want[i]) {
+				t.Fatalf("AbsPow34 lane %d (src=%v [%#08x]): got %v [%#08x] want %v [%#08x] (len=%d)",
+					i, src[i], math.Float32bits(src[i]),
+					got[i], math.Float32bits(got[i]),
+					want[i], math.Float32bits(want[i]), len(src))
+			}
+		}
+	})
+}

--- a/f32/benchmark_test.go
+++ b/f32/benchmark_test.go
@@ -309,6 +309,28 @@ func BenchmarkAbs(b *testing.B) {
 	}
 }
 
+func BenchmarkAbsPow34(b *testing.B) {
+	for _, size := range benchSizes {
+		a, _, _, dst := makeBenchData32(size)
+		// Include negatives; AbsPow34 takes the magnitude before the power.
+		for i := 0; i < len(a); i += 2 {
+			a[i] = -a[i]
+		}
+		b.Run(fmt.Sprintf("SIMD_%d", size), func(b *testing.B) {
+			for i := 0; i < b.N; i++ {
+				AbsPow34(dst, a)
+			}
+			reportThroughput32(b, size*2)
+		})
+		b.Run(fmt.Sprintf("Go_%d", size), func(b *testing.B) {
+			for i := 0; i < b.N; i++ {
+				absPow34Go(dst, a)
+			}
+			reportThroughput32(b, size*2)
+		})
+	}
+}
+
 func BenchmarkNeg(b *testing.B) {
 	for _, size := range benchSizes {
 		a, _, _, dst := makeBenchData32(size)

--- a/f32/f32.go
+++ b/f32/f32.go
@@ -432,12 +432,58 @@ func DeinterleaveN(dsts [][]float32, src []float32) {
 
 // Sqrt computes element-wise square root: dst[i] = sqrt(a[i]).
 // Processes min(len(dst), len(a)) elements.
+//
+// The result is IEEE-754 correctly-rounded (round-to-nearest, ties to even) on
+// every backend: for each input it returns the float32 nearest the true square
+// root. This holds for VSQRTPS/SQRTPS on amd64 and FSQRT on arm64 (IEEE-754
+// mandates a correctly-rounded sqrt), and for the pure-Go fallback, which
+// computes float32(math.Sqrt(float64(x))). That fallback is a double rounding
+// (the correctly-rounded binary64 sqrt, then narrowed to binary32), yet it is
+// provably identical to the correctly-rounded binary32 sqrt: double rounding
+// through an intermediate format is innocuous for sqrt when the intermediate
+// carries at least 2*p+2 significand bits, and binary64's 53 bits exceed the
+// 2*24+2 = 50 that binary32 (p = 24) requires. All three backends therefore
+// return the same bits, so callers may compose bit-exact higher powers on top of
+// Sqrt (for example [AbsPow34]).
 func Sqrt(dst, a []float32) {
 	n := min(len(dst), len(a))
 	if n == 0 {
 		return
 	}
 	sqrt32(dst[:n], a[:n])
+}
+
+// AbsPow34 computes the element-wise 3/4 power of the magnitude:
+//
+//	dst[i] = |src[i]|^(3/4)
+//
+// evaluated as sqrt(|src[i]| * sqrt(|src[i]|)). Processes min(len(dst), len(src))
+// elements. dst may alias src (each output depends only on the matching input
+// element), so AbsPow34(x, x) computes the transform in place.
+//
+// This is the fused form of the C expression sqrtf(a * sqrtf(a)) with a = |x|,
+// and it is bit-identical to that expression on every backend: abs is exact, the
+// two square roots are IEEE-754 correctly-rounded (see [Sqrt]), and the middle
+// multiply is a single correctly-rounded float32 product. There is no add, so
+// the library's no-FMA contract does not apply. The result is the same bits on
+// VANDPS/VSQRTPS/VMULPS (amd64), FABS/FSQRT/FMUL (arm64), and the pure-Go
+// fallback; there is no relaxed tier.
+//
+// Range behavior is part of the contract, and this is NOT a full-range 3/4
+// power. The intermediate |x| * sqrt(|x|) is computed in float32, so it
+// overflows to +Inf once |x| exceeds about 2^85.33 (for example x = 2^100, whose
+// true |x|^0.75 = 2^75 is representable, still yields +Inf) and underflows to 0
+// for tiny |x| (for example x = 2^-100, true 2^-75, yields 0). This exactly
+// mirrors the C fused form. For an approximate 3/4 power over the whole range
+// without this intermediate saturation, use [Pow] with exp = 0.75. Edge cases:
+// 0 -> 0, +-Inf -> +Inf, NaN -> NaN (the NaN payload bits are not guaranteed
+// identical across backends, matching the rest of f32). It allocates nothing.
+func AbsPow34(dst, src []float32) {
+	n := min(len(dst), len(src))
+	if n == 0 {
+		return
+	}
+	absPow34_32(dst[:n], src[:n])
 }
 
 // Round rounds each element to the nearest integer, half away from zero:

--- a/f32/f32_amd64.go
+++ b/f32/f32_amd64.go
@@ -304,6 +304,27 @@ func sqrt32(dst, a []float32) {
 	sqrtImpl(dst, a)
 }
 
+// absPow34_32 dispatches AbsPow34 directly to a //go:noescape kernel (rather than
+// through a function-pointer table) so the caller's dst/src do not escape to the
+// heap: an indirect call through a func value defeats //go:noescape and forces a
+// per-call allocation, which would break the zero-allocation contract. The
+// direct-dispatch shape mirrors the exp/relu/pow family in this file. AbsPow34
+// needs no FMA, so plain AVX gates the VEX kernel (AVX-512 CPUs also have AVX and
+// run it bit-identically). Unlike exp/relu/pow, no minimum-length guard is needed:
+// like the element-wise abs/neg/sqrt kernels, these compute the block count with a
+// shift and fall through to a scalar tail for short inputs, so a full-width load is
+// never issued out of bounds.
+func absPow34_32(dst, src []float32) {
+	switch {
+	case cpu.X86.AVX:
+		absPow34AVX(dst, src)
+	case cpu.X86.SSE2:
+		absPow34SSE(dst, src)
+	default:
+		absPow34Go(dst, src)
+	}
+}
+
 func reciprocal32(dst, a []float32) {
 	reciprocalImpl(dst, a)
 }
@@ -842,6 +863,9 @@ func clampScaleAVX(dst, src []float32, minVal, maxVal, scale float32)
 func sqrtAVX(dst, a []float32)
 
 //go:noescape
+func absPow34AVX(dst, src []float32)
+
+//go:noescape
 func roundAVX(dst, src []float32)
 
 //go:noescape
@@ -970,6 +994,9 @@ func clampSSE(dst, a []float32, minVal, maxVal float32)
 
 //go:noescape
 func sqrtSSE(dst, a []float32)
+
+//go:noescape
+func absPow34SSE(dst, src []float32)
 
 //go:noescape
 func reciprocalSSE(dst, a []float32)

--- a/f32/f32_amd64.s
+++ b/f32/f32_amd64.s
@@ -666,6 +666,54 @@ abs32_done:
     VZEROUPPER
     RET
 
+// func absPow34AVX(dst, src []float32)
+// dst[i] = |src[i]|^(3/4) = sqrt(|x| * sqrt(|x|)). Four single correctly-rounded
+// float32 ops per lane: VANDPS (abs) -> VSQRTPS -> VMULPS -> VSQRTPS. No add, so
+// the no-FMA contract is not in play; the middle product stays in float32 so it
+// overflows/underflows exactly as C's sqrtf(a*sqrtf(a)) does.
+TEXT ·absPow34AVX(SB), NOSPLIT, $0-48
+    MOVQ dst_base+0(FP), DX
+    MOVQ dst_len+8(FP), CX
+    MOVQ src_base+24(FP), SI
+
+    VMOVUPS absf32mask<>(SB), Y2   // Y2 = abs mask (X2 = low 128 for the tail)
+
+    MOVQ CX, AX
+    SHRQ $3, AX
+    JZ   abspow34_avx_remainder
+
+abspow34_avx_loop8:
+    VMOVUPS (SI), Y0
+    VANDPS Y0, Y2, Y0          // Y0 = |x|
+    VSQRTPS Y0, Y1            // Y1 = sqrt(|x|)
+    VMULPS Y0, Y1, Y1        // Y1 = |x| * sqrt(|x|)
+    VSQRTPS Y1, Y1          // Y1 = sqrt(|x| * sqrt(|x|))
+    VMOVUPS Y1, (DX)
+    ADDQ $32, SI
+    ADDQ $32, DX
+    DECQ AX
+    JNZ  abspow34_avx_loop8
+
+abspow34_avx_remainder:
+    ANDQ $7, CX
+    JZ   abspow34_avx_done
+
+abspow34_avx_scalar:
+    VMOVSS (SI), X0
+    VANDPS X0, X2, X0
+    VSQRTSS X0, X0, X1
+    VMULSS X0, X1, X1
+    VSQRTSS X1, X1, X1
+    VMOVSS X1, (DX)
+    ADDQ $4, SI
+    ADDQ $4, DX
+    DECQ CX
+    JNZ  abspow34_avx_scalar
+
+abspow34_avx_done:
+    VZEROUPPER
+    RET
+
 // func negAVX(dst, a []float32)
 TEXT ·negAVX(SB), NOSPLIT, $0-48
     MOVQ dst_base+0(FP), DX
@@ -1981,6 +2029,51 @@ abs32_sse_scalar:
     JNZ  abs32_sse_scalar
 
 abs32_sse_done:
+    RET
+
+// func absPow34SSE(dst, src []float32)
+// SSE2 form of AbsPow34: ANDPS (abs) -> SQRTPS -> MULPS -> SQRTPS, 4 lanes per
+// block plus a scalar tail. Bit-identical to absPow34AVX and absPow34Go.
+TEXT ·absPow34SSE(SB), NOSPLIT, $0-48
+    MOVQ dst_base+0(FP), DX
+    MOVQ dst_len+8(FP), CX
+    MOVQ src_base+24(FP), SI
+
+    MOVUPS absf32mask<>(SB), X2
+
+    MOVQ CX, AX
+    SHRQ $2, AX
+    JZ   abspow34_sse_remainder
+
+abspow34_sse_loop4:
+    MOVUPS (SI), X0
+    ANDPS X2, X0             // X0 = |x|
+    SQRTPS X0, X1           // X1 = sqrt(|x|)
+    MULPS X0, X1           // X1 = |x| * sqrt(|x|)
+    SQRTPS X1, X1         // X1 = sqrt(|x| * sqrt(|x|))
+    MOVUPS X1, (DX)
+    ADDQ $16, SI
+    ADDQ $16, DX
+    DECQ AX
+    JNZ  abspow34_sse_loop4
+
+abspow34_sse_remainder:
+    ANDQ $3, CX
+    JZ   abspow34_sse_done
+
+abspow34_sse_scalar:
+    MOVSS (SI), X0
+    ANDPS X2, X0
+    SQRTSS X0, X1
+    MULSS X0, X1
+    SQRTSS X1, X1
+    MOVSS X1, (DX)
+    ADDQ $4, SI
+    ADDQ $4, DX
+    DECQ CX
+    JNZ  abspow34_sse_scalar
+
+abspow34_sse_done:
     RET
 
 // func negSSE(dst, a []float32)

--- a/f32/f32_arm64.go
+++ b/f32/f32_arm64.go
@@ -527,6 +527,14 @@ func sqrt32(dst, a []float32) {
 	sqrt32Go(dst, a)
 }
 
+func absPow34_32(dst, src []float32) {
+	if hasNEON && len(dst) >= 4 {
+		absPow34NEON(dst, src)
+		return
+	}
+	absPow34Go(dst, src)
+}
+
 func round32(dst, src []float32) {
 	if hasNEON && len(dst) >= 4 {
 		roundNEON(dst, src)
@@ -615,6 +623,9 @@ func cumulativeSum32(dst, a []float32) {
 
 //go:noescape
 func sqrtNEON(dst, a []float32)
+
+//go:noescape
+func absPow34NEON(dst, src []float32)
 
 //go:noescape
 func roundNEON(dst, src []float32)

--- a/f32/f32_arm64.s
+++ b/f32/f32_arm64.s
@@ -1024,6 +1024,53 @@ sqrt32_loop1:
 sqrt32_done:
     RET
 
+// absPow34NEON: dst[i] = |src[i]|^(3/4) = sqrt(|x| * sqrt(|x|)).
+// FABS -> FSQRT -> FMUL -> FSQRT, four lanes per block plus a scalar tail. abs is
+// exact, both sqrts are IEEE-754 correctly-rounded (FSQRT) and the middle product
+// is a single correctly-rounded FMUL, so this is bit-identical to the amd64 and
+// Go paths. The middle product stays in float32, overflowing/underflowing exactly
+// as C's sqrtf(a*sqrtf(a)). The vector float ops are WORD-encoded (Go's arm64
+// assembler has no NEON mnemonics); each WORD's comment is cross-checked against
+// arm64asm by TestArm64WordEncodings.
+//
+// func absPow34NEON(dst, src []float32)
+TEXT ·absPow34NEON(SB), NOSPLIT, $0-48
+    MOVD dst_base+0(FP), R0
+    MOVD dst_len+8(FP), R2
+    MOVD src_base+24(FP), R1
+
+    LSR $2, R2, R3
+    CBZ R3, abspow34_scalar
+
+abspow34_loop4:
+    VLD1.P 16(R1), [V0.S4]
+    WORD $0x4EA0F800           // FABS V0.4S, V0.4S
+    WORD $0x6EA1F801           // FSQRT V1.4S, V0.4S
+    WORD $0x6E21DC01           // FMUL V1.4S, V0.4S, V1.4S
+    WORD $0x6EA1F821           // FSQRT V1.4S, V1.4S
+    VST1.P [V1.S4], 16(R0)
+    SUB $1, R3
+    CBNZ R3, abspow34_loop4
+
+abspow34_scalar:
+    AND $3, R2
+    CBZ R2, abspow34_done
+
+abspow34_loop1:
+    FMOVS (R1), F0
+    FABSS F0, F0
+    FSQRTS F0, F1
+    FMULS F0, F1, F1
+    FSQRTS F1, F1
+    FMOVS F1, (R0)
+    ADD $4, R0
+    ADD $4, R1
+    SUB $1, R2
+    CBNZ R2, abspow34_loop1
+
+abspow34_done:
+    RET
+
 // roundNEON: round-half-away-from-zero using FRINTA (round to nearest, ties to
 // away), which matches math.Round exactly. The float32 analogue of f64's
 // roundNEON.

--- a/f32/f32_go.go
+++ b/f32/f32_go.go
@@ -424,6 +424,26 @@ func sqrt32Go(dst, a []float32) {
 	}
 }
 
+// absPow34Go is the pure-Go reference for AbsPow34: dst[i] = |src[i]|^(3/4),
+// evaluated as sqrt(|x| * sqrt(|x|)) with every step at float32 precision so it
+// matches the SIMD kernels bit-for-bit. The middle multiply MUST stay in float32
+// (p := ax * s, both operands float32): widening it to float64 would suppress the
+// intermediate overflow to +Inf (for |x| >~ 2^85.33) and underflow to 0 (tiny
+// |x|) that are part of the AbsPow34 contract, mirroring C's sqrtf(a*sqrtf(a)).
+// See the AbsPow34 doc comment.
+func absPow34Go(dst, src []float32) {
+	if len(dst) == 0 {
+		return
+	}
+	_ = src[len(dst)-1]
+	for i := range dst {
+		ax := math.Float32frombits(math.Float32bits(src[i]) &^ (1 << float32SignBitPos))
+		s := float32(math.Sqrt(float64(ax)))
+		p := ax * s // genuine float32 product: overflows to +Inf / underflows to 0
+		dst[i] = float32(math.Sqrt(float64(p)))
+	}
+}
+
 // round32Go rounds each element to the nearest integer, half away from zero,
 // matching math.Round. This is the trusted reference and the path that runs on
 // architectures without SIMD.

--- a/f32/f32_other.go
+++ b/f32/f32_other.go
@@ -44,6 +44,7 @@ func deinterleaveN32(dsts [][]float32, src []float32, n int) {
 	deinterleaveNGo(dsts, src, n)
 }
 func sqrt32(dst, a []float32)                               { sqrt32Go(dst, a) }
+func absPow34_32(dst, src []float32)                        { absPow34Go(dst, src) }
 func round32(dst, src []float32)                            { round32Go(dst, src) }
 func reciprocal32(dst, a []float32)                         { reciprocal32Go(dst, a) }
 func minIdx32(a []float32) int                              { return minIdxGo(a) }

--- a/f32/sqrt_rounding_test.go
+++ b/f32/sqrt_rounding_test.go
@@ -45,17 +45,19 @@ func sqrtCorrectOracle(x float32) float32 {
 }
 
 // sqrtSweepInputs builds the representative input sweep from the design: specials
-// (0, -0, +Inf, NaN), perfect squares, all powers of two and four, a dense
-// contiguous band of float32 bit patterns around 1.0, a full-range exponent
-// sweep, subnormals, constructed near-midpoint targets, and random draws across
-// the whole positive range. Exhaustive portions shrink under -short.
+// (0, -0, +Inf, NaN), small integers and half-integers, all powers of two and
+// four, a dense contiguous band of float32 bit patterns around 1.0, a full-range
+// exponent sweep, subnormals, constructed near-midpoint targets, and random draws
+// across the whole positive range. Exhaustive portions shrink under -short.
 func sqrtSweepInputs(short bool) []float32 {
 	in := make([]float32, 0, 1<<21)
 
-	// Specials and small perfect squares (exact roots).
+	// Specials, then every small integer and half-integer up to 2048. The perfect
+	// squares among them have exact roots; the rest have irrational roots that
+	// exercise the rounding decision.
 	in = append(in, 0, float32(math.Copysign(0, -1)), float32(math.Inf(1)), float32(math.NaN()))
 	for k := 0; k <= 2048; k++ {
-		in = append(in, float32(k), float32(k)*0.5) // perfect squares and half-integers
+		in = append(in, float32(k), float32(k)*0.5) // all integers and half-integers 0..2048
 	}
 
 	// All powers of two (even exponents are also the powers of four): exact roots

--- a/f32/sqrt_rounding_test.go
+++ b/f32/sqrt_rounding_test.go
@@ -1,0 +1,183 @@
+package f32
+
+import (
+	"math"
+	"math/big"
+	"math/rand"
+	"testing"
+)
+
+// This file empirically establishes the documented Sqrt contract: f32.Sqrt is
+// IEEE-754 correctly-rounded (round-to-nearest, ties to even) on every backend,
+// including the pure-Go fallback whose float32(math.Sqrt(float64(x))) is a double
+// rounding. The oracle is an independent math/big.Float square root rounded to
+// float32; if the dispatched SIMD path AND the pure-Go path both match it
+// bit-for-bit across the sweep, the doc claim holds on the running architecture
+// (NEON here, AVX/SSE under GOARCH=amd64). See the Sqrt doc comment.
+
+// bigSqrtToF32 returns the correctly-rounded float32 square root of v via a
+// 240-bit big.Float, independent of math.Sqrt and of the hardware sqrt. 240 bits
+// is far above 2*24+2, so rounding the big result to float32 is itself a benign
+// double rounding and yields the correctly-rounded binary32 sqrt.
+func bigSqrtToF32(v float32) float32 {
+	bf := new(big.Float).SetPrec(240).SetFloat64(float64(v)) // exact: float32 -> float64
+	bf.Sqrt(bf)
+	out, _ := bf.Float32()
+	return out
+}
+
+// sqrtCorrectOracle is the correctly-rounded reference for sqrt over the tested
+// domain: non-negative finite inputs plus 0, +Inf, and NaN. Negatives (which the
+// sweep does not use) and NaN map to NaN, matching every backend.
+func sqrtCorrectOracle(x float32) float32 {
+	switch {
+	case x != x: // NaN
+		return float32(math.NaN())
+	case x < 0:
+		return float32(math.NaN())
+	case math.IsInf(float64(x), 1):
+		return float32(math.Inf(1))
+	case x == 0:
+		return x // sqrt(+0) = +0, sqrt(-0) = -0 (sign preserved)
+	default:
+		return bigSqrtToF32(x)
+	}
+}
+
+// sqrtSweepInputs builds the representative input sweep from the design: specials
+// (0, -0, +Inf, NaN), perfect squares, all powers of two and four, a dense
+// contiguous band of float32 bit patterns around 1.0, a full-range exponent
+// sweep, subnormals, constructed near-midpoint targets, and random draws across
+// the whole positive range. Exhaustive portions shrink under -short.
+func sqrtSweepInputs(short bool) []float32 {
+	in := make([]float32, 0, 1<<21)
+
+	// Specials and small perfect squares (exact roots).
+	in = append(in, 0, float32(math.Copysign(0, -1)), float32(math.Inf(1)), float32(math.NaN()))
+	for k := 0; k <= 2048; k++ {
+		in = append(in, float32(k), float32(k)*0.5) // perfect squares and half-integers
+	}
+
+	// All powers of two (even exponents are also the powers of four): exact roots
+	// at 2^(2k), and 2^k*sqrt(2) irrational roots at 2^(2k+1).
+	for e := -149; e <= 127; e++ {
+		in = append(in, float32(math.Ldexp(1, e)))
+	}
+
+	// Dense contiguous band of float32 values straddling 1.0. This is where the
+	// bulk of the rounding decisions live.
+	oneBits := math.Float32bits(1.0)
+	band := uint32(1 << 18)
+	if short {
+		band = 1 << 12
+	}
+	for d := uint32(1); d <= band; d++ {
+		in = append(in, math.Float32frombits(oneBits-d), math.Float32frombits(oneBits+d))
+	}
+
+	// Full-range exponent sweep: every binade, several mantissa fractions.
+	for e := -140; e <= 120; e++ {
+		base := math.Ldexp(1, e)
+		for f := range 16 {
+			in = append(in, float32(base*(1.0+float64(f)/16.0)))
+		}
+	}
+
+	// Subnormals: the smallest positive float32 values.
+	for bits := uint32(1); bits <= 4096; bits++ {
+		in = append(in, math.Float32frombits(bits))
+	}
+
+	rng := rand.New(rand.NewSource(0x59A17)) //nolint:gosec // deterministic test vectors
+
+	// Constructed near-midpoint targets: for random representable r, the exact
+	// midpoint m between r and its successor is squared and rounded to float32, so
+	// sqrt of the result sits on a rounding boundary. Feeding m*m and its float32
+	// neighbours probes whether the backend rounds the boundary the same way the
+	// oracle does.
+	midCount := 40000
+	if short {
+		midCount = 2000
+	}
+	for range midCount {
+		e := rng.Intn(120) - 60
+		r := float32(math.Ldexp(1+rng.Float64(), e))
+		next := math.Nextafter32(r, float32(math.Inf(1)))
+		m := (float64(r) + float64(next)) / 2 // exact in float64: r, next are adjacent float32
+		x := float32(m * m)
+		in = append(in,
+			x,
+			math.Nextafter32(x, float32(math.Inf(1))),
+			math.Nextafter32(x, 0),
+		)
+	}
+
+	// Random draws across the whole positive float32 range (any bit pattern,
+	// keeping only non-negative finite values).
+	randCount := 200000
+	if short {
+		randCount = 5000
+	}
+	for range randCount {
+		x := math.Float32frombits(rng.Uint32() & 0x7fffffff) // clear sign bit
+		if math.IsInf(float64(x), 0) || x != x {
+			continue
+		}
+		in = append(in, x)
+	}
+
+	return in
+}
+
+// TestSqrt_CorrectlyRounded verifies both the dispatched f32.Sqrt (the running
+// architecture's SIMD kernel, NEON here or AVX/SSE under Rosetta) and the pure-Go
+// sqrt32Go against the big.Float oracle, bit-for-bit, over the whole sweep. A
+// non-multiple-of-4 total length plus a one-element shift exercise the SIMD
+// scalar tail with different values in it.
+func TestSqrt_CorrectlyRounded(t *testing.T) {
+	in := sqrtSweepInputs(testing.Short())
+	t.Logf("sweep size: %d inputs", len(in))
+
+	check := func(name string, got []float32, src []float32) {
+		for i := range got {
+			want := sqrtCorrectOracle(src[i])
+			if !bitsEqF32(got[i], want) {
+				t.Fatalf("%s: Sqrt(%v [%#08x]) = %v [%#08x], want %v [%#08x]",
+					name, src[i], math.Float32bits(src[i]),
+					got[i], math.Float32bits(got[i]),
+					want, math.Float32bits(want))
+			}
+		}
+	}
+
+	// Dispatched path over the full slice (SIMD vector body + tail).
+	dst := make([]float32, len(in))
+	Sqrt(dst, in)
+	check("Sqrt(full)", dst, in)
+
+	// Shifted by one so different values land in the SIMD scalar tail.
+	if len(in) > 1 {
+		src := in[1:]
+		d2 := make([]float32, len(src))
+		Sqrt(d2, src)
+		check("Sqrt(shift1)", d2, src)
+	}
+
+	// Small lengths (1..3) exercise the arm64 NEON dispatcher's sub-block Go
+	// fallback (len < 4) and the scalar-only path on every backend, which the large
+	// full and shift1 slices above never reach. A mid-sweep window keeps the values
+	// normal rather than the leading specials.
+	mid := len(in) / 2
+	for n := 1; n <= 3 && mid+n <= len(in); n++ {
+		src := in[mid : mid+n]
+		dn := make([]float32, n)
+		Sqrt(dn, src)
+		check("Sqrt(smallN)", dn, src)
+	}
+
+	// Pure-Go path directly: this is the double-rounding claim under test,
+	// independent of which SIMD kernel the dispatcher would pick.
+	dgo := make([]float32, len(in))
+	sqrt32Go(dgo, in)
+	check("sqrt32Go", dgo, in)
+}


### PR DESCRIPTION
Closes #183.

Two deliverables.

**1. Documents `f32.Sqrt` as IEEE-754 correctly-rounded** (round-to-nearest-even) on every backend. `VSQRTPS`/`SQRTPS` (amd64) and `FSQRT` (arm64) are correctly-rounded by the ISA. The Go fallback computes `float32(math.Sqrt(float64(x)))`; that double rounding is provably innocuous for square root because binary64's 53-bit significand exceeds the `2*24+2 = 50` bits the classical result requires for `+ - * / sqrt`, so it returns the correctly-rounded binary32 result for every input. This lets callers compose bit-exact higher powers.

**2. Adds `f32.AbsPow34(dst, src []float32)`:** `dst[i] = |src[i]|^(3/4)` via `sqrt(|x| * sqrt(|x|))`, mirroring the C `sqrtf(a * sqrtf(a))` bit-for-bit. Backends: amd64 AVX (`VANDPS`/`VSQRTPS`/`VMULPS`/`VSQRTPS`) and SSE, arm64 NEON (hand-encoded `FABS`/`FSQRT`/`FMUL`/`FSQRT`), and a Go fallback. Each element is three single correctly-rounded float32 ops (no add, so the no-FMA contract is not in play), so the result is bit-identical across all backends with no relaxed tier, and `dst` may alias `src`.

**Contract note:** the intermediate `|x| * sqrt(|x|)` is a float32 multiply, so like the C form it saturates to `+Inf` for `|x|` above roughly `2^85.33` and underflows to `0` for very small `|x|`, even though the true `|x|^(3/4)` would be representable. This is intentional and matches the reference sample-for-sample; callers needing the full-range 3/4 power should use the approximate `Pow`. The Go reference keeps the middle multiply in float32 so it reproduces this exactly.

**Tests:** `TestSqrt_CorrectlyRounded` and `TestAbsPow34` validate bit-for-bit against an independent `math/big.Float` oracle over dense sweeps (bands around 1.0, powers of two and four, subnormals, near-midpoints, the overflow/underflow thresholds, `MaxFloat32`, `SmallestNonzeroFloat32`, `0`/`+Inf`/`NaN`/`-0.0`), plus alloc-free, tail-untouched, clamp, aliasing, unaligned-operand, dispatch-pin, and differential-fuzz coverage, and a `BenchmarkAbsPow34`.

**Hardware verification:** verified bit-exact on real hardware. AVX2 (i7-1260P) ran the AVX and SSE kernels; NEON (Raspberry Pi 5) ran the `FSQRT`/NEON kernels; both matched the `big.Float` oracle across the full sweep, allocs = 0.

Note for reviewers: the amd64 dispatch for AbsPow34 uses a direct `cpu.X86.AVX`/`SSE2` switch rather than the function-pointer table, matching the exp/relu/pow family, because an indirect call through a func value defeats `//go:noescape` and forced 2 allocs/run, breaking the zero-alloc contract.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added `AbsPow34` for element-wise 3/4-power magnitude calculations on float32 data.
  * Added optimized support across supported CPU architectures with automatic fallback behavior.
  * Expanded `Sqrt` documentation to describe its correctly rounded IEEE-754 results.

* **Tests**
  * Added comprehensive correctness, edge-case, aliasing, allocation, dispatch, and fuzz coverage.
  * Added validation for correctly rounded square-root results.

* **Benchmarks**
  * Added throughput benchmarks comparing optimized and Go implementations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->