### PR TITLE
i32: add FIRValidQ15, an int32 valid convolution with Q15 taps (#181)

### DIFF
--- a/i32/benchmark_test.go
+++ b/i32/benchmark_test.go
@@ -280,3 +280,30 @@ func BenchmarkMaxAbs_1003(b *testing.B) { benchmarkMaxAbs(b, 1003, MaxAbs) }
 func BenchmarkMaxAbsGo_25(b *testing.B)   { benchmarkMaxAbs(b, 25, maxAbsGo) }
 func BenchmarkMaxAbsGo_1000(b *testing.B) { benchmarkMaxAbs(b, 1000, maxAbsGo) }
 func BenchmarkMaxAbsGo_1003(b *testing.B) { benchmarkMaxAbs(b, 1003, maxAbsGo) }
+
+// FIRValidQ15 is a sliding valid convolution: each of the outLen = n - kl + 1
+// outputs runs the full kl-tap inner loop, so cost scales with outLen*kl. The
+// 5-tap case is combFilterConst; the 16-tap case stresses a longer kernel.
+// SetBytes counts the outputs written, 4 bytes per int32.
+func benchmarkFIRValidQ15(b *testing.B, kl int, fn func(dst, x []int32, taps []int16)) {
+	b.Helper()
+	x := make([]int32, benchN)
+	taps := make([]int16, kl)
+	for i := range x {
+		x[i] = int32(i*7 - 3000)
+	}
+	for i := range taps {
+		taps[i] = int16(i*11 - 3)
+	}
+	dst := make([]int32, benchN-kl+1)
+	b.SetBytes(int64(benchN-kl+1) * 4)
+	for b.Loop() {
+		fn(dst, x, taps)
+	}
+}
+
+func BenchmarkFIRValidQ15_5(b *testing.B)  { benchmarkFIRValidQ15(b, 5, FIRValidQ15) }
+func BenchmarkFIRValidQ15_16(b *testing.B) { benchmarkFIRValidQ15(b, 16, FIRValidQ15) }
+
+func BenchmarkFIRValidQ15Go_5(b *testing.B)  { benchmarkFIRValidQ15(b, 5, firValidQ15Go) }
+func BenchmarkFIRValidQ15Go_16(b *testing.B) { benchmarkFIRValidQ15(b, 16, firValidQ15Go) }

--- a/i32/fir.go
+++ b/i32/fir.go
@@ -1,0 +1,50 @@
+package i32
+
+// FIRValidQ15 writes the int32 valid convolution of x with the Q15 taps into
+// dst, computing min(len(dst), len(x)-len(taps)+1) outputs in correlation
+// orientation. It is the integer analog of the f32 ConvolveValidMaxAbs
+// orientation and covers libopus combFilterConst.
+//
+// For output i it computes:
+//
+//	dst[i] = sum over j in [0, len(taps)) of int32(int64(taps[j]) * int64(x[i+j]) >> 15)
+//
+// which is a "valid" convolution in correlation (non-flipped) orientation:
+// taps[j] multiplies x[i+j], not x[i+len(taps)-1-j]. The full valid output has
+// len(x)-len(taps)+1 samples; the count is clamped to len(dst) and any trailing
+// capacity in dst past that is left untouched.
+//
+// Each tap product is Q15-TRUNCATED before it is added: the 64-bit product
+// int64(taps[j])*int64(x[i+j]) is arithmetically shifted right by 15 (toward
+// -inf, no rounding constant), matching go-opus MULT16_32_Q15 bit-for-bit. The
+// truncation is per product, NOT a single truncation of the final sum, so a
+// fault that quantized only the final accumulator instead would diverge. The running accumulator is
+// two's-complement wrapping int32: intermediate and final sums wrap rather than
+// saturating, so the SIMD and pure-Go paths are bit-identical across the full
+// int32 range and there is no relaxed tier. This variant is NON-saturating; a
+// saturating variant (FIRValidQ15Sat) can follow for the comb-filter sigSat
+// consumer that clamps to int16 range.
+//
+// Empty taps or an x shorter than taps produces no output and writes nothing
+// (the valid-output count would otherwise underflow). When len(x) == len(taps)
+// there is exactly one output.
+//
+// dst must NOT overlap x. The SIMD kernels load whole sliding windows of x ahead
+// of the stores into dst, so an overlapping dst could clobber input lanes a later
+// output has not yet read. x and taps are read-only; the call allocates nothing.
+func FIRValidQ15(dst, x []int32, taps []int16) {
+	// Guard first: an empty taps or an x shorter than taps makes the
+	// len(x)-len(taps)+1 valid-output count underflow, so reject both before it
+	// is computed.
+	if len(taps) == 0 || len(x) < len(taps) {
+		return
+	}
+	outLen := len(x) - len(taps) + 1
+	n := min(len(dst), outLen)
+	if n == 0 {
+		return
+	}
+	// x and taps are passed whole: the kernel reads the sliding window x[i+j] up
+	// to index n-1+len(taps)-1 <= len(x)-1, so x must not be pre-sliced to n.
+	firValidQ15I32(dst[:n], x, taps)
+}

--- a/i32/fir_amd64_test.go
+++ b/i32/fir_amd64_test.go
@@ -1,0 +1,137 @@
+//go:build amd64
+
+package i32
+
+import (
+	"math"
+	"testing"
+
+	"github.com/tphakala/simd/cpu"
+)
+
+// TestFIRValidQ15AVX2_ParityWithGo drives the kernel directly across output
+// lengths that force the 8-wide vector body plus every scalar-output-tail
+// remainder, over the combFilterConst tap count (5) and neighbors. MinInt16/
+// MaxInt16 ride the ends of taps and MinInt32/MaxInt32 the ends of x, so the
+// sign-extension into VPMULDQ and the wrap are exercised at every length.
+func TestFIRValidQ15AVX2_ParityWithGo(t *testing.T) {
+	if !cpu.X86.AVX2 {
+		t.Skip("AVX2 not available")
+	}
+	tapCounts := []int{1, 2, 3, 5, 8, 16}
+	outLens := []int{8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 23, 24, 31, 32, 33, 40}
+	for _, kl := range tapCounts {
+		taps := genI16(kl, uint32(kl)*17+3)
+		taps[0] = math.MinInt16
+		taps[kl-1] = math.MaxInt16
+		for _, outLen := range outLens {
+			xl := outLen + kl - 1
+			x := genI32(xl, uint32(xl)*7+uint32(kl))
+			x[0] = math.MinInt32
+			x[xl-1] = math.MaxInt32
+			got := make([]int32, outLen)
+			want := make([]int32, outLen)
+			firValidQ15AVX2(got, x, taps)
+			firValidQ15Go(want, x, taps)
+			for i := range got {
+				if got[i] != want[i] {
+					t.Fatalf("firValidQ15AVX2 kl=%d outLen=%d: dst[%d] = %d, want %d", kl, outLen, i, got[i], want[i])
+				}
+			}
+		}
+	}
+}
+
+// TestFIRValidQ15AVX2_OverRead catches a kernel that reads x past len(x). The
+// in-range body is tame (samples in -2..2), while the slack past len(x) is
+// poisoned with 0x55555555, a large non-zero value that is NOT an additive
+// identity (unlike a zero or an even count of MinInt32, whose over-read would be
+// invisible in an additive accumulate). x is backing[:xl] over a backing with 16
+// int32 of still-allocated slack, so a kernel that loads a stray window block or
+// runs the tap loop one element too far lands in the poison and its result flips
+// away from the reference over x[:xl]; a correct kernel stops at len(x)-1 and
+// stays equal. The taps are 0x4000 (0.5 in Q15) so every poisoned lane makes a
+// large, visible contribution.
+func TestFIRValidQ15AVX2_OverRead(t *testing.T) {
+	if !cpu.X86.AVX2 {
+		t.Skip("AVX2 not available")
+	}
+	const poison = int32(0x55555555)
+	for _, kl := range []int{1, 2, 5, 8} {
+		taps := make([]int16, kl)
+		for i := range taps {
+			taps[i] = 0x4000
+		}
+		for _, outLen := range []int{8, 9, 11, 13, 16, 17, 23, 31} {
+			xl := outLen + kl - 1
+			const slack = 16 // >= one widest output block worth of window
+			backing := make([]int32, xl+slack)
+			for i := range backing {
+				if i < xl {
+					backing[i] = int32(i%5 - 2) // tame body: -2..2
+				} else {
+					backing[i] = poison
+				}
+			}
+			x := backing[:xl]
+			got := make([]int32, outLen)
+			want := make([]int32, outLen)
+			firValidQ15AVX2(got, x, taps)
+			firValidQ15Go(want, x, taps)
+			for i := range got {
+				if got[i] != want[i] {
+					t.Fatalf("firValidQ15AVX2 kl=%d outLen=%d: dst[%d] = %d, want %d: kernel read x past len into poison", kl, outLen, i, got[i], want[i])
+				}
+			}
+		}
+	}
+}
+
+// TestFIRValidQ15AVX2_NoOverwrite guards the scalar-output tail: the kernel may
+// not write past n when n is not a multiple of the 8-output block.
+func TestFIRValidQ15AVX2_NoOverwrite(t *testing.T) {
+	if !cpu.X86.AVX2 {
+		t.Skip("AVX2 not available")
+	}
+	const outLen = 11
+	taps := genI16(5, 81)
+	x := genI32(outLen+len(taps)-1, 82)
+	dst := make([]int32, outLen+8)
+	for i := range dst {
+		dst[i] = math.MaxInt32 // sentinel
+	}
+	firValidQ15AVX2(dst[:outLen], x, taps)
+	for i := outLen; i < len(dst); i++ {
+		if dst[i] != math.MaxInt32 {
+			t.Errorf("firValidQ15AVX2 wrote past end at dst[%d] = %d", i, dst[i])
+		}
+	}
+}
+
+// TestFIRValidQ15AVX2_AllocFree asserts the kernel runs allocation-free, the
+// repo's zero-allocation contract enforced at the kernel boundary.
+func TestFIRValidQ15AVX2_AllocFree(t *testing.T) {
+	if !cpu.X86.AVX2 {
+		t.Skip("AVX2 not available")
+	}
+	x := make([]int32, 1024)
+	taps := make([]int16, 5)
+	dst := make([]int32, 1020)
+	if got := testing.AllocsPerRun(100, func() { firValidQ15AVX2(dst, x, taps) }); got != 0 {
+		t.Errorf("firValidQ15AVX2 allocated %v times per run, want 0", got)
+	}
+}
+
+// TestFIRValidQ15Dispatch_ReachesSIMD pins the dispatch state FIRValidQ15 depends
+// on. It is a white-box check: the AVX2 kernel is bit-identical to the Go
+// reference by design, so a dispatcher that silently routed every call to Go would
+// pass every parity test. It must not call t.Parallel(): it reads package-level
+// dispatch state.
+func TestFIRValidQ15Dispatch_ReachesSIMD(t *testing.T) {
+	if hasAVX2 != cpu.X86.AVX2 {
+		t.Fatalf("hasAVX2 = %v but cpu.X86.AVX2 = %v: dispatch flag is not wired to CPU detection", hasAVX2, cpu.X86.AVX2)
+	}
+	if minAVX2FIR > 16 {
+		t.Fatalf("minAVX2FIR = %d exceeds two vector blocks: FIRValidQ15 would not vectorize at the lengths it was written for", minAVX2FIR)
+	}
+}

--- a/i32/fir_arm64_test.go
+++ b/i32/fir_arm64_test.go
@@ -1,0 +1,137 @@
+//go:build arm64
+
+package i32
+
+import (
+	"math"
+	"testing"
+
+	"github.com/tphakala/simd/cpu"
+)
+
+// TestFIRValidQ15NEON_ParityWithGo drives the kernel directly across output
+// lengths that force the 4-wide vector body plus every scalar-output-tail
+// remainder, over the combFilterConst tap count (5) and neighbors. MinInt16/
+// MaxInt16 ride the ends of taps and MinInt32/MaxInt32 the ends of x, so the
+// sign-extension into SMULL and the wrap are exercised at every length.
+func TestFIRValidQ15NEON_ParityWithGo(t *testing.T) {
+	if !cpu.ARM64.NEON {
+		t.Skip("NEON not available")
+	}
+	tapCounts := []int{1, 2, 3, 5, 8, 16}
+	outLens := []int{4, 5, 6, 7, 8, 9, 11, 13, 16, 17, 23, 24, 31, 32, 33, 40}
+	for _, kl := range tapCounts {
+		taps := genI16(kl, uint32(kl)*17+3)
+		taps[0] = math.MinInt16
+		taps[kl-1] = math.MaxInt16
+		for _, outLen := range outLens {
+			xl := outLen + kl - 1
+			x := genI32(xl, uint32(xl)*7+uint32(kl))
+			x[0] = math.MinInt32
+			x[xl-1] = math.MaxInt32
+			got := make([]int32, outLen)
+			want := make([]int32, outLen)
+			firValidQ15NEON(got, x, taps)
+			firValidQ15Go(want, x, taps)
+			for i := range got {
+				if got[i] != want[i] {
+					t.Fatalf("firValidQ15NEON kl=%d outLen=%d: dst[%d] = %d, want %d", kl, outLen, i, got[i], want[i])
+				}
+			}
+		}
+	}
+}
+
+// TestFIRValidQ15NEON_OverRead catches a kernel that reads x past len(x). The
+// in-range body is tame (samples in -2..2), while the slack past len(x) is
+// poisoned with 0x55555555, a large non-zero value that is NOT an additive
+// identity (unlike a zero or an even count of MinInt32, whose over-read would be
+// invisible in an additive accumulate). x is backing[:xl] over a backing with 16
+// int32 of still-allocated slack, so a kernel that loads a stray window block or
+// runs the tap loop one element too far lands in the poison and its result flips
+// away from the reference over x[:xl]; a correct kernel stops at len(x)-1 and
+// stays equal. The taps are 0x4000 (0.5 in Q15) so every poisoned lane makes a
+// large, visible contribution.
+func TestFIRValidQ15NEON_OverRead(t *testing.T) {
+	if !cpu.ARM64.NEON {
+		t.Skip("NEON not available")
+	}
+	const poison = int32(0x55555555)
+	for _, kl := range []int{1, 2, 5, 8} {
+		taps := make([]int16, kl)
+		for i := range taps {
+			taps[i] = 0x4000
+		}
+		for _, outLen := range []int{4, 5, 6, 7, 8, 9, 11, 13, 17, 23} {
+			xl := outLen + kl - 1
+			const slack = 16 // >= one widest output block worth of window
+			backing := make([]int32, xl+slack)
+			for i := range backing {
+				if i < xl {
+					backing[i] = int32(i%5 - 2) // tame body: -2..2
+				} else {
+					backing[i] = poison
+				}
+			}
+			x := backing[:xl]
+			got := make([]int32, outLen)
+			want := make([]int32, outLen)
+			firValidQ15NEON(got, x, taps)
+			firValidQ15Go(want, x, taps)
+			for i := range got {
+				if got[i] != want[i] {
+					t.Fatalf("firValidQ15NEON kl=%d outLen=%d: dst[%d] = %d, want %d: kernel read x past len into poison", kl, outLen, i, got[i], want[i])
+				}
+			}
+		}
+	}
+}
+
+// TestFIRValidQ15NEON_NoOverwrite guards the scalar-output tail: the kernel may
+// not write past n when n is not a multiple of the 4-output block.
+func TestFIRValidQ15NEON_NoOverwrite(t *testing.T) {
+	if !cpu.ARM64.NEON {
+		t.Skip("NEON not available")
+	}
+	const outLen = 11
+	taps := genI16(5, 81)
+	x := genI32(outLen+len(taps)-1, 82)
+	dst := make([]int32, outLen+8)
+	for i := range dst {
+		dst[i] = math.MaxInt32 // sentinel
+	}
+	firValidQ15NEON(dst[:outLen], x, taps)
+	for i := outLen; i < len(dst); i++ {
+		if dst[i] != math.MaxInt32 {
+			t.Errorf("firValidQ15NEON wrote past end at dst[%d] = %d", i, dst[i])
+		}
+	}
+}
+
+// TestFIRValidQ15NEON_AllocFree asserts the kernel runs allocation-free, the
+// repo's zero-allocation contract enforced at the kernel boundary.
+func TestFIRValidQ15NEON_AllocFree(t *testing.T) {
+	if !cpu.ARM64.NEON {
+		t.Skip("NEON not available")
+	}
+	x := make([]int32, 1024)
+	taps := make([]int16, 5)
+	dst := make([]int32, 1020)
+	if got := testing.AllocsPerRun(100, func() { firValidQ15NEON(dst, x, taps) }); got != 0 {
+		t.Errorf("firValidQ15NEON allocated %v times per run, want 0", got)
+	}
+}
+
+// TestFIRValidQ15Dispatch_ReachesNEON pins the dispatch state FIRValidQ15 depends
+// on. It is a white-box check: the NEON kernel is bit-identical to the Go
+// reference by design, so a dispatcher that silently routed every call to Go would
+// pass every parity test. It must not call t.Parallel(): it reads package-level
+// dispatch state.
+func TestFIRValidQ15Dispatch_ReachesNEON(t *testing.T) {
+	if hasNEON != cpu.ARM64.NEON {
+		t.Fatalf("hasNEON = %v but cpu.ARM64.NEON = %v: dispatch flag is not wired to CPU detection", hasNEON, cpu.ARM64.NEON)
+	}
+	if minNEONFIR > 8 {
+		t.Fatalf("minNEONFIR = %d exceeds two vector blocks: FIRValidQ15 would not vectorize at the lengths it was written for", minNEONFIR)
+	}
+}

--- a/i32/fir_test.go
+++ b/i32/fir_test.go
@@ -1,0 +1,375 @@
+package i32
+
+import (
+	"encoding/binary"
+	"math"
+	"testing"
+)
+
+// Tests for FIRValidQ15, the int32 valid convolution (correlation orientation)
+// with int16 Q15 taps. Each tap product is Q15-TRUNCATED before it is added and
+// the accumulator wraps in int32, so the load-bearing behaviors are (1) per-
+// product truncation, distinct from truncating the final sum, and (2) the
+// two's-complement wrap, distinct from saturation.
+
+// genI16 produces a deterministic spread of int16 taps from the same LCG as
+// genI32, taking the high 16 bits so sign and magnitude vary at every index.
+func genI16(n int, seed uint32) []int16 {
+	s := make([]int16, n)
+	x := seed*2654435761 + 1
+	for i := range s {
+		x = x*1664525 + 1013904223
+		s[i] = int16(x >> 16)
+	}
+	return s
+}
+
+// i16sFromBits reinterprets raw bytes as little-endian int16s, one per 2-byte
+// chunk, organically reaching MinInt16/MaxInt16 where the sign extension into the
+// signed multiply is most likely to be mishandled.
+func i16sFromBits(raw []byte) []int16 {
+	out := make([]int16, len(raw)/2)
+	for i := range out {
+		out[i] = int16(binary.LittleEndian.Uint16(raw[i*2:]))
+	}
+	return out
+}
+
+// firValidQ15Oracle computes the valid convolution independently of
+// firValidQ15Go on two axes. The per-tap Q15 shift is a manual floor division by
+// 2^15 (not the >> operator the reference uses), and the taps are accumulated as
+// an exact int64 sum truncated to int32 once at the end (not the per-add int32
+// wrap the reference performs). The two are equal because wrapping int32 addition
+// is addition modulo 2^32 and the exact sum of a handful of int32 products cannot
+// overflow int64, so int32(exactSum) reproduces the wrapping accumulate. It pins
+// the reference rather than trusting a formula shared with it.
+func firValidQ15Oracle(dst, x []int32, taps []int16) {
+	if len(taps) == 0 || len(x) < len(taps) {
+		return
+	}
+	outLen := len(x) - len(taps) + 1
+	n := min(len(dst), outLen)
+	const q = int64(1) << 15
+	for i := range n {
+		var acc int64 // exact sum of the truncated int32 products
+		for j := range taps {
+			prod := int64(taps[j]) * int64(x[i+j]) // exact: |prod| <= 2^46
+			// Floor-divide by 2^15 (truncation toward -inf), computed without >>.
+			shifted := prod / q
+			if prod%q != 0 && prod < 0 {
+				shifted--
+			}
+			acc += int64(int32(shifted)) // per-product int32 truncation (2^31 -> MinInt32)
+		}
+		dst[i] = int32(acc) // single wrap of the exact sum == the per-add wrapping accumulate
+	}
+}
+
+// TestFIRValidQ15OracleSelfCheck confirms the oracle encodes per-product
+// truncation toward -inf and the wrap, so the parity tests rest on a checked
+// foundation. -1 (Q15) times a small positive sample yields a negative product
+// that floors below zero; a positive product just below 2^15 truncates to zero.
+func TestFIRValidQ15OracleSelfCheck(t *testing.T) {
+	// taps=[-1] over x=[1]: product = -1, floor(-1/2^15) = -1, not 0.
+	dst := make([]int32, 1)
+	firValidQ15Oracle(dst, []int32{1}, []int16{-1})
+	if dst[0] != -1 {
+		t.Fatalf("oracle floor: got %d, want -1 (truncation toward -inf)", dst[0])
+	}
+	// taps=[1] over x=[0x7FFF]: product = 32767 < 2^15, truncates to 0.
+	firValidQ15Oracle(dst, []int32{0x7FFF}, []int16{1})
+	if dst[0] != 0 {
+		t.Fatalf("oracle truncate: got %d, want 0", dst[0])
+	}
+}
+
+// TestFIRValidQ15 sweeps a grid of (len(x), len(taps)) against both the pure-Go
+// reference and the independent oracle, so a fault cannot hide by agreeing with
+// the reference alone. The tap counts include 5 (the combFilterConst driver), and
+// the x lengths span the vector-output loop plus a scalar-output tail on both
+// arches as well as short outputs that route to the Go path. MinInt32/MaxInt32
+// ride the ends of x and MinInt16/MaxInt16 the ends of taps so the extremes are
+// always in play.
+func TestFIRValidQ15(t *testing.T) {
+	tapCounts := []int{1, 2, 3, 5, 8, 16}
+	xLens := []int{1, 2, 3, 4, 5, 8, 9, 11, 16, 17, 20, 24, 31, 32, 33, 40, 64, 65, 100, 128}
+	for _, kl := range tapCounts {
+		taps := genI16(kl, uint32(kl)*101+7)
+		taps[0] = math.MinInt16
+		taps[kl-1] = math.MaxInt16
+		for _, xl := range xLens {
+			x := genI32(xl, uint32(xl)*13+uint32(kl))
+			x[0] = math.MinInt32
+			x[xl-1] = math.MaxInt32
+
+			outLen := 0
+			if xl >= kl {
+				outLen = xl - kl + 1
+			}
+			dst := make([]int32, outLen)
+			ref := make([]int32, outLen)
+			orc := make([]int32, outLen)
+			FIRValidQ15(dst, x, taps)
+			firValidQ15Go(ref, x, taps)
+			firValidQ15Oracle(orc, x, taps)
+			for i := range dst {
+				if dst[i] != ref[i] {
+					t.Fatalf("FIRValidQ15 kl=%d xl=%d: dst[%d] = %d, want %d (reference)", kl, xl, i, dst[i], ref[i])
+				}
+				if dst[i] != orc[i] {
+					t.Fatalf("FIRValidQ15 kl=%d xl=%d: dst[%d] = %d, want %d (oracle)", kl, xl, i, dst[i], orc[i])
+				}
+			}
+		}
+	}
+}
+
+// TestFIRValidQ15_PerProductTruncation pins the go-opus MULT16_32_Q15 semantics:
+// each tap product is truncated to Q15 BEFORE it is added, not the final sum. Two
+// taps of 1 over samples of 0x4000 give products of 16384, each of which
+// truncates to 0 (16384 >> 15 = 0), so every output is 0. A build that summed the
+// full products (32768) and truncated once would get 32768 >> 15 = 1 per output.
+// The sample lengths force the Go path, the NEON vector body and the AVX2 vector
+// body plus scalar tails.
+func TestFIRValidQ15_PerProductTruncation(t *testing.T) {
+	taps := []int16{1, 1}
+	for _, xl := range []int{2, 5, 12, 20} {
+		x := make([]int32, xl)
+		for i := range x {
+			x[i] = 0x4000
+		}
+		outLen := xl - 1
+		dst := make([]int32, outLen)
+		orc := make([]int32, outLen)
+		FIRValidQ15(dst, x, taps)
+		firValidQ15Oracle(orc, x, taps)
+		for i := range dst {
+			if dst[i] != 0 {
+				t.Fatalf("FIRValidQ15 per-product truncation xl=%d: dst[%d] = %d, want 0 (final-sum truncation gives 1)", xl, i, dst[i])
+			}
+			if orc[i] != 0 {
+				t.Fatalf("oracle per-product truncation xl=%d: orc[%d] = %d, want 0", xl, i, orc[i])
+			}
+		}
+	}
+}
+
+// TestFIRValidQ15_Wrap pins the wrapping (non-saturating) accumulate. taps of
+// MinInt16 over samples of MinInt32 give a product of 2^46, whose Q15 truncation
+// is 2^31, which wraps to MinInt32 per product; a saturating build would clamp to
+// MaxInt32. A single such tap is used so the output is exactly the wrapped
+// product. The length forces the vector body and the tail on both arches.
+func TestFIRValidQ15_Wrap(t *testing.T) {
+	taps := []int16{math.MinInt16}
+	const xl = 20
+	x := make([]int32, xl)
+	for i := range x {
+		x[i] = math.MinInt32
+	}
+	dst := make([]int32, xl) // outLen = xl - 1 + 1 = xl
+	FIRValidQ15(dst, x, taps)
+	orc := make([]int32, xl)
+	firValidQ15Oracle(orc, x, taps)
+	for i := range dst {
+		if dst[i] != math.MinInt32 {
+			t.Fatalf("FIRValidQ15 wrap: dst[%d] = %d, want %d (wrap, not saturate)", i, dst[i], int32(math.MinInt32))
+		}
+		if orc[i] != math.MinInt32 {
+			t.Fatalf("oracle wrap: orc[%d] = %d, want %d", i, orc[i], int32(math.MinInt32))
+		}
+	}
+}
+
+// TestFIRValidQ15_Guards exercises the CRITICAL guard: empty taps or an x shorter
+// than taps must produce no output (the valid-output count would otherwise
+// underflow), leaving dst untouched and never panicking. len(x) == len(taps)
+// produces exactly one output.
+func TestFIRValidQ15_Guards(t *testing.T) {
+	const sentinel = int32(0x0BADF00D)
+	mkDst := func(n int) []int32 {
+		d := make([]int32, n)
+		for i := range d {
+			d[i] = sentinel
+		}
+		return d
+	}
+	untouched := func(name string, d []int32, from int) {
+		for i := from; i < len(d); i++ {
+			if d[i] != sentinel {
+				t.Fatalf("%s: dst[%d] = %d, want untouched sentinel", name, i, d[i])
+			}
+		}
+	}
+
+	// Empty taps (nil and empty slice): no output, dst fully untouched, no panic.
+	d := mkDst(3)
+	FIRValidQ15(d, []int32{1, 2, 3}, nil)
+	untouched("nil taps", d, 0)
+	FIRValidQ15(d, []int32{1, 2, 3}, []int16{})
+	untouched("empty taps", d, 0)
+
+	// x shorter than taps: no output, dst untouched, no panic.
+	d = mkDst(3)
+	FIRValidQ15(d, []int32{1, 2}, []int16{1, 2, 3})
+	untouched("short x", d, 0)
+	FIRValidQ15(d, nil, []int16{1})
+	untouched("nil x", d, 0)
+
+	// nil everything: no panic, nothing to check.
+	FIRValidQ15(nil, nil, nil)
+
+	// Empty dst with valid taps and x: exercises the n == 0 early return (len(dst)
+	// clamps n to 0) in both the public wrapper and the self-guarding reference. No
+	// panic, nothing written.
+	FIRValidQ15([]int32{}, []int32{1, 2, 3}, []int16{1})
+	firValidQ15Go([]int32{}, []int32{1, 2, 3}, []int16{1})
+
+	// len(x) == len(taps): exactly one output; the rest of dst stays untouched.
+	x := []int32{2, 3, 4}
+	taps := []int16{1 << 14, 1 << 13, 1 << 12}
+	d = mkDst(4)
+	FIRValidQ15(d, x, taps)
+	orc := make([]int32, 1)
+	firValidQ15Oracle(orc, x, taps)
+	if d[0] != orc[0] {
+		t.Fatalf("len(x)==len(taps): dst[0] = %d, want %d (exactly one output)", d[0], orc[0])
+	}
+	untouched("single output", d, 1)
+}
+
+// TestFIRValidQ15_Clamp covers outLen > len(dst): only len(dst) outputs are
+// written and they match the oracle over the same inputs; nothing past len(dst)
+// is computed. The clamp length forces both the vector body and a scalar tail.
+func TestFIRValidQ15_Clamp(t *testing.T) {
+	x := genI32(40, 51)
+	taps := genI16(5, 52)
+	const shortN = 20 // fewer than the 36 available outputs
+	short := make([]int32, shortN)
+	FIRValidQ15(short, x, taps)
+
+	fullOut := len(x) - len(taps) + 1
+	ref := make([]int32, fullOut)
+	firValidQ15Oracle(ref, x, taps)
+	for i := range short {
+		if short[i] != ref[i] {
+			t.Fatalf("FIRValidQ15 clamp: dst[%d] = %d, want %d", i, short[i], ref[i])
+		}
+	}
+}
+
+// TestFIRValidQ15_TailUntouched plants sentinels past the output count and
+// confirms the scalar-output tail stops exactly at n. outLen = 26 leaves a
+// 2-output tail on both the 8-wide (AVX2) and 4-wide (NEON) bodies.
+func TestFIRValidQ15_TailUntouched(t *testing.T) {
+	x := genI32(30, 61)
+	taps := genI16(5, 62)
+	outLen := len(x) - len(taps) + 1 // 26
+	dst := make([]int32, outLen+8)
+	for i := range dst {
+		dst[i] = math.MaxInt32 // non-zero sentinel
+	}
+	FIRValidQ15(dst[:outLen], x, taps)
+	for i := outLen; i < len(dst); i++ {
+		if dst[i] != math.MaxInt32 {
+			t.Errorf("FIRValidQ15 wrote past outLen at dst[%d] = %d", i, dst[i])
+		}
+	}
+}
+
+// TestFIRValidQ15_Unaligned holds x, taps and dst at mutually different element
+// offsets so neither an aligned-load nor an aligned-store substitution can
+// survive, across lengths that straddle a vector block and its tail on both
+// arches.
+func TestFIRValidQ15_Unaligned(t *testing.T) {
+	const span = 400
+	baseX := genI32(span, 71)
+	baseTaps := genI16(60, 72)
+	backing := make([]int32, span)
+	for _, kl := range []int{1, 3, 5, 8} {
+		for _, xl := range []int{8, 9, 16, 17, 33, 64} {
+			outLen := xl - kl + 1
+			for off := range 8 {
+				x := baseX[off+1 : off+1+xl]
+				taps := baseTaps[off+2 : off+2+kl]
+				dst := backing[off+3 : off+3+outLen]
+				FIRValidQ15(dst, x, taps)
+				ref := make([]int32, outLen)
+				firValidQ15Oracle(ref, x, taps)
+				for i := range dst {
+					if dst[i] != ref[i] {
+						t.Fatalf("FIRValidQ15 unaligned kl=%d xl=%d off=%d: dst[%d] = %d, want %d", kl, xl, off, i, dst[i], ref[i])
+					}
+				}
+			}
+		}
+	}
+}
+
+// TestFIRValidQ15_AllocFree declares the buffers INSIDE the measured closure so
+// only allocations forced by the call itself are counted. 5 taps is the comb
+// filter case.
+func TestFIRValidQ15_AllocFree(t *testing.T) {
+	if n := testing.AllocsPerRun(50, func() {
+		var x [1000]int32
+		var taps [5]int16
+		var dst [996]int32
+		FIRValidQ15(dst[:], x[:], taps[:])
+	}); n != 0 {
+		t.Errorf("FIRValidQ15 forces %v caller allocations per run, want 0", n)
+	}
+}
+
+// firSeeds seeds raw byte buffers for x and taps whose element counts bracket the
+// 4/8-lane block boundaries and the guard (taps longer than x, empty taps).
+func firSeeds(f *testing.F) {
+	f.Helper()
+	xLens := []int{0, 1, 2, 3, 4, 5, 8, 9, 12, 16, 17, 24, 32, 33, 40, 64}
+	tapLens := []int{0, 1, 2, 3, 5, 8, 16}
+	for _, xl := range xLens {
+		for _, tl := range tapLens {
+			xRaw := make([]byte, xl*4)
+			for i := range xRaw {
+				xRaw[i] = byte(i*37 + 11)
+			}
+			tRaw := make([]byte, tl*2)
+			for i := range tRaw {
+				tRaw[i] = byte(i*53 + 7)
+			}
+			f.Add(xRaw, tRaw)
+		}
+	}
+}
+
+// FuzzFIRValidQ15 differentially fuzzes the dispatched FIRValidQ15 against the
+// pure-Go reference and the independent oracle over arbitrary int32 samples and
+// int16 taps, so tail handling, the guard and the wrap are explored past the
+// hand-picked seeds. The guard path (empty taps or short x) is checked to write
+// nothing.
+func FuzzFIRValidQ15(f *testing.F) {
+	firSeeds(f)
+	f.Fuzz(func(t *testing.T, xRaw, tapsRaw []byte) {
+		x := i32sFromBits(xRaw)
+		taps := i16sFromBits(tapsRaw)
+
+		if len(taps) == 0 || len(x) < len(taps) {
+			dst := []int32{7, 7, 7}
+			FIRValidQ15(dst, x, taps)
+			for i, v := range dst {
+				if v != 7 {
+					t.Fatalf("guard path wrote dst[%d] = %d (len(x)=%d len(taps)=%d)", i, v, len(x), len(taps))
+				}
+			}
+			return
+		}
+
+		outLen := len(x) - len(taps) + 1
+		got := make([]int32, outLen)
+		want := make([]int32, outLen)
+		orc := make([]int32, outLen)
+		FIRValidQ15(got, x, taps)
+		firValidQ15Go(want, x, taps)
+		firValidQ15Oracle(orc, x, taps)
+		equalI32(t, "FIRValidQ15/ref", got, want)
+		equalI32(t, "FIRValidQ15/oracle", got, orc)
+	})
+}

--- a/i32/i32_amd64.go
+++ b/i32/i32_amd64.go
@@ -195,3 +195,23 @@ func maxAbsI32(a []int32) int32 {
 
 //go:noescape
 func maxAbsAVX2(a []int32) int32
+
+// minAVX2FIR is one 8-wide (256-bit) output block: FIRValidQ15's AVX2 kernel
+// vectorizes over 8 outputs per iteration with a scalar-output tail, so it gates
+// on AVX2 and at least one full 8-output block; shorter outputs use the pure-Go
+// reference. The kernel is correct at any output length via the scalar-output
+// tail, so this is a performance cut only, never a safety requirement. It gates
+// on AVX2 because VPMULDQ/VPSRLQ/VPSLLQ/VPBLENDD/VPADDD are 256-bit integer ops.
+// len(dst) here is already the clamped output count n from the public FIRValidQ15.
+const minAVX2FIR = 8
+
+func firValidQ15I32(dst, x []int32, taps []int16) {
+	if hasAVX2 && len(dst) >= minAVX2FIR {
+		firValidQ15AVX2(dst, x, taps)
+		return
+	}
+	firValidQ15Go(dst, x, taps)
+}
+
+//go:noescape
+func firValidQ15AVX2(dst, x []int32, taps []int16)

--- a/i32/i32_amd64.s
+++ b/i32/i32_amd64.s
@@ -687,3 +687,87 @@ maxabs_ret_max:
     MOVL DX, ret+24(FP)
     VZEROUPPER
     RET
+
+// func firValidQ15AVX2(dst, x []int32, taps []int16)
+// int32 valid convolution in correlation orientation with int16 Q15 taps,
+// vectorized over the OUTPUT index: 8 outputs per iteration. For output block i
+// the accumulator Y2 starts at zero and, for each tap j, loads the sliding window
+// x[i+j .. i+j+7] (one unaligned VMOVDQU that supplies the tap-j contribution for
+// all 8 outputs at once, since output i+k reads lane k of the window), broadcasts
+// taps[j] sign-extended to int32, forms the 8 Q15-TRUNCATED products with the
+// exact scaleQ15AVX2 recombine (VPMULDQ even + VPSRLQ $32 slide + VPMULDQ odd,
+// each VPSRLQ $15 to keep the low 32 = arithmetic-shift result, VPSLLQ $32 +
+// VPBLENDD $0xAA to reassemble), and VPADDD-accumulates them (wrapping int32). The
+// window pointer BX slides by 4 bytes per tap; the taps pointer R10 by 2. After
+// all taps the 8 outputs are stored. The scalar-output tail runs the full inner
+// tap loop per remaining output (MOVLQSX/MOVWQSX, IMULQ, SARQ $15, ADDL), so the
+// per-product truncation is preserved and the result is bit-exact with
+// firValidQ15Go. The dispatch gates n = len(dst) >= 8, and the kernel reads x only
+// up to index n-1+len(taps)-1 <= len(x)-1, so there is no over-read. dst must not
+// overlap x. Frame is dst+x+taps slice headers: dst+0, x+24, taps+48.
+TEXT ·firValidQ15AVX2(SB), NOSPLIT, $0-72
+    MOVQ dst_base+0(FP), DX
+    MOVQ dst_len+8(FP), CX        // n = number of outputs
+    MOVQ x_base+24(FP), SI        // x base = window base for output block 0
+    MOVQ taps_base+48(FP), DI     // taps base (constant)
+    MOVQ taps_len+56(FP), R8      // number of taps (>=1)
+
+    MOVQ CX, R9
+    SHRQ $3, R9                   // R9 = n / 8 = full 8-output blocks
+    JZ   fir_avx2_tail
+
+fir_avx2_block:
+    VPXOR Y2, Y2, Y2             // acc = 0
+    MOVQ  SI, BX                 // BX = window pointer = block base
+    MOVQ  DI, R10                // R10 = taps pointer
+    MOVQ  R8, R11                // R11 = tap counter
+fir_avx2_tap:
+    MOVWQSX (R10), AX           // AX = int64(taps[j]), sign-extended int16
+    VMOVD   AX, X3
+    VPBROADCASTD X3, Y3          // taps[j] in all 8 int32 lanes
+    VMOVDQU  (BX), Y0            // window x[i+j .. i+j+7]
+    VPMULDQ  Y3, Y0, Y4          // even-lane products (4x int64)
+    VPSRLQ   $32, Y0, Y1         // slide odd lanes into even positions
+    VPMULDQ  Y3, Y1, Y5          // odd-lane products (4x int64)
+    VPSRLQ   $15, Y4, Y4         // low 32 of each = even result lanes
+    VPSRLQ   $15, Y5, Y5         // low 32 of each = odd result lanes
+    VPSLLQ   $32, Y5, Y5         // lift odd results to positions 1,3,5,7
+    VPBLENDD $0xAA, Y5, Y4, Y6   // merge: 1,3,5,7 <- Y5 (odd), 0,2,4,6 <- Y4 (even)
+    VPADDD   Y6, Y2, Y2          // acc += 8 Q15-truncated products (wrapping)
+    ADDQ  $4, BX                 // slide window by 1 int32
+    ADDQ  $2, R10                // next tap (int16)
+    DECQ  R11
+    JNZ   fir_avx2_tap
+    VMOVDQU Y2, (DX)             // store 8 outputs
+    ADDQ  $32, SI                // next block window base
+    ADDQ  $32, DX                // next dst block
+    DECQ  R9
+    JNZ   fir_avx2_block
+
+fir_avx2_tail:
+    ANDQ $7, CX                  // CX = n mod 8 = scalar-output tail count
+    JZ   fir_avx2_done
+fir_avx2_tail_out:
+    XORL R11, R11               // acc32 = 0
+    MOVQ SI, BX                 // BX = window pointer for this output
+    MOVQ DI, R10                // R10 = taps pointer
+    MOVQ R8, R12                // R12 = tap counter
+fir_avx2_tail_tap:
+    MOVWQSX (R10), AX          // int64(taps[j])
+    MOVLQSX (BX), R13          // int64(x[i+j])
+    IMULQ   R13, AX            // taps[j] * x[i+j] (|p| <= 2^46)
+    SARQ    $15, AX            // Q15 truncating arithmetic shift
+    ADDL    AX, R11            // acc32 += low 32 (wrapping)
+    ADDQ    $4, BX             // slide window by 1 int32
+    ADDQ    $2, R10            // next tap
+    DECQ    R12
+    JNZ     fir_avx2_tail_tap
+    MOVL    R11, (DX)          // store output
+    ADDQ    $4, SI             // next output window base
+    ADDQ    $4, DX             // next dst
+    DECQ    CX
+    JNZ     fir_avx2_tail_out
+
+fir_avx2_done:
+    VZEROUPPER
+    RET

--- a/i32/i32_arm64.go
+++ b/i32/i32_arm64.go
@@ -181,3 +181,22 @@ func maxAbsI32(a []int32) int32 {
 
 //go:noescape
 func maxAbsNEON(a []int32) int32
+
+// minNEONFIR is one 4-wide (.4S) output block: FIRValidQ15's NEON kernel
+// vectorizes over 4 outputs per iteration with a scalar-output tail, so it gates
+// on NEON and at least one full 4-output block; shorter outputs use the pure-Go
+// reference. The kernel is correct at any output length via the scalar-output
+// tail, so this is a performance cut only, never a safety requirement. len(dst)
+// here is already the clamped output count n from the public FIRValidQ15.
+const minNEONFIR = 4
+
+func firValidQ15I32(dst, x []int32, taps []int16) {
+	if hasNEON && len(dst) >= minNEONFIR {
+		firValidQ15NEON(dst, x, taps)
+		return
+	}
+	firValidQ15Go(dst, x, taps)
+}
+
+//go:noescape
+func firValidQ15NEON(dst, x []int32, taps []int16)

--- a/i32/i32_arm64.s
+++ b/i32/i32_arm64.s
@@ -546,3 +546,79 @@ maxabs_neon_combine:
     CSEL GE, R6, R7, R0             // R0 = max(R6, R7) = max(maxVal, -minVal)
     MOVW R0, ret+24(FP)
     RET
+
+// func firValidQ15NEON(dst, x []int32, taps []int16)
+// int32 valid convolution in correlation orientation with int16 Q15 taps,
+// vectorized over the OUTPUT index: 4 outputs per iteration. For output block i
+// the accumulator V16 starts at zero and, for each tap j, loads the sliding window
+// x[i+j .. i+j+3] (one VLD1 that supplies the tap-j contribution for all 4 outputs
+// at once, since output i+k reads lane k of the window), broadcasts taps[j] (DUP
+// from W2, sign-extended by MOVH), forms the 4 Q15-TRUNCATED products with the
+// exact scaleQ15NEON widen-shift-narrow (SMULL/SMULL2 to int64, SSHR .2D #15,
+// XTN/XTN2 to the low 32 bits), and ADD .4S-accumulates them (wrapping int32). The
+// window pointer R7 slides by 4 bytes per tap; the taps pointer R8 by 2. After all
+// taps the 4 outputs are stored. The scalar-output tail runs the full inner tap
+// loop per remaining output (MOVH/MOVW sign-extend, MUL, ASR #15, ADDW), so the
+// per-product truncation is preserved and the result is bit-exact with
+// firValidQ15Go. All SMULL/SMULL2/SSHR/XTN/XTN2/DUP WORDs are the scaleQ15NEON
+// encodings verbatim (cross-checked by TestArm64WordEncodings). The dispatch gates
+// n = len(dst) >= 4, and the kernel reads x only up to index n-1+len(taps)-1 <=
+// len(x)-1, so there is no over-read. dst must not overlap x. Frame is dst+x+taps
+// slice headers: dst+0, x+24, taps+48.
+TEXT ·firValidQ15NEON(SB), NOSPLIT, $0-72
+    MOVD dst_base+0(FP), R0
+    MOVD dst_len+8(FP), R3         // n = number of outputs
+    MOVD x_base+24(FP), R1         // x base = window base for output block 0
+    MOVD taps_base+48(FP), R6      // taps base (constant)
+    MOVD taps_len+56(FP), R5       // number of taps (>=1)
+
+    LSR  $2, R3, R4               // R4 = n / 4 = full 4-output blocks
+    CBZ  R4, fir_neon_tail
+
+fir_neon_block:
+    VEOR V16.B16, V16.B16, V16.B16 // acc = 0
+    MOVD R1, R7                    // R7 = window pointer = block base
+    MOVD R6, R8                    // R8 = taps pointer
+    MOVD R5, R9                    // R9 = tap counter
+fir_neon_tap:
+    MOVH.P 2(R8), R2             // R2 = taps[j], sign-extended int16 (W2 for DUP)
+    WORD $0x4E040C41            // DUP V1.4S, W2   (taps[j] in all 4 int32 lanes)
+    VLD1 (R7), [V0.S4]          // window x[i+j .. i+j+3]
+    ADD  $4, R7                  // slide window by 1 int32
+    WORD $0x0EA1C002           // SMULL V2.2D, V0.2S, V1.2S   (lanes 0,1 -> 2 int64)
+    WORD $0x4EA1C003           // SMULL2 V3.2D, V0.4S, V1.4S  (lanes 2,3 -> 2 int64)
+    WORD $0x4F710442           // SSHR V2.2D, V2.2D, #15
+    WORD $0x4F710463           // SSHR V3.2D, V3.2D, #15
+    WORD $0x0EA12844           // XTN V4.2S, V2.2D   (low 32 of results 0,1)
+    WORD $0x4EA12864           // XTN2 V4.4S, V3.2D  (low 32 of results 2,3)
+    VADD V4.S4, V16.S4, V16.S4  // acc += 4 Q15-truncated products (wrapping)
+    SUB  $1, R9
+    CBNZ R9, fir_neon_tap
+    VST1.P [V16.S4], 16(R0)      // store 4 outputs
+    ADD  $16, R1                 // next block window base
+    SUB  $1, R4
+    CBNZ R4, fir_neon_block
+
+fir_neon_tail:
+    AND  $3, R3, R4              // R4 = n mod 4 = scalar-output tail count
+    CBZ  R4, fir_neon_done
+fir_neon_tail_out:
+    MOVD $0, R11                // acc32 = 0
+    MOVD R1, R7                 // R7 = window pointer for this output
+    MOVD R6, R8                 // R8 = taps pointer
+    MOVD R5, R9                 // R9 = tap counter
+fir_neon_tail_tap:
+    MOVH.P 2(R8), R10          // R10 = int64(taps[j]), sign-extended
+    MOVW.P 4(R7), R12          // R12 = int64(x[i+j]), sign-extended
+    MUL  R10, R12, R12         // taps[j] * x[i+j] (|p| <= 2^46)
+    ASR  $15, R12, R12         // Q15 truncating arithmetic shift
+    ADDW R12, R11, R11         // acc32 += low 32 (wrapping)
+    SUB  $1, R9
+    CBNZ R9, fir_neon_tail_tap
+    MOVW.P R11, 4(R0)          // store output
+    ADD  $4, R1                // next output window base
+    SUB  $1, R4
+    CBNZ R4, fir_neon_tail_out
+
+fir_neon_done:
+    RET

--- a/i32/i32_go.go
+++ b/i32/i32_go.go
@@ -179,3 +179,46 @@ func scaleQ15Go(dst, a []int32, k int16) {
 		dst[i] = int32(int64(k) * int64(a[i]) >> scaleQ15Shift)
 	}
 }
+
+// firValidQ15Shift is the Q15 fixed-point position of each tap product: the
+// 64-bit int64(taps[j])*int64(x[i+j]) is arithmetically shifted right by 15 to
+// land the Q15 fractional scale back in int32 range, per product, before it is
+// accumulated (MULT16_32_Q15, a truncating shift with no rounding constant).
+const firValidQ15Shift = 15
+
+// firValidQ15Go writes the int32 valid convolution in correlation orientation
+// that is FIRValidQ15's source of truth:
+//
+//	dst[i] = sum_j int32(int64(taps[j]) * int64(x[i+j]) >> 15)
+//
+// for i in [0, n), n = min(len(dst), len(x)-len(taps)+1). Each tap product is
+// Q15-truncated (an arithmetic right shift, no rounding) BEFORE it is added, and
+// the accumulator is two's-complement wrapping int32, matching MULT16_32_Q15 and
+// a wrapping accumulate exactly. The product |taps[j] * x[i+j]| <= 2^15 * 2^31 =
+// 2^46 stays inside int64; only the per-product int32() cast and the running add
+// wrap. The public FIRValidQ15 applies the empty-taps / short-x guard and clamps
+// dst, but this function is self-guarding (it recomputes the safe output count),
+// so a direct fallback call cannot read x out of range. dst must not overlap x.
+func firValidQ15Go(dst, x []int32, taps []int16) {
+	if len(taps) == 0 || len(x) < len(taps) {
+		return
+	}
+	outLen := len(x) - len(taps) + 1
+	n := min(len(dst), outLen)
+	if n == 0 {
+		return
+	}
+	kl := len(taps)
+	for i := range n {
+		// One slice bound per output instead of a per-element x[i+j] check:
+		// i+kl <= (n-1)+kl <= len(x) because n <= len(x)-kl+1, so w has length kl
+		// and w[j] is provably in range for every j in [0, kl).
+		w := x[i : i+kl]
+		var acc int32 // wrapping int32 accumulator
+		for j := range taps {
+			p := int32(int64(taps[j]) * int64(w[j]) >> firValidQ15Shift)
+			acc += p // two's-complement wrapping add
+		}
+		dst[i] = acc
+	}
+}

--- a/i32/i32_go.go
+++ b/i32/i32_go.go
@@ -183,8 +183,9 @@ func scaleQ15Go(dst, a []int32, k int16) {
 // firValidQ15Shift is the Q15 fixed-point position of each tap product: the
 // 64-bit int64(taps[j])*int64(x[i+j]) is arithmetically shifted right by 15 to
 // land the Q15 fractional scale back in int32 range, per product, before it is
-// accumulated (MULT16_32_Q15, a truncating shift with no rounding constant).
-const firValidQ15Shift = 15
+// accumulated (MULT16_32_Q15, a truncating shift with no rounding constant). It
+// is tied to scaleQ15Shift so the two Q15 kernels cannot drift out of lockstep.
+const firValidQ15Shift = scaleQ15Shift
 
 // firValidQ15Go writes the int32 valid convolution in correlation orientation
 // that is FIRValidQ15's source of truth:

--- a/i32/i32_other.go
+++ b/i32/i32_other.go
@@ -20,3 +20,5 @@ func scaleQ31I32(dst, a []int32, k int32) { scaleQ31Go(dst, a, k) }
 func scaleQ15I32(dst, a []int32, k int16) { scaleQ15Go(dst, a, k) }
 
 func butterflyI32(lo, hi []int32) { butterflyGo(lo, hi) }
+
+func firValidQ15I32(dst, x []int32, taps []int16) { firValidQ15Go(dst, x, taps) }


### PR DESCRIPTION
## Summary

Adds `FIRValidQ15(dst, x []int32, taps []int16)`, the valid (correlation orientation) int32 convolution with int16 Q15 taps: for output `i`, `dst[i] = sum over j of int32(int64(taps[j]) * int64(x[i+j]) >> 15)`. Each tap product is Q15-truncated (an arithmetic shift toward -inf, no rounding constant, matching go-opus `MULT16_32_Q15`) BEFORE it is added, and the accumulator is two's-complement wrapping int32, so the SIMD and pure-Go paths are bit-identical across the full int32 range with no relaxed tier. The truncation is per product, not a single truncation of the final sum. This is the integer analog of the float `ConvolveValidMaxAbs` orientation and covers libopus `combFilterConst`.

The full valid-output count is `len(x)-len(taps)+1`; it is clamped to `len(dst)` and any trailing dst capacity is left untouched. Empty taps or an x shorter than taps produces no output (the count would otherwise underflow); when `len(x)==len(taps)` there is exactly one output. This variant is NON-saturating; a saturating variant (`FIRValidQ15Sat`) can follow for the comb-filter `sigSat` consumer. `dst` must not overlap `x`: the SIMD kernels load whole sliding windows of x ahead of the stores.

Kernels are bit-identical across amd64 AVX2, arm64 NEON, and the Go fallback. Each vectorizes over the output index (8 outputs amd64 / 4 arm64 per iteration): for every tap it broadcasts `taps[j]`, loads the sliding window `x[i+j..]`, forms the Q15-truncated products with the same `VPMULDQ`+`VPSRLQ` recombine (amd64) and `SMULL`/`SSHR`/`XTN` widen-shift-narrow (arm64) as ScaleQ15, and accumulates with `VPADDD`/`ADD`; a scalar-output tail handles the remainder. The NEON kernel reuses ScaleQ15's `WORD` encodings verbatim. Direct i32 dispatch keeps it allocation-free. x and taps are passed whole so the windows stay in range (max read index `n-1+len(taps)-1 <= len(x)-1`).

## Related issues

Part of #181 (the `FIRValidQ15` building block; `ScaleQ31`/`ScaleQ15` in #187, `Butterfly` in #188, `MaxAbs` in #189). This completes the four building blocks requested in #181.

## Test plan

- [x] Parity against the Go reference and an independent int64 oracle over a `(len(x), len(taps))` grid forcing the vector-output loop and the scalar-output tail
- [x] Per-product-vs-final-sum truncation pin, explicit guard tests (empty/short taps write nothing, no panic), a MinInt32/MinInt16 wrap case, dst clamp, tail-untouched, unaligned, alloc-free (0 allocs/op), dispatch-pin
- [x] Over-read poison guard (`0x55555555` planted past the last window over a full-block slack) on both arches, differential fuzz over x and taps bytes
- [x] Verified bit-exact on real AVX2 hardware (i7-1260P) and real NEON hardware (Raspberry Pi 5); `TestArm64WordEncodings` cross-checks the reused `WORD` encodings