### PR TITLE
i32: add MaxAbs, the celtMaxabs32 peak-magnitude reduction (#181)

### DIFF
--- a/i32/benchmark_test.go
+++ b/i32/benchmark_test.go
@@ -259,3 +259,24 @@ func BenchmarkButterfly_1003(b *testing.B) { benchmarkButterfly(b, 1003, Butterf
 func BenchmarkButterflyGo_25(b *testing.B)   { benchmarkButterfly(b, 25, butterflyGo) }
 func BenchmarkButterflyGo_1000(b *testing.B) { benchmarkButterfly(b, 1000, butterflyGo) }
 func BenchmarkButterflyGo_1003(b *testing.B) { benchmarkButterfly(b, 1003, butterflyGo) }
+
+// MaxAbs is a reduction reading a single slice, like Sum: SetBytes counts a.
+func benchmarkMaxAbs(b *testing.B, n int, fn func(a []int32) int32) {
+	b.Helper()
+	a := make([]int32, n)
+	for i := range a {
+		a[i] = int32(i*7 - 3000)
+	}
+	b.SetBytes(int64(n) * 4)
+	for b.Loop() {
+		_ = fn(a)
+	}
+}
+
+func BenchmarkMaxAbs_25(b *testing.B)   { benchmarkMaxAbs(b, 25, MaxAbs) }
+func BenchmarkMaxAbs_1000(b *testing.B) { benchmarkMaxAbs(b, 1000, MaxAbs) }
+func BenchmarkMaxAbs_1003(b *testing.B) { benchmarkMaxAbs(b, 1003, MaxAbs) }
+
+func BenchmarkMaxAbsGo_25(b *testing.B)   { benchmarkMaxAbs(b, 25, maxAbsGo) }
+func BenchmarkMaxAbsGo_1000(b *testing.B) { benchmarkMaxAbs(b, 1000, maxAbsGo) }
+func BenchmarkMaxAbsGo_1003(b *testing.B) { benchmarkMaxAbs(b, 1003, maxAbsGo) }

--- a/i32/i32_amd64.go
+++ b/i32/i32_amd64.go
@@ -177,3 +177,21 @@ func minMaxI32(res []int32) (minVal, maxVal int32) {
 
 //go:noescape
 func minMaxAVX2(res []int32) (minVal, maxVal int32)
+
+// minAVX2MaxAbs is one 8-wide (256-bit) block, an independent literal like the
+// tier-3 thresholds above. The kernel does the signed min/max reduction in
+// 8-wide VPMINSD/VPMAXSD lanes with a scalar tail before combining to
+// max(maxVal, -minVal), so it gates on AVX2 and at least one full 8-element
+// block; shorter slices use the pure-Go reference. a is non-empty (the public
+// MaxAbs guards the empty case).
+const minAVX2MaxAbs = 8
+
+func maxAbsI32(a []int32) int32 {
+	if hasAVX2 && len(a) >= minAVX2MaxAbs {
+		return maxAbsAVX2(a)
+	}
+	return maxAbsGo(a)
+}
+
+//go:noescape
+func maxAbsAVX2(a []int32) int32

--- a/i32/i32_amd64.s
+++ b/i32/i32_amd64.s
@@ -609,3 +609,81 @@ butterfly_scalar:
 butterfly_done:
     VZEROUPPER
     RET
+
+// func maxAbsAVX2(a []int32) int32
+// Peak magnitude with celtMaxabs32 semantics: the same signed int32 min/max
+// reduction as minMaxAVX2 (VMOVDQU block 0 into both accumulators, VPMINSD/
+// VPMAXSD fold, horizontal reduce to a scalar min in AX and max in DX, CMPL
+// scalar tail), then a combine to max(maxVal, -minVal). NEGL forms -minVal with
+// the two's-complement wrap (-MinInt32 == MinInt32), and the signed CMPL/JGE
+// picks the larger of maxVal and -minVal. The dispatch gates len(a) >= 8, so at
+// least one full 8-element block exists; every compare is signed, matching
+// maxAbsGo exactly. Frame is one slice header plus the int32 return: a+0, ret+24.
+TEXT ·maxAbsAVX2(SB), NOSPLIT, $0-28
+    MOVQ a_base+0(FP), R8
+    MOVQ a_len+8(FP), CX             // n (>=8)
+    MOVQ CX, R9
+    SHRQ $3, R9                      // R9 = full 8-element blocks (>=1)
+    VMOVDQU (R8), Y0                 // min acc = block 0
+    VMOVDQU (R8), Y1                 // max acc = block 0
+    MOVQ R9, AX                      // block counter
+    DECQ AX                          // blocks remaining after block 0
+    JZ   maxabs_reduce               // single block: accumulators already hold it
+    LEAQ 32(R8), SI                  // working ptr at block 1
+maxabs_loop:
+    VMOVDQU (SI), Y2
+    VPMINSD Y2, Y0, Y0               // Y0 = lanewise min(Y2, Y0)
+    VPMAXSD Y2, Y1, Y1               // Y1 = lanewise max(Y2, Y1)
+    ADDQ $32, SI
+    DECQ AX
+    JNZ  maxabs_loop
+
+maxabs_reduce:
+
+    // horizontal min of Y0 -> AX (low 32 bits), max of Y1 -> DX (low 32 bits)
+    VEXTRACTI128 $1, Y0, X3
+    VPMINSD X3, X0, X0               // fold lanes 4..7 into 0..3
+    VPSHUFD $0x4E, X0, X3            // swap 64-bit halves
+    VPMINSD X3, X0, X0
+    VPSHUFD $0xB1, X0, X3            // swap 32-bit within pairs
+    VPMINSD X3, X0, X0               // lane0 = min over all 8 lanes
+    MOVQ X0, AX                      // EAX = running min
+
+    VEXTRACTI128 $1, Y1, X3
+    VPMAXSD X3, X1, X1
+    VPSHUFD $0x4E, X1, X3
+    VPMAXSD X3, X1, X1
+    VPSHUFD $0xB1, X1, X3
+    VPMAXSD X3, X1, X1
+    MOVQ X1, DX                      // EDX = running max
+
+    // scalar tail: (n mod 8) residuals at &a[fullBlocks*8]
+    MOVQ CX, BX
+    ANDQ $7, BX
+    JZ   maxabs_combine
+    MOVQ R9, R10
+    SHLQ $5, R10                     // fullBlocks * 32 bytes
+    ADDQ R8, R10                     // tail ptr
+maxabs_tail:
+    MOVL (R10), R11                  // r (32-bit)
+    CMPL R11, AX
+    JGE  maxabs_tail_max
+    MOVL R11, AX                     // r < min -> new min
+maxabs_tail_max:
+    CMPL R11, DX
+    JLE  maxabs_tail_next
+    MOVL R11, DX                     // r > max -> new max
+maxabs_tail_next:
+    ADDQ $4, R10
+    DECQ BX
+    JNZ  maxabs_tail
+
+maxabs_combine:
+    NEGL AX                          // AX = -min (wrapping; -MinInt32 == MinInt32)
+    CMPL DX, AX                      // signed max vs -min
+    JGE  maxabs_ret_max              // max >= -min: result = max (DX)
+    MOVL AX, DX                      // else result = -min
+maxabs_ret_max:
+    MOVL DX, ret+24(FP)
+    VZEROUPPER
+    RET

--- a/i32/i32_arm64.go
+++ b/i32/i32_arm64.go
@@ -163,3 +163,21 @@ func minMaxI32(res []int32) (minVal, maxVal int32) {
 
 //go:noescape
 func minMaxNEON(res []int32) (minVal, maxVal int32)
+
+// minNEONMaxAbs is one 4-wide (.4S) block, an independent literal like the
+// tier-3 thresholds above. The kernel does the signed min/max reduction in
+// 4-wide SMIN/SMAX lanes with SMINV/SMAXV folds and a scalar tail before
+// combining to max(maxVal, -minVal), so it gates on NEON and at least one full
+// 4-element block; shorter slices use the pure-Go reference. a is non-empty (the
+// public MaxAbs guards the empty case).
+const minNEONMaxAbs = 4
+
+func maxAbsI32(a []int32) int32 {
+	if hasNEON && len(a) >= minNEONMaxAbs {
+		return maxAbsNEON(a)
+	}
+	return maxAbsGo(a)
+}
+
+//go:noescape
+func maxAbsNEON(a []int32) int32

--- a/i32/i32_arm64.s
+++ b/i32/i32_arm64.s
@@ -493,3 +493,56 @@ butterfly_neon_loop1:
 
 butterfly_neon_done:
     RET
+
+// func maxAbsNEON(a []int32) int32
+// Peak magnitude with celtMaxabs32 semantics: the same signed int32 min/max
+// reduction as minMaxNEON (VLD1 block 0 into both accumulators, WORD-encoded
+// SMIN/SMAX fold, SMINV/SMAXV across-lane reduce into R5=min/R6=max via FMOVS,
+// CSEL scalar tail), then a combine to max(maxVal, -minVal). NEG forms -minVal
+// with the two's-complement wrap (-MinInt32 == MinInt32); the low 32 bits of the
+// negate are correct regardless of the accumulator's upper bits (FMOVS
+// zero-extends, the tail sign-extends), so the combine compares in 32-bit CMPW
+// and the MOVW store keeps the low 32 bits. The signed CSEL GE then picks the
+// larger of maxVal and -minVal. The SMIN/SMAX/SMINV/SMAXV WORDs are the
+// minMaxNEON encodings verbatim (cross-checked by asmcheck_test.go). The dispatch
+// gates len(a) >= 4, so at least one full 4-element block exists. Frame is one
+// slice header plus the int32 return: a+0, ret+24.
+TEXT ·maxAbsNEON(SB), NOSPLIT, $0-28
+    MOVD a_base+0(FP), R2
+    MOVD a_len+8(FP), R3
+    LSR  $2, R3, R4                  // R4 = full 4-element blocks (>=1)
+    VLD1 (R2), [V0.S4]               // V0 = block 0 (min acc), no advance
+    VLD1.P 16(R2), [V1.S4]           // V1 = block 0 (max acc), advance to block 1
+    SUB  $1, R4                      // blocks remaining after block 0
+    CBZ  R4, maxabs_neon_reduce      // single block: accumulators hold it; R2 at tail
+maxabs_neon_loop:
+    VLD1.P 16(R2), [V2.S4]           // load block + advance
+    WORD $0x4EA26C00                 // SMIN V0.4S, V0.4S, V2.4S
+    WORD $0x4EA26421                 // SMAX V1.4S, V1.4S, V2.4S
+    SUB  $1, R4
+    CBNZ R4, maxabs_neon_loop
+
+maxabs_neon_reduce:
+    WORD $0x4EB1A803                 // SMINV S3, V0.4S
+    WORD $0x4EB0A824                 // SMAXV S4, V1.4S
+    FMOVS F3, R5                     // R5 = running min (low 32 = int32)
+    FMOVS F4, R6                     // R6 = running max (low 32 = int32)
+
+    // scalar tail: (n mod 4) residuals (R2 already at &a[fullBlocks*4])
+    AND  $3, R3, R4
+    CBZ  R4, maxabs_neon_combine
+maxabs_neon_tail:
+    MOVW.P 4(R2), R7                 // r (sign-extended; low 32 = int32)
+    CMPW R5, R7                      // (R7 - R5), signed 32-bit
+    CSEL LT, R7, R5, R5             // R5 = min(r, R5)
+    CMPW R6, R7
+    CSEL GT, R7, R6, R6             // R6 = max(r, R6)
+    SUB  $1, R4
+    CBNZ R4, maxabs_neon_tail
+
+maxabs_neon_combine:
+    NEG  R5, R7                      // R7 = -min (low 32 = wrapping int32 negate)
+    CMPW R7, R6                      // (R6 - R7), signed 32-bit: max vs -min
+    CSEL GE, R6, R7, R0             // R0 = max(R6, R7) = max(maxVal, -minVal)
+    MOVW R0, ret+24(FP)
+    RET

--- a/i32/i32_go.go
+++ b/i32/i32_go.go
@@ -80,6 +80,21 @@ func minMaxGo(res []int32) (minVal, maxVal int32) {
 	return lo, hi
 }
 
+// maxAbsGo is MaxAbs's source of truth: the peak magnitude with celtMaxabs32
+// semantics. It runs the signed min/max scan, then returns max(hi, -lo), where
+// -lo is a WRAPPING int32 negate (-MinInt32 == MinInt32). This is NOT per-lane
+// abs-then-max: for a = [MinInt32, -3] it returns max(-3, MinInt32) = -3, not 3.
+// minMaxGo requires a non-empty a, so the public MaxAbs guards the len==0 case
+// before dispatch.
+func maxAbsGo(a []int32) int32 {
+	lo, hi := minMaxGo(a) // reuse the signed min/max scan
+	neg := -lo            // wrapping: -MinInt32 == MinInt32
+	if hi > neg {
+		return hi
+	}
+	return neg
+}
+
 // negWhereNegGo writes the branchless conditional negate that is NegWhereNeg's
 // source of truth. For each lane it broadcasts sign[i]'s IEEE-754 sign bit into
 // a full-width int32 mask m via an arithmetic right shift (m = -1 when the sign

--- a/i32/i32_other.go
+++ b/i32/i32_other.go
@@ -12,6 +12,8 @@ func sumI32(a []int32) int32   { return sumGo(a) }
 
 func minMaxI32(res []int32) (minVal, maxVal int32) { return minMaxGo(res) }
 
+func maxAbsI32(a []int32) int32 { return maxAbsGo(a) }
+
 func negWhereNegI32(dst, mag []int32, sign []float32) { negWhereNegGo(dst, mag, sign) }
 
 func scaleQ31I32(dst, a []int32, k int32) { scaleQ31Go(dst, a, k) }

--- a/i32/maxabs.go
+++ b/i32/maxabs.go
@@ -1,0 +1,33 @@
+package i32
+
+// MaxAbs returns the peak magnitude of a as a single signed min/max scan, the
+// exact integer form of libopus celtMaxabs32.
+//
+// It is defined as:
+//
+//	minVal, maxVal := signed min and max over a
+//	return max(maxVal, -minVal)
+//
+// where -minVal is a WRAPPING int32 negate. This is deliberately NOT a per-lane
+// absolute-value-then-max: the two differ when a MinInt32 element sits beside a
+// negative one. For a = [MinInt32, -3], MaxAbs computes max(-3, -MinInt32) =
+// max(-3, MinInt32) = -3, whereas abs-then-max would give 3. MaxAbs follows the
+// max(maxVal, -minVal) form of the consumer rather than the intuitive
+// absolute-value peak. (This example lives in the MinInt32 overflow regime below,
+// which the mirrored CELT data never reaches; every representable input agrees.)
+//
+// The result type is int32, matching celtMaxabs32's opus_val32 return. The
+// magnitude of MinInt32 (2^31) is not representable in int32, so a slice whose
+// peak is driven by a MinInt32 element returns a wrapped (negative) value:
+// -MinInt32 wraps back to MinInt32. The CELT data this mirrors never reaches
+// that input; the wrap is documented, not hidden. Every result is bit-identical
+// across the AVX2, NEON and pure-Go backends (there is no relaxed tier), because
+// signed min/max has no accumulation order.
+//
+// An empty a returns 0. a is read-only; the call allocates nothing.
+func MaxAbs(a []int32) int32 {
+	if len(a) == 0 {
+		return 0
+	}
+	return maxAbsI32(a)
+}

--- a/i32/maxabs_amd64_test.go
+++ b/i32/maxabs_amd64_test.go
@@ -1,0 +1,119 @@
+//go:build amd64
+
+package i32
+
+import (
+	"math"
+	"testing"
+
+	"github.com/tphakala/simd/cpu"
+)
+
+// TestMaxAbsAVX2_ParityWithGo drives the kernel directly across lengths that force
+// the 8-wide vector body plus every scalar-tail remainder (block boundaries and
+// primes in 8..40), over lengths the dispatcher would route the same way, so a
+// threshold change cannot quietly reduce this to a test of the Go reference against
+// itself. MinInt32 rides index 0 so the wrapping -minVal combine is exercised, and
+// MaxInt32 rides the last index so the scalar tail must be folded in.
+func TestMaxAbsAVX2_ParityWithGo(t *testing.T) {
+	if !cpu.X86.AVX2 {
+		t.Skip("AVX2 not available")
+	}
+	lens := []int{8, 9, 11, 13, 16, 17, 19, 23, 24, 29, 31, 32, 37, 40}
+	for _, n := range lens {
+		a := genI32(n, 71)
+		a[0] = math.MinInt32
+		a[n-1] = math.MaxInt32
+		if got, want := maxAbsAVX2(a), maxAbsGo(a); got != want {
+			t.Fatalf("maxAbsAVX2 n=%d = %d, want %d (reference)", n, got, want)
+		}
+		if got, want := maxAbsAVX2(a), maxAbsOracle(a); got != want {
+			t.Fatalf("maxAbsAVX2 n=%d = %d, want %d (oracle)", n, got, want)
+		}
+	}
+}
+
+// TestMaxAbsAVX2_PlantedExtreme plants the result-driving extreme at every position
+// of a block-plus-tail length, so a kernel that drops a vector lane or skips the
+// scalar tail misses the extreme where it lives and is caught. MaxInt32 drives the
+// answer through the max accumulator; MinInt32+1 (a large-magnitude negative)
+// drives it through the min accumulator, so both lanes are load-bearing.
+func TestMaxAbsAVX2_PlantedExtreme(t *testing.T) {
+	if !cpu.X86.AVX2 {
+		t.Skip("AVX2 not available")
+	}
+	const n = 11 // one 8-wide block + 3 tail
+	for _, ext := range []int32{math.MaxInt32, math.MinInt32 + 1} {
+		for pos := range n {
+			a := make([]int32, n)
+			for i := range a {
+				a[i] = int32(i%3 - 1) // tame body: -1, 0, 1
+			}
+			a[pos] = ext
+			if got, want := maxAbsAVX2(a), maxAbsOracle(a); got != want {
+				t.Fatalf("maxAbsAVX2 ext=%d pos=%d = %d, want %d", ext, pos, got, want)
+			}
+		}
+	}
+}
+
+// TestMaxAbsAVX2_OverRead catches a kernel that reads past len(a). The in-range
+// body is tame (values in -1..1, so the true peak magnitude is 1), while the slack
+// past n is poisoned with the absolute extremes MinInt32 and MaxInt32, which would
+// dominate the signed min/max reduction if read. a is backing[:n] over a backing of
+// length n+8 (one full 8-wide block of slack), so a kernel that reads a stray block
+// or a scalar tail past n lands in the poisoned (still allocated) memory and its
+// result flips away from the oracle over a[:n]; a correct kernel stops at n and
+// stays equal. For a min/max reduction the poison must be MORE extreme than any
+// in-range element, the opposite of an additive kernel where a zero or an
+// even-count MinInt32 would be an invisible identity.
+func TestMaxAbsAVX2_OverRead(t *testing.T) {
+	if !cpu.X86.AVX2 {
+		t.Skip("AVX2 not available")
+	}
+	for _, n := range []int{8, 9, 11, 13, 16, 17, 23, 31} {
+		backing := make([]int32, n+8)
+		for i := range backing {
+			backing[i] = int32(i%3 - 1) // tame body: -1, 0, 1
+		}
+		for i := n; i < len(backing); i++ {
+			if i%2 == 0 {
+				backing[i] = math.MinInt32
+			} else {
+				backing[i] = math.MaxInt32
+			}
+		}
+		a := backing[:n]
+		if got, want := maxAbsAVX2(a), maxAbsOracle(a); got != want {
+			t.Fatalf("maxAbsAVX2 n=%d = %d, want %d: kernel read past n into poisoned slack", n, got, want)
+		}
+	}
+}
+
+// TestMaxAbsAVX2_AllocFree asserts the kernel runs allocation-free, the repo's
+// zero-allocation contract enforced at the kernel boundary.
+func TestMaxAbsAVX2_AllocFree(t *testing.T) {
+	if !cpu.X86.AVX2 {
+		t.Skip("AVX2 not available")
+	}
+	a := make([]int32, 1024)
+	for i := range a {
+		a[i] = int32(i*7 - 3000)
+	}
+	if got := testing.AllocsPerRun(100, func() { _ = maxAbsAVX2(a) }); got != 0 {
+		t.Errorf("maxAbsAVX2 allocated %v times per run, want 0", got)
+	}
+}
+
+// TestMaxAbsDispatch_ReachesSIMD pins the dispatch state MaxAbs depends on. It is a
+// white-box check: the AVX2 kernel is bit-identical to the Go reference by design,
+// so a dispatcher that silently routed every call to Go would pass every parity
+// test. It must not call t.Parallel(): it reads package-level dispatch state.
+func TestMaxAbsDispatch_ReachesSIMD(t *testing.T) {
+	if hasAVX2 != cpu.X86.AVX2 {
+		t.Fatalf("hasAVX2 = %v but cpu.X86.AVX2 = %v: dispatch flag is not wired to CPU detection", hasAVX2, cpu.X86.AVX2)
+	}
+	if minAVX2MaxAbs > 16 {
+		t.Fatalf("minAVX2MaxAbs = %d exceeds two vector blocks: MaxAbs would not vectorize at the lengths it was written for", minAVX2MaxAbs)
+	}
+}

--- a/i32/maxabs_arm64_test.go
+++ b/i32/maxabs_arm64_test.go
@@ -1,0 +1,119 @@
+//go:build arm64
+
+package i32
+
+import (
+	"math"
+	"testing"
+
+	"github.com/tphakala/simd/cpu"
+)
+
+// TestMaxAbsNEON_ParityWithGo drives the kernel directly across lengths that force
+// the 4-wide vector body plus every scalar-tail remainder (block boundaries and
+// primes in 4..40), over lengths the dispatcher would route the same way, so a
+// threshold change cannot quietly reduce this to a test of the Go reference against
+// itself. MinInt32 rides index 0 so the wrapping -minVal combine is exercised, and
+// MaxInt32 rides the last index so the scalar tail must be folded in.
+func TestMaxAbsNEON_ParityWithGo(t *testing.T) {
+	if !cpu.ARM64.NEON {
+		t.Skip("NEON not available")
+	}
+	lens := []int{4, 5, 7, 8, 9, 11, 13, 16, 17, 19, 23, 24, 29, 31, 32, 37, 40}
+	for _, n := range lens {
+		a := genI32(n, 71)
+		a[0] = math.MinInt32
+		a[n-1] = math.MaxInt32
+		if got, want := maxAbsNEON(a), maxAbsGo(a); got != want {
+			t.Fatalf("maxAbsNEON n=%d = %d, want %d (reference)", n, got, want)
+		}
+		if got, want := maxAbsNEON(a), maxAbsOracle(a); got != want {
+			t.Fatalf("maxAbsNEON n=%d = %d, want %d (oracle)", n, got, want)
+		}
+	}
+}
+
+// TestMaxAbsNEON_PlantedExtreme plants the result-driving extreme at every position
+// of a block-plus-tail length, so a kernel that drops a vector lane or skips the
+// scalar tail misses the extreme where it lives and is caught. MaxInt32 drives the
+// answer through the max accumulator; MinInt32+1 (a large-magnitude negative)
+// drives it through the min accumulator, so both lanes are load-bearing.
+func TestMaxAbsNEON_PlantedExtreme(t *testing.T) {
+	if !cpu.ARM64.NEON {
+		t.Skip("NEON not available")
+	}
+	const n = 11 // two 4-wide blocks + 3 tail
+	for _, ext := range []int32{math.MaxInt32, math.MinInt32 + 1} {
+		for pos := range n {
+			a := make([]int32, n)
+			for i := range a {
+				a[i] = int32(i%3 - 1) // tame body: -1, 0, 1
+			}
+			a[pos] = ext
+			if got, want := maxAbsNEON(a), maxAbsOracle(a); got != want {
+				t.Fatalf("maxAbsNEON ext=%d pos=%d = %d, want %d", ext, pos, got, want)
+			}
+		}
+	}
+}
+
+// TestMaxAbsNEON_OverRead catches a kernel that reads past len(a). The in-range
+// body is tame (values in -1..1, so the true peak magnitude is 1), while the slack
+// past n is poisoned with the absolute extremes MinInt32 and MaxInt32, which would
+// dominate the signed min/max reduction if read. a is backing[:n] over a backing of
+// length n+8 (two full 4-wide blocks of slack), so a kernel that reads a stray block
+// or a scalar tail past n lands in the poisoned (still allocated) memory and its
+// result flips away from the oracle over a[:n]; a correct kernel stops at n and
+// stays equal. For a min/max reduction the poison must be MORE extreme than any
+// in-range element, the opposite of an additive kernel where a zero or an
+// even-count MinInt32 would be an invisible identity.
+func TestMaxAbsNEON_OverRead(t *testing.T) {
+	if !cpu.ARM64.NEON {
+		t.Skip("NEON not available")
+	}
+	for _, n := range []int{4, 5, 7, 9, 11, 13, 17, 23, 31} {
+		backing := make([]int32, n+8)
+		for i := range backing {
+			backing[i] = int32(i%3 - 1) // tame body: -1, 0, 1
+		}
+		for i := n; i < len(backing); i++ {
+			if i%2 == 0 {
+				backing[i] = math.MinInt32
+			} else {
+				backing[i] = math.MaxInt32
+			}
+		}
+		a := backing[:n]
+		if got, want := maxAbsNEON(a), maxAbsOracle(a); got != want {
+			t.Fatalf("maxAbsNEON n=%d = %d, want %d: kernel read past n into poisoned slack", n, got, want)
+		}
+	}
+}
+
+// TestMaxAbsNEON_AllocFree asserts the kernel runs allocation-free, the repo's
+// zero-allocation contract enforced at the kernel boundary.
+func TestMaxAbsNEON_AllocFree(t *testing.T) {
+	if !cpu.ARM64.NEON {
+		t.Skip("NEON not available")
+	}
+	a := make([]int32, 1024)
+	for i := range a {
+		a[i] = int32(i*7 - 3000)
+	}
+	if got := testing.AllocsPerRun(100, func() { _ = maxAbsNEON(a) }); got != 0 {
+		t.Errorf("maxAbsNEON allocated %v times per run, want 0", got)
+	}
+}
+
+// TestMaxAbsDispatch_ReachesNEON pins the dispatch state MaxAbs depends on. It is a
+// white-box check: the NEON kernel is bit-identical to the Go reference by design,
+// so a dispatcher that silently routed every call to Go would pass every parity
+// test. It must not call t.Parallel(): it reads package-level dispatch state.
+func TestMaxAbsDispatch_ReachesNEON(t *testing.T) {
+	if hasNEON != cpu.ARM64.NEON {
+		t.Fatalf("hasNEON = %v but cpu.ARM64.NEON = %v: dispatch flag is not wired to CPU detection", hasNEON, cpu.ARM64.NEON)
+	}
+	if minNEONMaxAbs > 8 {
+		t.Fatalf("minNEONMaxAbs = %d exceeds two vector blocks: MaxAbs would not vectorize at the lengths it was written for", minNEONMaxAbs)
+	}
+}

--- a/i32/maxabs_test.go
+++ b/i32/maxabs_test.go
@@ -1,0 +1,234 @@
+package i32
+
+import (
+	"math"
+	"math/rand"
+	"testing"
+)
+
+// Tests for MaxAbs, the peak-magnitude reduction defined as libopus celtMaxabs32:
+// max(maxVal, -minVal) over a single signed min/max scan, with -minVal a WRAPPING
+// int32 negate. The load-bearing case is a MinInt32 element beside a negative one,
+// where celtMaxabs32 (max of maxVal and the wrapped -minVal) diverges from the
+// intuitive per-lane abs-then-max: for [MinInt32, -3] the answer is -3, not 3.
+
+// maxAbsOracle computes celtMaxabs32 independently of maxAbsGo: it scans for the
+// signed min and max, then wraps -min through int64 -> int32 (a different code
+// path than the int32 unary minus in the reference) and returns the larger. It
+// pins the reference rather than trusting a formula shared with it.
+func maxAbsOracle(a []int32) int32 {
+	if len(a) == 0 {
+		return 0
+	}
+	lo, hi := a[0], a[0]
+	for _, v := range a {
+		if v < lo {
+			lo = v
+		}
+		if v > hi {
+			hi = v
+		}
+	}
+	neg := int32(-int64(lo)) // wrap -lo into int32: -MinInt32 -> MinInt32
+	if hi > neg {
+		return hi
+	}
+	return neg
+}
+
+// absThenMax is the WRONG definition MaxAbs must NOT implement: per-lane wrapping
+// abs, then the maximum. It differs from celtMaxabs32 exactly when a MinInt32
+// element rides beside a negative one; TestMaxAbs_Divergence pins that gap so a
+// VPABSD-based rewrite could never pass silently.
+func absThenMax(a []int32) int32 {
+	var m int32
+	for i, v := range a {
+		av := v
+		if av < 0 {
+			av = -av // wrapping abs: -MinInt32 == MinInt32
+		}
+		if i == 0 || av > m {
+			m = av
+		}
+	}
+	return m
+}
+
+// TestMaxAbsOracle confirms the oracle itself encodes the wrap and the divergence,
+// so the parity tests below rest on a checked foundation.
+func TestMaxAbsOracle(t *testing.T) {
+	if got := maxAbsOracle([]int32{math.MinInt32, -3}); got != -3 {
+		t.Fatalf("oracle([MinInt32,-3]) = %d, want -3", got)
+	}
+	if got := maxAbsOracle([]int32{math.MinInt32}); got != math.MinInt32 {
+		t.Fatalf("oracle([MinInt32]) = %d, want %d", got, int32(math.MinInt32))
+	}
+	if got := absThenMax([]int32{math.MinInt32, -3}); got != 3 {
+		t.Fatalf("absThenMax([MinInt32,-3]) = %d, want 3 (the wrong answer MaxAbs must avoid)", got)
+	}
+}
+
+// TestMaxAbs sweeps every tier-3 length against both the pure-Go reference and the
+// independent oracle, so a fault cannot hide by agreeing with the reference alone.
+// MinInt32 rides index 0 so the wrapping -minVal combine is exercised at every
+// length, and MaxInt32 rides the last index so the scalar tail must be folded in.
+func TestMaxAbs(t *testing.T) {
+	for _, n := range tier3Lengths {
+		a := genI32(n, 71)
+		if n > 0 {
+			a[0] = math.MinInt32
+			a[n-1] = math.MaxInt32
+		}
+		got := MaxAbs(a)
+		// maxAbsGo requires a non-empty slice (only the public MaxAbs guards
+		// empty), so the reference parity is checked for n > 0 only; the oracle
+		// covers the empty case.
+		if n > 0 {
+			if want := maxAbsGo(a); got != want {
+				t.Fatalf("MaxAbs n=%d = %d, want %d (reference)", n, got, want)
+			}
+		}
+		if want := maxAbsOracle(a); got != want {
+			t.Fatalf("MaxAbs n=%d = %d, want %d (oracle)", n, got, want)
+		}
+	}
+}
+
+// TestMaxAbs_Random crosses random int32 (organically hitting the full range) with
+// the hand-picked specials, at every length that straddles a vector block and its
+// scalar tail on both arches, checking against the reference and the oracle.
+func TestMaxAbs_Random(t *testing.T) {
+	rng := rand.New(rand.NewSource(19))
+	specials := []int32{math.MinInt32, math.MaxInt32, 0, -1, 1}
+	for _, n := range []int{1, 3, 4, 7, 8, 9, 15, 16, 17, 31, 33, 100, 1000} {
+		for trial := range 20 {
+			a := make([]int32, n)
+			for i := range a {
+				if rng.Intn(3) == 0 {
+					a[i] = specials[rng.Intn(len(specials))]
+				} else {
+					a[i] = int32(rng.Uint32())
+				}
+			}
+			got := MaxAbs(a)
+			if want := maxAbsGo(a); got != want {
+				t.Fatalf("MaxAbs n=%d trial=%d = %d, want %d (reference)", n, trial, got, want)
+			}
+			if want := maxAbsOracle(a); got != want {
+				t.Fatalf("MaxAbs n=%d trial=%d = %d, want %d (oracle)", n, trial, got, want)
+			}
+		}
+	}
+}
+
+// TestMaxAbs_Cases pins the hand-crafted contracts in isolation, spanning both the
+// Go path (n below the SIMD thresholds) and the vector path.
+func TestMaxAbs_Cases(t *testing.T) {
+	cases := []struct {
+		name string
+		a    []int32
+		want int32
+	}{
+		{"empty", []int32{}, 0},
+		{"nil", nil, 0},
+		{"single-min", []int32{math.MinInt32}, math.MinInt32},
+		{"single-max", []int32{math.MaxInt32}, math.MaxInt32},
+		{"single-neg", []int32{-42}, 42},
+		{"min-beside-neg", []int32{math.MinInt32, -3}, -3},
+		{"all-positive", []int32{1, 2, 3, 4, 5}, 5},
+		{"all-negative", []int32{-1, -2, -3, -4, -5}, 5},
+		{"mixed", []int32{-10, 3, -7, 2}, 10},
+		{"all-minus-one", []int32{-1, -1, -1, -1}, 1},
+		// The divergence at a full AVX2 block (8) and a NEON block (4): a MinInt32
+		// beside negatives keeps the answer at -3 (celtMaxabs32), not 3 (abs-max).
+		{"min-beside-neg-neon", []int32{math.MinInt32, -3, -3, -3}, -3},
+		{"min-beside-neg-avx", []int32{math.MinInt32, -3, -3, -3, -3, -3, -3, -3}, -3},
+	}
+	for _, c := range cases {
+		if got := MaxAbs(c.a); got != c.want {
+			t.Errorf("MaxAbs(%s) = %d, want %d", c.name, got, c.want)
+		}
+		if got := maxAbsOracle(c.a); got != c.want {
+			t.Errorf("oracle(%s) = %d, want %d", c.name, got, c.want)
+		}
+	}
+}
+
+// TestMaxAbs_Divergence pins the whole point of the primitive: the celtMaxabs32
+// definition diverges from per-lane abs-then-max whenever a MinInt32 element rides
+// beside a negative one. It checks lengths on the Go path and both SIMD paths so a
+// VPABSD/ABS-based kernel would be caught on every backend.
+func TestMaxAbs_Divergence(t *testing.T) {
+	for _, n := range []int{2, 3, 4, 5, 8, 9, 16, 17} {
+		a := make([]int32, n)
+		for i := range a {
+			a[i] = -3
+		}
+		a[0] = math.MinInt32
+		got := MaxAbs(a)
+		if got != -3 {
+			t.Fatalf("MaxAbs divergence n=%d = %d, want -3 (celtMaxabs32)", n, got)
+		}
+		if wrong := absThenMax(a); got == wrong {
+			t.Fatalf("MaxAbs divergence n=%d matched abs-then-max (%d): it must NOT be built on VPABSD", n, wrong)
+		}
+	}
+}
+
+// TestMaxAbs_Unaligned sweeps every element offset so neither an aligned-load
+// substitution nor an off-by-one block boundary can survive. The driving extremes
+// ride the ends so the head block and the scalar tail both stay load-bearing.
+func TestMaxAbs_Unaligned(t *testing.T) {
+	const span = 300
+	backing := genI32(span, 33)
+	for _, n := range []int{4, 5, 7, 8, 9, 11, 17, 25, 33, 64, 240} {
+		for off := range 8 {
+			a := backing[off+1 : off+1+n]
+			// Save and plant extremes at both ends, then restore afterwards.
+			first, last := a[0], a[n-1]
+			a[0] = math.MinInt32
+			a[n-1] = math.MaxInt32
+			got := MaxAbs(a)
+			if want := maxAbsGo(a); got != want {
+				t.Fatalf("MaxAbs unaligned n=%d off=%d = %d, want %d (reference)", n, off, got, want)
+			}
+			if want := maxAbsOracle(a); got != want {
+				t.Fatalf("MaxAbs unaligned n=%d off=%d = %d, want %d (oracle)", n, off, got, want)
+			}
+			a[0], a[n-1] = first, last
+		}
+	}
+}
+
+// TestMaxAbs_AllocFree confirms the scalar return forces no caller allocation. The
+// buffer is declared INSIDE the measured closure so only allocations forced by
+// MaxAbs itself are counted.
+func TestMaxAbs_AllocFree(t *testing.T) {
+	if got := testing.AllocsPerRun(50, func() {
+		var a [1000]int32
+		_ = MaxAbs(a[:])
+	}); got != 0 {
+		t.Errorf("MaxAbs forces %v caller allocations per run, want 0", got)
+	}
+}
+
+// FuzzMaxAbs differentially fuzzes the dispatched MaxAbs against the pure-Go
+// reference and the independent oracle over arbitrary int32 samples, so tail
+// handling and the wrap are explored past the hand-picked seeds. It reuses
+// addLenSeeds, whose element counts bracket the 4/8-lane block boundaries.
+func FuzzMaxAbs(f *testing.F) {
+	addLenSeeds(f)
+	f.Fuzz(func(t *testing.T, raw []byte) {
+		a := i32sFromBits(raw)
+		got := MaxAbs(a)
+		// maxAbsGo requires a non-empty slice; the oracle covers the empty case.
+		if len(a) > 0 {
+			if want := maxAbsGo(a); got != want {
+				t.Fatalf("MaxAbs = %d, want %d (reference, len=%d)", got, want, len(a))
+			}
+		}
+		if want := maxAbsOracle(a); got != want {
+			t.Fatalf("MaxAbs = %d, want %d (oracle, len=%d)", got, want, len(a))
+		}
+	})
+}


### PR DESCRIPTION
## Summary

Adds `MaxAbs(a []int32) int32`, the peak-magnitude reduction defined as libopus `celtMaxabs32`: over a single signed min/max scan it returns `max(maxVal, -minVal)`, where `-minVal` is a wrapping int32 negate. This is deliberately NOT a per-lane absolute-value-then-max, which diverges when a MinInt32 element sits beside a negative one (for `[MinInt32, -3]` MaxAbs gives `-3`, abs-then-max gives `3`). Every representable input agrees with the `max(maxVal, -minVal)` consumer; the MinInt32 magnitude (2^31) is not representable in int32, so a MinInt32-driven peak returns a wrapped negative value, a documented edge the mirrored CELT data never reaches. An empty `a` returns 0.

Kernels are bit-identical across amd64 AVX2, arm64 NEON, and the Go fallback. Each copies the proven signed min/max vector reduction (`VPMINSD`/`VPMAXSD`; `SMIN`/`SMAX`/`SMINV`/`SMAXV`) then combines to `max(maxVal, -minVal)` with a wrapping negate. The combine stays in the 32-bit signed domain on both arches (`NEGL`/`CMPL` on amd64, `NEG`/`CMPW` on arm64): on arm64 the `SMINV`/`SMAXV` result is zero-extended by `FMOVS` while the scalar tail is sign-extended, so a 64-bit compare would mis-order (a four-element all `-1` slice must give `1`, not `-1`); `CMPW` compares the correct low 32 bits and `MOVW` stores them. `maxAbsGo` reuses `minMaxGo`. Direct i32 dispatch keeps it allocation-free.

## Related issues

Part of #181 (the `MaxAbs` building block; `ScaleQ31`/`ScaleQ15` in #187, `Butterfly` in #188). `FIRValidQ15` remains.

## Test plan

- [x] Parity against the Go reference and an independent int64 oracle over a length sweep forcing the vector body and the scalar tail on both widths
- [x] Explicit `celtMaxabs32`-vs-abs-then-max divergence pin (`[MinInt32,-3]` gives `-3`, not `3`), the MinInt32 and all-negative (`CMPW`) edges, empty to 0, unaligned starts
- [x] Over-read poison guard (absolute extremes planted past `n` over a full-block slack) on both arches, alloc-free (0 allocs/op), dispatch-pin, differential fuzz
- [x] Verified bit-exact on real AVX2 hardware (i7-1260P) and real NEON hardware (Raspberry Pi 5); `TestArm64WordEncodings` cross-checks the reused `WORD` encodings against `arm64asm`