### PR TITLE
i32: add NegWhereNeg, a branchless sign-transfer conditional-negate (#182)

### DIFF
--- a/i32/benchmark_test.go
+++ b/i32/benchmark_test.go
@@ -166,3 +166,26 @@ func BenchmarkAbs_1003(b *testing.B) { benchmarkAbs(b, 1003, Abs) }
 func BenchmarkAbsGo_25(b *testing.B)   { benchmarkAbs(b, 25, absGo) }
 func BenchmarkAbsGo_1000(b *testing.B) { benchmarkAbs(b, 1000, absGo) }
 func BenchmarkAbsGo_1003(b *testing.B) { benchmarkAbs(b, 1003, absGo) }
+
+func benchmarkNegWhereNeg(b *testing.B, n int, fn func(dst, mag []int32, sign []float32)) {
+	b.Helper()
+	mag := make([]int32, n)
+	sign := make([]float32, n)
+	dst := make([]int32, n)
+	for i := range mag {
+		mag[i] = int32(i*7 - 3000)
+		sign[i] = float32(i%3 - 1) // mix of -1, 0, 1 so both the negate and keep branches run
+	}
+	b.SetBytes(int64(n) * 4 * 3)
+	for b.Loop() {
+		fn(dst, mag, sign)
+	}
+}
+
+func BenchmarkNegWhereNeg_25(b *testing.B)   { benchmarkNegWhereNeg(b, 25, NegWhereNeg) }
+func BenchmarkNegWhereNeg_1000(b *testing.B) { benchmarkNegWhereNeg(b, 1000, NegWhereNeg) }
+func BenchmarkNegWhereNeg_1003(b *testing.B) { benchmarkNegWhereNeg(b, 1003, NegWhereNeg) }
+
+func BenchmarkNegWhereNegGo_25(b *testing.B)   { benchmarkNegWhereNeg(b, 25, negWhereNegGo) }
+func BenchmarkNegWhereNegGo_1000(b *testing.B) { benchmarkNegWhereNeg(b, 1000, negWhereNegGo) }
+func BenchmarkNegWhereNegGo_1003(b *testing.B) { benchmarkNegWhereNeg(b, 1003, negWhereNegGo) }

--- a/i32/i32_amd64.go
+++ b/i32/i32_amd64.go
@@ -97,6 +97,24 @@ func sumAVX2(a []int32) int32
 //go:noescape
 func absAVX2(dst, a []int32)
 
+// minAVX2NegWhereNeg is one 8-wide (256-bit) block, an independent literal like
+// the tier-3 thresholds above. The kernel is correct at any length (it falls
+// through to a scalar tail), so this is a performance cut only, never a safety
+// requirement. It gates on AVX2 because VPSRAD/VPXOR/VPSUBD are 256-bit integer
+// ops.
+const minAVX2NegWhereNeg = 8
+
+func negWhereNegI32(dst, mag []int32, sign []float32) {
+	if hasAVX2 && len(dst) >= minAVX2NegWhereNeg {
+		negWhereNegAVX2(dst, mag, sign)
+		return
+	}
+	negWhereNegGo(dst, mag, sign)
+}
+
+//go:noescape
+func negWhereNegAVX2(dst, mag []int32, sign []float32)
+
 // minMaxI32 dispatches the signed int32 min/max reduction. The AVX2 kernel does
 // the reduction in 8-wide VPMINSD/VPMAXSD lanes with a scalar tail, so it gates
 // on AVX2 and at least one full 8-element block; shorter slices use the pure-Go

--- a/i32/i32_amd64.s
+++ b/i32/i32_amd64.s
@@ -384,3 +384,55 @@ abs_avx2_store:
 abs_avx2_done:
     VZEROUPPER
     RET
+
+// func negWhereNegAVX2(dst, mag []int32, sign []float32)
+// Branchless conditional negate, 8 lanes per iteration. VPSRAD $31 on the raw
+// float32 sign lanes broadcasts each sign bit to a full-width int32 mask m
+// (all-ones iff the sign bit is set, so -0.0/-Inf/-NaN negate); VPXOR then
+// VPSUBD apply (mag ^ m) - m, which is -mag when m = -1 (MinInt32 wraps to
+// itself) and mag when m = 0. Bit-identical to negWhereNegGo. The scalar tail
+// does the same on 32-bit GPRs with SARL/XORL/SUBL, where NEGL-equivalent wrap
+// of MinInt32 stays MinInt32. Frame is 3 slice headers: dst+0, mag+24, sign+48.
+TEXT ·negWhereNegAVX2(SB), NOSPLIT, $0-72
+    MOVQ dst_base+0(FP), DX
+    MOVQ dst_len+8(FP), CX
+    MOVQ mag_base+24(FP), SI
+    MOVQ sign_base+48(FP), DI
+
+    MOVQ CX, AX
+    SHRQ $3, AX                // AX = n / 8
+    JZ   negwhereneg_avx2_tail
+
+negwhereneg_avx2_loop8:
+    VMOVDQU (DI), Y1           // sign lanes (raw float32 bits)
+    VPSRAD  $31, Y1, Y1        // Y1 = sign >> 31 = mask m
+    VMOVDQU (SI), Y0           // mag
+    VPXOR   Y1, Y0, Y0         // mag ^ m
+    VPSUBD  Y1, Y0, Y0         // (mag ^ m) - m
+    VMOVDQU Y0, (DX)
+    ADDQ $32, SI
+    ADDQ $32, DI
+    ADDQ $32, DX
+    DECQ AX
+    JNZ  negwhereneg_avx2_loop8
+
+negwhereneg_avx2_tail:
+    ANDQ $7, CX
+    JZ   negwhereneg_avx2_done
+
+negwhereneg_avx2_scalar:
+    MOVL (DI), BX              // sign bits
+    SARL $31, BX               // BX = mask m
+    MOVL (SI), AX              // mag
+    XORL BX, AX                // mag ^ m
+    SUBL BX, AX                // (mag ^ m) - m
+    MOVL AX, (DX)
+    ADDQ $4, SI
+    ADDQ $4, DI
+    ADDQ $4, DX
+    DECQ CX
+    JNZ  negwhereneg_avx2_scalar
+
+negwhereneg_avx2_done:
+    VZEROUPPER
+    RET

--- a/i32/i32_arm64.go
+++ b/i32/i32_arm64.go
@@ -84,6 +84,23 @@ func sumNEON(a []int32) int32
 //go:noescape
 func absNEON(dst, a []int32)
 
+// minNEONNegWhereNeg is one 4-wide (.4S) block, an independent literal like the
+// tier-3 thresholds above. The kernel is correct at any length (it falls through
+// to a scalar tail), so this is a performance cut only, never a safety
+// requirement.
+const minNEONNegWhereNeg = 4
+
+func negWhereNegI32(dst, mag []int32, sign []float32) {
+	if hasNEON && len(dst) >= minNEONNegWhereNeg {
+		negWhereNegNEON(dst, mag, sign)
+		return
+	}
+	negWhereNegGo(dst, mag, sign)
+}
+
+//go:noescape
+func negWhereNegNEON(dst, mag []int32, sign []float32)
+
 // minMaxI32 dispatches the signed int32 min/max reduction. The NEON kernel does
 // the reduction in 4-wide SMIN/SMAX lanes with a single-instruction SMINV/SMAXV
 // across-vector fold and a scalar tail, so it gates on NEON and at least one full

--- a/i32/i32_arm64.s
+++ b/i32/i32_arm64.s
@@ -298,3 +298,49 @@ abs_neon_scalar:
 
 abs_neon_done:
     RET
+
+// func negWhereNegNEON(dst, mag []int32, sign []float32)
+// Branchless conditional negate, 4 lanes per iteration. SSHR V1.4S,#31 broadcasts
+// each sign lane's IEEE-754 sign bit to a full-width int32 mask m (all-ones iff
+// the sign bit is set, so -0.0/-Inf/-NaN negate); EOR then SUB apply (mag ^ m) -
+// m, which is -mag when m = -1 (MinInt32 wraps to itself) and mag when m = 0.
+// Bit-identical to negWhereNegGo. The scalar tail does the same in 64-bit GPRs:
+// ASR $31 of the sign-extended sign word yields m = 0 or -1, and the MOVW store
+// keeps the low 32 bits so -MinInt32 wraps back to MinInt32. The SSHR/EOR/SUB
+// WORDs are cross-checked against arm64asm by TestArm64WordEncodings. Frame is 3
+// slice headers: dst+0, mag+24, sign+48.
+TEXT ·negWhereNegNEON(SB), NOSPLIT, $0-72
+    MOVD dst_base+0(FP), R0
+    MOVD dst_len+8(FP), R3
+    MOVD mag_base+24(FP), R1
+    MOVD sign_base+48(FP), R2
+
+    LSR  $2, R3, R4            // R4 = n / 4
+    CBZ  R4, negwhereneg_neon_remainder
+
+negwhereneg_neon_loop4:
+    VLD1.P 16(R2), [V1.S4]     // sign
+    WORD $0x4F210421           // SSHR V1.4S, V1.4S, #31   -> mask m
+    VLD1.P 16(R1), [V0.S4]     // mag
+    WORD $0x6E211C00           // EOR V0.16B, V0.16B, V1.16B  -> mag ^ m
+    WORD $0x6EA18400           // SUB V0.4S, V0.4S, V1.4S     -> (mag ^ m) - m
+    VST1.P [V0.S4], 16(R0)
+    SUB  $1, R4
+    CBNZ R4, negwhereneg_neon_loop4
+
+negwhereneg_neon_remainder:
+    AND  $3, R3
+    CBZ  R3, negwhereneg_neon_done
+
+negwhereneg_neon_scalar:
+    MOVW.P 4(R2), R6           // sign bits, sign-extended
+    ASR  $31, R6, R6           // m = sign >> 31 = 0 or -1
+    MOVW.P 4(R1), R5           // mag, sign-extended
+    EOR  R6, R5, R5            // mag ^ m
+    SUB  R6, R5, R5            // (mag ^ m) - m
+    MOVW.P R5, 4(R0)           // low 32 bits: -MinInt32 wraps to MinInt32
+    SUB  $1, R3
+    CBNZ R3, negwhereneg_neon_scalar
+
+negwhereneg_neon_done:
+    RET

--- a/i32/i32_go.go
+++ b/i32/i32_go.go
@@ -1,5 +1,12 @@
 package i32
 
+import "math"
+
+// float32SignBitPos is the IEEE-754 float32 sign bit position. An arithmetic
+// right shift of the raw bits by this amount broadcasts the sign bit across a
+// full int32 lane (all-ones when set, zero otherwise).
+const float32SignBitPos = 31
+
 // Pure-Go reference implementations.
 //
 // These are the source of truth for behavior: every SIMD kernel is validated
@@ -71,4 +78,25 @@ func minMaxGo(res []int32) (minVal, maxVal int32) {
 		}
 	}
 	return lo, hi
