### PR TITLE
i32: add ScaleQ31 and ScaleQ15, truncating fixed-point scale-by-scalar (#181)

### DIFF
--- a/i32/benchmark_test.go
+++ b/i32/benchmark_test.go
@@ -189,3 +189,47 @@ func BenchmarkNegWhereNeg_1003(b *testing.B) { benchmarkNegWhereNeg(b, 1003, Neg
 func BenchmarkNegWhereNegGo_25(b *testing.B)   { benchmarkNegWhereNeg(b, 25, negWhereNegGo) }
 func BenchmarkNegWhereNegGo_1000(b *testing.B) { benchmarkNegWhereNeg(b, 1000, negWhereNegGo) }
 func BenchmarkNegWhereNegGo_1003(b *testing.B) { benchmarkNegWhereNeg(b, 1003, negWhereNegGo) }
+
+func benchmarkScaleQ31(b *testing.B, n int, fn func(dst, a []int32, k int32)) {
+	b.Helper()
+	a := make([]int32, n)
+	dst := make([]int32, n)
+	for i := range a {
+		a[i] = int32(i*7 - 3000)
+	}
+	const k = int32(0x40000000) // 0.5 in Q31
+	b.SetBytes(int64(n) * 4 * 2)
+	for b.Loop() {
+		fn(dst, a, k)
+	}
+}
+
+func BenchmarkScaleQ31_25(b *testing.B)   { benchmarkScaleQ31(b, 25, ScaleQ31) }
+func BenchmarkScaleQ31_1000(b *testing.B) { benchmarkScaleQ31(b, 1000, ScaleQ31) }
+func BenchmarkScaleQ31_1003(b *testing.B) { benchmarkScaleQ31(b, 1003, ScaleQ31) }
+
+func BenchmarkScaleQ31Go_25(b *testing.B)   { benchmarkScaleQ31(b, 25, scaleQ31Go) }
+func BenchmarkScaleQ31Go_1000(b *testing.B) { benchmarkScaleQ31(b, 1000, scaleQ31Go) }
+func BenchmarkScaleQ31Go_1003(b *testing.B) { benchmarkScaleQ31(b, 1003, scaleQ31Go) }
+
+func benchmarkScaleQ15(b *testing.B, n int, fn func(dst, a []int32, k int16)) {
+	b.Helper()
+	a := make([]int32, n)
+	dst := make([]int32, n)
+	for i := range a {
+		a[i] = int32(i*7 - 3000)
+	}
+	const k = int16(0x4000) // 0.5 in Q15
+	b.SetBytes(int64(n) * 4 * 2)
+	for b.Loop() {
+		fn(dst, a, k)
+	}
+}
+
+func BenchmarkScaleQ15_25(b *testing.B)   { benchmarkScaleQ15(b, 25, ScaleQ15) }
+func BenchmarkScaleQ15_1000(b *testing.B) { benchmarkScaleQ15(b, 1000, ScaleQ15) }
+func BenchmarkScaleQ15_1003(b *testing.B) { benchmarkScaleQ15(b, 1003, ScaleQ15) }
+
+func BenchmarkScaleQ15Go_25(b *testing.B)   { benchmarkScaleQ15(b, 25, scaleQ15Go) }
+func BenchmarkScaleQ15Go_1000(b *testing.B) { benchmarkScaleQ15(b, 1000, scaleQ15Go) }
+func BenchmarkScaleQ15Go_1003(b *testing.B) { benchmarkScaleQ15(b, 1003, scaleQ15Go) }

--- a/i32/i32_amd64.go
+++ b/i32/i32_amd64.go
@@ -115,6 +115,38 @@ func negWhereNegI32(dst, mag []int32, sign []float32) {
 //go:noescape
 func negWhereNegAVX2(dst, mag []int32, sign []float32)
 
+// minAVX2ScaleQ31 and minAVX2ScaleQ15 are one 8-wide (256-bit) block each,
+// independent literals like the tier-3 thresholds above. Both kernels are correct
+// at any length (each falls through to a scalar tail), so these are performance
+// cuts only, never a safety requirement. They gate on AVX2 because VPMULDQ/VPSRLQ/
+// VPSLLQ/VPBLENDD are 256-bit integer ops.
+const (
+	minAVX2ScaleQ31 = 8
+	minAVX2ScaleQ15 = 8
+)
+
+func scaleQ31I32(dst, a []int32, k int32) {
+	if hasAVX2 && len(dst) >= minAVX2ScaleQ31 {
+		scaleQ31AVX2(dst, a, k)
+		return
+	}
+	scaleQ31Go(dst, a, k)
+}
+
+func scaleQ15I32(dst, a []int32, k int16) {
+	if hasAVX2 && len(dst) >= minAVX2ScaleQ15 {
+		scaleQ15AVX2(dst, a, k)
+		return
+	}
+	scaleQ15Go(dst, a, k)
+}
+
+//go:noescape
+func scaleQ31AVX2(dst, a []int32, k int32)
+
+//go:noescape
+func scaleQ15AVX2(dst, a []int32, k int16)
+
 // minMaxI32 dispatches the signed int32 min/max reduction. The AVX2 kernel does
 // the reduction in 8-wide VPMINSD/VPMAXSD lanes with a scalar tail, so it gates
 // on AVX2 and at least one full 8-element block; shorter slices use the pure-Go

--- a/i32/i32_amd64.s
+++ b/i32/i32_amd64.s
@@ -436,3 +436,125 @@ negwhereneg_avx2_scalar:
 negwhereneg_avx2_done:
     VZEROUPPER
     RET
+
+// Fixed-point scale-by-scalar kernels (AVX2).
+//
+// AVX2 has VPMULDQ (signed 32x32 -> 64) but no 64-bit ARITHMETIC shift (VPSRAQ is
+// AVX-512). The kernels lean on one fact: for a 64-bit product p with |p| <= 2^62
+// and result = int32(p >> s), the LOW 32 bits of a LOGICAL shift (VPSRLQ $s) equal
+// the low 32 bits of the arithmetic shift. Result bit i (0..31) reads p bit (i+s),
+// and i+s <= 31+31 = 62 <= 63 is always a real bit of p for both shift kinds; the
+// two differ only in bits >= 32 (sign-fill vs zero-fill), which the int32() cast
+// discards. So VPSRLQ then keep the low 32 bits is exact, including the
+// a=k=MinInt32 wrap (2^62 >> 31 = 2^31 -> MinInt32). No EVEX is emitted: VPMULDQ,
+// VPSRLQ, VPSLLQ and VPBLENDD are all AVX2, and k reaches the vector via VMOVD to
+// an xmm then the AVX2 xmm->ymm VPBROADCASTD (VEX). The GP-register-source
+// VPBROADCASTD is AVX-512-only and would SIGILL on an AVX2-only core, so it is
+// avoided; k is sign-extended to int32 first (int32 for Q31, int16 for Q15) since
+// VPMULDQ is a signed 32x32 multiply.
+//
+// Per 8 int32: VPMULDQ folds the even 32-bit lanes (0,2,4,6) into 4 int64
+// products; VPSRLQ $32 slides the odd lanes (1,3,5,7) into even positions for a
+// second VPMULDQ; each product set is VPSRLQ $s so its low 32 bits hold the
+// result lane; VPSLLQ $32 lifts the odd results to positions 1,3,5,7; and
+// VPBLENDD $0xAA merges even (mask bit 0 -> second source) with odd (mask bit 1 ->
+// first source). The Go operand order is VPBLENDD $imm, YfromMask1, YfromMask0,
+// Ydst, so the shifted-odd register is listed FIRST. The scalar tail does the same
+// in 64-bit GPRs (MOVLQSX, IMULQ, SARQ $s, MOVL store). dst may alias a exactly:
+// each block/lane reads a before it stores dst. Frame is two slice headers plus
+// the scalar k: dst+0, a+24, k+48.
+
+// func scaleQ31AVX2(dst, a []int32, k int32)
+TEXT ·scaleQ31AVX2(SB), NOSPLIT, $0-52
+    MOVQ    dst_base+0(FP), DX
+    MOVQ    dst_len+8(FP), CX
+    MOVQ    a_base+24(FP), SI
+    MOVLQSX k+48(FP), BX          // BX = int64(k) for the scalar tail
+    VMOVD   BX, X3                // low 32 bits = int32(k)
+    VPBROADCASTD X3, Y3           // AVX2 xmm->ymm broadcast: k in all 8 int32 lanes
+
+    MOVQ CX, AX
+    SHRQ $3, AX                   // AX = n / 8
+    JZ   scaleq31_avx2_tail
+
+scaleq31_avx2_loop8:
+    VMOVDQU  (SI), Y0             // a[i..i+7]
+    VPMULDQ  Y3, Y0, Y4           // even-lane products a0,a2,a4,a6 * k (4x int64)
+    VPSRLQ   $32, Y0, Y1          // slide odd lanes a1,a3,a5,a7 into even positions
+    VPMULDQ  Y3, Y1, Y5           // odd-lane products a1,a3,a5,a7 * k (4x int64)
+    VPSRLQ   $31, Y4, Y4          // low 32 of each int64 = even result lanes
+    VPSRLQ   $31, Y5, Y5          // low 32 of each int64 = odd result lanes
+    VPSLLQ   $32, Y5, Y5          // lift odd results to 32-bit positions 1,3,5,7
+    VPBLENDD $0xAA, Y5, Y4, Y2    // lanes 1,3,5,7 <- Y5 (odd), 0,2,4,6 <- Y4 (even)
+    VMOVDQU  Y2, (DX)
+    ADDQ $32, SI
+    ADDQ $32, DX
+    DECQ AX
+    JNZ  scaleq31_avx2_loop8
+
+scaleq31_avx2_tail:
+    ANDQ $7, CX
+    JZ   scaleq31_avx2_done
+
+scaleq31_avx2_scalar:
+    MOVLQSX (SI), AX              // int64(a[i])
+    IMULQ   BX, AX                // a[i] * k (64-bit, no overflow: |p| <= 2^62)
+    SARQ    $31, AX               // arithmetic shift right 31
+    MOVL    AX, (DX)              // low 32 bits: wraps like int32()
+    ADDQ $4, SI
+    ADDQ $4, DX
+    DECQ CX
+    JNZ  scaleq31_avx2_scalar
+
+scaleq31_avx2_done:
+    VZEROUPPER
+    RET
+
+// func scaleQ15AVX2(dst, a []int32, k int16)
+// Identical recombine to scaleQ31AVX2 with a shift of 15. k is a signed int16, so
+// it is sign-extended to int32 before the broadcast (VPMULDQ is signed 32x32) and
+// to int64 for the tail; |k * a[i]| <= 2^46, well inside the int64 product.
+TEXT ·scaleQ15AVX2(SB), NOSPLIT, $0-50
+    MOVQ    dst_base+0(FP), DX
+    MOVQ    dst_len+8(FP), CX
+    MOVQ    a_base+24(FP), SI
+    MOVWQSX k+48(FP), BX          // BX = int64(k), sign-extended int16 (also tail k)
+    VMOVD   BX, X3                // low 32 bits = int32(k)
+    VPBROADCASTD X3, Y3           // AVX2 xmm->ymm broadcast of int32(k)
+
+    MOVQ CX, AX
+    SHRQ $3, AX                   // AX = n / 8
+    JZ   scaleq15_avx2_tail
+
+scaleq15_avx2_loop8:
+    VMOVDQU  (SI), Y0             // a[i..i+7]
+    VPMULDQ  Y3, Y0, Y4           // even-lane products a0,a2,a4,a6 * k (4x int64)
+    VPSRLQ   $32, Y0, Y1          // slide odd lanes a1,a3,a5,a7 into even positions
+    VPMULDQ  Y3, Y1, Y5           // odd-lane products a1,a3,a5,a7 * k (4x int64)
+    VPSRLQ   $15, Y4, Y4          // low 32 of each int64 = even result lanes
+    VPSRLQ   $15, Y5, Y5          // low 32 of each int64 = odd result lanes
+    VPSLLQ   $32, Y5, Y5          // lift odd results to 32-bit positions 1,3,5,7
+    VPBLENDD $0xAA, Y5, Y4, Y2    // lanes 1,3,5,7 <- Y5 (odd), 0,2,4,6 <- Y4 (even)
+    VMOVDQU  Y2, (DX)
+    ADDQ $32, SI
+    ADDQ $32, DX
+    DECQ AX
+    JNZ  scaleq15_avx2_loop8
+
+scaleq15_avx2_tail:
+    ANDQ $7, CX
+    JZ   scaleq15_avx2_done
+
+scaleq15_avx2_scalar:
+    MOVLQSX (SI), AX              // int64(a[i])
+    IMULQ   BX, AX                // k * a[i] (64-bit, |p| <= 2^46)
+    SARQ    $15, AX               // arithmetic shift right 15
+    MOVL    AX, (DX)              // low 32 bits: wraps like int32()
+    ADDQ $4, SI
+    ADDQ $4, DX
+    DECQ CX
+    JNZ  scaleq15_avx2_scalar
+
+scaleq15_avx2_done:
+    VZEROUPPER
+    RET

--- a/i32/i32_arm64.go
+++ b/i32/i32_arm64.go
@@ -101,6 +101,37 @@ func negWhereNegI32(dst, mag []int32, sign []float32) {
 //go:noescape
 func negWhereNegNEON(dst, mag []int32, sign []float32)
 
+// minNEONScaleQ31 and minNEONScaleQ15 are one 4-wide (.4S) block each,
+// independent literals like the tier-3 thresholds above. Both kernels are correct
+// at any length (each falls through to a scalar tail), so these are performance
+// cuts only, never a safety requirement.
+const (
+	minNEONScaleQ31 = 4
+	minNEONScaleQ15 = 4
+)
+
+func scaleQ31I32(dst, a []int32, k int32) {
+	if hasNEON && len(dst) >= minNEONScaleQ31 {
+		scaleQ31NEON(dst, a, k)
+		return
+	}
+	scaleQ31Go(dst, a, k)
+}
+
+func scaleQ15I32(dst, a []int32, k int16) {
+	if hasNEON && len(dst) >= minNEONScaleQ15 {
+		scaleQ15NEON(dst, a, k)
+		return
+	}
+	scaleQ15Go(dst, a, k)
+}
+
+//go:noescape
+func scaleQ31NEON(dst, a []int32, k int32)
+
+//go:noescape
+func scaleQ15NEON(dst, a []int32, k int16)
+
 // minMaxI32 dispatches the signed int32 min/max reduction. The NEON kernel does
 // the reduction in 4-wide SMIN/SMAX lanes with a single-instruction SMINV/SMAXV
 // across-vector fold and a scalar tail, so it gates on NEON and at least one full

--- a/i32/i32_arm64.s
+++ b/i32/i32_arm64.s
@@ -344,3 +344,99 @@ negwhereneg_neon_scalar:
 
 negwhereneg_neon_done:
     RET
+
+// Fixed-point scale-by-scalar kernels (NEON / ASIMD).
+//
+// Unlike AVX2, NEON has a native 64-bit ARITHMETIC shift (SSHR .2D), so the Q31/
+// Q15 scale is a clean widen-shift-narrow: SMULL/SMULL2 multiply the int32 lanes
+// by the broadcast coefficient into int64 products (Q=0 takes lanes 0,1; Q=1 the
+// SMULL2 form takes lanes 2,3), SSHR .2D arithmetically shifts each 64-bit product
+// right by the fixed-point position, and XTN/XTN2 narrow the low 32 bits of each
+// int64 back to int32 (truncation = the int32() wrap, so a=k=MinInt32's 2^62 >> 31
+// = 2^31 lands as MinInt32). k is broadcast with DUP from a W register: MOVW
+// sign-extends the int32 for Q31, MOVH the int16 for Q15, and both leave int64(k)
+// in the register for the scalar tail (MUL then ASR then a MOVW store that keeps
+// the low 32 bits). dst may alias a exactly: each block/lane reads a before it
+// stores dst. SMULL/SMULL2/SSHR/XTN/XTN2/DUP have no Go assembler mnemonic and are
+// hand-encoded WORD directives with the decoded form in the trailing comment
+// (cross-checked against arm64asm by TestArm64WordEncodings). Frame is two slice
+// headers plus the scalar k: dst+0, a+24, k+48.
+
+// func scaleQ31NEON(dst, a []int32, k int32)
+TEXT ·scaleQ31NEON(SB), NOSPLIT, $0-52
+    MOVD dst_base+0(FP), R0
+    MOVD dst_len+8(FP), R3
+    MOVD a_base+24(FP), R1
+    MOVW k+48(FP), R2          // R2 = int64(k), sign-extended int32 (also tail k)
+    WORD $0x4E040C41           // DUP V1.4S, W2   (k in all 4 int32 lanes)
+
+    LSR  $2, R3, R4            // R4 = n / 4
+    CBZ  R4, scaleq31_neon_remainder
+
+scaleq31_neon_loop4:
+    VLD1.P 16(R1), [V0.S4]     // a[i..i+3]
+    WORD $0x0EA1C002           // SMULL V2.2D, V0.2S, V1.2S   (lanes 0,1 -> 2 int64)
+    WORD $0x4EA1C003           // SMULL2 V3.2D, V0.4S, V1.4S  (lanes 2,3 -> 2 int64)
+    WORD $0x4F610442           // SSHR V2.2D, V2.2D, #31
+    WORD $0x4F610463           // SSHR V3.2D, V3.2D, #31
+    WORD $0x0EA12844           // XTN V4.2S, V2.2D   (low 32 of results 0,1)
+    WORD $0x4EA12864           // XTN2 V4.4S, V3.2D  (low 32 of results 2,3)
+    VST1.P [V4.S4], 16(R0)
+    SUB  $1, R4
+    CBNZ R4, scaleq31_neon_loop4
+
+scaleq31_neon_remainder:
+    AND  $3, R3
+    CBZ  R3, scaleq31_neon_done
+
+scaleq31_neon_scalar:
+    MOVW.P 4(R1), R5           // a[i], sign-extended to 64-bit
+    MUL  R2, R5, R5            // a[i] * k (64-bit, |p| <= 2^62)
+    ASR  $31, R5, R5           // arithmetic shift right 31
+    MOVW.P R5, 4(R0)           // low 32 bits: wraps like int32()
+    SUB  $1, R3
+    CBNZ R3, scaleq31_neon_scalar
+
+scaleq31_neon_done:
+    RET
+
+// func scaleQ15NEON(dst, a []int32, k int16)
+// Identical widen-shift-narrow to scaleQ31NEON with a shift of 15. k is a signed
+// int16, sign-extended by MOVH to int64(k); |k * a[i]| <= 2^46, well inside the
+// int64 product.
+TEXT ·scaleQ15NEON(SB), NOSPLIT, $0-50
+    MOVD dst_base+0(FP), R0
+    MOVD dst_len+8(FP), R3
+    MOVD a_base+24(FP), R1
+    MOVH k+48(FP), R2          // R2 = int64(k), sign-extended int16 (also tail k)
+    WORD $0x4E040C41           // DUP V1.4S, W2   (k in all 4 int32 lanes)
+
+    LSR  $2, R3, R4            // R4 = n / 4
+    CBZ  R4, scaleq15_neon_remainder
+
+scaleq15_neon_loop4:
+    VLD1.P 16(R1), [V0.S4]     // a[i..i+3]
+    WORD $0x0EA1C002           // SMULL V2.2D, V0.2S, V1.2S   (lanes 0,1 -> 2 int64)
+    WORD $0x4EA1C003           // SMULL2 V3.2D, V0.4S, V1.4S  (lanes 2,3 -> 2 int64)
+    WORD $0x4F710442           // SSHR V2.2D, V2.2D, #15
+    WORD $0x4F710463           // SSHR V3.2D, V3.2D, #15
+    WORD $0x0EA12844           // XTN V4.2S, V2.2D   (low 32 of results 0,1)
+    WORD $0x4EA12864           // XTN2 V4.4S, V3.2D  (low 32 of results 2,3)
+    VST1.P [V4.S4], 16(R0)
+    SUB  $1, R4
+    CBNZ R4, scaleq15_neon_loop4
+
+scaleq15_neon_remainder:
+    AND  $3, R3
+    CBZ  R3, scaleq15_neon_done
+
+scaleq15_neon_scalar:
+    MOVW.P 4(R1), R5           // a[i], sign-extended to 64-bit
+    MUL  R2, R5, R5            // k * a[i] (64-bit, |p| <= 2^46)
+    ASR  $15, R5, R5           // arithmetic shift right 15
+    MOVW.P R5, 4(R0)           // low 32 bits: wraps like int32()
+    SUB  $1, R3
+    CBNZ R3, scaleq15_neon_scalar
+
+scaleq15_neon_done:
+    RET

--- a/i32/i32_go.go
+++ b/i32/i32_go.go
@@ -100,3 +100,46 @@ func negWhereNegGo(dst, mag []int32, sign []float32) {
 		dst[i] = (mag[i] ^ m) - m
 	}
 }
+
+// scaleQ31Shift is the fixed-point position of the Q31 result: the full 64-bit
+// product int64(a)*int64(k) is arithmetically shifted right by 31 to land the
+// Q31 fractional scale back in int32 range.
+const scaleQ31Shift = 31
+
+// scaleQ15Shift is the Q15 counterpart: MULT16_32_Q15 multiplies a full int32 by
+// an int16 Q15 coefficient and arithmetically shifts right by 15.
+const scaleQ15Shift = 15
+
+// scaleQ31Go writes the wrapping truncating Q31 scale that is ScaleQ31's source
+// of truth: dst[i] = int32(int64(a[i]) * int64(k) >> 31). The product is formed
+// in int64 (|a|,|k| <= 2^31 so |product| <= 2^62, never overflowing int64), the
+// shift is an arithmetic (sign-preserving) right shift that truncates toward
+// -inf, and the int32() cast wraps rather than saturates: a[i]=k=MinInt32 gives
+// 2^62 >> 31 = 2^31, which wraps to MinInt32. dst may alias a exactly (each lane
+// reads a[i] before its own dst[i] store). dst may be empty; the len-0 guard
+// protects the len(dst)-1 BCE hint.
+func scaleQ31Go(dst, a []int32, k int32) {
+	if len(dst) == 0 {
+		return
+	}
+	_ = a[len(dst)-1] // BCE hint: a is indexed [0, len(dst))
+	for i := range dst {
+		dst[i] = int32(int64(a[i]) * int64(k) >> scaleQ31Shift)
+	}
+}
+
+// scaleQ15Go writes the wrapping truncating Q15 scale that is ScaleQ15's source
+// of truth: dst[i] = int32(int64(k) * int64(a[i]) >> 15). k is a signed int16
+// coefficient and a[i] a full int32 sample, so |product| <= 2^15 * 2^31 = 2^46,
+// far inside int64; the arithmetic shift truncates toward -inf and the int32()
+// cast wraps. dst may alias a exactly. dst may be empty; the len-0 guard protects
+// the len(dst)-1 BCE hint.
+func scaleQ15Go(dst, a []int32, k int16) {
+	if len(dst) == 0 {
+		return
+	}
+	_ = a[len(dst)-1] // BCE hint: a is indexed [0, len(dst))
+	for i := range dst {
+		dst[i] = int32(int64(k) * int64(a[i]) >> scaleQ15Shift)
+	}
+}

--- a/i32/i32_other.go
+++ b/i32/i32_other.go
@@ -13,3 +13,6 @@ func sumI32(a []int32) int32   { return sumGo(a) }
 func minMaxI32(res []int32) (minVal, maxVal int32) { return minMaxGo(res) }
 
 func negWhereNegI32(dst, mag []int32, sign []float32) { negWhereNegGo(dst, mag, sign) }
+
+func scaleQ31I32(dst, a []int32, k int32) { scaleQ31Go(dst, a, k) }
+func scaleQ15I32(dst, a []int32, k int16) { scaleQ15Go(dst, a, k) }

--- a/i32/scale.go
+++ b/i32/scale.go
@@ -1,0 +1,55 @@
+package i32
+
+// Fixed-point scale-by-scalar on int32 slices.
+//
+// ScaleQ31 and ScaleQ15 multiply every int32 sample by a single fixed-point
+// coefficient and shift the product back into int32 range, the integer form of
+// libopus MULT32_32_Q31 and MULT16_32_Q15. Both are truncating (an arithmetic
+// right shift, no rounding) and wrap in int32 rather than saturating, so the
+// SIMD and pure-Go paths are bit-identical across the full int32 range and there
+// is no relaxed tier. The product is always formed in a 64-bit intermediate, so
+// it never overflows before the shift; only the final int32() cast wraps.
+
+// ScaleQ31 writes dst[i] = int32(int64(a[i]) * int64(k) >> 31) for i in [0, n),
+// n = min(len(dst), len(a)). It is the integer MULT32_32_Q31: a and k are both
+// interpreted as signed 32-bit values, multiplied into a 64-bit product, then
+// arithmetically shifted right by 31 (truncating toward -inf, no rounding). Any
+// trailing capacity in dst past n is left untouched.
+//
+// The result wraps in int32 rather than saturating. The extreme case
+// a[i] = k = MinInt32 gives a product of 2^62, whose arithmetic shift by 31 is
+// 2^31; that does not fit int32 and wraps to MinInt32, exactly as the pure-Go
+// reference computes. Every result is bit-identical across all backends.
+//
+// dst may alias a exactly (element for element): each lane reads a[i] before its
+// own dst[i] store and the forward iteration never revisits a written lane, so
+// the samples can be scaled in place. dst must not otherwise overlap a: the SIMD
+// kernels load a whole block of a before storing the block of dst, so a shifted
+// dst/a overlay could clobber input lanes a later iteration has not read yet.
+func ScaleQ31(dst, a []int32, k int32) {
+	n := min(len(dst), len(a))
+	if n == 0 {
+		return
+	}
+	scaleQ31I32(dst[:n], a[:n], k)
+}
+
+// ScaleQ15 writes dst[i] = int32(int64(k) * int64(a[i]) >> 15) for i in [0, n),
+// n = min(len(dst), len(a)). It is the integer MULT16_32_Q15: the coefficient k
+// is a signed 16-bit Q15 value, each a[i] a full signed int32 sample, and the
+// 64-bit product is arithmetically shifted right by 15 (truncating toward -inf,
+// no rounding). Any trailing capacity in dst past n is left untouched.
+//
+// The result wraps in int32 rather than saturating; the product |k * a[i]| is at
+// most 2^46 so it never overflows the int64 intermediate, and only the final
+// int32() cast can wrap. Every result is bit-identical across all backends.
+//
+// dst may alias a exactly (element for element), scaling the samples in place,
+// under the same rule and caveat as [ScaleQ31].
+func ScaleQ15(dst, a []int32, k int16) {
+	n := min(len(dst), len(a))
+	if n == 0 {
+		return
+	}
+	scaleQ15I32(dst[:n], a[:n], k)
+}

--- a/i32/scale_amd64_test.go
+++ b/i32/scale_amd64_test.go
@@ -1,0 +1,142 @@
+//go:build amd64
+
+package i32
+
+import (
+	"math"
+	"testing"
+
+	"github.com/tphakala/simd/cpu"
+)
+
+// TestScaleQ31AVX2_ParityWithGo drives the kernel directly across the full tier-3
+// sweep, over lengths the dispatcher would never route to it, so a threshold
+// change cannot quietly reduce this to a test of the Go reference against itself.
+// MinInt32 rides index 0 under k=MinInt32 so the wrap is exercised at every
+// length, and the VPMULDQ even/odd recombine is checked against the oracle at
+// every position via the value-matrix test in scale_test.go.
+//
+//nolint:dupl // The Q31/Q15 parity sweep is intentionally identical bar the kernel, ref and coefficient type.
+func TestScaleQ31AVX2_ParityWithGo(t *testing.T) {
+	if !cpu.X86.AVX2 {
+		t.Skip("AVX2 not available")
+	}
+	ks := []int32{math.MinInt32, math.MaxInt32, 1, -1, 0x40000000, 0x12345678}
+	for _, n := range tier3Lengths {
+		a := genI32(n, 41)
+		if n > 0 {
+			a[0] = math.MinInt32
+			a[n-1] = math.MaxInt32
+		}
+		for _, k := range ks {
+			got := make([]int32, n)
+			want := make([]int32, n)
+			scaleQ31AVX2(got, a, k)
+			scaleQ31Go(want, a, k)
+			for i := range want {
+				if got[i] != want[i] {
+					t.Fatalf("scaleQ31AVX2 n=%d k=%d: dst[%d] = %d, want %d", n, k, i, got[i], want[i])
+				}
+				if o := scaleQ31Oracle(a[i], k); got[i] != o {
+					t.Fatalf("scaleQ31AVX2 n=%d k=%d: dst[%d] = %d, want %d (oracle)", n, k, i, got[i], o)
+				}
+			}
+		}
+	}
+}
+
+// TestScaleQ15AVX2_ParityWithGo is the Q15 counterpart over the int16 range.
+//
+//nolint:dupl // The Q31/Q15 parity sweep is intentionally identical bar the kernel, ref and coefficient type.
+func TestScaleQ15AVX2_ParityWithGo(t *testing.T) {
+	if !cpu.X86.AVX2 {
+		t.Skip("AVX2 not available")
+	}
+	ks := []int16{math.MinInt16, math.MaxInt16, 1, -1, 0x4000, 0x1234}
+	for _, n := range tier3Lengths {
+		a := genI32(n, 42)
+		if n > 0 {
+			a[0] = math.MinInt32
+			a[n-1] = math.MaxInt32
+		}
+		for _, k := range ks {
+			got := make([]int32, n)
+			want := make([]int32, n)
+			scaleQ15AVX2(got, a, k)
+			scaleQ15Go(want, a, k)
+			for i := range want {
+				if got[i] != want[i] {
+					t.Fatalf("scaleQ15AVX2 n=%d k=%d: dst[%d] = %d, want %d", n, k, i, got[i], want[i])
+				}
+				if o := scaleQ15Oracle(a[i], k); got[i] != o {
+					t.Fatalf("scaleQ15AVX2 n=%d k=%d: dst[%d] = %d, want %d (oracle)", n, k, i, got[i], o)
+				}
+			}
+		}
+	}
+}
+
+// TestScaleAVX2_NoOverwrite guards the scalar tails: neither kernel may write past
+// n when n is not a multiple of the 8-lane block.
+func TestScaleAVX2_NoOverwrite(t *testing.T) {
+	if !cpu.X86.AVX2 {
+		t.Skip("AVX2 not available")
+	}
+	const n = 11
+	a := genI32(n, 43)
+	dst := make([]int32, n+8)
+
+	for i := range dst {
+		dst[i] = math.MaxInt32 // sentinel
+	}
+	scaleQ31AVX2(dst[:n], a, 0x0BADBEEF)
+	for i := n; i < len(dst); i++ {
+		if dst[i] != math.MaxInt32 {
+			t.Errorf("scaleQ31AVX2 wrote past end at dst[%d] = %d", i, dst[i])
+		}
+	}
+
+	for i := range dst {
+		dst[i] = math.MaxInt32
+	}
+	scaleQ15AVX2(dst[:n], a, 0x2BAD)
+	for i := n; i < len(dst); i++ {
+		if dst[i] != math.MaxInt32 {
+			t.Errorf("scaleQ15AVX2 wrote past end at dst[%d] = %d", i, dst[i])
+		}
+	}
+}
+
+// TestScaleAVX2_AllocFree asserts the kernels run allocation-free, the repo's
+// zero-allocation contract enforced at the kernel boundary.
+func TestScaleAVX2_AllocFree(t *testing.T) {
+	if !cpu.X86.AVX2 {
+		t.Skip("AVX2 not available")
+	}
+	const n = 1024
+	a := make([]int32, n)
+	dst := make([]int32, n)
+	if got := testing.AllocsPerRun(100, func() { scaleQ31AVX2(dst, a, 0x12345678) }); got != 0 {
+		t.Errorf("scaleQ31AVX2 allocated %v times per run, want 0", got)
+	}
+	if got := testing.AllocsPerRun(100, func() { scaleQ15AVX2(dst, a, 0x1234) }); got != 0 {
+		t.Errorf("scaleQ15AVX2 allocated %v times per run, want 0", got)
+	}
+}
+
+// TestScaleDispatch_ReachesSIMD pins the dispatch state ScaleQ31/ScaleQ15 depend
+// on. It is a white-box check: the AVX2 kernels are bit-identical to the Go
+// reference by design, so a dispatcher that silently routed every call to Go would
+// pass every parity test. It must not call t.Parallel(): it reads package-level
+// dispatch state.
+func TestScaleDispatch_ReachesSIMD(t *testing.T) {
+	if hasAVX2 != cpu.X86.AVX2 {
+		t.Fatalf("hasAVX2 = %v but cpu.X86.AVX2 = %v: dispatch flag is not wired to CPU detection", hasAVX2, cpu.X86.AVX2)
+	}
+	if minAVX2ScaleQ31 > 16 {
+		t.Fatalf("minAVX2ScaleQ31 = %d exceeds two vector blocks: ScaleQ31 would not vectorize at the lengths it was written for", minAVX2ScaleQ31)
+	}
+	if minAVX2ScaleQ15 > 16 {
+		t.Fatalf("minAVX2ScaleQ15 = %d exceeds two vector blocks: ScaleQ15 would not vectorize at the lengths it was written for", minAVX2ScaleQ15)
+	}
+}

--- a/i32/scale_arm64_test.go
+++ b/i32/scale_arm64_test.go
@@ -1,0 +1,142 @@
+//go:build arm64
+
+package i32
+
+import (
+	"math"
+	"testing"
+
+	"github.com/tphakala/simd/cpu"
+)
+
+// TestScaleQ31NEON_ParityWithGo drives the kernel directly across the full tier-3
+// sweep, over lengths the dispatcher would never route to it, so a threshold
+// change cannot quietly reduce this to a test of the Go reference against itself.
+// MinInt32 rides index 0 under k=MinInt32 so the wrap is exercised at every
+// length; the SMULL/XTN lane order is checked against the oracle at every position
+// via the value-matrix test in scale_test.go.
+//
+//nolint:dupl // The Q31/Q15 parity sweep is intentionally identical bar the kernel, ref and coefficient type.
+func TestScaleQ31NEON_ParityWithGo(t *testing.T) {
+	if !cpu.ARM64.NEON {
+		t.Skip("NEON not available")
+	}
+	ks := []int32{math.MinInt32, math.MaxInt32, 1, -1, 0x40000000, 0x12345678}
+	for _, n := range tier3Lengths {
+		a := genI32(n, 41)
+		if n > 0 {
+			a[0] = math.MinInt32
+			a[n-1] = math.MaxInt32
+		}
+		for _, k := range ks {
+			got := make([]int32, n)
+			want := make([]int32, n)
+			scaleQ31NEON(got, a, k)
+			scaleQ31Go(want, a, k)
+			for i := range want {
+				if got[i] != want[i] {
+					t.Fatalf("scaleQ31NEON n=%d k=%d: dst[%d] = %d, want %d", n, k, i, got[i], want[i])
+				}
+				if o := scaleQ31Oracle(a[i], k); got[i] != o {
+					t.Fatalf("scaleQ31NEON n=%d k=%d: dst[%d] = %d, want %d (oracle)", n, k, i, got[i], o)
+				}
+			}
+		}
+	}
+}
+
+// TestScaleQ15NEON_ParityWithGo is the Q15 counterpart over the int16 range.
+//
+//nolint:dupl // The Q31/Q15 parity sweep is intentionally identical bar the kernel, ref and coefficient type.
+func TestScaleQ15NEON_ParityWithGo(t *testing.T) {
+	if !cpu.ARM64.NEON {
+		t.Skip("NEON not available")
+	}
+	ks := []int16{math.MinInt16, math.MaxInt16, 1, -1, 0x4000, 0x1234}
+	for _, n := range tier3Lengths {
+		a := genI32(n, 42)
+		if n > 0 {
+			a[0] = math.MinInt32
+			a[n-1] = math.MaxInt32
+		}
+		for _, k := range ks {
+			got := make([]int32, n)
+			want := make([]int32, n)
+			scaleQ15NEON(got, a, k)
+			scaleQ15Go(want, a, k)
+			for i := range want {
+				if got[i] != want[i] {
+					t.Fatalf("scaleQ15NEON n=%d k=%d: dst[%d] = %d, want %d", n, k, i, got[i], want[i])
+				}
+				if o := scaleQ15Oracle(a[i], k); got[i] != o {
+					t.Fatalf("scaleQ15NEON n=%d k=%d: dst[%d] = %d, want %d (oracle)", n, k, i, got[i], o)
+				}
+			}
+		}
+	}
+}
+
+// TestScaleNEON_NoOverwrite guards the scalar tails: neither kernel may write past
+// n when n is not a multiple of the 4-lane block.
+func TestScaleNEON_NoOverwrite(t *testing.T) {
+	if !cpu.ARM64.NEON {
+		t.Skip("NEON not available")
+	}
+	const n = 11
+	a := genI32(n, 43)
+	dst := make([]int32, n+8)
+
+	for i := range dst {
+		dst[i] = math.MaxInt32 // sentinel
+	}
+	scaleQ31NEON(dst[:n], a, 0x0BADBEEF)
+	for i := n; i < len(dst); i++ {
+		if dst[i] != math.MaxInt32 {
+			t.Errorf("scaleQ31NEON wrote past end at dst[%d] = %d", i, dst[i])
+		}
+	}
+
+	for i := range dst {
+		dst[i] = math.MaxInt32
+	}
+	scaleQ15NEON(dst[:n], a, 0x2BAD)
+	for i := n; i < len(dst); i++ {
+		if dst[i] != math.MaxInt32 {
+			t.Errorf("scaleQ15NEON wrote past end at dst[%d] = %d", i, dst[i])
+		}
+	}
+}
+
+// TestScaleNEON_AllocFree asserts the kernels run allocation-free, the repo's
+// zero-allocation contract enforced at the kernel boundary.
+func TestScaleNEON_AllocFree(t *testing.T) {
+	if !cpu.ARM64.NEON {
+		t.Skip("NEON not available")
+	}
+	const n = 1024
+	a := make([]int32, n)
+	dst := make([]int32, n)
+	if got := testing.AllocsPerRun(100, func() { scaleQ31NEON(dst, a, 0x12345678) }); got != 0 {
+		t.Errorf("scaleQ31NEON allocated %v times per run, want 0", got)
+	}
+	if got := testing.AllocsPerRun(100, func() { scaleQ15NEON(dst, a, 0x1234) }); got != 0 {
+		t.Errorf("scaleQ15NEON allocated %v times per run, want 0", got)
+	}
+}
+
+// TestScaleDispatch_ReachesNEON pins the dispatch state ScaleQ31/ScaleQ15 depend
+// on. It is a white-box check: the NEON kernels are bit-identical to the Go
+// reference by design, so a dispatcher that silently routed every call to Go would
+// pass every parity test. It must not call t.Parallel(): it reads package-level
+// dispatch state.
+func TestScaleDispatch_ReachesNEON(t *testing.T) {
+	if hasNEON != cpu.ARM64.NEON {
+		t.Fatalf("hasNEON = %v but cpu.ARM64.NEON = %v: dispatch flag is not wired to CPU detection", hasNEON, cpu.ARM64.NEON)
+	}
+	if minNEONScaleQ31 > 8 {
+		t.Fatalf("minNEONScaleQ31 = %d exceeds two vector blocks: ScaleQ31 would not vectorize at the lengths it was written for", minNEONScaleQ31)
+	}
+	if minNEONScaleQ15 > 8 {
+		t.Fatalf("minNEONScaleQ15 = %d exceeds two vector blocks: ScaleQ15 would not vectorize at the lengths it was written for", minNEONScaleQ15)
+	}
+}

--- a/i32/scale_test.go
+++ b/i32/scale_test.go
@@ -1,0 +1,393 @@
+package i32
+
+import (
+	"math"
+	"math/big"
+	"testing"
+)
+
+// Tests for ScaleQ31 and ScaleQ15, the truncating fixed-point scale-by-scalar
+// pair. Both wrap in int32 rather than saturating, so the load-bearing case is
+// MinInt32 * MinInt32 = 2^62, whose arithmetic shift by 31 is 2^31 and wraps back
+// to MinInt32: a saturating implementation would return MaxInt32 and fail here.
+
+// scaleQ31Oracle computes the Q31 scale in arbitrary precision, fully independent
+// of the int64 arithmetic in scaleQ31Go and the SIMD kernels. big.Int.Rsh is a
+// floor (arithmetic) shift, matching Go's signed >>, and the final int32() drops
+// the value back to a 32-bit lane exactly as a store does, so 2^31 wraps to
+// MinInt32. It pins the reference rather than trusting a formula shared with it.
+func scaleQ31Oracle(a, k int32) int32 {
+	return scaleOracle(a, int64(k), 31)
+}
+
+// scaleQ15Oracle is the Q15 counterpart: k is a signed int16 coefficient, shift 15.
+func scaleQ15Oracle(a int32, k int16) int32 {
+	return scaleOracle(a, int64(k), 15)
+}
+
+func scaleOracle(a int32, k int64, shift uint) int32 {
+	p := new(big.Int).Mul(big.NewInt(int64(a)), big.NewInt(k))
+	p.Rsh(p, shift) // floor shift, matches Go's arithmetic >>
+	return int32(p.Int64())
+}
+
+// TestScaleQ31 sweeps every tier-3 length against both the pure-Go reference and
+// the arbitrary-precision oracle, so a fault cannot hide by agreeing with the
+// reference alone. MinInt32 rides index 0 so that under k=MinInt32 the wrap is
+// exercised at every length; MaxInt32 rides the last index to stress the tail.
+func TestScaleQ31(t *testing.T) {
+	ks := []int32{math.MinInt32, 1, 0x12345678}
+	for _, n := range tier3Lengths {
+		a := genI32(n, 21)
+		if n > 0 {
+			a[0] = math.MinInt32
+			a[n-1] = math.MaxInt32
+		}
+		for _, k := range ks {
+			dst := make([]int32, n)
+			ref := make([]int32, n)
+			ScaleQ31(dst, a, k)
+			scaleQ31Go(ref, a, k)
+			for i := range dst {
+				if dst[i] != ref[i] {
+					t.Fatalf("ScaleQ31 n=%d k=%d: dst[%d] = %d, want %d (reference)", n, k, i, dst[i], ref[i])
+				}
+				if want := scaleQ31Oracle(a[i], k); dst[i] != want {
+					t.Fatalf("ScaleQ31 n=%d k=%d: dst[%d] = %d, want %d (oracle)", n, k, i, dst[i], want)
+				}
+			}
+		}
+	}
+}
+
+// TestScaleQ15 mirrors TestScaleQ31 over the int16 coefficient range.
+func TestScaleQ15(t *testing.T) {
+	ks := []int16{math.MinInt16, 1, 0x1234}
+	for _, n := range tier3Lengths {
+		a := genI32(n, 23)
+		if n > 0 {
+			a[0] = math.MinInt32
+			a[n-1] = math.MaxInt32
+		}
+		for _, k := range ks {
+			dst := make([]int32, n)
+			ref := make([]int32, n)
+			ScaleQ15(dst, a, k)
+			scaleQ15Go(ref, a, k)
+			for i := range dst {
+				if dst[i] != ref[i] {
+					t.Fatalf("ScaleQ15 n=%d k=%d: dst[%d] = %d, want %d (reference)", n, k, i, dst[i], ref[i])
+				}
+				if want := scaleQ15Oracle(a[i], k); dst[i] != want {
+					t.Fatalf("ScaleQ15 n=%d k=%d: dst[%d] = %d, want %d (oracle)", n, k, i, dst[i], want)
+				}
+			}
+		}
+	}
+}
+
+// TestScaleQ31_ValueMatrix crosses the load-bearing samples with the full
+// coefficient matrix and plants each sample in every lane position across a
+// length that spans a vector block plus a scalar tail on both arches, so a lane
+// error, an index error, and a value the recombine mishandles are all caught. The
+// even/odd lane split of the AVX2 VPMULDQ path makes the per-position sweep
+// essential: a swapped even/odd blend only shows up at specific positions.
+func TestScaleQ31_ValueMatrix(t *testing.T) {
+	as := []int32{math.MinInt32, math.MaxInt32, 0, -1, 1, 2, 0x12345678, -0x12345678, 0x7FFFFFFE}
+	ks := []int32{math.MinInt32, math.MaxInt32, 0, 1, -1, 2, 0x40000000, -0x40000000, 0x2BADF00D}
+	const n = 11 // one 8-wide AVX2 block + 3 tail; two 4-wide NEON blocks + 3 tail
+	filler := genI32(n, 24)
+	for _, k := range ks {
+		for _, av := range as {
+			for pos := range n {
+				a := append([]int32(nil), filler...)
+				a[pos] = av
+				dst := make([]int32, n)
+				ScaleQ31(dst, a, k)
+				for i := range dst {
+					if want := scaleQ31Oracle(a[i], k); dst[i] != want {
+						t.Fatalf("ScaleQ31 a=%d k=%d pos=%d: dst[%d] = %d, want %d", av, k, pos, i, dst[i], want)
+					}
+				}
+			}
+		}
+	}
+}
+
+// TestScaleQ15_ValueMatrix is the Q15 counterpart across the int16 coefficient
+// space, including MinInt16/MaxInt16 which have no int32 wrap of their own but
+// must sign-extend correctly into the signed 32x32 multiply.
+func TestScaleQ15_ValueMatrix(t *testing.T) {
+	as := []int32{math.MinInt32, math.MaxInt32, 0, -1, 1, 2, 0x12345678, -0x12345678, 0x7FFFFFFE}
+	ks := []int16{math.MinInt16, math.MaxInt16, 0, 1, -1, 2, -2, 0x4000, 0x2BAD}
+	const n = 11
+	filler := genI32(n, 25)
+	for _, k := range ks {
+		for _, av := range as {
+			for pos := range n {
+				a := append([]int32(nil), filler...)
+				a[pos] = av
+				dst := make([]int32, n)
+				ScaleQ15(dst, a, k)
+				for i := range dst {
+					if want := scaleQ15Oracle(a[i], k); dst[i] != want {
+						t.Fatalf("ScaleQ15 a=%d k=%d pos=%d: dst[%d] = %d, want %d", av, k, pos, i, dst[i], want)
+					}
+				}
+			}
+		}
+	}
+}
+
+// TestScale_Wrap pins the two extreme contracts in isolation: MinInt32 * MinInt32
+// wraps to MinInt32 (a saturating build would return MaxInt32), and k=0 zeroes
+// every lane. n=11 forces both the vector body and the scalar tail on both arches.
+func TestScale_Wrap(t *testing.T) {
+	const n = 11
+	minInts := make([]int32, n)
+	for i := range minInts {
+		minInts[i] = math.MinInt32
+	}
+
+	// Q31: MinInt32 * MinInt32 = 2^62, >>31 = 2^31 -> MinInt32.
+	dst := make([]int32, n)
+	ScaleQ31(dst, minInts, math.MinInt32)
+	for i := range dst {
+		if dst[i] != math.MinInt32 {
+			t.Fatalf("ScaleQ31 MinInt32*MinInt32: dst[%d] = %d, want %d (wrap, not saturate)", i, dst[i], int32(math.MinInt32))
+		}
+	}
+
+	// Q31: k=0 zeroes everything.
+	for i := range dst {
+		dst[i] = -1
+	}
+	ScaleQ31(dst, minInts, 0)
+	for i := range dst {
+		if dst[i] != 0 {
+			t.Fatalf("ScaleQ31 k=0: dst[%d] = %d, want 0", i, dst[i])
+		}
+	}
+
+	// Q15: MinInt32 * MinInt16 = 2^46, >>15 = 2^31 -> MinInt32.
+	ScaleQ15(dst, minInts, math.MinInt16)
+	for i := range dst {
+		if want := scaleQ15Oracle(math.MinInt32, math.MinInt16); dst[i] != want {
+			t.Fatalf("ScaleQ15 MinInt32*MinInt16: dst[%d] = %d, want %d", i, dst[i], want)
+		}
+	}
+	// Confirm the oracle itself says this wraps to MinInt32.
+	if got := scaleQ15Oracle(math.MinInt32, math.MinInt16); got != math.MinInt32 {
+		t.Fatalf("ScaleQ15 oracle MinInt32*MinInt16 = %d, want %d", got, int32(math.MinInt32))
+	}
+
+	// Q15: k=0 zeroes everything.
+	for i := range dst {
+		dst[i] = -1
+	}
+	ScaleQ15(dst, minInts, 0)
+	for i := range dst {
+		if dst[i] != 0 {
+			t.Fatalf("ScaleQ15 k=0: dst[%d] = %d, want 0", i, dst[i])
+		}
+	}
+}
+
+// TestScale_TailUntouched plants sentinels past the clamp point at n=11 (one
+// 8-wide AVX2 block + 3 tail, two 4-wide NEON blocks + the same tail), so both
+// vector bodies run and both scalar tails must stop exactly at n.
+func TestScale_TailUntouched(t *testing.T) {
+	const n = 11
+	a := genI32(n, 26)
+
+	dst := make([]int32, n+8)
+	for i := range dst {
+		dst[i] = math.MaxInt32 // non-zero sentinel
+	}
+	ScaleQ31(dst[:n], a, 0x0BADBEEF)
+	for i := n; i < len(dst); i++ {
+		if dst[i] != math.MaxInt32 {
+			t.Errorf("ScaleQ31 wrote past end at dst[%d] = %d", i, dst[i])
+		}
+	}
+
+	for i := range dst {
+		dst[i] = math.MaxInt32
+	}
+	ScaleQ15(dst[:n], a, 0x2BAD)
+	for i := n; i < len(dst); i++ {
+		if dst[i] != math.MaxInt32 {
+			t.Errorf("ScaleQ15 wrote past end at dst[%d] = %d", i, dst[i])
+		}
+	}
+}
+
+// TestScale_Clamp covers mismatched dst/a lengths and the empty no-op: n is the
+// shorter of dst and a, and nothing past it is touched.
+func TestScale_Clamp(t *testing.T) {
+	a := genI32(40, 27)
+
+	short := make([]int32, 25) // dst shortest: n = 25
+	ScaleQ31(short, a, 0x12345678)
+	for i := range short {
+		if want := scaleQ31Oracle(a[i], 0x12345678); short[i] != want {
+			t.Fatalf("ScaleQ31 short dst: dst[%d] = %d, want %d", i, short[i], want)
+		}
+	}
+
+	long := make([]int32, 40)
+	for i := range long {
+		long[i] = -7 // sentinel
+	}
+	ScaleQ31(long, a[:25], 0x12345678) // a shortest: n = 25, long[25:] untouched
+	for i := 25; i < len(long); i++ {
+		if long[i] != -7 {
+			t.Fatalf("ScaleQ31 wrote past a clamp at dst[%d] = %d", i, long[i])
+		}
+	}
+
+	// Empty inputs are a no-op.
+	ScaleQ31(nil, nil, 5)
+	ScaleQ15(nil, nil, 5)
+	one := []int32{42}
+	ScaleQ31(one, nil, 5)
+	ScaleQ15(one, nil, 5)
+	if one[0] != 42 {
+		t.Errorf("ScaleQ31/ScaleQ15 wrote on empty input: %v", one)
+	}
+}
+
+// TestScale_Aliasing scales the samples in place (dst == a) and confirms every
+// lane matches the oracle computed from the saved originals. The kernel reads
+// each a lane before its own store, so the in-place overlay is well defined lane
+// by lane. MinInt32 rides index 0 so the wrap is exercised in place.
+func TestScale_Aliasing(t *testing.T) {
+	for _, n := range []int{1, 4, 7, 8, 11, 16, 17, 33, 64} {
+		const k31 = int32(-0x40000000)
+		buf := genI32(n, 28)
+		if n > 0 {
+			buf[0] = math.MinInt32
+		}
+		orig := append([]int32(nil), buf...)
+		ScaleQ31(buf, buf, k31) // dst aliases a
+		for i := range buf {
+			if want := scaleQ31Oracle(orig[i], k31); buf[i] != want {
+				t.Fatalf("ScaleQ31 in-place n=%d: dst[%d] = %d, want %d", n, i, buf[i], want)
+			}
+		}
+
+		const k15 = int16(-0x4000)
+		buf2 := genI32(n, 29)
+		if n > 0 {
+			buf2[0] = math.MinInt32
+		}
+		orig2 := append([]int32(nil), buf2...)
+		ScaleQ15(buf2, buf2, k15)
+		for i := range buf2 {
+			if want := scaleQ15Oracle(orig2[i], k15); buf2[i] != want {
+				t.Fatalf("ScaleQ15 in-place n=%d: dst[%d] = %d, want %d", n, i, buf2[i], want)
+			}
+		}
+	}
+}
+
+// TestScale_UnalignedOperands sweeps all eight element offsets, holding dst and a
+// at different offsets from one another so neither is reliably aligned and an
+// aligned-load or aligned-store substitution cannot survive.
+func TestScale_UnalignedOperands(t *testing.T) {
+	const span = 300
+	baseA := genI32(span, 31)
+	backing := make([]int32, span)
+	const k31 = int32(0x50000001)
+	const k15 = int16(0x3777)
+	for _, n := range []int{8, 9, 11, 17, 25, 33, 64, 240} {
+		for off := range 8 {
+			a := baseA[off+1 : off+1+n]
+			dst := backing[off+3 : off+3+n]
+			ScaleQ31(dst, a, k31)
+			for i := range n {
+				if want := scaleQ31Oracle(a[i], k31); dst[i] != want {
+					t.Fatalf("ScaleQ31 unaligned n=%d off=%d: dst[%d] = %d, want %d", n, off, i, dst[i], want)
+				}
+			}
+			ScaleQ15(dst, a, k15)
+			for i := range n {
+				if want := scaleQ15Oracle(a[i], k15); dst[i] != want {
+					t.Fatalf("ScaleQ15 unaligned n=%d off=%d: dst[%d] = %d, want %d", n, off, i, dst[i], want)
+				}
+			}
+		}
+	}
+}
+
+// TestScale_AllocFree declares the buffers INSIDE the measured closure so only
+// allocations forced by the scale itself are counted.
+func TestScale_AllocFree(t *testing.T) {
+	if n := testing.AllocsPerRun(50, func() {
+		var a, dst [1000]int32
+		ScaleQ31(dst[:], a[:], 0x12345678)
+	}); n != 0 {
+		t.Errorf("ScaleQ31 forces %v caller allocations per run, want 0", n)
+	}
+	if n := testing.AllocsPerRun(50, func() {
+		var a, dst [1000]int32
+		ScaleQ15(dst[:], a[:], 0x1234)
+	}); n != 0 {
+		t.Errorf("ScaleQ15 forces %v caller allocations per run, want 0", n)
+	}
+}
+
+// scaleLenSeeds seeds raw byte buffers whose int32 element counts cover 0 through
+// ~70, hitting every remainder around the 8/16-lane unrolls plus larger blocks.
+func scaleLenSeeds(f *testing.F) {
+	f.Helper()
+	lens := []int{0, 1, 2, 3, 4, 7, 8, 9, 15, 16, 17, 23, 24, 31, 32, 33, 47, 48, 63, 64, 65, 70, 128, 257}
+	for _, n := range lens {
+		raw := make([]byte, n*4)
+		for i := range raw {
+			raw[i] = byte(i*37 + 11)
+		}
+		f.Add(raw, int32(0x12345678))
+	}
+}
+
+// FuzzScaleQ31 differentially fuzzes the dispatched ScaleQ31 against the pure-Go
+// reference and the arbitrary-precision oracle over arbitrary int32 samples and an
+// arbitrary int32 coefficient, so tail handling and the wrap are explored past the
+// hand-picked seeds.
+func FuzzScaleQ31(f *testing.F) {
+	scaleLenSeeds(f)
+	f.Fuzz(func(t *testing.T, raw []byte, k int32) {
+		a := i32sFromBits(raw)
+		got := make([]int32, len(a))
+		want := make([]int32, len(a))
+		ScaleQ31(got, a, k)
+		scaleQ31Go(want, a, k)
+		equalI32(t, "ScaleQ31", got, want)
+		for i := range got {
+			if o := scaleQ31Oracle(a[i], k); got[i] != o {
+				t.Fatalf("ScaleQ31 oracle mismatch at %d: got %d want %d (len=%d, k=%d)", i, got[i], o, len(a), k)
+			}
+		}
+	})
+}
+
+// FuzzScaleQ15 is the Q15 counterpart; the int16 coefficient is fuzzed as the low
+// 16 bits of the provided int32.
+func FuzzScaleQ15(f *testing.F) {
+	scaleLenSeeds(f)
+	f.Fuzz(func(t *testing.T, raw []byte, kRaw int32) {
+		k := int16(kRaw)
+		a := i32sFromBits(raw)
+		got := make([]int32, len(a))
+		want := make([]int32, len(a))
+		ScaleQ15(got, a, k)
+		scaleQ15Go(want, a, k)
+		equalI32(t, "ScaleQ15", got, want)
+		for i := range got {
+			if o := scaleQ15Oracle(a[i], k); got[i] != o {
+				t.Fatalf("ScaleQ15 oracle mismatch at %d: got %d want %d (len=%d, k=%d)", i, got[i], o, len(a), k)
+			}
+		}
+	})
+}


### PR DESCRIPTION
First of four PRs for #181 (the i32 fixed-point building blocks). This one adds the scale-by-scalar pair; `Butterfly`, `MaxAbs`, and `FIRValidQ15` follow separately.

Adds `i32.ScaleQ31(dst, a []int32, k int32)` and `i32.ScaleQ15(dst, a []int32, k int16)`, the truncating fixed-point scale-by-scalar primitives:

- `ScaleQ31`: `dst[i] = int32(int64(a[i]) * int64(k) >> 31)`, matching libopus `MULT32_32_Q31`.
- `ScaleQ15`: `dst[i] = int32(int64(k) * int64(a[i]) >> 15)`, matching libopus `MULT16_32_Q15`.

Both are **truncating** (an arithmetic, floor-toward-negative-infinity shift with no rounding) and **wrapping** (a `MinInt32` magnitude scaled by `MinInt32` gives `2^62 >> 31 = 2^31`, which wraps back to `MinInt32`). These are the building blocks the integer transform and gain kernels need (`haar1`, `denormaliseBands`) in a bit-exact fixed-point DSP port.

A note on the semantics: the issue text describes the Q-format multiply with a `+ (1<<14)` rounding term, but the authoritative reference (`go-opus/internal/fixedmath/fixed_generic.go`, bit-exact against libopus) shows these macros **truncate**, with no rounding constant. This PR implements the verified truncating behavior; the rounded `_P` variants are separate macros the FFT/bands path does not use.

The kernels are bit-identical across amd64 AVX2, arm64 NEON, and the Go fallback, with no relaxed tier. On AVX2, `VPMULDQ` does the signed 32x32->64 products on the even and odd lanes; since AVX2 has no 64-bit arithmetic shift (`VPSRAQ` is AVX-512), it uses `VPSRLQ` and keeps the low 32 bits, which equal the arithmetic-shift result because the sign-fill difference lands only in bits the `int32` cast discards. NEON uses `SMULL`/`SMULL2` then the native `SSHR .2D` then `XTN`/`XTN2`. Dispatch is the direct `hasAVX2`/`hasNEON` + threshold-const + branch form, so the ops stay allocation-free.

Tests validate against the Go reference and an independent `math/big` oracle over a magnitude x coefficient value matrix (`MinInt32`/`MaxInt32`/`0`/`-1` magnitudes crossed with `MinInt32`/`MaxInt32`/`0`/`+-1`/powers-of-two coefficients, and the `int16` range for Q15), with explicit assertions for the `MinInt32 * MinInt32` wrap and negative-product floor truncation, plus alloc-free, tail-untouched, clamp, aliasing, unaligned-operand, dispatch-pin, and differential-fuzz (both operand and coefficient) coverage, and `BenchmarkScaleQ31`/`BenchmarkScaleQ15`.

Verified bit-exact on real hardware: the AVX2 kernels (including the even/odd `VPMULDQ` recombine) ran on the i7-1260P; the NEON kernels ran on a Raspberry Pi 5; both matched the reference and the `math/big` oracle across the full matrix, allocs = 0, plus ~1.8M fuzz executions clean.
