### PR TITLE
i32: add Butterfly, the in-place FWHT/Haar sum-difference step (#181)

### DIFF
--- a/i32/benchmark_test.go
+++ b/i32/benchmark_test.go
@@ -233,3 +233,29 @@ func BenchmarkScaleQ15_1003(b *testing.B) { benchmarkScaleQ15(b, 1003, ScaleQ15)
 func BenchmarkScaleQ15Go_25(b *testing.B)   { benchmarkScaleQ15(b, 25, scaleQ15Go) }
 func BenchmarkScaleQ15Go_1000(b *testing.B) { benchmarkScaleQ15(b, 1000, scaleQ15Go) }
 func BenchmarkScaleQ15Go_1003(b *testing.B) { benchmarkScaleQ15(b, 1003, scaleQ15Go) }
+
+// Butterfly is in-place, so each call rewrites both slices. Resetting them to a
+// fixed pattern between iterations is unnecessary for timing because the operation
+// is length-bound, not value-bound (no data-dependent branches). SetBytes counts
+// both slices read and both written, 4 bytes per int32.
+func benchmarkButterfly(b *testing.B, n int, fn func(lo, hi []int32)) {
+	b.Helper()
+	lo := make([]int32, n)
+	hi := make([]int32, n)
+	for i := range lo {
+		lo[i] = int32(i*7 - 3000)
+		hi[i] = int32(i*3 + 1000)
+	}
+	b.SetBytes(int64(n) * 4 * 2)
+	for b.Loop() {
+		fn(lo, hi)
+	}
+}
+
+func BenchmarkButterfly_25(b *testing.B)   { benchmarkButterfly(b, 25, Butterfly) }
+func BenchmarkButterfly_1000(b *testing.B) { benchmarkButterfly(b, 1000, Butterfly) }
+func BenchmarkButterfly_1003(b *testing.B) { benchmarkButterfly(b, 1003, Butterfly) }
+
+func BenchmarkButterflyGo_25(b *testing.B)   { benchmarkButterfly(b, 25, butterflyGo) }
+func BenchmarkButterflyGo_1000(b *testing.B) { benchmarkButterfly(b, 1000, butterflyGo) }
+func BenchmarkButterflyGo_1003(b *testing.B) { benchmarkButterfly(b, 1003, butterflyGo) }

--- a/i32/butterfly.go
+++ b/i32/butterfly.go
@@ -1,6 +1,6 @@
 package i32
 
-// In-place radix-2 butterfly on two equal-length int32 slices.
+// In-place radix-2 butterfly on two int32 slices.
 //
 // Butterfly is the Hadamard/Haar radix-2 step of a fast Walsh-Hadamard
 // transform (FWHT): for each lane it replaces the pair (lo, hi) with their sum

--- a/i32/butterfly.go
+++ b/i32/butterfly.go
@@ -1,0 +1,30 @@
+package i32
+
+// In-place radix-2 butterfly on two equal-length int32 slices.
+//
+// Butterfly is the Hadamard/Haar radix-2 step of a fast Walsh-Hadamard
+// transform (FWHT): for each lane it replaces the pair (lo, hi) with their sum
+// and difference, (lo+hi, lo-hi). Both the add and the subtract wrap in int32
+// rather than saturating, so the SIMD and pure-Go paths are bit-identical across
+// the full int32 range and there is no relaxed tier. It is the haar1 combine
+// applied after a Q31 scale of both lanes: lo, hi = lo+hi, lo-hi.
+
+// Butterfly writes lo[i], hi[i] = lo[i]+hi[i], lo[i]-hi[i] for i in [0, n),
+// n = min(len(lo), len(hi)). The sum and difference are two's-complement
+// wrapping int32 operations (a+b and a-b modulo 2^32), matching a VPADDD/VPSUBD
+// or ADD/SUB .4S lane exactly, so a sum that overflows or a difference that
+// underflows wraps rather than saturating. Any trailing capacity past n in
+// either slice is left untouched.
+//
+// Each lane reads both lo[i] and hi[i] before writing either, and iteration is
+// forward, so the operation is well defined in place lane by lane. lo and hi
+// must NOT overlap each other, though: the SIMD kernels load a whole block of
+// both lo and hi before storing either block, so an overlapping region would
+// clobber input lanes a later iteration has not yet read. Pass two distinct slices.
+func Butterfly(lo, hi []int32) {
+	n := min(len(lo), len(hi))
+	if n == 0 {
+		return
+	}
+	butterflyI32(lo[:n], hi[:n])
+}

--- a/i32/butterfly_amd64_test.go
+++ b/i32/butterfly_amd64_test.go
@@ -1,0 +1,100 @@
+//go:build amd64
+
+package i32
+
+import (
+	"math"
+	"testing"
+
+	"github.com/tphakala/simd/cpu"
+)
+
+// TestButterflyAVX2_ParityWithGo drives the kernel directly across the full
+// tier-3 sweep, over lengths the dispatcher would never route to it, so a
+// threshold change cannot quietly reduce this to a test of the Go reference
+// against itself. Index 0 carries MinInt32/1 (the difference underflows) and the
+// last index MaxInt32/1 (the sum overflows), so both wraps run at every length,
+// and the lane order is checked against the oracle at every position via the
+// value-matrix test in butterfly_test.go.
+func TestButterflyAVX2_ParityWithGo(t *testing.T) {
+	if !cpu.X86.AVX2 {
+		t.Skip("AVX2 not available")
+	}
+	for _, n := range tier3Lengths {
+		lo := genI32(n, 41)
+		hi := genI32(n, 42)
+		if n > 0 {
+			lo[0], hi[0] = math.MinInt32, 1
+			lo[n-1], hi[n-1] = math.MaxInt32, 1
+		}
+		origLo := append([]int32(nil), lo...)
+		origHi := append([]int32(nil), hi...)
+
+		gotLo := append([]int32(nil), lo...)
+		gotHi := append([]int32(nil), hi...)
+		wantLo := append([]int32(nil), lo...)
+		wantHi := append([]int32(nil), hi...)
+		butterflyAVX2(gotLo, gotHi)
+		butterflyGo(wantLo, wantHi)
+		for i := range gotLo {
+			if gotLo[i] != wantLo[i] || gotHi[i] != wantHi[i] {
+				t.Fatalf("butterflyAVX2 n=%d: at %d got (%d,%d), want (%d,%d)", n, i, gotLo[i], gotHi[i], wantLo[i], wantHi[i])
+			}
+			if ws, wd := butterflyOracle(origLo[i], origHi[i]); gotLo[i] != ws || gotHi[i] != wd {
+				t.Fatalf("butterflyAVX2 n=%d: at %d got (%d,%d), oracle (%d,%d)", n, i, gotLo[i], gotHi[i], ws, wd)
+			}
+		}
+	}
+}
+
+// TestButterflyAVX2_NoOverwrite guards the scalar tail: the kernel may not write
+// past n when n is not a multiple of the 8-lane block, in either slice.
+func TestButterflyAVX2_NoOverwrite(t *testing.T) {
+	if !cpu.X86.AVX2 {
+		t.Skip("AVX2 not available")
+	}
+	const n = 11
+	lo := genI32(n+8, 43)
+	hi := genI32(n+8, 44)
+	for i := n; i < len(lo); i++ {
+		lo[i] = math.MaxInt32
+		hi[i] = math.MinInt32
+	}
+	butterflyAVX2(lo[:n], hi[:n])
+	for i := n; i < len(lo); i++ {
+		if lo[i] != math.MaxInt32 {
+			t.Errorf("butterflyAVX2 wrote past end of lo at %d = %d", i, lo[i])
+		}
+		if hi[i] != math.MinInt32 {
+			t.Errorf("butterflyAVX2 wrote past end of hi at %d = %d", i, hi[i])
+		}
+	}
+}
+
+// TestButterflyAVX2_AllocFree asserts the kernel runs allocation-free, the repo's
+// zero-allocation contract enforced at the kernel boundary.
+func TestButterflyAVX2_AllocFree(t *testing.T) {
+	if !cpu.X86.AVX2 {
+		t.Skip("AVX2 not available")
+	}
+	const n = 1024
+	lo := make([]int32, n)
+	hi := make([]int32, n)
+	if got := testing.AllocsPerRun(100, func() { butterflyAVX2(lo, hi) }); got != 0 {
+		t.Errorf("butterflyAVX2 allocated %v times per run, want 0", got)
+	}
+}
+
+// TestButterflyDispatch_ReachesSIMD pins the dispatch state Butterfly depends on.
+// It is a white-box check: the AVX2 kernel is bit-identical to the Go reference by
+// design, so a dispatcher that silently routed every call to Go would pass every
+// parity test. It must not call t.Parallel(): it reads package-level dispatch
+// state.
+func TestButterflyDispatch_ReachesSIMD(t *testing.T) {
+	if hasAVX2 != cpu.X86.AVX2 {
+		t.Fatalf("hasAVX2 = %v but cpu.X86.AVX2 = %v: dispatch flag is not wired to CPU detection", hasAVX2, cpu.X86.AVX2)
+	}
+	if minAVX2Butterfly > 16 {
+		t.Fatalf("minAVX2Butterfly = %d exceeds two vector blocks: Butterfly would not vectorize at the lengths it was written for", minAVX2Butterfly)
+	}
+}

--- a/i32/butterfly_arm64_test.go
+++ b/i32/butterfly_arm64_test.go
@@ -1,0 +1,100 @@
+//go:build arm64
+
+package i32
+
+import (
+	"math"
+	"testing"
+
+	"github.com/tphakala/simd/cpu"
+)
+
+// TestButterflyNEON_ParityWithGo drives the kernel directly across the full
+// tier-3 sweep, over lengths the dispatcher would never route to it, so a
+// threshold change cannot quietly reduce this to a test of the Go reference
+// against itself. Index 0 carries MinInt32/1 (the difference underflows) and the
+// last index MaxInt32/1 (the sum overflows), so both wraps run at every length,
+// and the lane order is checked against the oracle at every position via the
+// value-matrix test in butterfly_test.go.
+func TestButterflyNEON_ParityWithGo(t *testing.T) {
+	if !cpu.ARM64.NEON {
+		t.Skip("NEON not available")
+	}
+	for _, n := range tier3Lengths {
+		lo := genI32(n, 41)
+		hi := genI32(n, 42)
+		if n > 0 {
+			lo[0], hi[0] = math.MinInt32, 1
+			lo[n-1], hi[n-1] = math.MaxInt32, 1
+		}
+		origLo := append([]int32(nil), lo...)
+		origHi := append([]int32(nil), hi...)
+
+		gotLo := append([]int32(nil), lo...)
+		gotHi := append([]int32(nil), hi...)
+		wantLo := append([]int32(nil), lo...)
+		wantHi := append([]int32(nil), hi...)
+		butterflyNEON(gotLo, gotHi)
+		butterflyGo(wantLo, wantHi)
+		for i := range gotLo {
+			if gotLo[i] != wantLo[i] || gotHi[i] != wantHi[i] {
+				t.Fatalf("butterflyNEON n=%d: at %d got (%d,%d), want (%d,%d)", n, i, gotLo[i], gotHi[i], wantLo[i], wantHi[i])
+			}
+			if ws, wd := butterflyOracle(origLo[i], origHi[i]); gotLo[i] != ws || gotHi[i] != wd {
+				t.Fatalf("butterflyNEON n=%d: at %d got (%d,%d), oracle (%d,%d)", n, i, gotLo[i], gotHi[i], ws, wd)
+			}
+		}
+	}
+}
+
+// TestButterflyNEON_NoOverwrite guards the scalar tail: the kernel may not write
+// past n when n is not a multiple of the 4-lane block, in either slice.
+func TestButterflyNEON_NoOverwrite(t *testing.T) {
+	if !cpu.ARM64.NEON {
+		t.Skip("NEON not available")
+	}
+	const n = 11
+	lo := genI32(n+8, 43)
+	hi := genI32(n+8, 44)
+	for i := n; i < len(lo); i++ {
+		lo[i] = math.MaxInt32
+		hi[i] = math.MinInt32
+	}
+	butterflyNEON(lo[:n], hi[:n])
+	for i := n; i < len(lo); i++ {
+		if lo[i] != math.MaxInt32 {
+			t.Errorf("butterflyNEON wrote past end of lo at %d = %d", i, lo[i])
+		}
+		if hi[i] != math.MinInt32 {
+			t.Errorf("butterflyNEON wrote past end of hi at %d = %d", i, hi[i])
+		}
+	}
+}
+
+// TestButterflyNEON_AllocFree asserts the kernel runs allocation-free, the repo's
+// zero-allocation contract enforced at the kernel boundary.
+func TestButterflyNEON_AllocFree(t *testing.T) {
+	if !cpu.ARM64.NEON {
+		t.Skip("NEON not available")
+	}
+	const n = 1024
+	lo := make([]int32, n)
+	hi := make([]int32, n)
+	if got := testing.AllocsPerRun(100, func() { butterflyNEON(lo, hi) }); got != 0 {
+		t.Errorf("butterflyNEON allocated %v times per run, want 0", got)
+	}
+}
+
+// TestButterflyDispatch_ReachesNEON pins the dispatch state Butterfly depends on.
+// It is a white-box check: the NEON kernel is bit-identical to the Go reference by
+// design, so a dispatcher that silently routed every call to Go would pass every
+// parity test. It must not call t.Parallel(): it reads package-level dispatch
+// state.
+func TestButterflyDispatch_ReachesNEON(t *testing.T) {
+	if hasNEON != cpu.ARM64.NEON {
+		t.Fatalf("hasNEON = %v but cpu.ARM64.NEON = %v: dispatch flag is not wired to CPU detection", hasNEON, cpu.ARM64.NEON)
+	}
+	if minNEONButterfly > 8 {
+		t.Fatalf("minNEONButterfly = %d exceeds two vector blocks: Butterfly would not vectorize at the lengths it was written for", minNEONButterfly)
+	}
+}

--- a/i32/butterfly_test.go
+++ b/i32/butterfly_test.go
@@ -1,0 +1,283 @@
+package i32
+
+import (
+	"math"
+	"testing"
+)
+
+// Tests for Butterfly, the in-place radix-2 Hadamard/Haar step
+// lo, hi = lo+hi, lo-hi. Both the sum and the difference wrap in int32 rather
+// than saturating, so the load-bearing cases are the overflow of lo+hi and the
+// underflow of lo-hi: a saturating build would clamp to MaxInt32/MinInt32 and
+// fail these. lo and hi must be distinct slices; overlap is unsupported.
+
+// butterflyOracle computes the sum and difference in int64 and truncates each
+// back to int32, fully independent of the direct int32 arithmetic in butterflyGo
+// and the SIMD kernels. int32 add and sub are arithmetic modulo 2^32, so
+// truncating the exact int64 result reproduces the wrap exactly; it pins the
+// reference rather than trusting a formula shared with it.
+func butterflyOracle(lo, hi int32) (s, d int32) {
+	return int32(int64(lo) + int64(hi)), int32(int64(lo) - int64(hi))
+}
+
+// TestButterflyOracle confirms the oracle itself encodes the wrap, so the parity
+// tests below rest on a checked foundation: MinInt32-1 wraps to MaxInt32 and
+// MaxInt32+1 wraps to MinInt32, the two behaviors a saturating build gets wrong.
+func TestButterflyOracle(t *testing.T) {
+	if s, d := butterflyOracle(math.MinInt32, 1); s != math.MinInt32+1 || d != math.MaxInt32 {
+		t.Fatalf("oracle(MinInt32,1) = (%d,%d), want (%d,%d)", s, d, int32(math.MinInt32+1), int32(math.MaxInt32))
+	}
+	if s, d := butterflyOracle(math.MaxInt32, 1); s != math.MinInt32 || d != math.MaxInt32-1 {
+		t.Fatalf("oracle(MaxInt32,1) = (%d,%d), want (%d,%d)", s, d, int32(math.MinInt32), int32(math.MaxInt32-1))
+	}
+}
+
+// TestButterfly sweeps every tier-3 length against both the pure-Go reference and
+// the arbitrary-precision-free int64 oracle, so a fault cannot hide by agreeing
+// with the reference alone. Index 0 carries MinInt32/1 (the difference underflows
+// to MaxInt32) and the last index MaxInt32/1 (the sum overflows to MinInt32), so
+// both wraps are exercised at every length, at the head and riding the tail.
+func TestButterfly(t *testing.T) {
+	for _, n := range tier3Lengths {
+		lo := genI32(n, 51)
+		hi := genI32(n, 52)
+		if n > 0 {
+			lo[0], hi[0] = math.MinInt32, 1
+			lo[n-1], hi[n-1] = math.MaxInt32, 1
+		}
+		origLo := append([]int32(nil), lo...)
+		origHi := append([]int32(nil), hi...)
+
+		refLo := append([]int32(nil), lo...)
+		refHi := append([]int32(nil), hi...)
+		butterflyGo(refLo, refHi)
+
+		Butterfly(lo, hi)
+		for i := range lo {
+			if lo[i] != refLo[i] || hi[i] != refHi[i] {
+				t.Fatalf("Butterfly n=%d: at %d got (%d,%d), reference (%d,%d)", n, i, lo[i], hi[i], refLo[i], refHi[i])
+			}
+			if ws, wd := butterflyOracle(origLo[i], origHi[i]); lo[i] != ws || hi[i] != wd {
+				t.Fatalf("Butterfly n=%d: at %d got (%d,%d), oracle (%d,%d)", n, i, lo[i], hi[i], ws, wd)
+			}
+		}
+	}
+}
+
+// TestButterfly_ValueMatrix crosses the load-bearing samples for lo and hi and
+// plants each pair in every lane position across a length that spans a vector
+// block plus a scalar tail on both arches, so a lane error, an index error, and a
+// value the wrap mishandles are all caught at whichever position exposes them.
+func TestButterfly_ValueMatrix(t *testing.T) {
+	vals := []int32{math.MinInt32, math.MaxInt32, 0, -1, 1, 2, 0x12345678, -0x12345678, 0x7FFFFFFE}
+	const n = 11 // one 8-wide AVX2 block + 3 tail; two 4-wide NEON blocks + 3 tail
+	fillerLo := genI32(n, 53)
+	fillerHi := genI32(n, 54)
+	for _, lv := range vals {
+		for _, hv := range vals {
+			for pos := range n {
+				lo := append([]int32(nil), fillerLo...)
+				hi := append([]int32(nil), fillerHi...)
+				lo[pos] = lv
+				hi[pos] = hv
+				origLo := append([]int32(nil), lo...)
+				origHi := append([]int32(nil), hi...)
+				Butterfly(lo, hi)
+				for i := range lo {
+					ws, wd := butterflyOracle(origLo[i], origHi[i])
+					if lo[i] != ws || hi[i] != wd {
+						t.Fatalf("Butterfly lv=%d hv=%d pos=%d: at %d got (%d,%d), want (%d,%d)", lv, hv, pos, i, lo[i], hi[i], ws, wd)
+					}
+				}
+			}
+		}
+	}
+}
+
+// TestButterfly_Wrap pins the two extreme contracts in isolation. n=11 forces
+// both the vector body and the scalar tail on both arches. lo=MinInt32,hi=1 gives
+// sum MinInt32+1 and difference MinInt32-1, which wraps to MaxInt32 (a saturating
+// build would return MinInt32); lo=MaxInt32,hi=1 gives sum MaxInt32+1, which wraps
+// to MinInt32 (a saturating build would return MaxInt32).
+func TestButterfly_Wrap(t *testing.T) {
+	const n = 11
+	lo := make([]int32, n)
+	hi := make([]int32, n)
+
+	for i := range lo {
+		lo[i], hi[i] = math.MinInt32, 1
+	}
+	Butterfly(lo, hi)
+	for i := range lo {
+		if lo[i] != math.MinInt32+1 {
+			t.Fatalf("Butterfly MinInt32+1 sum: lo[%d] = %d, want %d", i, lo[i], int32(math.MinInt32+1))
+		}
+		if hi[i] != math.MaxInt32 {
+			t.Fatalf("Butterfly MinInt32-1 diff: hi[%d] = %d, want %d (wrap, not saturate)", i, hi[i], int32(math.MaxInt32))
+		}
+	}
+
+	for i := range lo {
+		lo[i], hi[i] = math.MaxInt32, 1
+	}
+	Butterfly(lo, hi)
+	for i := range lo {
+		if lo[i] != math.MinInt32 {
+			t.Fatalf("Butterfly MaxInt32+1 sum: lo[%d] = %d, want %d (wrap, not saturate)", i, lo[i], int32(math.MinInt32))
+		}
+		if hi[i] != math.MaxInt32-1 {
+			t.Fatalf("Butterfly MaxInt32-1 diff: hi[%d] = %d, want %d", i, hi[i], int32(math.MaxInt32-1))
+		}
+	}
+}
+
+// TestButterfly_TailUntouched plants sentinels past the clamp point at n=11 (one
+// 8-wide AVX2 block + 3 tail, two 4-wide NEON blocks + the same tail) in both
+// slices, so both vector bodies run and both scalar tails must stop exactly at n.
+func TestButterfly_TailUntouched(t *testing.T) {
+	const n = 11
+	lo := genI32(n+8, 55)
+	hi := genI32(n+8, 56)
+	for i := n; i < len(lo); i++ {
+		lo[i] = math.MaxInt32
+		hi[i] = math.MinInt32
+	}
+	Butterfly(lo[:n], hi[:n])
+	for i := n; i < len(lo); i++ {
+		if lo[i] != math.MaxInt32 {
+			t.Errorf("Butterfly wrote past end of lo at %d = %d", i, lo[i])
+		}
+		if hi[i] != math.MinInt32 {
+			t.Errorf("Butterfly wrote past end of hi at %d = %d", i, hi[i])
+		}
+	}
+}
+
+// TestButterfly_Clamp covers mismatched lengths and the empty no-op: n is the
+// shorter of lo and hi, only the first n of each are updated, and nothing past it
+// is touched.
+func TestButterfly_Clamp(t *testing.T) {
+	// lo shorter: n = len(lo) = 25.
+	lo := genI32(25, 57)
+	hi := genI32(40, 58)
+	origLo := append([]int32(nil), lo...)
+	origHi := append([]int32(nil), hi...)
+	Butterfly(lo, hi)
+	for i := range lo {
+		if ws, wd := butterflyOracle(origLo[i], origHi[i]); lo[i] != ws || hi[i] != wd {
+			t.Fatalf("Butterfly clamp lo: at %d got (%d,%d), want (%d,%d)", i, lo[i], hi[i], ws, wd)
+		}
+	}
+	for i := 25; i < len(hi); i++ {
+		if hi[i] != origHi[i] {
+			t.Fatalf("Butterfly wrote past n into hi[%d] = %d, want %d", i, hi[i], origHi[i])
+		}
+	}
+
+	// hi shorter: n = len(hi) = 25.
+	lo2 := genI32(40, 59)
+	hi2 := genI32(25, 60)
+	origLo2 := append([]int32(nil), lo2...)
+	origHi2 := append([]int32(nil), hi2...)
+	Butterfly(lo2, hi2)
+	for i := range hi2 {
+		if ws, wd := butterflyOracle(origLo2[i], origHi2[i]); lo2[i] != ws || hi2[i] != wd {
+			t.Fatalf("Butterfly clamp hi: at %d got (%d,%d), want (%d,%d)", i, lo2[i], hi2[i], ws, wd)
+		}
+	}
+	for i := 25; i < len(lo2); i++ {
+		if lo2[i] != origLo2[i] {
+			t.Fatalf("Butterfly wrote past n into lo[%d] = %d, want %d", i, lo2[i], origLo2[i])
+		}
+	}
+
+	// Empty inputs are a no-op.
+	Butterfly(nil, nil)
+	one := []int32{42}
+	Butterfly(one, nil)
+	if one[0] != 42 {
+		t.Errorf("Butterfly wrote on empty input: %v", one)
+	}
+}
+
+// TestButterfly_DistinctSlices confirms the documented contract that lo and hi
+// are distinct backing arrays and transform correctly. It deliberately does NOT
+// exercise overlapping lo/hi, which is unsupported: the SIMD kernels load a whole
+// block of both before storing either, so an overlap would clobber unread input.
+func TestButterfly_DistinctSlices(t *testing.T) {
+	const n = 64
+	lo := genI32(n, 63)
+	hi := genI32(n, 64)
+	origLo := append([]int32(nil), lo...)
+	origHi := append([]int32(nil), hi...)
+	Butterfly(lo, hi)
+	for i := range lo {
+		if ws, wd := butterflyOracle(origLo[i], origHi[i]); lo[i] != ws || hi[i] != wd {
+			t.Fatalf("Butterfly distinct n=%d: at %d got (%d,%d), want (%d,%d)", n, i, lo[i], hi[i], ws, wd)
+		}
+	}
+}
+
+// TestButterfly_UnalignedOperands sweeps all eight element offsets into separate
+// backing arrays for lo and hi, so neither slice starts at a reliable alignment
+// and an aligned-load or aligned-store substitution cannot survive.
+func TestButterfly_UnalignedOperands(t *testing.T) {
+	const span = 320
+	backingLo := genI32(span, 61)
+	backingHi := genI32(span, 62)
+	for _, n := range []int{4, 5, 8, 9, 11, 17, 25, 33, 64, 240} {
+		for off := range 8 {
+			lo := backingLo[off+1 : off+1+n]
+			hi := backingHi[off+1 : off+1+n]
+			origLo := append([]int32(nil), lo...)
+			origHi := append([]int32(nil), hi...)
+			Butterfly(lo, hi)
+			for i := range n {
+				if ws, wd := butterflyOracle(origLo[i], origHi[i]); lo[i] != ws || hi[i] != wd {
+					t.Fatalf("Butterfly unaligned n=%d off=%d: at %d got (%d,%d), want (%d,%d)", n, off, i, lo[i], hi[i], ws, wd)
+				}
+			}
+		}
+	}
+}
+
+// TestButterfly_AllocFree declares the buffers INSIDE the measured closure so only
+// allocations forced by the butterfly itself are counted.
+func TestButterfly_AllocFree(t *testing.T) {
+	if n := testing.AllocsPerRun(50, func() {
+		var lo, hi [1000]int32
+		Butterfly(lo[:], hi[:])
+	}); n != 0 {
+		t.Errorf("Butterfly forces %v caller allocations per run, want 0", n)
+	}
+}
+
+// FuzzButterfly differentially fuzzes the dispatched Butterfly against the pure-Go
+// reference and the int64 oracle. The raw bytes are split into two equal halves
+// (lo and hi) copied into distinct backing arrays, so tail handling and the wrap
+// are explored past the hand-picked seeds. It reuses addLenSeeds, whose element
+// counts bracket the 8/16-lane unroll boundaries.
+func FuzzButterfly(f *testing.F) {
+	addLenSeeds(f)
+	f.Fuzz(func(t *testing.T, raw []byte) {
+		v := i32sFromBits(raw)
+		h := len(v) / 2
+		lo := append([]int32(nil), v[:h]...)
+		hi := append([]int32(nil), v[h:2*h]...)
+		origLo := append([]int32(nil), lo...)
+		origHi := append([]int32(nil), hi...)
+
+		refLo := append([]int32(nil), lo...)
+		refHi := append([]int32(nil), hi...)
+		butterflyGo(refLo, refHi)
+
+		Butterfly(lo, hi)
+		equalI32(t, "Butterfly.lo", lo, refLo)
+		equalI32(t, "Butterfly.hi", hi, refHi)
+		for i := range lo {
+			if ws, wd := butterflyOracle(origLo[i], origHi[i]); lo[i] != ws || hi[i] != wd {
+				t.Fatalf("Butterfly oracle mismatch at %d: got (%d,%d) want (%d,%d) (len=%d)", i, lo[i], hi[i], ws, wd, len(lo))
+			}
+		}
+	})
+}

--- a/i32/i32_amd64.go
+++ b/i32/i32_amd64.go
@@ -147,6 +147,23 @@ func scaleQ31AVX2(dst, a []int32, k int32)
 //go:noescape
 func scaleQ15AVX2(dst, a []int32, k int16)
 
+// minAVX2Butterfly is one 8-wide (256-bit) block, an independent literal like
+// the tier-3 thresholds above. The kernel is correct at any length (it falls
+// through to a scalar tail), so this is a performance cut only, never a safety
+// requirement. It gates on AVX2 because VPADDD/VPSUBD are 256-bit integer ops.
+const minAVX2Butterfly = 8
+
+func butterflyI32(lo, hi []int32) {
+	if hasAVX2 && len(lo) >= minAVX2Butterfly {
+		butterflyAVX2(lo, hi)
+		return
+	}
+	butterflyGo(lo, hi)
+}
+
+//go:noescape
+func butterflyAVX2(lo, hi []int32)
+
 // minMaxI32 dispatches the signed int32 min/max reduction. The AVX2 kernel does
 // the reduction in 8-wide VPMINSD/VPMAXSD lanes with a scalar tail, so it gates
 // on AVX2 and at least one full 8-element block; shorter slices use the pure-Go

--- a/i32/i32_amd64.s
+++ b/i32/i32_amd64.s
@@ -558,3 +558,54 @@ scaleq15_avx2_scalar:
 scaleq15_avx2_done:
     VZEROUPPER
     RET
+
+// func butterflyAVX2(lo, hi []int32)
+// In-place radix-2 butterfly, 8 int32 per iteration: each block loads lo and hi,
+// forms the wrapping sum (VPADDD) and difference (VPSUBD) into fresh registers
+// BEFORE storing either, then writes lo = lo+hi and hi = lo-hi. Reading the whole
+// block of both inputs before either store is what makes the in-place update safe
+// and is also why lo and hi must not overlap. The scalar tail does the same on
+// 32-bit GPRs, computing the sum in R8 while AX still holds lo so SUBL forms the
+// difference from the unmodified lo. Every add/sub wraps in a 32-bit lane, matching
+// butterflyGo exactly. Frame is two slice headers: lo+0, hi+24.
+TEXT ·butterflyAVX2(SB), NOSPLIT, $0-48
+    MOVQ lo_base+0(FP), SI
+    MOVQ lo_len+8(FP), CX
+    MOVQ hi_base+24(FP), DI
+
+    MOVQ CX, AX
+    SHRQ $3, AX
+    JZ   butterfly_remainder
+
+butterfly_loop8:
+    VMOVDQU (SI), Y0          // lo block
+    VMOVDQU (DI), Y1          // hi block
+    VPADDD  Y1, Y0, Y2        // Y2 = lo + hi
+    VPSUBD  Y1, Y0, Y3        // Y3 = lo - hi
+    VMOVDQU Y2, (SI)          // lo = lo + hi
+    VMOVDQU Y3, (DI)          // hi = lo - hi
+    ADDQ $32, SI
+    ADDQ $32, DI
+    DECQ AX
+    JNZ  butterfly_loop8
+
+butterfly_remainder:
+    ANDQ $7, CX
+    JZ   butterfly_done
+
+butterfly_scalar:
+    MOVL (SI), AX             // lo
+    MOVL (DI), BX             // hi
+    MOVL AX, R8
+    ADDL BX, R8              // R8 = lo + hi (wraps in 32-bit)
+    SUBL BX, AX              // AX = lo - hi (AX still holds lo)
+    MOVL R8, (SI)            // lo = lo + hi
+    MOVL AX, (DI)            // hi = lo - hi
+    ADDQ $4, SI
+    ADDQ $4, DI
+    DECQ CX
+    JNZ  butterfly_scalar
+
+butterfly_done:
+    VZEROUPPER
+    RET

--- a/i32/i32_arm64.go
+++ b/i32/i32_arm64.go
@@ -132,6 +132,23 @@ func scaleQ31NEON(dst, a []int32, k int32)
 //go:noescape
 func scaleQ15NEON(dst, a []int32, k int16)
 
+// minNEONButterfly is one 4-wide (.4S) block, an independent literal like the
+// tier-3 thresholds above. The kernel is correct at any length (it falls through
+// to a scalar tail), so this is a performance cut only, never a safety
+// requirement.
+const minNEONButterfly = 4
+
+func butterflyI32(lo, hi []int32) {
+	if hasNEON && len(lo) >= minNEONButterfly {
+		butterflyNEON(lo, hi)
+		return
+	}
+	butterflyGo(lo, hi)
+}
+
+//go:noescape
+func butterflyNEON(lo, hi []int32)
+
 // minMaxI32 dispatches the signed int32 min/max reduction. The NEON kernel does
 // the reduction in 4-wide SMIN/SMAX lanes with a single-instruction SMINV/SMAXV
 // across-vector fold and a scalar tail, so it gates on NEON and at least one full

--- a/i32/i32_arm64.s
+++ b/i32/i32_arm64.s
@@ -440,3 +440,56 @@ scaleq15_neon_scalar:
 
 scaleq15_neon_done:
     RET
+
+// func butterflyNEON(lo, hi []int32)
+// In-place radix-2 butterfly, 4 int32 per iteration: each block loads lo and hi,
+// forms the wrapping sum (ADD .4S -> V2) and difference (SUB .4S -> V3) BEFORE
+// storing either, then writes lo = lo+hi and hi = lo-hi. Both loads precede both
+// stores, so each block of lo and hi is read in full before either is written;
+// that ordering is what makes the in-place update safe (and why lo and hi must not
+// overlap). The loads are plain VLD1 with a manual ADD $16 advance because each
+// slice uses a single pointer register for both its load and its store, so a
+// post-increment load (VLD1.P) would advance that pointer before the in-place store
+// and misaddress it. The ADD/SUB .4S
+// WORDs are the addNEON/subNEON encodings with the destination lane in V2 (sum)
+// and V3 (diff); they are cross-checked against arm64asm by TestArm64WordEncodings.
+// The scalar tail computes both results from the unmodified lo/hi in W registers
+// (ADDW/SUBW) so it wraps identically. Frame is two slice headers: lo+0, hi+24.
+TEXT ·butterflyNEON(SB), NOSPLIT, $0-48
+    MOVD lo_base+0(FP), R0
+    MOVD lo_len+8(FP), R3
+    MOVD hi_base+24(FP), R1
+
+    LSR  $2, R3, R4            // R4 = n / 4
+    CBZ  R4, butterfly_neon_remainder
+
+butterfly_neon_loop4:
+    VLD1 (R0), [V0.S4]         // lo
+    VLD1 (R1), [V1.S4]         // hi
+    WORD $0x4EA18402           // ADD V2.4S, V0.4S, V1.4S   (sum = lo + hi)
+    WORD $0x6EA18403           // SUB V3.4S, V0.4S, V1.4S   (diff = lo - hi)
+    VST1 [V2.S4], (R0)         // lo = lo + hi
+    VST1 [V3.S4], (R1)         // hi = lo - hi
+    ADD  $16, R0
+    ADD  $16, R1
+    SUB  $1, R4
+    CBNZ R4, butterfly_neon_loop4
+
+butterfly_neon_remainder:
+    AND  $3, R3
+    CBZ  R3, butterfly_neon_done
+
+butterfly_neon_loop1:
+    MOVW (R0), R5             // lo
+    MOVW (R1), R6             // hi
+    ADDW R6, R5, R7           // R7 = lo + hi (wraps in 32-bit)
+    SUBW R6, R5, R8           // R8 = lo - hi
+    MOVW R7, (R0)             // lo = lo + hi
+    MOVW R8, (R1)             // hi = lo - hi
+    ADD  $4, R0
+    ADD  $4, R1
+    SUB  $1, R3
+    CBNZ R3, butterfly_neon_loop1
+
+butterfly_neon_done:
+    RET

--- a/i32/i32_go.go
+++ b/i32/i32_go.go
@@ -101,6 +101,27 @@ func negWhereNegGo(dst, mag []int32, sign []float32) {
 	}
 }
 
+// butterflyGo writes the in-place radix-2 butterfly that is Butterfly's source
+// of truth: lo[i], hi[i] = lo[i]+hi[i], lo[i]-hi[i]. Both operations wrap in
+// int32 (addition and subtraction modulo 2^32), matching the VPADDD/VPSUBD and
+// ADD/SUB .4S lanes exactly. Each lane forms the sum and difference into
+// temporaries before writing either output, so lo[i] is read for the difference
+// before its own store overwrites it and the in-place update is well defined.
+// lo and hi must not overlap each other. lo may be empty; the len-0 guard
+// protects the len(lo)-1 BCE hint.
+func butterflyGo(lo, hi []int32) {
+	if len(lo) == 0 {
+		return
+	}
+	_ = hi[len(lo)-1] // BCE hint: hi is indexed [0, len(lo))
+	for i := range lo {
+		s := lo[i] + hi[i] // wrapping int32 sum
+		d := lo[i] - hi[i] // wrapping int32 difference
+		lo[i] = s
+		hi[i] = d
+	}
+}
+
 // scaleQ31Shift is the fixed-point position of the Q31 result: the full 64-bit
 // product int64(a)*int64(k) is arithmetically shifted right by 31 to land the
 // Q31 fractional scale back in int32 range.

--- a/i32/i32_other.go
+++ b/i32/i32_other.go
@@ -16,3 +16,5 @@ func negWhereNegI32(dst, mag []int32, sign []float32) { negWhereNegGo(dst, mag, 
 
 func scaleQ31I32(dst, a []int32, k int32) { scaleQ31Go(dst, a, k) }
 func scaleQ15I32(dst, a []int32, k int16) { scaleQ15Go(dst, a, k) }
+
+func butterflyI32(lo, hi []int32) { butterflyGo(lo, hi) }


### PR DESCRIPTION
## Summary

Adds `Butterfly(lo, hi []int32)`, the in-place radix-2 butterfly: for `i` in `[0, n)`, `n = min(len(lo), len(hi))`, it writes `lo[i], hi[i] = lo[i]+hi[i], lo[i]-hi[i]`. Both the sum and the difference wrap in int32 (two's complement, modulo 2^32) rather than saturating, so the SIMD and pure-Go paths are bit-identical across the full int32 range with no relaxed tier. This is the radix-2 butterfly shared by the fast Walsh-Hadamard transform and the CELT `haar1` step: after a Q31 scale of both lanes, `haar1` becomes `ScaleQ31` on each lane followed by `Butterfly`.

The update is in place lane by lane (each lane reads both `lo[i]` and `hi[i]` before writing either, and iteration is forward). `lo` and `hi` must not overlap each other: the SIMD kernels load a whole block of both before storing either block, so an overlapping region could clobber input a later iteration has not yet read.

Kernels are bit-identical across amd64 AVX2, arm64 NEON, and the Go fallback. AVX2 loads 8 int32 of each slice and forms `VPADDD` (sum) and `VPSUBD` (difference) into fresh registers before storing both. NEON does the same 4-wide with `ADD`/`SUB .4S` (hand-encoded `WORD`s, cross-checked against `arm64asm`), using plain `VLD1` loads with a manual advance because each slice shares one pointer for its load and its store. Direct i32 dispatch (`hasAVX2`/`hasNEON` + threshold const + branch), so it stays allocation-free.

## Related issues

Part of #181 (the `Butterfly` building block; `ScaleQ31`/`ScaleQ15` landed in #187). `MaxAbs` and `FIRValidQ15` remain.

## Test plan

- [x] Parity against the Go reference and an independent int64 oracle over a length sweep (0..64 plus 100/127/128/129/240/255/256/257/1000/1003/1024) forcing both the vector loop and the scalar tail on both widths
- [x] Explicit MinInt32/MaxInt32 wrap assertions, per-position value matrix, tail-untouched, mismatched-length clamp, distinct-slice, unaligned starts, alloc-free (0 allocs/op), dispatch-pin
- [x] Differential fuzz (dispatched path vs reference vs oracle): ~10M+ executions clean
- [x] Verified bit-exact on real AVX2 hardware (i7-1260P) and real NEON hardware (Raspberry Pi 5); `TestArm64WordEncodings` cross-checks both new `WORD` encodings against `arm64asm`