+}
+
+// negWhereNegGo writes the branchless conditional negate that is NegWhereNeg's
+// source of truth. For each lane it broadcasts sign[i]'s IEEE-754 sign bit into
+// a full-width int32 mask m via an arithmetic right shift (m = -1 when the sign
+// bit is set, including -0.0, -Inf and -NaN; m = 0 otherwise) and computes
+// (mag[i] ^ m) - m: that is -mag[i] when m = -1 and mag[i] when m = 0, with the
+// two's-complement wrap of int32 negation so a MinInt32 magnitude maps back to
+// MinInt32 (matching Abs). mag and sign are indexed in lockstep with dst, so
+// dst may alias mag. dst may be empty; the len-0 guard below protects the
+// len(dst)-1 BCE hints.
+func negWhereNegGo(dst, mag []int32, sign []float32) {
+	if len(dst) == 0 {
+		return
+	}
+	_ = mag[len(dst)-1]  // BCE hint: mag is indexed [0, len(dst))
+	_ = sign[len(dst)-1] // BCE hint: sign is indexed [0, len(dst))
+	for i := range dst {
+		m := int32(math.Float32bits(sign[i])) >> float32SignBitPos
+		dst[i] = (mag[i] ^ m) - m
+	}
 }

--- a/i32/i32_other.go
+++ b/i32/i32_other.go
@@ -11,3 +11,5 @@ func absI32(dst, a []int32)    { absGo(dst, a) }
 func sumI32(a []int32) int32   { return sumGo(a) }
 
 func minMaxI32(res []int32) (minVal, maxVal int32) { return minMaxGo(res) }
