### PR TITLE
f32: add CopySign, an exact elementwise IEEE copysign (#182)

### DIFF
--- a/f32/benchmark_test.go
+++ b/f32/benchmark_test.go
@@ -331,6 +331,24 @@ func BenchmarkAbsPow34(b *testing.B) {
 	}
 }
 
+func BenchmarkCopySign(b *testing.B) {
+	for _, size := range benchSizes {
+		mag, sign, _, dst := makeBenchData32(size)
+		b.Run(fmt.Sprintf("SIMD_%d", size), func(b *testing.B) {
+			for i := 0; i < b.N; i++ {
+				CopySign(dst, mag, sign)
+			}
+			reportThroughput32(b, size*3)
+		})
+		b.Run(fmt.Sprintf("Go_%d", size), func(b *testing.B) {
+			for i := 0; i < b.N; i++ {
+				copySign32Go(dst, mag, sign)
+			}
+			reportThroughput32(b, size*3)
+		})
+	}
+}
+
 func BenchmarkNeg(b *testing.B) {
 	for _, size := range benchSizes {
 		a, _, _, dst := makeBenchData32(size)

--- a/f32/copysign_amd64_test.go
+++ b/f32/copysign_amd64_test.go
@@ -1,0 +1,137 @@
+//go:build amd64
+
+package f32
+
+import (
+	"math"
+	"testing"
+
+	"github.com/tphakala/simd/cpu"
+)
+
+// copySignInterestingInputs returns a compact mag/sign pair set that stresses the
+// CopySign contract: signed zeros, infinities, both-signed NaN, the float32
+// extremes, subnormals, and normals of both signs.
+func copySignInterestingInputs() (mag, sign []float32) {
+	m := copySignMagValues()
+	s := copySignSignValues()
+	mag = make([]float32, 0, len(m))
+	sign = make([]float32, 0, len(m))
+	for i := range m {
+		mag = append(mag, m[i])
+		sign = append(sign, s[i%len(s)])
+	}
+	return mag, sign
+}
+
+// tiledCopySignInputs repeats the interesting pairs until at least minLen long so
+// a prefix at every length exercises the vector body and every scalar-tail
+// remainder of the 8-wide AVX and 4-wide SSE kernels.
+func tiledCopySignInputs(minLen int) (mag, sign []float32) {
+	bm, bs := copySignInterestingInputs()
+	for len(mag) < minLen {
+		mag = append(mag, bm...)
+		sign = append(sign, bs...)
+	}
+	return mag, sign
+}
+
+// checkCopySignKernel drives kern directly over every prefix length so a
+// dispatcher threshold change can never quietly reduce this to a test of the Go
+// reference against itself. Each result must be bit-identical to copySign32Go.
+func checkCopySignKernel(t *testing.T, name string, kern func(dst, mag, sign []float32)) {
+	t.Helper()
+	mag, sign := tiledCopySignInputs(64)
+	for n := 1; n <= len(mag); n++ {
+		m := mag[:n]
+		s := sign[:n]
+		got := make([]float32, n)
+		want := make([]float32, n)
+		kern(got, m, s)
+		copySign32Go(want, m, s)
+		for i := range got {
+			if !bitsEqF32(got[i], want[i]) {
+				t.Fatalf("%s n=%d lane %d: mag=%v[%#08x] sign=%v[%#08x] got %v[%#08x] want %v[%#08x]",
+					name, n, i, m[i], math.Float32bits(m[i]), s[i], math.Float32bits(s[i]),
+					got[i], math.Float32bits(got[i]), want[i], math.Float32bits(want[i]))
+			}
+		}
+	}
+}
+
+func TestCopySignAVX_ParityWithGo(t *testing.T) {
+	if !cpu.X86.AVX {
+		t.Skip("AVX not available")
+	}
+	checkCopySignKernel(t, "copySignAVX", copySignAVX)
+}
+
+func TestCopySignSSE_ParityWithGo(t *testing.T) {
+	if !cpu.X86.SSE2 {
+		t.Skip("SSE2 not available")
+	}
+	checkCopySignKernel(t, "copySignSSE", copySignSSE)
+}
+
+// TestCopySignKernels_AllocFree asserts the kernels run allocation-free at the
+// kernel boundary, mirroring the public-API alloc test.
+func TestCopySignKernels_AllocFree(t *testing.T) {
+	const n = 1024
+	mag := make([]float32, n)
+	sign := make([]float32, n)
+	dst := make([]float32, n)
+	kernels := []struct {
+		name string
+		fn   func()
+		skip bool
+	}{
+		{"copySignAVX", func() { copySignAVX(dst, mag, sign) }, !cpu.X86.AVX},
+		{"copySignSSE", func() { copySignSSE(dst, mag, sign) }, !cpu.X86.SSE2},
+	}
+	for _, k := range kernels {
+		if k.skip {
+			continue
+		}
+		if got := testing.AllocsPerRun(100, k.fn); got != 0 {
+			t.Errorf("%s allocated %v times per run, want 0", k.name, got)
+		}
+	}
+}
+
+// TestCopySignDispatch_amd64 runs the public CopySign against the exact kernel the
+// direct-branch dispatcher (copySign32) should select for the detected CPU
+// features, over lengths that straddle the block boundaries. Because AVX, SSE, and
+// the Go fallback are bit-identical by design, this output comparison confirms the
+// dispatched path returns correct bits but cannot by itself prove WHICH kernel ran
+// (a silent Go fallback produces the same bits); that the SIMD branch is actually
+// taken is confirmed by coverage instrumentation on a host that has the feature.
+// It is white-box (reads the cpu flags the dispatcher reads) and must not call
+// t.Parallel().
+func TestCopySignDispatch_amd64(t *testing.T) {
+	mag, sign := tiledCopySignInputs(64)
+
+	var want func(dst, mag, sign []float32)
+	switch {
+	case cpu.X86.AVX:
+		want = copySignAVX
+	case cpu.X86.SSE2:
+		want = copySignSSE
+	default:
+		want = copySign32Go
+	}
+
+	for _, n := range []int{1, 4, 7, 8, 15, 16, 33, len(mag)} {
+		m := mag[:n]
+		s := sign[:n]
+		gotDispatch := make([]float32, n)
+		gotKernel := make([]float32, n)
+		CopySign(gotDispatch, m, s)
+		want(gotKernel, m, s)
+		for i := range gotDispatch {
+			if !bitsEqF32(gotDispatch[i], gotKernel[i]) {
+				t.Fatalf("n=%d: CopySign dispatched to a different kernel than expected at lane %d: got %v want %v",
+					n, i, gotDispatch[i], gotKernel[i])
+			}
+		}
+	}
+}

--- a/f32/copysign_arm64_test.go
+++ b/f32/copysign_arm64_test.go
@@ -1,0 +1,108 @@
+//go:build arm64
+
+package f32
+
+import (
+	"math"
+	"testing"
+
+	"github.com/tphakala/simd/cpu"
+)
+
+// copySignInterestingInputs returns a compact mag/sign pair set that stresses the
+// CopySign contract: signed zeros, infinities, both-signed NaN, the float32
+// extremes, subnormals, and normals of both signs.
+func copySignInterestingInputs() (mag, sign []float32) {
+	m := copySignMagValues()
+	s := copySignSignValues()
+	mag = make([]float32, 0, len(m))
+	sign = make([]float32, 0, len(m))
+	for i := range m {
+		mag = append(mag, m[i])
+		sign = append(sign, s[i%len(s)])
+	}
+	return mag, sign
+}
+
+// tiledCopySignInputs repeats the interesting pairs until at least minLen long so
+// a prefix at every length exercises the vector body and every scalar-tail
+// remainder of the 4-wide NEON kernel.
+func tiledCopySignInputs(minLen int) (mag, sign []float32) {
+	bm, bs := copySignInterestingInputs()
+	for len(mag) < minLen {
+		mag = append(mag, bm...)
+		sign = append(sign, bs...)
+	}
+	return mag, sign
+}
+
+// TestCopySignNEON_ParityWithGo drives the hand-encoded NEON kernel directly over
+// every prefix length, catching a wrong WORD (the BIT insert or the DUP mask
+// broadcast), a mishandled 4-element remainder, a dropped scalar tail, or a lane
+// error that SIMD-vs-SIMD agreement would miss. Each result must be bit-identical
+// to copySign32Go.
+func TestCopySignNEON_ParityWithGo(t *testing.T) {
+	if !hasNEON {
+		t.Skip("NEON required")
+	}
+	mag, sign := tiledCopySignInputs(64)
+	for n := 1; n <= len(mag); n++ {
+		m := mag[:n]
+		s := sign[:n]
+		got := make([]float32, n)
+		want := make([]float32, n)
+		copySignNEON(got, m, s)
+		copySign32Go(want, m, s)
+		for i := range got {
+			if !bitsEqF32(got[i], want[i]) {
+				t.Fatalf("copySignNEON n=%d lane %d: mag=%v[%#08x] sign=%v[%#08x] got %v[%#08x] want %v[%#08x]",
+					n, i, m[i], math.Float32bits(m[i]), s[i], math.Float32bits(s[i]),
+					got[i], math.Float32bits(got[i]), want[i], math.Float32bits(want[i]))
+			}
+		}
+	}
+}
+
+// TestCopySignNEON_AllocFree asserts the kernel runs allocation-free at the kernel
+// boundary.
+func TestCopySignNEON_AllocFree(t *testing.T) {
+	if !hasNEON {
+		t.Skip("NEON required")
+	}
+	const n = 1024
+	mag := make([]float32, n)
+	sign := make([]float32, n)
+	dst := make([]float32, n)
+	if got := testing.AllocsPerRun(100, func() { copySignNEON(dst, mag, sign) }); got != 0 {
+		t.Errorf("copySignNEON allocated %v times per run, want 0", got)
+	}
+}
+
+// TestCopySignDispatch_arm64 pins the dispatch inputs copySign32 reads: hasNEON
+// must reflect CPU detection so a mis-wired flag cannot silently strand every call
+// on the Go path. It is white-box (reads package-level state) and must not call
+// t.Parallel(). The NEON length threshold matches the abs/neg family (>= 4),
+// verified by driving one below-threshold and one at-threshold length through the
+// public CopySign and confirming both match the reference.
+func TestCopySignDispatch_arm64(t *testing.T) {
+	if hasNEON != cpu.ARM64.NEON {
+		t.Fatalf("hasNEON = %v but cpu.ARM64.NEON = %v: dispatch flag is not wired to CPU detection", hasNEON, cpu.ARM64.NEON)
+	}
+	for _, n := range []int{3, 4} { // below the >=4 NEON threshold and at it
+		mag := make([]float32, n)
+		sign := make([]float32, n)
+		for i := range mag {
+			mag[i] = float32(i)*2.5 - 1
+			sign[i] = float32(i) - 1.5 // mixes both signs
+		}
+		got := make([]float32, n)
+		want := make([]float32, n)
+		CopySign(got, mag, sign)
+		copySign32Go(want, mag, sign)
+		for i := range got {
+			if !bitsEqF32(got[i], want[i]) {
+				t.Fatalf("CopySign n=%d lane %d: got %v want %v", n, i, got[i], want[i])
+			}
+		}
+	}
+}

--- a/f32/copysign_test.go
+++ b/f32/copysign_test.go
@@ -1,0 +1,337 @@
+package f32
+
+import (
+	"math"
+	"testing"
+)
+
+// Tests for CopySign: dst[i] = |mag[i]| carrying sign[i]'s sign bit, exactly the
+// IEEE copysign bit formula (clear mag's sign bit, OR in sign's). The op is pure
+// bit manipulation with no rounding, so it is bit-identical across amd64
+// (VANDPS/VORPS), arm64 (BIT), and copySign32Go, and equals math.Copysign
+// elementwise. The oracle is therefore just the bit formula / math.Copysign; no
+// big.Float is needed.
+
+// negNaN32 is a float32 NaN with the sign bit set, so the sign kernels have a
+// negative-NaN sign operand to exercise.
+func negNaN32() float32 {
+	return math.Float32frombits(math.Float32bits(float32(math.NaN())) | (1 << float32SignBitPos))
+}
+
+// copySignOracle is the independent reference via math.Copysign. For finite and
+// infinite magnitudes it is exact (only the sign bit moves, |mag| is already an
+// exact float32); for a NaN magnitude it returns a NaN, which bitsEqF32 treats as
+// equal regardless of payload.
+func copySignOracle(mag, sign float32) float32 {
+	return float32(math.Copysign(float64(mag), float64(sign)))
+}
+
+// copySignMagValues is the magnitude side of the value matrix: signed zeros,
+// infinities, both-signed NaN, the float32 extremes, subnormals of both signs,
+// and ordinary normals of both signs.
+func copySignMagValues() []float32 {
+	return []float32{
+		0, float32(math.Copysign(0, -1)),
+		float32(math.Inf(1)), float32(math.Inf(-1)),
+		float32(math.NaN()), negNaN32(),
+		math.MaxFloat32, -math.MaxFloat32,
+		math.SmallestNonzeroFloat32, -math.SmallestNonzeroFloat32,
+		math.Float32frombits(7),  // positive subnormal
+		math.Float32frombits(70), // another subnormal
+		3.5, -3.5, 1, -1, 1e30, -1e-30,
+	}
+}
+
+// copySignSignValues is the sign side of the value matrix: signed zeros, +-1,
+// +-Inf, and +-NaN. Every one has an unambiguous sign bit.
+func copySignSignValues() []float32 {
+	return []float32{
+		0, float32(math.Copysign(0, -1)),
+		1, -1,
+		float32(math.Inf(1)), float32(math.Inf(-1)),
+		float32(math.NaN()), negNaN32(),
+	}
+}
+
+// signBitSet reports whether v's IEEE sign bit (bit 31) is set.
+func signBitSet(v float32) bool {
+	return math.Float32bits(v)&(1<<float32SignBitPos) != 0
+}
+
+// TestCopySign checks the dispatched CopySign, the pure-Go copySign32Go, and the
+// math.Copysign oracle against the exact bit formula over a length sweep and the
+// full mag x sign value matrix, then asserts the sign-of-sign predicate directly
+// (a +0.0 sign never negates, a -0.0 sign always does).
+func TestCopySign(t *testing.T) {
+	mags := copySignMagValues()
+	// Add a negative subnormal so both signs of subnormals are present.
+	mags = append(mags, -math.Float32frombits(7))
+	signs := copySignSignValues()
+
+	// Flatten the matrix into parallel mag/sign slices, then run every prefix
+	// length so the SIMD vector body and every scalar-tail remainder are covered.
+	flatMag := make([]float32, 0, len(mags)*len(signs))
+	flatSign := make([]float32, 0, len(mags)*len(signs))
+	for _, m := range mags {
+		for _, s := range signs {
+			flatMag = append(flatMag, m)
+			flatSign = append(flatSign, s)
+		}
+	}
+
+	// Per-element expected via the exact bit formula.
+	expect := func(m, s float32) float32 {
+		bits := (math.Float32bits(m) &^ (1 << float32SignBitPos)) | (math.Float32bits(s) & (1 << float32SignBitPos))
+		return math.Float32frombits(bits)
+	}
+
+	n := len(flatMag)
+	for length := 1; length <= n; length++ {
+		mag := flatMag[:length]
+		sign := flatSign[:length]
+
+		gotDispatch := make([]float32, length)
+		gotGo := make([]float32, length)
+		CopySign(gotDispatch, mag, sign)
+		copySign32Go(gotGo, mag, sign)
+
+		for i := range gotDispatch {
+			want := expect(mag[i], sign[i])
+			if !bitsEqF32(gotDispatch[i], want) {
+				t.Fatalf("CopySign len=%d lane %d: mag=%v[%#08x] sign=%v[%#08x] got %v[%#08x] want %v[%#08x]",
+					length, i, mag[i], math.Float32bits(mag[i]), sign[i], math.Float32bits(sign[i]),
+					gotDispatch[i], math.Float32bits(gotDispatch[i]), want, math.Float32bits(want))
+			}
+			if !bitsEqF32(gotGo[i], want) {
+				t.Fatalf("copySign32Go len=%d lane %d: got %v[%#08x] want %v[%#08x]",
+					length, i, gotGo[i], math.Float32bits(gotGo[i]), want, math.Float32bits(want))
+			}
+			if oracle := copySignOracle(mag[i], sign[i]); !bitsEqF32(gotDispatch[i], oracle) {
+				t.Fatalf("CopySign vs math.Copysign len=%d lane %d: got %v[%#08x] oracle %v[%#08x]",
+					length, i, gotDispatch[i], math.Float32bits(gotDispatch[i]), oracle, math.Float32bits(oracle))
+			}
+		}
+	}
+
+	// Direct sign-predicate assertions on a finite non-zero magnitude, where the
+	// result sign is observable (a NaN result's sign is not checked because
+	// bitsEqF32 is payload-agnostic).
+	const mag = 3.5
+	dst := make([]float32, 1)
+	for _, s := range signs {
+		CopySign(dst, []float32{mag}, []float32{s})
+		if got, want := signBitSet(dst[0]), signBitSet(s); got != want {
+			t.Errorf("CopySign(%v, %v): result sign bit = %v, want %v (result=%v)", mag, s, got, want, dst[0])
+		}
+	}
+	// The -0.0 sign must negate; the +0.0 sign must not.
+	CopySign(dst, []float32{mag}, []float32{float32(math.Copysign(0, -1))})
+	if dst[0] != -mag {
+		t.Errorf("CopySign(%v, -0.0) = %v, want %v (sign bit predicate, not comparison)", mag, dst[0], -mag)
+	}
+	CopySign(dst, []float32{mag}, []float32{0})
+	if dst[0] != mag {
+		t.Errorf("CopySign(%v, +0.0) = %v, want %v", mag, dst[0], mag)
+	}
+}
+
+// TestCopySign_AllocFree pins the zero-allocation contract; buffers live inside
+// the measured closure so only genuine per-call heap traffic counts.
+func TestCopySign_AllocFree(t *testing.T) {
+	if n := testing.AllocsPerRun(50, func() {
+		var mag, sign, dst [1000]float32
+		CopySign(dst[:], mag[:], sign[:])
+	}); n != 0 {
+		t.Errorf("CopySign forces %v caller allocations per run, want 0", n)
+	}
+}
+
+// TestCopySign_TailUntouched plants non-zero sentinels past n=11 (one 8-wide AVX
+// block + 3 tail, two 4-wide SSE/NEON blocks + 3 tail) so both vector bodies run
+// and both scalar tails must stop exactly at n.
+func TestCopySign_TailUntouched(t *testing.T) {
+	const n = 11
+	mag := make([]float32, n)
+	sign := make([]float32, n)
+	for i := range mag {
+		mag[i] = float32(i) + 0.5
+		sign[i] = -1 // negate every result so a stray write is visible
+	}
+	dst := make([]float32, n+8)
+	const sentinel = float32(-987.125)
+	for i := range dst {
+		dst[i] = sentinel
+	}
+	CopySign(dst[:n], mag, sign)
+	for i := n; i < len(dst); i++ {
+		if dst[i] != sentinel {
+			t.Errorf("CopySign wrote past end at dst[%d] = %v, want sentinel %v", i, dst[i], sentinel)
+		}
+	}
+}
+
+// TestCopySign_Clamp covers mismatched lengths across all three slices, in both
+// directions, and the empty no-op.
+func TestCopySign_Clamp(t *testing.T) {
+	mag := make([]float32, 40)
+	sign := make([]float32, 40)
+	for i := range mag {
+		mag[i] = float32(i) * 1.5
+		sign[i] = float32(1 - 2*(i&1)) // alternate +1 / -1
+	}
+
+	// dst shortest: n = 25.
+	short := make([]float32, 25)
+	CopySign(short, mag, sign)
+	for i := range short {
+		if want := copySignOracle(mag[i], sign[i]); !bitsEqF32(short[i], want) {
+			t.Fatalf("CopySign short dst: dst[%d] = %v, want %v", i, short[i], want)
+		}
+	}
+
+	// mag shortest: n = 15; dst[15:] must be untouched.
+	long := make([]float32, 40)
+	for i := range long {
+		long[i] = -7 // sentinel
+	}
+	CopySign(long, mag[:15], sign)
+	for i := range 15 {
+		if want := copySignOracle(mag[i], sign[i]); !bitsEqF32(long[i], want) {
+			t.Fatalf("CopySign mag-short: dst[%d] = %v, want %v", i, long[i], want)
+		}
+	}
+	for i := 15; i < len(long); i++ {
+		if long[i] != -7 {
+			t.Fatalf("CopySign wrote past clamp (mag short) at dst[%d] = %v", i, long[i])
+		}
+	}
+
+	// sign shortest: n = 10; dst[10:] must be untouched.
+	long2 := make([]float32, 40)
+	for i := range long2 {
+		long2[i] = -7
+	}
+	CopySign(long2, mag, sign[:10])
+	for i := range 10 {
+		if want := copySignOracle(mag[i], sign[i]); !bitsEqF32(long2[i], want) {
+			t.Fatalf("CopySign sign-short: dst[%d] = %v, want %v", i, long2[i], want)
+		}
+	}
+	for i := 10; i < len(long2); i++ {
+		if long2[i] != -7 {
+			t.Fatalf("CopySign wrote past clamp (sign short) at dst[%d] = %v", i, long2[i])
+		}
+	}
+
+	// Empty no-op: a non-empty dst with empty inputs must be untouched.
+	CopySign(nil, nil, nil)
+	one := []float32{42}
+	CopySign(one, nil, nil)
+	if one[0] != 42 {
+		t.Errorf("CopySign wrote on empty input: %v", one)
+	}
+	CopySign(one, []float32{1}, nil)
+	if one[0] != 42 {
+		t.Errorf("CopySign wrote with empty sign: %v", one)
+	}
+}
+
+// TestCopySign_Aliasing verifies the documented in-place safety: dst may alias
+// mag and/or sign since each output depends only on its own index.
+func TestCopySign_Aliasing(t *testing.T) {
+	for _, n := range []int{1, 3, 4, 7, 8, 9, 15, 16, 17, 33, 64} {
+		mag := make([]float32, n)
+		sign := make([]float32, n)
+		for i := range mag {
+			mag[i] = float32(i)*0.75 - 3
+			sign[i] = float32(i)*0.5 - 5 // mixes both signs across the range
+		}
+
+		// dst == mag: result overwrites the magnitude buffer.
+		want := make([]float32, n)
+		CopySign(want, mag, sign)
+		a := append([]float32(nil), mag...)
+		CopySign(a, a, sign)
+		for i := range a {
+			if !bitsEqF32(a[i], want[i]) {
+				t.Fatalf("CopySign dst==mag n=%d: dst[%d] = %v, want %v", n, i, a[i], want[i])
+			}
+		}
+
+		// dst == sign: result overwrites the sign buffer.
+		b := append([]float32(nil), sign...)
+		CopySign(b, mag, b)
+		for i := range b {
+			if !bitsEqF32(b[i], want[i]) {
+				t.Fatalf("CopySign dst==sign n=%d: dst[%d] = %v, want %v", n, i, b[i], want[i])
+			}
+		}
+
+		// Full self-alias CopySign(x, x, x): |x| with x's own sign is x itself, an
+		// identity that holds for every float32 (including NaN payloads and signed zeros).
+		c := append([]float32(nil), mag...)
+		selfWant := make([]float32, n)
+		CopySign(selfWant, mag, mag)
+		CopySign(c, c, c)
+		for i := range c {
+			if !bitsEqF32(c[i], selfWant[i]) {
+				t.Fatalf("CopySign(x,x,x) n=%d: dst[%d] = %v, want %v", n, i, c[i], selfWant[i])
+			}
+			if !bitsEqF32(c[i], mag[i]) {
+				t.Fatalf("CopySign(x,x,x) n=%d: dst[%d] = %v, want identity %v", n, i, c[i], mag[i])
+			}
+		}
+	}
+}
+
+// TestCopySign_UnalignedOperands sweeps all eight element offsets, holding dst,
+// mag, and sign at different offsets so none is reliably 16- or 32-byte aligned;
+// an aligned-load or aligned-store substitution cannot survive the suite.
+func TestCopySign_UnalignedOperands(t *testing.T) {
+	const span = 320
+	magBase := make([]float32, span)
+	signBase := make([]float32, span)
+	for i := range magBase {
+		magBase[i] = float32(i)*0.5 - 40
+		signBase[i] = float32(i)*0.25 - 30
+	}
+	backing := make([]float32, span)
+	for _, n := range []int{4, 5, 7, 8, 9, 11, 17, 25, 33, 64, 240} {
+		for off := range 8 {
+			mag := magBase[off+1 : off+1+n]
+			sign := signBase[off+2 : off+2+n]
+			dst := backing[off+3 : off+3+n]
+			CopySign(dst, mag, sign)
+			for i := range n {
+				if want := copySignOracle(mag[i], sign[i]); !bitsEqF32(dst[i], want) {
+					t.Fatalf("CopySign unaligned n=%d off=%d: dst[%d] = %v, want %v", n, off, i, dst[i], want)
+				}
+			}
+		}
+	}
+}
+
+// FuzzCopySign differentially fuzzes the dispatched CopySign against copySign32Go
+// over arbitrary bit patterns for both mag and sign (organically producing NaN,
+// Inf, and subnormals). The two are bit-identical by construction, so any lane is
+// compared exactly (NaN treated as equal to NaN).
+func FuzzCopySign(f *testing.F) {
+	addByteLenSeeds(f)
+	f.Fuzz(func(t *testing.T, raw []byte) {
+		all := f32sBits(raw)
+		half := len(all) / 2
+		mag := all[:half]
+		sign := all[half : half*2]
+		got := make([]float32, half)
+		want := make([]float32, half)
+		CopySign(got, mag, sign)
+		copySign32Go(want, mag, sign)
+		for i := range got {
+			if !bitsEqF32(got[i], want[i]) {
+				t.Fatalf("CopySign lane %d (mag=%v[%#08x] sign=%v[%#08x]): got %v[%#08x] want %v[%#08x] (len=%d)",
+					i, mag[i], math.Float32bits(mag[i]), sign[i], math.Float32bits(sign[i]),
+					got[i], math.Float32bits(got[i]), want[i], math.Float32bits(want[i]), half)
+			}
+		}
+	})
+}

--- a/f32/f32.go
+++ b/f32/f32.go
@@ -203,6 +203,35 @@ func Neg(dst, a []float32) {
 	neg32(dst[:n], a[:n])
 }
 
+// CopySign composes each result from the magnitude of mag[i] and the sign of
+// sign[i]: dst[i] = |mag[i]| carrying sign[i]'s sign bit. It is exactly IEEE-754
+// copysign applied elementwise,
+//
+//	dst[i] = Float32frombits((Float32bits(mag[i]) &^ 0x80000000) | (Float32bits(sign[i]) & 0x80000000))
+//
+// which equals math.Copysign(mag[i], sign[i]) elementwise, and is bit-for-bit
+// identical to it for every non-NaN input. Processes
+// min(len(dst), len(mag), len(sign)) elements.
+//
+// The predicate is the IEEE sign bit (bit 31), not arithmetic comparison, so a
+// sign of -0.0 yields a negative result and a sign of +0.0 a positive one
+// (matching math.Copysign). NaN and Inf magnitudes keep their bits and take
+// sign[i]'s sign; CopySign preserves the input float32 NaN payload exactly, which
+// a float64 round trip through math.Copysign does not guarantee.
+//
+// The operation is pure bit manipulation with no rounding, so it is exact and
+// bit-identical across amd64 (VANDPS/VORPS), arm64 (BIT), and the pure-Go
+// fallback: there is no relaxed tier. dst may alias mag and/or sign, since each
+// output depends only on its own index; CopySign(x, x, x) is a valid in-place
+// abs-with-own-sign (an identity). It allocates nothing.
+func CopySign(dst, mag, sign []float32) {
+	n := minLen(len(dst), len(mag), len(sign))
+	if n == 0 {
+		return
+	}
+	copySign32(dst[:n], mag[:n], sign[:n])
+}
+
 // FMA computes fused multiply-add: dst[i] = a[i] * b[i] + c[i].
 func FMA(dst, a, b, c []float32) {
 	n := min(len(c), minLen(len(dst), len(a), len(b)))

--- a/f32/f32_amd64.go
+++ b/f32/f32_amd64.go
@@ -284,6 +284,26 @@ func neg32(dst, a []float32) {
 	negImpl(dst, a)
 }
 
+// copySign32 dispatches CopySign directly to a //go:noescape kernel (rather than
+// through a function-pointer table) so the caller's slices do not escape to the
+// heap: an indirect call through a func value defeats //go:noescape and forces a
+// per-call allocation, breaking the zero-allocation contract. The direct-dispatch
+// shape mirrors absPow34_32. CopySign is plain bit manipulation (VANDPS/VORPS),
+// so plain AVX gates the VEX kernel (AVX-512 CPUs also have AVX and run it
+// bit-identically) and SSE2 covers the rest. Like abs/neg, no minimum-length
+// guard is needed: the kernels compute the block count with a shift and fall
+// through to a scalar tail, so a full-width load is never issued out of bounds.
+func copySign32(dst, mag, sign []float32) {
+	switch {
+	case cpu.X86.AVX:
+		copySignAVX(dst, mag, sign)
+	case cpu.X86.SSE2:
+		copySignSSE(dst, mag, sign)
+	default:
+		copySign32Go(dst, mag, sign)
+	}
+}
+
 func subFromScalar32(dst, a []float32, s float32) {
 	// Compose using already-dispatched primitives: (s - a) == (-a) + s.
 	// Each step is internally vectorized or falls back to Go via the global impl
@@ -851,6 +871,9 @@ func absAVX(dst, a []float32)
 func negAVX(dst, a []float32)
 
 //go:noescape
+func copySignAVX(dst, mag, sign []float32)
+
+//go:noescape
 func fmaAVX(dst, a, b, c []float32)
 
 //go:noescape
@@ -985,6 +1008,9 @@ func absSSE(dst, a []float32)
 
 //go:noescape
 func negSSE(dst, a []float32)
+
+//go:noescape
+func copySignSSE(dst, mag, sign []float32)
 
 //go:noescape
 func fmaSSE(dst, a, b, c []float32)

--- a/f32/f32_amd64.s
+++ b/f32/f32_amd64.s
@@ -752,6 +752,59 @@ neg32_done:
     VZEROUPPER
     RET
 
+// func copySignAVX(dst, mag, sign []float32)
+// dst[i] = |mag[i]| carrying sign[i]'s sign bit. Pure bit manipulation:
+// VANDPS absf32mask clears mag's sign bit (|mag|), VANDPS roundf32_signmask
+// isolates sign's sign bit, and VORPS combines them. No rounding, so bit-
+// identical to copySignSSE, copySignNEON, and copySign32Go. Reuses the shared
+// abs/sign RODATA masks; 8 lanes per block plus a scalar tail.
+TEXT ·copySignAVX(SB), NOSPLIT, $0-72
+    MOVQ dst_base+0(FP), DX
+    MOVQ dst_len+8(FP), CX
+    MOVQ mag_base+24(FP), SI
+    MOVQ sign_base+48(FP), DI
+
+    VMOVUPS absf32mask<>(SB), Y2       // Y2 = 0x7fffffff x8 (X2 = low 128 for the tail)
+    VMOVUPS roundf32_signmask<>(SB), Y3   // Y3 = 0x80000000 x8 (X3 = low 128 for the tail)
+
+    MOVQ CX, AX
+    SHRQ $3, AX
+    JZ   copysign_avx_remainder
+
+copysign_avx_loop8:
+    VMOVUPS (SI), Y0
+    VMOVUPS (DI), Y1
+    VANDPS Y0, Y2, Y0          // Y0 = |mag|
+    VANDPS Y1, Y3, Y1          // Y1 = sign & sign bit
+    VORPS Y0, Y1, Y0           // Y0 = |mag| carrying sign's sign bit
+    VMOVUPS Y0, (DX)
+    ADDQ $32, SI
+    ADDQ $32, DI
+    ADDQ $32, DX
+    DECQ AX
+    JNZ  copysign_avx_loop8
+
+copysign_avx_remainder:
+    ANDQ $7, CX
+    JZ   copysign_avx_done
+
+copysign_avx_scalar:
+    VMOVSS (SI), X0
+    VMOVSS (DI), X1
+    VANDPS X0, X2, X0
+    VANDPS X1, X3, X1
+    VORPS X0, X1, X0
+    VMOVSS X0, (DX)
+    ADDQ $4, SI
+    ADDQ $4, DI
+    ADDQ $4, DX
+    DECQ CX
+    JNZ  copysign_avx_scalar
+
+copysign_avx_done:
+    VZEROUPPER
+    RET
+
 // func fmaAVX(dst, a, b, c []float32)
 TEXT ·fmaAVX(SB), NOSPLIT, $0-96
     MOVQ dst_base+0(FP), DX
@@ -2113,6 +2166,56 @@ neg32_sse_scalar:
     JNZ  neg32_sse_scalar
 
 neg32_sse_done:
+    RET
+
+// func copySignSSE(dst, mag, sign []float32)
+// SSE2 form of CopySign: ANDPS absf32mask (|mag|), ANDPS roundf32_signmask
+// (sign's sign bit), ORPS to combine. 4 lanes per block plus a scalar tail.
+// Bit-identical to copySignAVX, copySignNEON, and copySign32Go.
+TEXT ·copySignSSE(SB), NOSPLIT, $0-72
+    MOVQ dst_base+0(FP), DX
+    MOVQ dst_len+8(FP), CX
+    MOVQ mag_base+24(FP), SI
+    MOVQ sign_base+48(FP), DI
+
+    MOVUPS absf32mask<>(SB), X2
+    MOVUPS roundf32_signmask<>(SB), X3
+
+    MOVQ CX, AX
+    SHRQ $2, AX
+    JZ   copysign_sse_remainder
+
+copysign_sse_loop4:
+    MOVUPS (SI), X0
+    MOVUPS (DI), X1
+    ANDPS X2, X0             // X0 = |mag|
+    ANDPS X3, X1             // X1 = sign & sign bit
+    ORPS X1, X0              // X0 = |mag| carrying sign's sign bit
+    MOVUPS X0, (DX)
+    ADDQ $16, SI
+    ADDQ $16, DI
+    ADDQ $16, DX
+    DECQ AX
+    JNZ  copysign_sse_loop4
+
+copysign_sse_remainder:
+    ANDQ $3, CX
+    JZ   copysign_sse_done
+
+copysign_sse_scalar:
+    MOVSS (SI), X0
+    MOVSS (DI), X1
+    ANDPS X2, X0
+    ANDPS X3, X1
+    ORPS X1, X0
+    MOVSS X0, (DX)
+    ADDQ $4, SI
+    ADDQ $4, DI
+    ADDQ $4, DX
+    DECQ CX
+    JNZ  copysign_sse_scalar
+
+copysign_sse_done:
     RET
 
 // func fmaSSE(dst, a, b, c []float32)

--- a/f32/f32_arm64.go
+++ b/f32/f32_arm64.go
@@ -112,6 +112,14 @@ func neg32(dst, a []float32) {
 	negGo(dst, a)
 }
 
+func copySign32(dst, mag, sign []float32) {
+	if hasNEON && len(dst) >= 4 {
+		copySignNEON(dst, mag, sign)
+		return
+	}
+	copySign32Go(dst, mag, sign)
+}
+
 func subFromScalar32(dst, a []float32, s float32) {
 	// Compose using already-dispatched primitives: (s - a) == (-a) + s.
 	// neg32 and addScalar each gate on hasNEON internally and fall back to pure
@@ -376,6 +384,9 @@ func absNEON(dst, a []float32)
 
 //go:noescape
 func negNEON(dst, a []float32)
+
+//go:noescape
+func copySignNEON(dst, mag, sign []float32)
 
 //go:noescape
 func fmaNEON(dst, a, b, c []float32)

--- a/f32/f32_arm64.s
+++ b/f32/f32_arm64.s
@@ -647,6 +647,56 @@ neg32_loop1:
 neg32_done:
     RET
 
+// copySignNEON: dst[i] = |mag[i]| carrying sign[i]'s sign bit. Builds the
+// 0x80000000-per-lane mask in V2, then BIT V0.16B, V1.16B, V2.16B inserts sign's
+// sign bit (where the mask is 1) into mag (where the mask is 0), which is exactly
+// copysign. Pure bit manipulation, so bit-identical to the amd64 and Go paths.
+// The scalar tail clears mag's sign bit and ORs in sign's with W-register logical
+// ops. The BIT WORD is cross-checked against arm64asm by TestArm64WordEncodings.
+//
+// func copySignNEON(dst, mag, sign []float32)
+TEXT ·copySignNEON(SB), NOSPLIT, $0-72
+    MOVD dst_base+0(FP), R0
+    MOVD dst_len+8(FP), R2
+    MOVD mag_base+24(FP), R1
+    MOVD sign_base+48(FP), R3
+
+    // Build the sign-bit mask 0x80000000 in all four lanes of V2.
+    MOVD $0x80000000, R4
+    FMOVS R4, F2
+    WORD $0x4E040442           // DUP V2.4S, V2.S[0]
+
+    LSR $2, R2, R5
+    CBZ R5, copysign_scalar
+
+copysign_loop4:
+    VLD1.P 16(R1), [V0.S4]     // mag
+    VLD1.P 16(R3), [V1.S4]     // sign
+    WORD $0x6EA21C20           // BIT V0.16B, V1.16B, V2.16B
+    VST1.P [V0.S4], 16(R0)
+    SUB $1, R5
+    CBNZ R5, copysign_loop4
+
+copysign_scalar:
+    AND $3, R2
+    CBZ R2, copysign_done
+
+copysign_loop1:
+    MOVWU (R1), R6            // mag bits
+    MOVWU (R3), R7            // sign bits
+    AND $0x7fffffff, R6, R6   // clear mag's sign bit -> |mag|
+    AND $0x80000000, R7, R7   // isolate sign's sign bit
+    ORR R7, R6, R6            // combine
+    MOVW R6, (R0)
+    ADD $4, R0
+    ADD $4, R1
+    ADD $4, R3
+    SUB $1, R2
+    CBNZ R2, copysign_loop1
+
+copysign_done:
+    RET
+
 // func fmaNEON(dst, a, b, c []float32)
 TEXT ·fmaNEON(SB), NOSPLIT, $0-96
     MOVD dst_base+0(FP), R0

--- a/f32/f32_go.go
+++ b/f32/f32_go.go
@@ -185,9 +185,11 @@ func negGo(dst, a []float32) {
 
 // copySign32Go is the pure-Go reference for CopySign: dst[i] carries |mag[i]|
 // with the sign bit of sign[i]. It is the exact IEEE copysign bit formula (clear
-// mag's sign bit, OR in sign's sign bit), so it matches math.Copysign and the
-// SIMD kernels bit-for-bit, including NaN payloads and signed zeros. mag and
-// sign are indexed independently, so dst may alias either.
+// mag's sign bit, OR in sign's sign bit), so it matches the SIMD kernels
+// bit-for-bit, including NaN payloads and signed zeros, and equals math.Copysign
+// for every non-NaN input (math.Copysign's float64 round trip does not guarantee
+// the same NaN payload). mag and sign are indexed independently, so dst may alias
+// either.
 func copySign32Go(dst, mag, sign []float32) {
 	if len(dst) == 0 {
 		return

--- a/f32/f32_go.go
+++ b/f32/f32_go.go
@@ -183,6 +183,24 @@ func negGo(dst, a []float32) {
 	}
 }
 
+// copySign32Go is the pure-Go reference for CopySign: dst[i] carries |mag[i]|
+// with the sign bit of sign[i]. It is the exact IEEE copysign bit formula (clear
+// mag's sign bit, OR in sign's sign bit), so it matches math.Copysign and the
+// SIMD kernels bit-for-bit, including NaN payloads and signed zeros. mag and
+// sign are indexed independently, so dst may alias either.
+func copySign32Go(dst, mag, sign []float32) {
+	if len(dst) == 0 {
+		return
+	}
+	_ = mag[len(dst)-1]
+	_ = sign[len(dst)-1]
+	for i := range dst {
+		m := math.Float32bits(mag[i]) &^ (1 << float32SignBitPos)
+		s := math.Float32bits(sign[i]) & (1 << float32SignBitPos)
+		dst[i] = math.Float32frombits(m | s)
+	}
+}
+
 func fmaGo(dst, a, b, c []float32) {
 	if len(dst) == 0 {
 		return

--- a/f32/f32_other.go
+++ b/f32/f32_other.go
@@ -16,6 +16,7 @@ func max32(a []float32) float32                        { return maxGo(a) }
 func maxAbs32(a []float32) float32                     { return maxAbsGo(a) }
 func abs32(dst, a []float32)                           { absGo(dst, a) }
 func neg32(dst, a []float32)                           { negGo(dst, a) }
+func copySign32(dst, mag, sign []float32)              { copySign32Go(dst, mag, sign) }
 func fma32(dst, a, b, c []float32)                     { fmaGo(dst, a, b, c) }
 func clamp32(dst, a []float32, minVal, maxVal float32) { clampGo(dst, a, minVal, maxVal) }
 func dotProductBatch32(results []float32, rows [][]float32, vec []float32) {


### PR DESCRIPTION
Part of #182 (the sign-transfer request). This is the first of two PRs; the companion `i32.NegWhereNeg` (int32 magnitude, float32 sign) follows separately.

Adds `f32.CopySign(dst, mag, sign []float32)`: sets `dst[i] = |mag[i]|` carrying `sign[i]`'s IEEE sign bit, i.e. `Float32frombits((Float32bits(mag[i]) &^ 0x80000000) | (Float32bits(sign[i]) & 0x80000000))`. This equals `math.Copysign` elementwise and is bit-for-bit identical to it for every non-NaN input.

The predicate is the IEEE **sign bit** (bit 31), not an arithmetic comparison, so a sign of `-0.0` yields a negative result and `+0.0` a positive one (matching `math.Copysign`). This is the recombination half of the split-magnitude-process-sign pipeline (companding, loudness compression), the vectorized "way back" that `f32.Abs` lacked.

The operation is pure bit manipulation with no rounding, so it is exact and **bit-identical across amd64** (`VANDPS`/`VANDPS`/`VORPS`, reusing the existing `absf32mask` and `roundf32_signmask` RODATA, adding no new tables), **arm64** (`DUP` to broadcast the `0x80000000` mask then `BIT` to insert `sign`'s sign bit into `mag`, hand-encoded), **and the pure-Go fallback**, with no relaxed tier. `dst` may alias `mag` and/or `sign`. Dispatched via a direct cpu-flag switch (not the function-pointer table) to keep the op allocation-free.

Tests validate bit-for-bit against `math.Copysign` and the pure-Go reference over a full mag x sign value matrix (signed zeros, `+-Inf`, `+-NaN`, `MaxFloat32`, subnormals of both signs, normals), plus alloc-free, tail-untouched, three-slice clamp, aliasing (`dst==mag`, `dst==sign`, and the `CopySign(x,x,x)` identity), unaligned-operand, dispatch-pin, and differential-fuzz coverage, and a `BenchmarkCopySign`.

Verified bit-exact on real hardware: AVX2 (i7-1260P) ran the AVX and SSE kernels; NEON (Raspberry Pi 5) ran the `BIT`-based kernel; both matched `math.Copysign` across the full matrix, allocs = 0.

Note for reviewers: `math.Copysign` is intentionally NOT used in the Go reference. Its `float32 -> float64 -> float32` round trip does not guarantee the input float32 NaN payload is preserved; the direct bit formula does, and stays bit-identical to the SIMD kernels.