+
+func negWhereNegI32(dst, mag []int32, sign []float32) { negWhereNegGo(dst, mag, sign) }

--- a/i32/sign.go
+++ b/i32/sign.go
@@ -21,11 +21,12 @@ package i32
 // under a negative sign maps back to MinInt32. Every result is bit-identical to
 // the pure-Go reference on all backends.
 //
-// dst may alias mag (each lane is read before its own store), which lets the
-// magnitudes be conditionally negated in place. dst and sign have different
-// element types; if their byte ranges happen to overlap the kernel still reads
-// each sign lane before writing the matching dst lane, so an in-place overlay is
-// well defined lane by lane.
+// dst may alias mag exactly (element for element): each lane reads mag[i] before
+// its own dst[i] store and the forward iteration never revisits a written lane,
+// so the magnitudes can be conditionally negated in place. dst must not otherwise
+// overlap mag or sign. The SIMD kernels load a whole block of sign (and mag)
+// before storing the block of dst, so a shifted dst/sign or dst/mag overlay could
+// clobber input lanes a later iteration has not read yet.
 func NegWhereNeg(dst, mag []int32, sign []float32) {
 	n := min(len(dst), len(mag), len(sign))
 	if n == 0 {

--- a/i32/sign.go
+++ b/i32/sign.go
@@ -1,0 +1,35 @@
+package i32
+
+// Sign-directed integer transforms on int32 slices.
+//
+// NegWhereNeg conditionally negates each int32 magnitude according to the sign
+// bit of a parallel float32 stream. It is the integer counterpart of applying a
+// sign: a decoder that carries magnitudes as int32 and their signs as float32
+// (for example a reconstructed spectrum whose signs live in a float mask) folds
+// the two back together in one pass. Like Abs it wraps in int32 rather than
+// saturating, so the SIMD and pure-Go paths are bit-identical across the full
+// int32 range and there is no relaxed tier.
+
+// NegWhereNeg writes dst[i] = -mag[i] when sign[i] has its IEEE-754 sign bit set
+// and dst[i] = mag[i] otherwise, for i in [0, n), n = min(len(dst), len(mag),
+// len(sign)). Any trailing capacity in dst past n is left untouched.
+//
+// The predicate is purely the sign bit of sign[i], so a negative zero (-0.0),
+// -Inf and every negative NaN all negate, while +0.0 and positive values do
+// not; the float32 magnitude itself is irrelevant. The negation wraps in int32
+// exactly as [Abs] does: -MinInt32 does not fit int32, so a MinInt32 magnitude
+// under a negative sign maps back to MinInt32. Every result is bit-identical to
+// the pure-Go reference on all backends.
+//
+// dst may alias mag (each lane is read before its own store), which lets the
+// magnitudes be conditionally negated in place. dst and sign have different
+// element types; if their byte ranges happen to overlap the kernel still reads
+// each sign lane before writing the matching dst lane, so an in-place overlay is
+// well defined lane by lane.
+func NegWhereNeg(dst, mag []int32, sign []float32) {
+	n := min(len(dst), len(mag), len(sign))
+	if n == 0 {
+		return
+	}
+	negWhereNegI32(dst[:n], mag[:n], sign[:n])
+}

--- a/i32/sign_amd64_test.go
+++ b/i32/sign_amd64_test.go
@@ -1,0 +1,88 @@
+//go:build amd64
+
+package i32
+
+import (
+	"math"
+	"testing"
+
+	"github.com/tphakala/simd/cpu"
+)
+
+// TestNegWhereNegAVX2_ParityWithGo drives the kernel directly across the full
+// tier-3 sweep, over lengths the dispatcher would never route to it, so a
+// threshold change cannot quietly reduce this to a test of the Go reference
+// against itself. MinInt32 rides index 0 under a -0.0 sign so the wrap is
+// exercised at every length.
+func TestNegWhereNegAVX2_ParityWithGo(t *testing.T) {
+	if !cpu.X86.AVX2 {
+		t.Skip("AVX2 not available")
+	}
+	for _, n := range tier3Lengths {
+		mag := genI32(n, 91)
+		sign := genSigns(n, 92)
+		if n > 0 {
+			mag[0] = math.MinInt32
+			sign[0] = math.Float32frombits(1 << 31) // -0.0
+		}
+		got := make([]int32, n)
+		want := make([]int32, n)
+		negWhereNegAVX2(got, mag, sign)
+		negWhereNegGo(want, mag, sign)
+		for i := range want {
+			if got[i] != want[i] {
+				t.Fatalf("negWhereNegAVX2 n=%d: dst[%d] = %d, want %d", n, i, got[i], want[i])
+			}
+		}
+	}
+}
+
+// TestNegWhereNegAVX2_NoOverwrite guards the scalar tail: the kernel must not
+// write past n even when n is not a multiple of the 8-lane block.
+func TestNegWhereNegAVX2_NoOverwrite(t *testing.T) {
+	if !cpu.X86.AVX2 {
+		t.Skip("AVX2 not available")
+	}
+	const n = 11
+	mag := genI32(n, 93)
+	sign := genSigns(n, 94)
+	dst := make([]int32, n+8)
+	for i := range dst {
+		dst[i] = math.MaxInt32 // sentinel
+	}
+	negWhereNegAVX2(dst[:n], mag, sign)
+	for i := n; i < len(dst); i++ {
+		if dst[i] != math.MaxInt32 {
+			t.Errorf("negWhereNegAVX2 wrote past end at dst[%d] = %d", i, dst[i])
+		}
+	}
+}
+
+// TestNegWhereNegAVX2_AllocFree asserts the kernel runs allocation-free, the
+// repo's zero-allocation contract enforced at the kernel boundary.
+func TestNegWhereNegAVX2_AllocFree(t *testing.T) {
+	if !cpu.X86.AVX2 {
+		t.Skip("AVX2 not available")
+	}
+	const n = 1024
+	mag := make([]int32, n)
+	sign := make([]float32, n)
+	dst := make([]int32, n)
+	if got := testing.AllocsPerRun(100, func() { negWhereNegAVX2(dst, mag, sign) }); got != 0 {
+		t.Errorf("negWhereNegAVX2 allocated %v times per run, want 0", got)
+	}
+}
+
+// TestNegWhereNegDispatch_ReachesSIMD pins the dispatch state NegWhereNeg
+// depends on. It is a white-box check: the AVX2 kernel is bit-identical to the
+// Go reference by design, so a dispatcher that silently routed every call to Go
+// would pass every parity test in this package. It must not call t.Parallel():
+// it reads package-level dispatch state.
+func TestNegWhereNegDispatch_ReachesSIMD(t *testing.T) {
+	if hasAVX2 != cpu.X86.AVX2 {
+		t.Fatalf("hasAVX2 = %v but cpu.X86.AVX2 = %v: dispatch flag is not wired to CPU detection", hasAVX2, cpu.X86.AVX2)
+	}
+	if minAVX2NegWhereNeg > 16 {
+		t.Fatalf("minAVX2NegWhereNeg = %d exceeds two vector blocks: NegWhereNeg would not vectorize at the lengths it was written for", minAVX2NegWhereNeg)
+	}
+}

--- a/i32/sign_arm64_test.go
+++ b/i32/sign_arm64_test.go
@@ -1,0 +1,88 @@
+//go:build arm64
+
+package i32
+
+import (
+	"math"
+	"testing"
+
+	"github.com/tphakala/simd/cpu"
+)
+
+// TestNegWhereNegNEON_ParityWithGo drives the kernel directly across the full
+// tier-3 sweep, over lengths the dispatcher would never route to it, so a
+// threshold change cannot quietly reduce this to a test of the Go reference
+// against itself. MinInt32 rides index 0 under a -0.0 sign so the wrap is
+// exercised at every length.
+func TestNegWhereNegNEON_ParityWithGo(t *testing.T) {
+	if !cpu.ARM64.NEON {
+		t.Skip("NEON not available")
+	}
+	for _, n := range tier3Lengths {
+		mag := genI32(n, 91)
+		sign := genSigns(n, 92)
+		if n > 0 {
+			mag[0] = math.MinInt32
+			sign[0] = math.Float32frombits(1 << 31) // -0.0
+		}
+		got := make([]int32, n)
+		want := make([]int32, n)
+		negWhereNegNEON(got, mag, sign)
+		negWhereNegGo(want, mag, sign)
+		for i := range want {
+			if got[i] != want[i] {
+				t.Fatalf("negWhereNegNEON n=%d: dst[%d] = %d, want %d", n, i, got[i], want[i])
+			}
+		}
+	}
+}
+
+// TestNegWhereNegNEON_NoOverwrite guards the scalar tail: the kernel must not
+// write past n even when n is not a multiple of the 4-lane block.
+func TestNegWhereNegNEON_NoOverwrite(t *testing.T) {
+	if !cpu.ARM64.NEON {
+		t.Skip("NEON not available")
+	}
+	const n = 11
+	mag := genI32(n, 93)
+	sign := genSigns(n, 94)
+	dst := make([]int32, n+8)
+	for i := range dst {
+		dst[i] = math.MaxInt32 // sentinel
+	}
+	negWhereNegNEON(dst[:n], mag, sign)
+	for i := n; i < len(dst); i++ {
+		if dst[i] != math.MaxInt32 {
+			t.Errorf("negWhereNegNEON wrote past end at dst[%d] = %d", i, dst[i])
+		}
+	}
+}
+
+// TestNegWhereNegNEON_AllocFree asserts the kernel runs allocation-free, the
+// repo's zero-allocation contract enforced at the kernel boundary.
+func TestNegWhereNegNEON_AllocFree(t *testing.T) {
+	if !cpu.ARM64.NEON {
+		t.Skip("NEON not available")
+	}
+	const n = 1024
+	mag := make([]int32, n)
+	sign := make([]float32, n)
+	dst := make([]int32, n)
+	if got := testing.AllocsPerRun(100, func() { negWhereNegNEON(dst, mag, sign) }); got != 0 {
+		t.Errorf("negWhereNegNEON allocated %v times per run, want 0", got)
+	}
+}
+
+// TestNegWhereNegDispatch_ReachesNEON pins the dispatch state NegWhereNeg
+// depends on. It is a white-box check: the NEON kernel is bit-identical to the
+// Go reference by design, so a dispatcher that silently routed every call to Go
+// would pass every parity test in this package. It must not call t.Parallel():
+// it reads package-level dispatch state.
+func TestNegWhereNegDispatch_ReachesNEON(t *testing.T) {
+	if hasNEON != cpu.ARM64.NEON {
+		t.Fatalf("hasNEON = %v but cpu.ARM64.NEON = %v: dispatch flag is not wired to CPU detection", hasNEON, cpu.ARM64.NEON)
+	}
+	if minNEONNegWhereNeg > 8 {
+		t.Fatalf("minNEONNegWhereNeg = %d exceeds two vector blocks: NegWhereNeg would not vectorize at the lengths it was written for", minNEONNegWhereNeg)
+	}
+}

--- a/i32/sign_test.go
+++ b/i32/sign_test.go
@@ -1,0 +1,313 @@
+package i32
+
+import (
+	"encoding/binary"
+	"math"
+	"testing"
+)
+
+// Tests for NegWhereNeg, the branchless conditional negate. The predicate is
+// purely the IEEE-754 sign bit of the float32 sign lane, so -0.0/-Inf/-NaN
+// negate while +0.0/+Inf/+NaN do not; the load-bearing magnitude is MinInt32,
+// whose negation does not fit int32 and must wrap in place, exactly as Abs does.
+
+// signbitF32 reports whether f's IEEE-754 sign bit is set, computed straight
+// from the bit pattern so it is deterministic for every input including -0.0,
+// -Inf and negative NaN (math.Signbit routes through float64, whose NaN sign
+// preservation is not guaranteed across architectures).
+func signbitF32(f float32) bool {
+	return math.Float32bits(f)>>31 != 0
+}
+
+// negWhereNegOracle is an independent reference: it branches on the sign bit and
+// negates in int64, then truncates to int32 the way a 32-bit lane store does.
+// Negating in int64 makes the MinInt32 wrap explicit rather than trusting the
+// int32 arithmetic under test: -int64(MinInt32) is +2^31, and int32() drops it
+// back to MinInt32, which is what the kernel must produce.
+func negWhereNegOracle(mag int32, sign float32) int32 {
+	if signbitF32(sign) {
+		return int32(-int64(mag))
+	}
+	return mag
+}
+
+// genSigns produces a deterministic spread of float32 sign lanes from a cheap
+// LCG, reinterpreting the raw 32-bit state as a float32 so sign bits, NaNs and
+// infinities all appear across the indices.
+func genSigns(n int, seed uint32) []float32 {
+	s := make([]float32, n)
+	x := seed*2654435761 + 1
+	for i := range s {
+		x = x*1664525 + 1013904223
+		s[i] = math.Float32frombits(x)
+	}
+	return s
+}
+
+// f32sFromBits reinterprets raw bytes as little-endian float32s, reaching the
+// full sign/exponent/mantissa space (including signed zeros, infinities and
+// NaNs) for the differential fuzz target.
+func f32sFromBits(raw []byte) []float32 {
+	out := make([]float32, len(raw)/4)
+	for i := range out {
+		out[i] = math.Float32frombits(binary.LittleEndian.Uint32(raw[i*4:]))
+	}
+	return out
+}
+
+// TestNegWhereNeg sweeps every tier-3 length against both the pure-Go reference
+// and the independent int64 oracle, so a fault cannot hide by agreeing with the
+// reference alone. MinInt32 rides index 0 under a guaranteed-negative sign so
+// the wrap is exercised at every length.
+func TestNegWhereNeg(t *testing.T) {
+	for _, n := range tier3Lengths {
+		mag := genI32(n, 71)
+		sign := genSigns(n, 72)
+		if n > 0 {
+			mag[0] = math.MinInt32
+			sign[0] = math.Float32frombits(1 << 31) // -0.0: sign bit set, negates
+		}
+		dst := make([]int32, n)
+		ref := make([]int32, n)
+		NegWhereNeg(dst, mag, sign)
+		negWhereNegGo(ref, mag, sign)
+		for i := range dst {
+			if dst[i] != ref[i] {
+				t.Fatalf("NegWhereNeg n=%d: dst[%d] = %d, want %d (reference)", n, i, dst[i], ref[i])
+			}
+			if want := negWhereNegOracle(mag[i], sign[i]); dst[i] != want {
+				t.Fatalf("NegWhereNeg n=%d: dst[%d] = %d, want %d (oracle)", n, i, dst[i], want)
+			}
+		}
+	}
+}
+
+// TestNegWhereNeg_ValueMatrix crosses the load-bearing magnitudes with the full
+// sign-class matrix and plants each pair in every lane position (rotating pos
+// across a length that spans a vector block plus a scalar tail on both arches),
+// so a lane or index error, and a sign-class the predicate mishandles, are both
+// caught.
+func TestNegWhereNeg_ValueMatrix(t *testing.T) {
+	mags := []int32{math.MinInt32, math.MaxInt32, 0, -1, 1, 0x12345678}
+	posZero := math.Float32frombits(0)
+	negZero := math.Float32frombits(1 << 31)
+	posNaN := math.Float32frombits(0x7FC00000)
+	negNaN := math.Float32frombits(0xFFC00000)
+	signs := []float32{posZero, negZero, 1, -1, float32(math.Inf(1)), float32(math.Inf(-1)), posNaN, negNaN}
+
+	const n = 11 // one 8-wide AVX2 block + 3 tail; two 4-wide NEON blocks + 3 tail
+	filler := genI32(n, 73)
+	fillerSign := genSigns(n, 74)
+	for _, m := range mags {
+		for _, s := range signs {
+			for pos := range n {
+				mag := append([]int32(nil), filler...)
+				sign := append([]float32(nil), fillerSign...)
+				mag[pos] = m
+				sign[pos] = s
+				dst := make([]int32, n)
+				NegWhereNeg(dst, mag, sign)
+				for i := range dst {
+					if want := negWhereNegOracle(mag[i], sign[i]); dst[i] != want {
+						t.Fatalf("NegWhereNeg mag=%d sign=%#08x pos=%d: dst[%d] = %d, want %d",
+							m, math.Float32bits(s), pos, i, dst[i], want)
+					}
+				}
+			}
+		}
+	}
+}
+
+// TestNegWhereNeg_SignPredicate pins the exact contract in isolation: a negative
+// zero negates, a positive zero does not, and MinInt32 negates back to itself.
+func TestNegWhereNeg_SignPredicate(t *testing.T) {
+	negZero := math.Float32frombits(1 << 31)
+	posZero := math.Float32frombits(0)
+	cases := []struct {
+		name string
+		mag  int32
+		sign float32
+		want int32
+	}{
+		{"-0.0 negates", 5, negZero, -5},
+		{"+0.0 keeps", 5, posZero, 5},
+		{"-1.0 negates", 5, -1, -5},
+		{"+1.0 keeps", 5, 1, 5},
+		{"-Inf negates", 5, float32(math.Inf(-1)), -5},
+		{"+Inf keeps", 5, float32(math.Inf(1)), 5},
+		{"-NaN negates", 5, math.Float32frombits(0xFFC00000), -5},
+		{"+NaN keeps", 5, math.Float32frombits(0x7FC00000), 5},
+		{"MinInt32 under -1.0 wraps to itself", math.MinInt32, -1, math.MinInt32},
+		{"MinInt32 under -0.0 wraps to itself", math.MinInt32, negZero, math.MinInt32},
+		{"MinInt32 under +0.0 unchanged", math.MinInt32, posZero, math.MinInt32},
+	}
+	for _, c := range cases {
+		dst := make([]int32, 1)
+		NegWhereNeg(dst, []int32{c.mag}, []float32{c.sign})
+		if dst[0] != c.want {
+			t.Errorf("%s: NegWhereNeg(%d, %#08x) = %d, want %d",
+				c.name, c.mag, math.Float32bits(c.sign), dst[0], c.want)
+		}
+	}
+}
+
+// TestNegWhereNeg_TailUntouched plants sentinels past the clamp point at n=11
+// (one 8-wide AVX2 block + 3 tail, two 4-wide NEON blocks + the same tail), so
+// both vector bodies run and both scalar tails must stop exactly at n.
+func TestNegWhereNeg_TailUntouched(t *testing.T) {
+	const n = 11
+	mag := genI32(n, 75)
+	sign := genSigns(n, 76)
+	dst := make([]int32, n+8)
+	for i := range dst {
+		dst[i] = math.MaxInt32 // non-zero sentinel
+	}
+	NegWhereNeg(dst[:n], mag, sign)
+	for i := n; i < len(dst); i++ {
+		if dst[i] != math.MaxInt32 {
+			t.Errorf("NegWhereNeg wrote past end at dst[%d] = %d", i, dst[i])
+		}
+	}
+}
+
+// TestNegWhereNeg_Clamp covers mismatched lengths across all three operands and
+// the empty no-op: n is the shortest of dst, mag and sign, and nothing past it
+// is touched.
+func TestNegWhereNeg_Clamp(t *testing.T) {
+	mag := genI32(40, 77)
+	sign := genSigns(40, 78)
+
+	short := make([]int32, 25) // dst shortest: n = 25
+	NegWhereNeg(short, mag, sign)
+	for i := range short {
+		if want := negWhereNegOracle(mag[i], sign[i]); short[i] != want {
+			t.Fatalf("NegWhereNeg short dst: dst[%d] = %d, want %d", i, short[i], want)
+		}
+	}
+
+	long := make([]int32, 40)
+	for i := range long {
+		long[i] = -7 // sentinel
+	}
+	NegWhereNeg(long, mag[:25], sign) // mag shortest: n = 25, long[25:] untouched
+	for i := 25; i < len(long); i++ {
+		if long[i] != -7 {
+			t.Fatalf("NegWhereNeg wrote past mag clamp at dst[%d] = %d", i, long[i])
+		}
+	}
+
+	for i := range long {
+		long[i] = -7
+	}
+	NegWhereNeg(long, mag, sign[:25]) // sign shortest: n = 25, long[25:] untouched
+	for i := 25; i < len(long); i++ {
+		if long[i] != -7 {
+			t.Fatalf("NegWhereNeg wrote past sign clamp at dst[%d] = %d", i, long[i])
+		}
+	}
+
+	NegWhereNeg(nil, nil, nil)
+	one := []int32{42}
+	NegWhereNeg(one, nil, nil)
+	if one[0] != 42 {
+		t.Errorf("NegWhereNeg wrote on empty input: %v", one)
+	}
+}
+
+// TestNegWhereNeg_Aliasing negates the magnitudes in place (dst == mag) and
+// confirms every lane matches the oracle computed from the saved originals. The
+// kernel reads each mag lane before its own store, so the in-place overlay is
+// well defined lane by lane.
+func TestNegWhereNeg_Aliasing(t *testing.T) {
+	for _, n := range []int{1, 4, 7, 8, 11, 16, 17, 33, 64} {
+		buf := genI32(n, 79)
+		if n > 0 {
+			buf[0] = math.MinInt32
+		}
+		orig := append([]int32(nil), buf...)
+		sign := genSigns(n, 80)
+		NegWhereNeg(buf, buf, sign) // dst aliases mag
+		for i := range buf {
+			if want := negWhereNegOracle(orig[i], sign[i]); buf[i] != want {
+				t.Fatalf("NegWhereNeg in-place n=%d: dst[%d] = %d, want %d", n, i, buf[i], want)
+			}
+		}
+	}
+}
+
+// TestNegWhereNeg_UnalignedOperands sweeps all eight element offsets, holding
+// dst, mag and sign at different offsets from one another so none is reliably
+// aligned and an aligned-load or aligned-store substitution cannot survive.
+func TestNegWhereNeg_UnalignedOperands(t *testing.T) {
+	const span = 300
+	baseMag := genI32(span, 81)
+	baseSign := genSigns(span, 82)
+	backing := make([]int32, span)
+	for _, n := range []int{8, 9, 11, 17, 25, 33, 64, 240} {
+		for off := range 8 {
+			mag := baseMag[off+1 : off+1+n]
+			sign := baseSign[off+2 : off+2+n]
+			dst := backing[off+3 : off+3+n]
+			NegWhereNeg(dst, mag, sign)
+			for i := range n {
+				if want := negWhereNegOracle(mag[i], sign[i]); dst[i] != want {
+					t.Fatalf("NegWhereNeg unaligned n=%d off=%d: dst[%d] = %d, want %d", n, off, i, dst[i], want)
+				}
+			}
+		}
+	}
+}
+
+// TestNegWhereNeg_AllocFree declares the buffers INSIDE the measured closure so
+// only allocations forced by NegWhereNeg itself are counted.
+func TestNegWhereNeg_AllocFree(t *testing.T) {
+	if n := testing.AllocsPerRun(50, func() {
+		var mag, dst [1000]int32
+		var sign [1000]float32
+		NegWhereNeg(dst[:], mag[:], sign[:])
+	}); n != 0 {
+		t.Errorf("NegWhereNeg forces %v caller allocations per run, want 0", n)
+	}
+}
+
+// negWhereNegLenSeeds seeds raw byte buffers whose float32/int32 element counts
+// cover 0 through ~70, hitting every remainder around the 8/16-lane unrolls plus
+// a couple of larger blocks.
+func negWhereNegLenSeeds(f *testing.F) {
+	f.Helper()
+	lens := []int{0, 1, 2, 3, 4, 7, 8, 9, 15, 16, 17, 23, 24, 31, 32, 33, 47, 48, 63, 64, 65, 70, 128, 257}
+	for _, n := range lens {
+		mag := make([]byte, n*4)
+		sign := make([]byte, n*4)
+		for i := range mag {
+			mag[i] = byte(i*37 + 11)
+			sign[i] = byte(i*29 + 5)
+		}
+		f.Add(mag, sign)
+	}
+}
+
+// FuzzNegWhereNeg differentially fuzzes the dispatched NegWhereNeg against the
+// pure-Go reference and the independent int64 oracle over arbitrary int32
+// magnitudes and arbitrary float32 sign bits, so tail handling and the sign-bit
+// predicate are explored past the hand-picked seeds.
+func FuzzNegWhereNeg(f *testing.F) {
+	negWhereNegLenSeeds(f)
+	f.Fuzz(func(t *testing.T, magRaw, signRaw []byte) {
+		mag := i32sFromBits(magRaw)
+		sign := f32sFromBits(signRaw)
+		n := min(len(mag), len(sign))
+		mag, sign = mag[:n], sign[:n]
+
+		got := make([]int32, n)
+		want := make([]int32, n)
+		NegWhereNeg(got, mag, sign)
+		negWhereNegGo(want, mag, sign)
+		equalI32(t, "NegWhereNeg", got, want)
+		for i := range got {
+			if o := negWhereNegOracle(mag[i], sign[i]); got[i] != o {
+				t.Fatalf("NegWhereNeg oracle mismatch at %d: got %d want %d (len=%d)", i, got[i], o, n)
+			}
+		}
+	})
+}


### PR DESCRIPTION
Part of #182 (the sign-transfer request). Companion to #185 (`f32.CopySign`); this is the int32-magnitude half.

Adds `i32.NegWhereNeg(dst, mag []int32, sign []float32)`: sets `dst[i] = mag[i]` negated where `sign[i]`'s IEEE sign bit is set, else `mag[i]`. Branchless: `dst[i] = (mag[i] ^ m) - m` with `m = int32(math.Float32bits(sign[i])) >> 31` (an arithmetic shift, so `m` is all-ones exactly when the float32 sign bit is set).

The predicate is the IEEE **sign bit** (bit 31), so a `-0.0`, `-Inf`, or negative-NaN sign negates and `+0.0`/positives do not. The negate wraps in two's complement: a `MinInt32` magnitude maps back to `MinInt32`, matching `i32.Abs`.

This is the int32-magnitude companion to `f32.CopySign`: it recombines an `int32` magnitude stream (for example the clamped output of `Float32ToInt32ScaleClamp`) with a parallel `float32` sign stream, the vectorized "way back" for the split-magnitude-process-sign pipeline, without the lossy `int32 -> float32 -> int32` round trip a pure-float `CopySign` would force.

The operation is exact bit/arithmetic with no rounding, so it is **bit-identical across amd64 AVX2** (`VMOVDQU` sign, `VPSRAD $31`, `VPXOR`, `VPSUBD`), **arm64 NEON** (`SSHR .4S #31`, `EOR`, `SUB`, hand-encoded), **and the Go fallback**, with no relaxed tier. `dst` may alias `mag`. Follows the `i32.Abs` dispatch template (`hasAVX2`/`hasNEON` var + threshold const + branch), so it stays allocation-free.

Tests validate against the branchless Go reference and an independent `int64` oracle over a full mag x sign value matrix (`MinInt32`/`MaxInt32`/`0`/`-1` crossed with signed zeros, `+-Inf`, `+-NaN`), with explicit assertions that `-0.0` negates, `+0.0` keeps, and `MinInt32` wraps to itself. Plus alloc-free, tail-untouched, three-slice clamp, aliasing, unaligned-operand, dispatch-pin, and a differential fuzz varying both the int32 magnitude bits and the float32 sign bits, and a `BenchmarkNegWhereNeg`.

Verified bit-exact on real hardware: AVX2 (i7-1260P) ran the `negWhereNegAVX2` kernel; NEON (Raspberry Pi 5) ran the NEON kernel; both matched the reference and oracle across the matrix, allocs = 0, plus 9.3M fuzz executions clean.
