### PR TITLE
cint: add fixed-point complex arithmetic for integer FFT butterflies (#180)

### DIFF
--- a/cint/benchmark_test.go
+++ b/cint/benchmark_test.go
@@ -1,0 +1,93 @@
+package cint
+
+import "testing"
+
+// Benchmarks pair the dispatched (SIMD) path with the pure-Go baseline so the
+// speedup is visible directly. benchN is the int32 lane count (benchN/2 complex).
+
+const benchN = 2048
+
+func benchData() (dst, a []int32, tw []int16) {
+	dst = make([]int32, benchN)
+	a = genI32(benchN, 1)
+	tw = genI16(benchN, 2)
+	return
+}
+
+func BenchmarkMul(b *testing.B) {
+	dst, a, tw := benchData()
+	b.SetBytes(benchN * (4 + 4 + 2)) // a read (int32), dst write (int32), tw read (int16)
+	for b.Loop() {
+		Mul(dst, a, tw)
+	}
+}
+
+func BenchmarkMulGo(b *testing.B) {
+	dst, a, tw := benchData()
+	b.SetBytes(benchN * (4 + 4 + 2))
+	for b.Loop() {
+		mulGo(dst, a, tw)
+	}
+}
+
+func BenchmarkMulConj(b *testing.B) {
+	dst, a, tw := benchData()
+	b.SetBytes(benchN * (4 + 4 + 2))
+	for b.Loop() {
+		MulConj(dst, a, tw)
+	}
+}
+
+func BenchmarkMulConjGo(b *testing.B) {
+	dst, a, tw := benchData()
+	b.SetBytes(benchN * (4 + 4 + 2))
+	for b.Loop() {
+		mulConjGo(dst, a, tw)
+	}
+}
+
+func BenchmarkMulByScalar(b *testing.B) {
+	a := genI32(benchN, 3)
+	b.SetBytes(benchN * 4)
+	for b.Loop() {
+		MulByScalar(a, 0x1234)
+	}
+}
+
+func BenchmarkMulByScalarGo(b *testing.B) {
+	a := genI32(benchN, 3)
+	b.SetBytes(benchN * 4)
+	for b.Loop() {
+		mulByScalarGo(a, 0x1234)
+	}
+}
+
+func BenchmarkAdd(b *testing.B) {
+	dst := make([]int32, benchN)
+	a := genI32(benchN, 4)
+	c := genI32(benchN, 5)
+	b.SetBytes(benchN * 4 * 3)
+	for b.Loop() {
+		Add(dst, a, c)
+	}
+}
+
+func BenchmarkAddGo(b *testing.B) {
+	dst := make([]int32, benchN)
+	a := genI32(benchN, 4)
+	c := genI32(benchN, 5)
+	b.SetBytes(benchN * 4 * 3)
+	for b.Loop() {
+		addGo(dst, a, c)
+	}
+}
+
+func BenchmarkSub(b *testing.B) {
+	dst := make([]int32, benchN)
+	a := genI32(benchN, 4)
+	c := genI32(benchN, 5)
+	b.SetBytes(benchN * 4 * 3)
+	for b.Loop() {
+		Sub(dst, a, c)
+	}
+}

--- a/cint/benchmark_test.go
+++ b/cint/benchmark_test.go
@@ -91,3 +91,13 @@ func BenchmarkSub(b *testing.B) {
 		Sub(dst, a, c)
 	}
 }
+
+func BenchmarkSubGo(b *testing.B) {
+	dst := make([]int32, benchN)
+	a := genI32(benchN, 4)
+	c := genI32(benchN, 5)
+	b.SetBytes(benchN * 4 * 3)
+	for b.Loop() {
+		subGo(dst, a, c)
+	}
+}

--- a/cint/cint.go
+++ b/cint/cint.go
@@ -1,0 +1,123 @@
+// Package cint provides SIMD-accelerated fixed-point complex arithmetic on
+// interleaved int32 slices, the integer FFT butterfly kernels of libopus
+// kiss_fft.
+//
+// # Data model
+//
+// Complex data is a []int32 of length 2*N laid out interleaved as
+// [r0,i0,r1,i1,...], one int32 per real or imaginary part. A twiddle factor is a
+// []int16 of length 2*N in Q15, laid out the same interleaved way. This matches
+// the C kiss_fft_cpx arrays libopus operates on.
+//
+// # Fixed-point semantics
+//
+// The scalar multiply is S_MUL(x, c) = int32(int64(x) * int64(c) >> 15): a
+// TRUNCATING Q15 multiply (an arithmetic right shift, NO rounding constant),
+// exactly the integer MULT16_32_Q15 of libopus. Every add and subtract wraps in
+// int32 (two's complement, no saturation). The products are always formed in a
+// 64-bit intermediate that never overflows (|int32 * int16| <= 2^46), so only the
+// final int32 cast wraps: the extreme MinInt32 * MinInt16 = 2^46 shifts to 2^31
+// and wraps to MinInt32. The SIMD and pure-Go paths are bit-identical across the
+// full int32 range; there is no relaxed tier.
+//
+// # Length handling
+//
+// Every function clamps to n = min of the applicable slice lengths and then masks
+// n down to a whole number of complex pairs (an even lane count, n &^= 1). This
+// is not a claimed precondition the caller must meet: a mismatched or odd-length
+// slice is not an error, it simply bounds the work to the leading whole complex
+// pairs both (or all) slices cover, and a trailing lone real lane is left
+// untouched. Masking to even also guarantees Mul and MulConj never read the
+// second half a[2k+1] / tw[2k+1] of a pair the slice does not fully contain.
+// Empty inputs write nothing.
+//
+// # Aliasing
+//
+// Mul, MulConj and MulByScalar may be used fully in place: dst may alias a
+// exactly, element for element (and MulByScalar is defined in place). Each SIMD
+// block reads its whole complex block of inputs into registers before storing any
+// output lane, so an exact overlay is well defined block by block. dst must not
+// otherwise overlap a at a shifted offset: a SIMD load pulls a block ahead of the
+// stores, so a shifted overlay could clobber input lanes a later iteration has
+// not yet read. Add and Sub write dst from separate a and b; pass a dst that does
+// not shift-overlap either input.
+//
+// # Guarantees
+//
+// All functions are zero-allocation (they write into caller-provided slices or
+// in place) and safe for concurrent use on non-overlapping slices.
+package cint
+
+// Add writes the wrapping complex sum dst[k] = a[k] + b[k] over the leading whole
+// complex pairs of dst, a and b. Complex addition is a lanewise real add on the
+// interleaved layout, so this is the flat int32 add over n = (min of the three
+// lengths) masked to an even lane count; each add wraps in int32 rather than
+// saturating. Any lane past n, including a trailing lone real, is left untouched.
+func Add(dst, a, b []int32) {
+	n := min(len(dst), len(a), len(b)) &^ 1
+	if n == 0 {
+		return
+	}
+	addCint(dst[:n], a[:n], b[:n])
+}
+
+// Sub writes the wrapping complex difference dst[k] = a[k] - b[k] over the
+// leading whole complex pairs of dst, a and b, the flat int32 subtract over the
+// even-masked min length. Each subtract wraps in int32. Any lane past n is left
+// untouched.
+func Sub(dst, a, b []int32) {
+	n := min(len(dst), len(a), len(b)) &^ 1
+	if n == 0 {
+		return
+	}
+	subCint(dst[:n], a[:n], b[:n])
+}
+
+// MulByScalar scales the complex data a in place by the Q15 scalar s:
+// a[j] = S_MUL(a[j], s) for every int32 lane, scaling both the real and the
+// imaginary part of each complex sample. It is the integer MULT16_32_Q15 applied
+// flat over the interleaved layout, truncating and wrapping in int32. The length
+// is masked to a whole number of complex pairs, so a trailing lone real lane in
+// an odd-length slice is left unscaled.
+func MulByScalar(a []int32, s int16) {
+	n := len(a) &^ 1
+	if n == 0 {
+		return
+	}
+	mulByScalarCint(a[:n], s)
+}
+
+// Mul writes the C_MUL complex multiply of a by the twiddle tw:
+//
+//	dst[2k]   = S_MUL(ar, br) - S_MUL(ai, bi)   // real
+//	dst[2k+1] = S_MUL(ar, bi) + S_MUL(ai, br)   // imag
+//
+// with ar,ai = a[2k],a[2k+1] and br,bi = tw[2k],tw[2k+1]. It runs over n = (min
+// of len(dst), len(a), len(tw)) masked to a whole number of complex pairs; a
+// trailing half-complex is never read or written. Each S_MUL truncates to int32
+// before the wrapping int32 combine. dst may alias a exactly for an in-place
+// transform; see the package doc on aliasing.
+func Mul(dst, a []int32, tw []int16) {
+	n := min(len(dst), len(a), len(tw)) &^ 1
+	if n == 0 {
+		return
+	}
+	mulCint(dst[:n], a[:n], tw[:n])
+}
+
+// MulConj writes the C_MUL complex multiply of a by the conjugated twiddle
+// conj(tw):
+//
+//	dst[2k]   = S_MUL(ar, br) + S_MUL(ai, bi)   // real
+//	dst[2k+1] = S_MUL(ai, br) - S_MUL(ar, bi)   // imag
+//
+// the correlation counterpart of Mul (the conjugate negates the twiddle
+// imaginary part). Same even-masked length handling, truncating Q15 arithmetic,
+// int32 wrap and in-place-alias support as Mul.
+func MulConj(dst, a []int32, tw []int16) {
+	n := min(len(dst), len(a), len(tw)) &^ 1
+	if n == 0 {
+		return
+	}
+	mulConjCint(dst[:n], a[:n], tw[:n])
+}

--- a/cint/cint_amd64.go
+++ b/cint/cint_amd64.go
@@ -1,0 +1,85 @@
+//go:build amd64
+
+package cint
+
+import "github.com/tphakala/simd/cpu"
+
+// hasAVX2 gates the SIMD kernels. Every kernel does integer ALU work on 256-bit
+// lanes (VPADDD / VPSUBD / VPMULDQ / VPSRLQ / VPSLLQ / VPBLENDD / VPMOVSXWD),
+// which requires AVX2, so this checks the CPU feature explicitly rather than
+// relying on length alone and falls back to the pure-Go reference otherwise.
+//
+// Dispatch is a direct CPU-flag switch, not an init-time function-pointer table:
+// a pointer table defeats //go:noescape and forces the slice arguments to the
+// heap, so every call would allocate. The explicit branch keeps the operations
+// zero-allocation.
+var hasAVX2 = cpu.X86.AVX2
+
+// Tier thresholds: the minimum lane count at which the AVX2 kernel is worth its
+// setup over the scalar loop, one 8-lane (256-bit) block each. Add, Sub and
+// MulByScalar step 8 int32 per block; Mul and MulConj step 8 int32 (4 complex)
+// per block, so all five gate at 8. Every kernel is correct at any length (each
+// falls through to a scalar tail), so these are performance cuts, never a safety
+// requirement. They are independent literals so retuning one cannot move another.
+const (
+	minAVX2Add         = 8
+	minAVX2Sub         = 8
+	minAVX2MulByScalar = 8
+	minAVX2Mul         = 8
+	minAVX2MulConj     = 8
+)
+
+func addCint(dst, a, b []int32) {
+	if hasAVX2 && len(dst) >= minAVX2Add {
+		addAVX2(dst, a, b)
+		return
+	}
+	addGo(dst, a, b)
+}
+
+func subCint(dst, a, b []int32) {
+	if hasAVX2 && len(dst) >= minAVX2Sub {
+		subAVX2(dst, a, b)
+		return
+	}
+	subGo(dst, a, b)
+}
+
+func mulByScalarCint(a []int32, s int16) {
+	if hasAVX2 && len(a) >= minAVX2MulByScalar {
+		mulByScalarAVX2(a, s)
+		return
+	}
+	mulByScalarGo(a, s)
+}
+
+func mulCint(dst, a []int32, tw []int16) {
+	if hasAVX2 && len(dst) >= minAVX2Mul {
+		mulAVX2(dst, a, tw)
+		return
+	}
+	mulGo(dst, a, tw)
+}
+
+func mulConjCint(dst, a []int32, tw []int16) {
+	if hasAVX2 && len(dst) >= minAVX2MulConj {
+		mulConjAVX2(dst, a, tw)
+		return
+	}
+	mulConjGo(dst, a, tw)
+}
+
+//go:noescape
+func addAVX2(dst, a, b []int32)
+
+//go:noescape
+func subAVX2(dst, a, b []int32)
+
+//go:noescape
+func mulByScalarAVX2(a []int32, s int16)
+
+//go:noescape
+func mulAVX2(dst, a []int32, tw []int16)
+
+//go:noescape
+func mulConjAVX2(dst, a []int32, tw []int16)

--- a/cint/cint_amd64.s
+++ b/cint/cint_amd64.s
@@ -1,0 +1,305 @@
+//go:build amd64
+
+#include "textflag.h"
+
+// Fixed-point complex arithmetic kernels (AVX2).
+//
+// Add and Sub are flat wrapping int32 lane ops (VPADDD / VPSUBD), 8 int32 per
+// iteration with a scalar tail. MulByScalar is the truncating Q15 scale-by-scalar
+// (MULT16_32_Q15) applied in place over the flat lane view, reusing the i32
+// ScaleQ15 recombine. Mul and MulConj are the C_MUL / conjugated complex multiply.
+//
+// The truncating Q15 product uses the same trick as the i32 ScaleQ15 kernel: AVX2
+// has VPMULDQ (signed 32x32 -> 64 on the EVEN 32-bit lanes) but no 64-bit
+// ARITHMETIC shift (VPSRAQ is AVX-512). For a product p with |p| <= 2^46 and
+// result int32(p >> 15), the LOW 32 bits of the LOGICAL shift VPSRLQ $15 equal the
+// low 32 bits of the arithmetic shift: result bit i reads p bit i+15, and
+// i+15 <= 31+15 = 46 <= 63 is a real bit of p for both shift kinds; they differ
+// only in bits >= 32 (sign-fill vs zero-fill), which the int32 store discards. So
+// VPSRLQ $15 then keep the low 32 bits is exact, including the MinInt32 * MinInt16
+// = 2^46 -> 2^31 -> MinInt32 wrap. No EVEX is emitted: VPMULDQ, VPSRLQ, VPSLLQ,
+// VPBLENDD, VPADDD, VPSUBD, VPMOVSXWD and the VMOVD/VPBROADCASTD scalar splat are
+// all AVX2 (the GP-register VPBROADCASTD is AVX-512 and is avoided).
+//
+// The complex multiply stays interleaved: for A = [ar0,ai0,ar1,ai1,...] and the
+// sign-extended twiddle T = [br0,bi0,...], VPSRLQ $32 slides the imaginary lanes
+// into the even positions so all four half-products ar*br, ai*bi, ar*bi, ai*br are
+// EVEN-lane VPMULDQ products; each is VPSRLQ $15 truncated; the real combine lands
+// in the even lanes and the imaginary combine (after VPSLLQ $32) in the odd lanes;
+// and VPBLENDD $0xAA merges them back to interleaved [r0,i0,r1,i1,...]. The Go
+// 3-operand order is dst-last: VPSUBD a, b, c is c = b - a. dst may alias a
+// exactly: each block loads a and tw in full before it stores dst. Reserved
+// registers (g in R14, GOT temp in R15) are untouched. Every kernel ends VZEROUPPER before RET.
+
+// func addAVX2(dst, a, b []int32)
+TEXT ·addAVX2(SB), NOSPLIT, $0-72
+    MOVQ dst_base+0(FP), DX
+    MOVQ dst_len+8(FP), CX
+    MOVQ a_base+24(FP), SI
+    MOVQ b_base+48(FP), DI
+
+    MOVQ CX, AX
+    SHRQ $3, AX
+    JZ   add_remainder
+
+add_loop8:
+    VMOVDQU (SI), Y0
+    VMOVDQU (DI), Y1
+    VPADDD  Y1, Y0, Y2         // Y2 = a + b
+    VMOVDQU Y2, (DX)
+    ADDQ $32, SI
+    ADDQ $32, DI
+    ADDQ $32, DX
+    DECQ AX
+    JNZ  add_loop8
+
+add_remainder:
+    ANDQ $7, CX
+    JZ   add_done
+
+add_scalar:
+    MOVL (SI), AX
+    ADDL (DI), AX
+    MOVL AX, (DX)
+    ADDQ $4, SI
+    ADDQ $4, DI
+    ADDQ $4, DX
+    DECQ CX
+    JNZ  add_scalar
+
+add_done:
+    VZEROUPPER
+    RET
+
+// func subAVX2(dst, a, b []int32)
+TEXT ·subAVX2(SB), NOSPLIT, $0-72
+    MOVQ dst_base+0(FP), DX
+    MOVQ dst_len+8(FP), CX
+    MOVQ a_base+24(FP), SI
+    MOVQ b_base+48(FP), DI
+
+    MOVQ CX, AX
+    SHRQ $3, AX
+    JZ   sub_remainder
+
+sub_loop8:
+    VMOVDQU (SI), Y0
+    VMOVDQU (DI), Y1
+    VPSUBD  Y1, Y0, Y2         // Y2 = a - b
+    VMOVDQU Y2, (DX)
+    ADDQ $32, SI
+    ADDQ $32, DI
+    ADDQ $32, DX
+    DECQ AX
+    JNZ  sub_loop8
+
+sub_remainder:
+    ANDQ $7, CX
+    JZ   sub_done
+
+sub_scalar:
+    MOVL (SI), AX
+    SUBL (DI), AX
+    MOVL AX, (DX)
+    ADDQ $4, SI
+    ADDQ $4, DI
+    ADDQ $4, DX
+    DECQ CX
+    JNZ  sub_scalar
+
+sub_done:
+    VZEROUPPER
+    RET
+
+// func mulByScalarAVX2(a []int32, s int16)
+// In-place truncating Q15 scale, 8 int32 per iteration: identical recombine to the
+// i32 scaleQ15AVX2 with the load and store sharing one pointer (dst aliases a). s
+// is a signed int16, sign-extended to int32 before the broadcast (VPMULDQ is signed
+// 32x32) and to int64 for the tail; |s * a[i]| <= 2^46. Frame is one slice header
+// plus the int16 scalar: a+0, s+24.
+TEXT ·mulByScalarAVX2(SB), NOSPLIT, $0-26
+    MOVQ    a_base+0(FP), SI
+    MOVQ    a_len+8(FP), CX
+    MOVWQSX s+24(FP), BX          // BX = int64(s), sign-extended int16 (also tail s)
+    VMOVD   BX, X3                // low 32 bits = int32(s)
+    VPBROADCASTD X3, Y3           // AVX2 xmm->ymm broadcast of int32(s)
+
+    MOVQ CX, AX
+    SHRQ $3, AX
+    JZ   mulbyscalar_avx2_tail
+
+mulbyscalar_avx2_loop8:
+    VMOVDQU  (SI), Y0             // a[i..i+7]
+    VPMULDQ  Y3, Y0, Y4           // even-lane products a0,a2,a4,a6 * s (4x int64)
+    VPSRLQ   $32, Y0, Y1          // slide odd lanes a1,a3,a5,a7 into even positions
+    VPMULDQ  Y3, Y1, Y5           // odd-lane products a1,a3,a5,a7 * s (4x int64)
+    VPSRLQ   $15, Y4, Y4          // low 32 of each int64 = even result lanes
+    VPSRLQ   $15, Y5, Y5          // low 32 of each int64 = odd result lanes
+    VPSLLQ   $32, Y5, Y5          // lift odd results to 32-bit positions 1,3,5,7
+    VPBLENDD $0xAA, Y5, Y4, Y2    // lanes 1,3,5,7 <- Y5 (odd), 0,2,4,6 <- Y4 (even)
+    VMOVDQU  Y2, (SI)             // in place: store scaled block over a
+    ADDQ $32, SI
+    DECQ AX
+    JNZ  mulbyscalar_avx2_loop8
+
+mulbyscalar_avx2_tail:
+    ANDQ $7, CX
+    JZ   mulbyscalar_avx2_done
+
+mulbyscalar_avx2_scalar:
+    MOVLQSX (SI), AX              // int64(a[i])
+    IMULQ   BX, AX                // s * a[i] (64-bit, |p| <= 2^46)
+    SARQ    $15, AX               // arithmetic shift right 15
+    MOVL    AX, (SI)              // low 32 bits: wraps like int32()
+    ADDQ $4, SI
+    DECQ CX
+    JNZ  mulbyscalar_avx2_scalar
+
+mulbyscalar_avx2_done:
+    VZEROUPPER
+    RET
+
+// func mulAVX2(dst, a []int32, tw []int16)
+// C_MUL complex multiply, 4 complex (8 int32) per iteration. dst+0, a+24, tw+48.
+TEXT ·mulAVX2(SB), NOSPLIT, $0-72
+    MOVQ dst_base+0(FP), DX
+    MOVQ dst_len+8(FP), CX        // n (int32 count, even)
+    MOVQ a_base+24(FP), SI
+    MOVQ tw_base+48(FP), DI
+
+    MOVQ CX, AX
+    SHRQ $3, AX                   // AX = n/8 = 4-complex blocks
+    JZ   mul_avx2_tail
+
+mul_avx2_loop8:
+    VMOVDQU   (SI), Y0            // A = [ar0,ai0,ar1,ai1,ar2,ai2,ar3,ai3]
+    VPMOVSXWD (DI), Y1            // T = [br0,bi0,...] sign-extended int16 -> int32
+    VPSRLQ    $32, Y0, Y2         // As: even 32-lanes = ai0,ai1,ai2,ai3
+    VPSRLQ    $32, Y1, Y3         // Ts: even 32-lanes = bi0,bi1,bi2,bi3
+    VPMULDQ   Y1, Y0, Y4         // prr = ar*br (4x int64)
+    VPMULDQ   Y3, Y2, Y5         // pii = ai*bi
+    VPMULDQ   Y3, Y0, Y6         // pri = ar*bi
+    VPMULDQ   Y1, Y2, Y7         // pir = ai*br
+    VPSRLQ    $15, Y4, Y4         // Q15 truncate: low 32 of each int64 (even lanes)
+    VPSRLQ    $15, Y5, Y5
+    VPSRLQ    $15, Y6, Y6
+    VPSRLQ    $15, Y7, Y7
+    VPSUBD    Y5, Y4, Y8         // re = prr - pii (even 32-lanes valid; odd don't-care)
+    VPADDD    Y7, Y6, Y9         // im = pri + pir (even 32-lanes valid)
+    VPSLLQ    $32, Y9, Y9         // move imag results to ODD 32-lanes
+    VPBLENDD  $0xAA, Y9, Y8, Y8   // even<-re (reals), odd<-im (imags): interleaved
+    VMOVDQU   Y8, (DX)
+    ADDQ $32, SI
+    ADDQ $16, DI
+    ADDQ $32, DX
+    DECQ AX
+    JNZ  mul_avx2_loop8
+
+mul_avx2_tail:
+    MOVQ CX, BX
+    ANDQ $7, BX                   // leftover int32 (even: 0,2,4,6)
+    SHRQ $1, BX                   // leftover complex count
+    JZ   mul_avx2_done
+
+mul_avx2_scalar:
+    MOVLQSX (SI), AX              // ar = int64(a[2k])
+    MOVLQSX 4(SI), R8             // ai = int64(a[2k+1])
+    MOVWQSX (DI), R9             // br = int64(tw[2k])
+    MOVWQSX 2(DI), R10            // bi = int64(tw[2k+1])
+    MOVQ  AX, R11
+    IMULQ R9, R11                 // ar*br
+    SARQ  $15, R11                // prr
+    MOVQ  R8, R12
+    IMULQ R10, R12                // ai*bi
+    SARQ  $15, R12                // pii
+    SUBL  R12, R11                // re = prr - pii (int32 wrap on low 32)
+    MOVL  R11, (DX)               // dst[2k] = re
+    MOVQ  AX, R11
+    IMULQ R10, R11                // ar*bi
+    SARQ  $15, R11                // pri
+    IMULQ R9, R8                  // ai*br
+    SARQ  $15, R8                 // pir
+    ADDL  R8, R11                 // im = pri + pir (int32 wrap on low 32)
+    MOVL  R11, 4(DX)              // dst[2k+1] = im
+    ADDQ $8, SI
+    ADDQ $4, DI
+    ADDQ $8, DX
+    DECQ BX
+    JNZ  mul_avx2_scalar
+
+mul_avx2_done:
+    VZEROUPPER
+    RET
+
+// func mulConjAVX2(dst, a []int32, tw []int16)
+// Conjugated complex multiply: the same four half-products as mulAVX2, but the
+// real combine adds (prr + pii) and the imaginary combine subtracts (pir - pri).
+TEXT ·mulConjAVX2(SB), NOSPLIT, $0-72
+    MOVQ dst_base+0(FP), DX
+    MOVQ dst_len+8(FP), CX        // n (int32 count, even)
+    MOVQ a_base+24(FP), SI
+    MOVQ tw_base+48(FP), DI
+
+    MOVQ CX, AX
+    SHRQ $3, AX                   // AX = n/8 = 4-complex blocks
+    JZ   mulconj_avx2_tail
+
+mulconj_avx2_loop8:
+    VMOVDQU   (SI), Y0            // A = [ar0,ai0,ar1,ai1,ar2,ai2,ar3,ai3]
+    VPMOVSXWD (DI), Y1            // T = [br0,bi0,...] sign-extended int16 -> int32
+    VPSRLQ    $32, Y0, Y2         // As: even 32-lanes = ai0..ai3
+    VPSRLQ    $32, Y1, Y3         // Ts: even 32-lanes = bi0..bi3
+    VPMULDQ   Y1, Y0, Y4         // prr = ar*br
+    VPMULDQ   Y3, Y2, Y5         // pii = ai*bi
+    VPMULDQ   Y3, Y0, Y6         // pri = ar*bi
+    VPMULDQ   Y1, Y2, Y7         // pir = ai*br
+    VPSRLQ    $15, Y4, Y4         // Q15 truncate (even lanes)
+    VPSRLQ    $15, Y5, Y5
+    VPSRLQ    $15, Y6, Y6
+    VPSRLQ    $15, Y7, Y7
+    VPADDD    Y5, Y4, Y8         // re = prr + pii (even 32-lanes valid)
+    VPSUBD    Y6, Y7, Y9         // im = pir - pri (Y7 - Y6, even 32-lanes valid)
+    VPSLLQ    $32, Y9, Y9         // move imag results to ODD 32-lanes
+    VPBLENDD  $0xAA, Y9, Y8, Y8   // even<-re, odd<-im: interleaved
+    VMOVDQU   Y8, (DX)
+    ADDQ $32, SI
+    ADDQ $16, DI
+    ADDQ $32, DX
+    DECQ AX
+    JNZ  mulconj_avx2_loop8
+
+mulconj_avx2_tail:
+    MOVQ CX, BX
+    ANDQ $7, BX                   // leftover int32 (even)
+    SHRQ $1, BX                   // leftover complex count
+    JZ   mulconj_avx2_done
+
+mulconj_avx2_scalar:
+    MOVLQSX (SI), AX              // ar
+    MOVLQSX 4(SI), R8             // ai
+    MOVWQSX (DI), R9             // br
+    MOVWQSX 2(DI), R10            // bi
+    MOVQ  AX, R11
+    IMULQ R9, R11                 // ar*br
+    SARQ  $15, R11                // prr
+    MOVQ  R8, R12
+    IMULQ R10, R12                // ai*bi
+    SARQ  $15, R12                // pii
+    ADDL  R12, R11                // re = prr + pii (int32 wrap on low 32)
+    MOVL  R11, (DX)               // dst[2k] = re
+    MOVQ  AX, R11
+    IMULQ R10, R11                // ar*bi
+    SARQ  $15, R11                // pri
+    IMULQ R9, R8                  // ai*br
+    SARQ  $15, R8                 // pir
+    SUBL  R11, R8                 // im = pir - pri (int32 wrap on low 32)
+    MOVL  R8, 4(DX)               // dst[2k+1] = im
+    ADDQ $8, SI
+    ADDQ $4, DI
+    ADDQ $8, DX
+    DECQ BX
+    JNZ  mulconj_avx2_scalar
+
+mulconj_avx2_done:
+    VZEROUPPER
+    RET

--- a/cint/cint_amd64_test.go
+++ b/cint/cint_amd64_test.go
@@ -174,13 +174,23 @@ func TestMulAVX2_AllocFree(t *testing.T) {
 	}
 	const n = 1024
 	a := make([]int32, n)
+	b := make([]int32, n)
 	tw := make([]int16, n)
 	dst := make([]int32, n)
 	if got := testing.AllocsPerRun(100, func() { mulAVX2(dst, a, tw) }); got != 0 {
 		t.Errorf("mulAVX2 allocated %v times per run, want 0", got)
 	}
+	if got := testing.AllocsPerRun(100, func() { mulConjAVX2(dst, a, tw) }); got != 0 {
+		t.Errorf("mulConjAVX2 allocated %v times per run, want 0", got)
+	}
 	if got := testing.AllocsPerRun(100, func() { mulByScalarAVX2(a, 0x1234) }); got != 0 {
 		t.Errorf("mulByScalarAVX2 allocated %v times per run, want 0", got)
+	}
+	if got := testing.AllocsPerRun(100, func() { addAVX2(dst, a, b) }); got != 0 {
+		t.Errorf("addAVX2 allocated %v times per run, want 0", got)
+	}
+	if got := testing.AllocsPerRun(100, func() { subAVX2(dst, a, b) }); got != 0 {
+		t.Errorf("subAVX2 allocated %v times per run, want 0", got)
 	}
 }
 

--- a/cint/cint_amd64_test.go
+++ b/cint/cint_amd64_test.go
@@ -1,0 +1,204 @@
+//go:build amd64
+
+package cint
+
+import (
+	"math"
+	"testing"
+
+	"github.com/tphakala/simd/cpu"
+)
+
+// Kernel-direct tests for the AVX2 path. They call the assembly kernels straight,
+// over lengths the dispatcher would never route to them (below the threshold), so a
+// threshold change cannot quietly reduce these to a test of the Go reference
+// against itself. The kernels are bit-identical to the Go reference by design, so
+// the dispatch-pin test is what proves the SIMD path is actually reached.
+
+// kernelEvenLengths drives the kernels at whole-pair lengths spanning zero, sub-
+// block, single-block, block+tail and multi-block sizes on the 4-complex (8 int32)
+// AVX2 blocks.
+var kernelEvenLengths = []int{2, 4, 6, 8, 10, 12, 14, 16, 18, 22, 24, 30, 32, 34, 64, 66, 128, 130}
+
+func TestMulAVX2_ParityWithGo(t *testing.T) {
+	if !cpu.X86.AVX2 {
+		t.Skip("AVX2 not available")
+	}
+	for _, n := range kernelEvenLengths {
+		a := genI32(n, 101)
+		tw := genI16(n, 102)
+		plantExtremes(a, tw)
+		got := make([]int32, n)
+		mulAVX2(got, a, tw)
+		checkMul(t, "mulAVX2", false, got, a, tw)
+	}
+}
+
+func TestMulConjAVX2_ParityWithGo(t *testing.T) {
+	if !cpu.X86.AVX2 {
+		t.Skip("AVX2 not available")
+	}
+	for _, n := range kernelEvenLengths {
+		a := genI32(n, 103)
+		tw := genI16(n, 104)
+		plantExtremes(a, tw)
+		got := make([]int32, n)
+		mulConjAVX2(got, a, tw)
+		checkMul(t, "mulConjAVX2", true, got, a, tw)
+	}
+}
+
+func TestMulByScalarAVX2_ParityWithGo(t *testing.T) {
+	if !cpu.X86.AVX2 {
+		t.Skip("AVX2 not available")
+	}
+	ss := []int16{math.MinInt16, math.MaxInt16, 1, -1, 0x4000}
+	for _, n := range kernelEvenLengths {
+		for _, s := range ss {
+			a := genI32(n, 105)
+			if n >= 2 {
+				a[0] = math.MinInt32
+				a[n-1] = math.MaxInt32
+			}
+			orig := append([]int32(nil), a...)
+			mulByScalarAVX2(a, s)
+			for i := range a {
+				if want := sMulBig(orig[i], s); a[i] != want {
+					t.Fatalf("mulByScalarAVX2 n=%d s=%d at %d: got %d want %d", n, s, i, a[i], want)
+				}
+			}
+		}
+	}
+}
+
+func TestAddSubAVX2_ParityWithGo(t *testing.T) {
+	if !cpu.X86.AVX2 {
+		t.Skip("AVX2 not available")
+	}
+	for _, n := range kernelEvenLengths {
+		a := genI32(n, 106)
+		b := genI32(n, 107)
+		if n >= 2 {
+			a[0], b[0] = math.MinInt32, -1
+			a[n-1], b[n-1] = math.MaxInt32, 1
+		}
+		got := make([]int32, n)
+		ref := make([]int32, n)
+		addAVX2(got, a, b)
+		addGo(ref, a, b)
+		for i := range got {
+			if got[i] != ref[i] {
+				t.Fatalf("addAVX2 n=%d at %d: got %d want %d", n, i, got[i], ref[i])
+			}
+		}
+		subAVX2(got, a, b)
+		subGo(ref, a, b)
+		for i := range got {
+			if got[i] != ref[i] {
+				t.Fatalf("subAVX2 n=%d at %d: got %d want %d", n, i, got[i], ref[i])
+			}
+		}
+	}
+}
+
+// TestMulAVX2_OverRead catches a kernel that reads past n or writes past n. The
+// in-range body is tame (values in -2..2, so every product is small), while the
+// slack past n in a and tw is poisoned with the absolute extremes, and the slack in
+// dst carries a sentinel. Backings are n + one full 8-int32 (8-int16) block, so a
+// kernel that reads a stray block lands in the poison and its in-range results flip
+// away from the tame oracle, and a kernel that writes a stray block overwrites the
+// dst sentinel. A correct kernel stops exactly at n on both sides.
+func TestMulAVX2_OverRead(t *testing.T) {
+	if !cpu.X86.AVX2 {
+		t.Skip("AVX2 not available")
+	}
+	testMulOverRead(t, "mulAVX2", false, mulAVX2)
+	testMulOverRead(t, "mulConjAVX2", true, mulConjAVX2)
+}
+
+func testMulOverRead(t *testing.T, name string, conj bool, kernel func(dst, a []int32, tw []int16)) {
+	t.Helper()
+	const slack = 8 // one full 4-complex block in int32 (and in int16) units
+	const sentinel = int32(0x5EED1234)
+	for _, n := range []int{8, 10, 12, 14, 18, 22, 30} {
+		ab := make([]int32, n+slack)
+		twb := make([]int16, n+slack)
+		dstb := make([]int32, n+slack)
+		for i := range ab {
+			ab[i] = int32(i%5 - 2) // tame body: -2..2
+			twb[i] = int16(i%5 - 2)
+			dstb[i] = sentinel
+		}
+		for i := n; i < n+slack; i++ {
+			if i%2 == 0 {
+				ab[i], twb[i] = math.MinInt32, math.MinInt16
+			} else {
+				ab[i], twb[i] = math.MaxInt32, math.MaxInt16
+			}
+		}
+		a, tw, dst := ab[:n], twb[:n], dstb[:n]
+		kernel(dst, a, tw)
+		checkMul(t, name, conj, dst, a, tw) // in-range lanes must be tame
+		for i := n; i < n+slack; i++ {
+			if dstb[i] != sentinel {
+				t.Fatalf("%s n=%d wrote past n at dst[%d] = %d (want sentinel)", name, n, i, dstb[i])
+			}
+		}
+	}
+}
+
+// TestMulByScalarAVX2_NoOverwrite guards the in-place scalar tail: it may not write
+// past n when n is not a multiple of the 8-lane block.
+func TestMulByScalarAVX2_NoOverwrite(t *testing.T) {
+	if !cpu.X86.AVX2 {
+		t.Skip("AVX2 not available")
+	}
+	const n = 10
+	a := make([]int32, n+8)
+	for i := range a {
+		a[i] = math.MaxInt32
+	}
+	mulByScalarAVX2(a[:n], 0x1234)
+	for i := n; i < len(a); i++ {
+		if a[i] != math.MaxInt32 {
+			t.Errorf("mulByScalarAVX2 wrote past end at a[%d] = %d", i, a[i])
+		}
+	}
+}
+
+// TestMulAVX2_AllocFree asserts the kernels run allocation-free at the kernel
+// boundary.
+func TestMulAVX2_AllocFree(t *testing.T) {
+	if !cpu.X86.AVX2 {
+		t.Skip("AVX2 not available")
+	}
+	const n = 1024
+	a := make([]int32, n)
+	tw := make([]int16, n)
+	dst := make([]int32, n)
+	if got := testing.AllocsPerRun(100, func() { mulAVX2(dst, a, tw) }); got != 0 {
+		t.Errorf("mulAVX2 allocated %v times per run, want 0", got)
+	}
+	if got := testing.AllocsPerRun(100, func() { mulByScalarAVX2(a, 0x1234) }); got != 0 {
+		t.Errorf("mulByScalarAVX2 allocated %v times per run, want 0", got)
+	}
+}
+
+// TestDispatchReachesSIMD_AVX2 pins the dispatch state the public API depends on. It
+// is a white-box check: the AVX2 kernels are bit-identical to the Go reference by
+// design, so a dispatcher that silently routed every call to Go would pass every
+// parity test. It must not call t.Parallel(): it reads package-level dispatch state.
+func TestDispatchReachesSIMD_AVX2(t *testing.T) {
+	if hasAVX2 != cpu.X86.AVX2 {
+		t.Fatalf("hasAVX2 = %v but cpu.X86.AVX2 = %v: dispatch flag is not wired to CPU detection", hasAVX2, cpu.X86.AVX2)
+	}
+	for name, th := range map[string]int{
+		"minAVX2Add": minAVX2Add, "minAVX2Sub": minAVX2Sub,
+		"minAVX2MulByScalar": minAVX2MulByScalar, "minAVX2Mul": minAVX2Mul,
+		"minAVX2MulConj": minAVX2MulConj,
+	} {
+		if th > 16 {
+			t.Fatalf("%s = %d exceeds two vector blocks: the op would not vectorize at the lengths it was written for", name, th)
+		}
+	}
+}

--- a/cint/cint_arm64.go
+++ b/cint/cint_arm64.go
@@ -1,0 +1,84 @@
+//go:build arm64
+
+package cint
+
+import "github.com/tphakala/simd/cpu"
+
+// hasNEON gates the SIMD kernels. Every kernel does integer ALU work on NEON
+// vectors, so it checks the CPU feature explicitly and falls back to the pure-Go
+// reference otherwise.
+//
+// Dispatch is a direct CPU-flag switch, not an init-time function-pointer table:
+// a pointer table defeats //go:noescape and forces the slice arguments to the
+// heap, so every call would allocate. The explicit branch keeps the operations
+// zero-allocation.
+var hasNEON = cpu.ARM64.NEON
+
+// Tier thresholds: one vector block each. Add, Sub and MulByScalar step 4 int32
+// (one .4S register) per block, so they gate at 4. Mul and MulConj deinterleave 4
+// complex (8 int32) per block via LD2/ST2, so they gate at 8. Every kernel is
+// correct at any length (each falls through to a scalar tail), so these are
+// performance cuts, never a safety requirement, and are independent literals so
+// retuning one cannot move another.
+const (
+	minNEONAdd         = 4
+	minNEONSub         = 4
+	minNEONMulByScalar = 4
+	minNEONMul         = 8
+	minNEONMulConj     = 8
+)
+
+func addCint(dst, a, b []int32) {
+	if hasNEON && len(dst) >= minNEONAdd {
+		addNEON(dst, a, b)
+		return
+	}
+	addGo(dst, a, b)
+}
+
+func subCint(dst, a, b []int32) {
+	if hasNEON && len(dst) >= minNEONSub {
+		subNEON(dst, a, b)
+		return
+	}
+	subGo(dst, a, b)
+}
+
+func mulByScalarCint(a []int32, s int16) {
+	if hasNEON && len(a) >= minNEONMulByScalar {
+		mulByScalarNEON(a, s)
+		return
+	}
+	mulByScalarGo(a, s)
+}
+
+func mulCint(dst, a []int32, tw []int16) {
+	if hasNEON && len(dst) >= minNEONMul {
+		mulNEON(dst, a, tw)
+		return
+	}
+	mulGo(dst, a, tw)
+}
+
+func mulConjCint(dst, a []int32, tw []int16) {
+	if hasNEON && len(dst) >= minNEONMulConj {
+		mulConjNEON(dst, a, tw)
+		return
+	}
+	mulConjGo(dst, a, tw)
+}
+
+//go:noescape
+func addNEON(dst, a, b []int32)
+
+//go:noescape
+func subNEON(dst, a, b []int32)
+
+//go:noescape
+func mulByScalarNEON(a []int32, s int16)
+
+//go:noescape
+func mulNEON(dst, a []int32, tw []int16)
+
+//go:noescape
+func mulConjNEON(dst, a []int32, tw []int16)

--- a/cint/cint_arm64.s
+++ b/cint/cint_arm64.s
@@ -21,11 +21,12 @@
 // [re, im] pair back to interleaved [r0,i0,r1,i1,...]. dst may alias a exactly:
 // each block deinterleaves its whole a and tw block before it stores dst.
 //
-// SXTL/SMULL/SMULL2/SSHR/XTN/XTN2/DUP and the ADD/SUB .4S combines have no Go
-// assembler mnemonic (or are pinned as verified encodings) and are hand-encoded
-// WORD directives with the decoded GNU form in the trailing comment, cross-checked
-// against golang.org/x/arch/arm64asm by TestArm64WordEncodings. LD2/ST2 use the
-// Go VLD2/VST2 mnemonics. Reserved registers (g in R28, R27/R18/R16/R17) are
+// SXTL/SMULL/SMULL2/SSHR/XTN/XTN2/DUP have no Go assembler mnemonic, and the
+// standalone Add/Sub kernels pin ADD/SUB .4S as verified WORD encodings (matching
+// i32); all are hand-encoded WORD directives with the decoded GNU form in the
+// trailing comment, cross-checked against golang.org/x/arch/arm64asm by
+// TestArm64WordEncodings. The Mul/MulConj re/im combines use the Go VADD/VSUB
+// mnemonics, and LD2/ST2 use VLD2/VST2. Reserved registers (g in R28, R27/R18/R16/R17) are
 // untouched. The scalar tails use the W-register (32-bit) ALU forms so they wrap
 // identically to the vector lanes.
 

--- a/cint/cint_arm64.s
+++ b/cint/cint_arm64.s
@@ -1,0 +1,294 @@
+//go:build arm64
+
+#include "textflag.h"
+
+// Fixed-point complex arithmetic kernels (NEON / ASIMD).
+//
+// Add and Sub are flat wrapping int32 lane ops (ADD / SUB .4S), 4 int32 per
+// iteration with a scalar tail. MulByScalar is the truncating Q15 scale-by-scalar
+// (MULT16_32_Q15) applied in place over the flat lane view, reusing the i32
+// ScaleQ15 widen-shift-narrow. Mul and MulConj are the C_MUL / conjugated complex
+// multiply, deinterleaved with LD2 and re-interleaved with ST2.
+//
+// The truncating Q15 product is a clean widen-shift-narrow: SMULL/SMULL2 multiply
+// the int32 lanes into int64 products, SSHR .2D #15 arithmetically shifts each
+// product right by 15 (truncating toward -inf, no rounding), and XTN/XTN2 narrow
+// the low 32 bits back to int32 (the narrowing is the int32 wrap, so
+// MinInt32 * MinInt16 = 2^46 >> 15 = 2^31 lands as MinInt32). The complex kernels
+// deinterleave a into V_ar/V_ai with LD2 .4S and the int16 twiddle into V_br/V_bi
+// with LD2 .4H, sign-extend the twiddle to int32 with SXTL (the #0 shift alias of
+// SSHLL), form the four half-products, combine with ADD/SUB .4S, and ST2 the
+// [re, im] pair back to interleaved [r0,i0,r1,i1,...]. dst may alias a exactly:
+// each block deinterleaves its whole a and tw block before it stores dst.
+//
+// SXTL/SMULL/SMULL2/SSHR/XTN/XTN2/DUP and the ADD/SUB .4S combines have no Go
+// assembler mnemonic (or are pinned as verified encodings) and are hand-encoded
+// WORD directives with the decoded GNU form in the trailing comment, cross-checked
+// against golang.org/x/arch/arm64asm by TestArm64WordEncodings. LD2/ST2 use the
+// Go VLD2/VST2 mnemonics. Reserved registers (g in R28, R27/R18/R16/R17) are
+// untouched. The scalar tails use the W-register (32-bit) ALU forms so they wrap
+// identically to the vector lanes.
+
+// func addNEON(dst, a, b []int32)
+TEXT ·addNEON(SB), NOSPLIT, $0-72
+    MOVD dst_base+0(FP), R0
+    MOVD dst_len+8(FP), R3
+    MOVD a_base+24(FP), R1
+    MOVD b_base+48(FP), R2
+
+    LSR $2, R3, R4
+    CBZ R4, add_neon_remainder
+
+add_neon_loop4:
+    VLD1.P 16(R1), [V0.S4]
+    VLD1.P 16(R2), [V1.S4]
+    WORD $0x4EA18402           // ADD V2.4S, V0.4S, V1.4S
+    VST1.P [V2.S4], 16(R0)
+    SUB $1, R4
+    CBNZ R4, add_neon_loop4
+
+add_neon_remainder:
+    AND $3, R3
+    CBZ R3, add_neon_done
+
+add_neon_loop1:
+    MOVW (R1), R5
+    MOVW (R2), R6
+    ADDW R6, R5, R5
+    MOVW R5, (R0)
+    ADD $4, R1
+    ADD $4, R2
+    ADD $4, R0
+    SUB $1, R3
+    CBNZ R3, add_neon_loop1
+
+add_neon_done:
+    RET
+
+// func subNEON(dst, a, b []int32)
+TEXT ·subNEON(SB), NOSPLIT, $0-72
+    MOVD dst_base+0(FP), R0
+    MOVD dst_len+8(FP), R3
+    MOVD a_base+24(FP), R1
+    MOVD b_base+48(FP), R2
+
+    LSR $2, R3, R4
+    CBZ R4, sub_neon_remainder
+
+sub_neon_loop4:
+    VLD1.P 16(R1), [V0.S4]
+    VLD1.P 16(R2), [V1.S4]
+    WORD $0x6EA18402           // SUB V2.4S, V0.4S, V1.4S
+    VST1.P [V2.S4], 16(R0)
+    SUB $1, R4
+    CBNZ R4, sub_neon_loop4
+
+sub_neon_remainder:
+    AND $3, R3
+    CBZ R3, sub_neon_done
+
+sub_neon_loop1:
+    MOVW (R1), R5
+    MOVW (R2), R6
+    SUBW R6, R5, R5
+    MOVW R5, (R0)
+    ADD $4, R1
+    ADD $4, R2
+    ADD $4, R0
+    SUB $1, R3
+    CBNZ R3, sub_neon_loop1
+
+sub_neon_done:
+    RET
+
+// func mulByScalarNEON(a []int32, s int16)
+// In-place truncating Q15 scale, 4 int32 per iteration: the i32 scaleQ15NEON
+// widen-shift-narrow with the load and store sharing R0 (dst aliases a). s is a
+// signed int16 broadcast with DUP from W2 (MOVH sign-extends it), and int64(s) in
+// R2 also serves the scalar tail. Frame is one slice header plus the int16 scalar:
+// a+0, s+24.
+TEXT ·mulByScalarNEON(SB), NOSPLIT, $0-26
+    MOVD a_base+0(FP), R0
+    MOVD a_len+8(FP), R3
+    MOVH s+24(FP), R2          // R2 = int64(s), sign-extended int16 (also tail s)
+    WORD $0x4E040C41           // DUP V1.4S, W2   (s in all 4 int32 lanes)
+
+    LSR  $2, R3, R4            // R4 = n / 4
+    CBZ  R4, mulbyscalar_neon_remainder
+
+mulbyscalar_neon_loop4:
+    VLD1 (R0), [V0.S4]         // a[i..i+3] (no advance; in-place store reuses R0)
+    WORD $0x0EA1C002           // SMULL V2.2D, V0.2S, V1.2S
+    WORD $0x4EA1C003           // SMULL2 V3.2D, V0.4S, V1.4S
+    WORD $0x4F710442           // SSHR V2.2D, V2.2D, #15
+    WORD $0x4F710463           // SSHR V3.2D, V3.2D, #15
+    WORD $0x0EA12844           // XTN V4.2S, V2.2D
+    WORD $0x4EA12864           // XTN2 V4.4S, V3.2D
+    VST1 [V4.S4], (R0)         // in place
+    ADD  $16, R0
+    SUB  $1, R4
+    CBNZ R4, mulbyscalar_neon_loop4
+
+mulbyscalar_neon_remainder:
+    AND  $3, R3
+    CBZ  R3, mulbyscalar_neon_done
+
+mulbyscalar_neon_scalar:
+    MOVW (R0), R5              // a[i], sign-extended
+    MUL  R2, R5, R5            // s * a[i] (64-bit, |p| <= 2^46)
+    ASR  $15, R5, R5           // arithmetic shift right 15
+    MOVW.P R5, 4(R0)           // low 32 bits: wraps like int32(); store + advance
+    SUB  $1, R3
+    CBNZ R3, mulbyscalar_neon_scalar
+
+mulbyscalar_neon_done:
+    RET
+
+// func mulNEON(dst, a []int32, tw []int16)
+// C_MUL complex multiply, 4 complex (8 int32) per iteration. dst+0, a+24, tw+48.
+TEXT ·mulNEON(SB), NOSPLIT, $0-72
+    MOVD dst_base+0(FP), R0
+    MOVD dst_len+8(FP), R3     // n (int32 count, even)
+    MOVD a_base+24(FP), R1
+    MOVD tw_base+48(FP), R2
+
+    LSR  $3, R3, R4            // R4 = n / 8 = 4-complex blocks
+    CBZ  R4, mul_neon_tail
+
+mul_neon_loop:
+    VLD2.P 32(R1), [V0.S4, V1.S4]    // V0=ar[0..3], V1=ai[0..3]
+    VLD2.P 16(R2), [V2.H4, V3.H4]    // V2=br[0..3] int16, V3=bi[0..3] int16
+    WORD $0x0F10A444           // SXTL V4.4S, V2.4H   (br int16 -> int32)
+    WORD $0x0F10A465           // SXTL V5.4S, V3.4H   (bi int16 -> int32)
+    WORD $0x0EA4C010           // SMULL V16.2D, V0.2S, V4.2S    (prr lanes 0,1)
+    WORD $0x4EA4C011           // SMULL2 V17.2D, V0.4S, V4.4S   (prr lanes 2,3)
+    WORD $0x4F710610           // SSHR V16.2D, V16.2D, #15
+    WORD $0x4F710631           // SSHR V17.2D, V17.2D, #15
+    WORD $0x0EA12A06           // XTN V6.2S, V16.2D    (prr low 32 of lanes 0,1)
+    WORD $0x4EA12A26           // XTN2 V6.4S, V17.2D   (prr low 32 of lanes 2,3)
+    WORD $0x0EA5C030           // SMULL V16.2D, V1.2S, V5.2S    (pii)
+    WORD $0x4EA5C031           // SMULL2 V17.2D, V1.4S, V5.4S
+    WORD $0x4F710610           // SSHR V16.2D, V16.2D, #15
+    WORD $0x4F710631           // SSHR V17.2D, V17.2D, #15
+    WORD $0x0EA12A07           // XTN V7.2S, V16.2D    (pii)
+    WORD $0x4EA12A27           // XTN2 V7.4S, V17.2D
+    WORD $0x0EA5C010           // SMULL V16.2D, V0.2S, V5.2S    (pri)
+    WORD $0x4EA5C011           // SMULL2 V17.2D, V0.4S, V5.4S
+    WORD $0x4F710610           // SSHR V16.2D, V16.2D, #15
+    WORD $0x4F710631           // SSHR V17.2D, V17.2D, #15
+    WORD $0x0EA12A08           // XTN V8.2S, V16.2D    (pri)
+    WORD $0x4EA12A28           // XTN2 V8.4S, V17.2D
+    WORD $0x0EA4C030           // SMULL V16.2D, V1.2S, V4.2S    (pir)
+    WORD $0x4EA4C031           // SMULL2 V17.2D, V1.4S, V4.4S
+    WORD $0x4F710610           // SSHR V16.2D, V16.2D, #15
+    WORD $0x4F710631           // SSHR V17.2D, V17.2D, #15
+    WORD $0x0EA12A09           // XTN V9.2S, V16.2D    (pir)
+    WORD $0x4EA12A29           // XTN2 V9.4S, V17.2D
+    VSUB V7.S4, V6.S4, V10.S4        // re = prr - pii
+    VADD V9.S4, V8.S4, V11.S4        // im = pri + pir
+    VST2.P [V10.S4, V11.S4], 32(R0)  // re-interleave -> dst
+    SUB  $1, R4
+    CBNZ R4, mul_neon_loop
+
+mul_neon_tail:
+    AND  $7, R3, R4            // leftover int32 (even)
+    LSR  $1, R4, R4            // leftover complex count
+    CBZ  R4, mul_neon_done
+
+mul_neon_scalar:
+    MOVW.P 4(R1), R5           // ar (sign-extended)
+    MOVW.P 4(R1), R6           // ai
+    MOVH.P 2(R2), R7           // br (sign-extended int16)
+    MOVH.P 2(R2), R8           // bi
+    MUL  R7, R5, R9            // ar*br
+    ASR  $15, R9, R9           // prr
+    MUL  R8, R6, R10           // ai*bi
+    ASR  $15, R10, R10         // pii
+    SUBW R10, R9, R11          // re = prr - pii (32-bit)
+    MOVW.P R11, 4(R0)          // dst[2k] = re
+    MUL  R8, R5, R12           // ar*bi
+    ASR  $15, R12, R12         // pri
+    MUL  R7, R6, R13           // ai*br
+    ASR  $15, R13, R13         // pir
+    ADDW R13, R12, R11         // im = pri + pir (32-bit)
+    MOVW.P R11, 4(R0)          // dst[2k+1] = im
+    SUB  $1, R4
+    CBNZ R4, mul_neon_scalar
+
+mul_neon_done:
+    RET
+
+// func mulConjNEON(dst, a []int32, tw []int16)
+// Conjugated complex multiply: same four half-products as mulNEON, but the real
+// combine adds (prr + pii) and the imaginary combine subtracts (pir - pri).
+TEXT ·mulConjNEON(SB), NOSPLIT, $0-72
+    MOVD dst_base+0(FP), R0
+    MOVD dst_len+8(FP), R3     // n (int32 count, even)
+    MOVD a_base+24(FP), R1
+    MOVD tw_base+48(FP), R2
+
+    LSR  $3, R3, R4            // R4 = n / 8 = 4-complex blocks
+    CBZ  R4, mulconj_neon_tail
+
+mulconj_neon_loop:
+    VLD2.P 32(R1), [V0.S4, V1.S4]    // V0=ar, V1=ai
+    VLD2.P 16(R2), [V2.H4, V3.H4]    // V2=br int16, V3=bi int16
+    WORD $0x0F10A444           // SXTL V4.4S, V2.4H
+    WORD $0x0F10A465           // SXTL V5.4S, V3.4H
+    WORD $0x0EA4C010           // SMULL V16.2D, V0.2S, V4.2S    (prr)
+    WORD $0x4EA4C011           // SMULL2 V17.2D, V0.4S, V4.4S
+    WORD $0x4F710610           // SSHR V16.2D, V16.2D, #15
+    WORD $0x4F710631           // SSHR V17.2D, V17.2D, #15
+    WORD $0x0EA12A06           // XTN V6.2S, V16.2D    (prr)
+    WORD $0x4EA12A26           // XTN2 V6.4S, V17.2D
+    WORD $0x0EA5C030           // SMULL V16.2D, V1.2S, V5.2S    (pii)
+    WORD $0x4EA5C031           // SMULL2 V17.2D, V1.4S, V5.4S
+    WORD $0x4F710610           // SSHR V16.2D, V16.2D, #15
+    WORD $0x4F710631           // SSHR V17.2D, V17.2D, #15
+    WORD $0x0EA12A07           // XTN V7.2S, V16.2D    (pii)
+    WORD $0x4EA12A27           // XTN2 V7.4S, V17.2D
+    WORD $0x0EA5C010           // SMULL V16.2D, V0.2S, V5.2S    (pri)
+    WORD $0x4EA5C011           // SMULL2 V17.2D, V0.4S, V5.4S
+    WORD $0x4F710610           // SSHR V16.2D, V16.2D, #15
+    WORD $0x4F710631           // SSHR V17.2D, V17.2D, #15
+    WORD $0x0EA12A08           // XTN V8.2S, V16.2D    (pri)
+    WORD $0x4EA12A28           // XTN2 V8.4S, V17.2D
+    WORD $0x0EA4C030           // SMULL V16.2D, V1.2S, V4.2S    (pir)
+    WORD $0x4EA4C031           // SMULL2 V17.2D, V1.4S, V4.4S
+    WORD $0x4F710610           // SSHR V16.2D, V16.2D, #15
+    WORD $0x4F710631           // SSHR V17.2D, V17.2D, #15
+    WORD $0x0EA12A09           // XTN V9.2S, V16.2D    (pir)
+    WORD $0x4EA12A29           // XTN2 V9.4S, V17.2D
+    VADD V7.S4, V6.S4, V10.S4        // re = prr + pii
+    VSUB V8.S4, V9.S4, V11.S4        // im = pir - pri
+    VST2.P [V10.S4, V11.S4], 32(R0)  // re-interleave -> dst
+    SUB  $1, R4
+    CBNZ R4, mulconj_neon_loop
+
+mulconj_neon_tail:
+    AND  $7, R3, R4            // leftover int32 (even)
+    LSR  $1, R4, R4            // leftover complex count
+    CBZ  R4, mulconj_neon_done
+
+mulconj_neon_scalar:
+    MOVW.P 4(R1), R5           // ar
+    MOVW.P 4(R1), R6           // ai
+    MOVH.P 2(R2), R7           // br
+    MOVH.P 2(R2), R8           // bi
+    MUL  R7, R5, R9            // ar*br
+    ASR  $15, R9, R9           // prr
+    MUL  R8, R6, R10           // ai*bi
+    ASR  $15, R10, R10         // pii
+    ADDW R10, R9, R11          // re = prr + pii (32-bit)
+    MOVW.P R11, 4(R0)          // dst[2k] = re
+    MUL  R8, R5, R12           // ar*bi
+    ASR  $15, R12, R12         // pri
+    MUL  R7, R6, R13           // ai*br
+    ASR  $15, R13, R13         // pir
+    SUBW R12, R13, R11         // im = pir - pri (32-bit)
+    MOVW.P R11, 4(R0)          // dst[2k+1] = im
+    SUB  $1, R4
+    CBNZ R4, mulconj_neon_scalar
+
+mulconj_neon_done:
+    RET

--- a/cint/cint_arm64_test.go
+++ b/cint/cint_arm64_test.go
@@ -1,0 +1,202 @@
+//go:build arm64
+
+package cint
+
+import (
+	"math"
+	"testing"
+
+	"github.com/tphakala/simd/cpu"
+)
+
+// Kernel-direct tests for the NEON path. They call the assembly kernels straight,
+// over lengths the dispatcher would never route to them, so a threshold change
+// cannot quietly reduce these to a test of the Go reference against itself. The
+// kernels are bit-identical to the Go reference by design, so the dispatch-pin test
+// is what proves the SIMD path is actually reached.
+
+// kernelEvenLengthsNEON drives the kernels at whole-pair lengths spanning zero,
+// sub-block, single-block, block+tail and multi-block sizes on the 4-complex
+// (8 int32) Mul blocks and the 4-int32 Add/Sub/MulByScalar blocks.
+var kernelEvenLengthsNEON = []int{2, 4, 6, 8, 10, 12, 14, 16, 18, 22, 24, 30, 32, 34, 64, 66, 128, 130}
+
+func TestMulNEON_ParityWithGo(t *testing.T) {
+	if !cpu.ARM64.NEON {
+		t.Skip("NEON not available")
+	}
+	for _, n := range kernelEvenLengthsNEON {
+		a := genI32(n, 101)
+		tw := genI16(n, 102)
+		plantExtremes(a, tw)
+		got := make([]int32, n)
+		mulNEON(got, a, tw)
+		checkMul(t, "mulNEON", false, got, a, tw)
+	}
+}
+
+func TestMulConjNEON_ParityWithGo(t *testing.T) {
+	if !cpu.ARM64.NEON {
+		t.Skip("NEON not available")
+	}
+	for _, n := range kernelEvenLengthsNEON {
+		a := genI32(n, 103)
+		tw := genI16(n, 104)
+		plantExtremes(a, tw)
+		got := make([]int32, n)
+		mulConjNEON(got, a, tw)
+		checkMul(t, "mulConjNEON", true, got, a, tw)
+	}
+}
+
+func TestMulByScalarNEON_ParityWithGo(t *testing.T) {
+	if !cpu.ARM64.NEON {
+		t.Skip("NEON not available")
+	}
+	ss := []int16{math.MinInt16, math.MaxInt16, 1, -1, 0x4000}
+	for _, n := range kernelEvenLengthsNEON {
+		for _, s := range ss {
+			a := genI32(n, 105)
+			if n >= 2 {
+				a[0] = math.MinInt32
+				a[n-1] = math.MaxInt32
+			}
+			orig := append([]int32(nil), a...)
+			mulByScalarNEON(a, s)
+			for i := range a {
+				if want := sMulBig(orig[i], s); a[i] != want {
+					t.Fatalf("mulByScalarNEON n=%d s=%d at %d: got %d want %d", n, s, i, a[i], want)
+				}
+			}
+		}
+	}
+}
+
+func TestAddSubNEON_ParityWithGo(t *testing.T) {
+	if !cpu.ARM64.NEON {
+		t.Skip("NEON not available")
+	}
+	for _, n := range kernelEvenLengthsNEON {
+		a := genI32(n, 106)
+		b := genI32(n, 107)
+		if n >= 2 {
+			a[0], b[0] = math.MinInt32, -1
+			a[n-1], b[n-1] = math.MaxInt32, 1
+		}
+		got := make([]int32, n)
+		ref := make([]int32, n)
+		addNEON(got, a, b)
+		addGo(ref, a, b)
+		for i := range got {
+			if got[i] != ref[i] {
+				t.Fatalf("addNEON n=%d at %d: got %d want %d", n, i, got[i], ref[i])
+			}
+		}
+		subNEON(got, a, b)
+		subGo(ref, a, b)
+		for i := range got {
+			if got[i] != ref[i] {
+				t.Fatalf("subNEON n=%d at %d: got %d want %d", n, i, got[i], ref[i])
+			}
+		}
+	}
+}
+
+// TestMulNEON_OverRead catches a kernel that reads past n or writes past n. The
+// in-range body is tame (values in -2..2), the slack past n in a and tw is poisoned
+// with the absolute extremes, and the slack in dst carries a sentinel. Backings are
+// n + one full 8-int32 (8-int16) block, so a stray read lands in the poison and
+// flips the in-range results, and a stray write overwrites the dst sentinel.
+func TestMulNEON_OverRead(t *testing.T) {
+	if !cpu.ARM64.NEON {
+		t.Skip("NEON not available")
+	}
+	testMulOverReadNEON(t, "mulNEON", false, mulNEON)
+	testMulOverReadNEON(t, "mulConjNEON", true, mulConjNEON)
+}
+
+func testMulOverReadNEON(t *testing.T, name string, conj bool, kernel func(dst, a []int32, tw []int16)) {
+	t.Helper()
+	const slack = 8
+	const sentinel = int32(0x5EED1234)
+	for _, n := range []int{8, 10, 12, 14, 18, 22, 30} {
+		ab := make([]int32, n+slack)
+		twb := make([]int16, n+slack)
+		dstb := make([]int32, n+slack)
+		for i := range ab {
+			ab[i] = int32(i%5 - 2) // tame body: -2..2
+			twb[i] = int16(i%5 - 2)
+			dstb[i] = sentinel
+		}
+		for i := n; i < n+slack; i++ {
+			if i%2 == 0 {
+				ab[i], twb[i] = math.MinInt32, math.MinInt16
+			} else {
+				ab[i], twb[i] = math.MaxInt32, math.MaxInt16
+			}
+		}
+		a, tw, dst := ab[:n], twb[:n], dstb[:n]
+		kernel(dst, a, tw)
+		checkMul(t, name, conj, dst, a, tw)
+		for i := n; i < n+slack; i++ {
+			if dstb[i] != sentinel {
+				t.Fatalf("%s n=%d wrote past n at dst[%d] = %d (want sentinel)", name, n, i, dstb[i])
+			}
+		}
+	}
+}
+
+// TestMulByScalarNEON_NoOverwrite guards the in-place scalar tail: it may not write
+// past n when n is not a multiple of the 4-lane block.
+func TestMulByScalarNEON_NoOverwrite(t *testing.T) {
+	if !cpu.ARM64.NEON {
+		t.Skip("NEON not available")
+	}
+	const n = 10
+	a := make([]int32, n+8)
+	for i := range a {
+		a[i] = math.MaxInt32
+	}
+	mulByScalarNEON(a[:n], 0x1234)
+	for i := n; i < len(a); i++ {
+		if a[i] != math.MaxInt32 {
+			t.Errorf("mulByScalarNEON wrote past end at a[%d] = %d", i, a[i])
+		}
+	}
+}
+
+// TestMulNEON_AllocFree asserts the kernels run allocation-free at the kernel
+// boundary.
+func TestMulNEON_AllocFree(t *testing.T) {
+	if !cpu.ARM64.NEON {
+		t.Skip("NEON not available")
+	}
+	const n = 1024
+	a := make([]int32, n)
+	tw := make([]int16, n)
+	dst := make([]int32, n)
+	if got := testing.AllocsPerRun(100, func() { mulNEON(dst, a, tw) }); got != 0 {
+		t.Errorf("mulNEON allocated %v times per run, want 0", got)
+	}
+	if got := testing.AllocsPerRun(100, func() { mulByScalarNEON(a, 0x1234) }); got != 0 {
+		t.Errorf("mulByScalarNEON allocated %v times per run, want 0", got)
+	}
+}
+
+// TestDispatchReachesSIMD_NEON pins the dispatch state the public API depends on. It
+// is a white-box check: the NEON kernels are bit-identical to the Go reference by
+// design, so a dispatcher that silently routed every call to Go would pass every
+// parity test. It must not call t.Parallel(): it reads package-level dispatch state.
+func TestDispatchReachesSIMD_NEON(t *testing.T) {
+	if hasNEON != cpu.ARM64.NEON {
+		t.Fatalf("hasNEON = %v but cpu.ARM64.NEON = %v: dispatch flag is not wired to CPU detection", hasNEON, cpu.ARM64.NEON)
+	}
+	for name, th := range map[string]int{
+		"minNEONAdd": minNEONAdd, "minNEONSub": minNEONSub,
+		"minNEONMulByScalar": minNEONMulByScalar, "minNEONMul": minNEONMul,
+		"minNEONMulConj": minNEONMulConj,
+	} {
+		if th > 16 {
+			t.Fatalf("%s = %d exceeds two vector blocks: the op would not vectorize at the lengths it was written for", name, th)
+		}
+	}
+}

--- a/cint/cint_arm64_test.go
+++ b/cint/cint_arm64_test.go
@@ -172,13 +172,23 @@ func TestMulNEON_AllocFree(t *testing.T) {
 	}
 	const n = 1024
 	a := make([]int32, n)
+	b := make([]int32, n)
 	tw := make([]int16, n)
 	dst := make([]int32, n)
 	if got := testing.AllocsPerRun(100, func() { mulNEON(dst, a, tw) }); got != 0 {
 		t.Errorf("mulNEON allocated %v times per run, want 0", got)
 	}
+	if got := testing.AllocsPerRun(100, func() { mulConjNEON(dst, a, tw) }); got != 0 {
+		t.Errorf("mulConjNEON allocated %v times per run, want 0", got)
+	}
 	if got := testing.AllocsPerRun(100, func() { mulByScalarNEON(a, 0x1234) }); got != 0 {
 		t.Errorf("mulByScalarNEON allocated %v times per run, want 0", got)
+	}
+	if got := testing.AllocsPerRun(100, func() { addNEON(dst, a, b) }); got != 0 {
+		t.Errorf("addNEON allocated %v times per run, want 0", got)
+	}
+	if got := testing.AllocsPerRun(100, func() { subNEON(dst, a, b) }); got != 0 {
+		t.Errorf("subNEON allocated %v times per run, want 0", got)
 	}
 }
 

--- a/cint/cint_go.go
+++ b/cint/cint_go.go
@@ -1,0 +1,120 @@
+package cint
+
+// Pure-Go reference implementations.
+//
+// These are the source of truth for behavior: every SIMD kernel is validated
+// for bit-exact parity against the functions here. They are compiled on every
+// architecture and used directly as the fallback when no SIMD path applies.
+//
+// The complex data is interleaved int32, [r0,i0,r1,i1,...], and the twiddle is
+// interleaved Q15 int16, [r0,i0,r1,i1,...]. sMul is the truncating Q15 multiply
+// S_MUL; every add and subtract wraps in int32 (two's complement, no
+// saturation), matching the SIMD lanes exactly across the full int32 range.
+
+// sMulShift is the Q15 fixed-point position: the 64-bit product of an int32
+// sample and an int16 Q15 coefficient is arithmetically shifted right by 15 to
+// land the result back in int32 range.
+const sMulShift = 15
+
+// sMul is the truncating fixed-point multiply S_MUL(x, c) = int32(int64(x) *
+// int64(c) >> 15). The product is formed in int64 (|x| <= 2^31, |c| <= 2^15, so
+// |product| <= 2^46, never overflowing int64), the shift is an arithmetic
+// (sign-preserving) right shift that truncates toward -inf with NO rounding
+// constant, and the int32() cast wraps rather than saturates: x = MinInt32,
+// c = MinInt16 gives 2^46 >> 15 = 2^31, which wraps to MinInt32. It is the
+// integer MULT16_32_Q15 of libopus, matching go-opus fixed_generic.go bit for
+// bit.
+func sMul(x int32, c int16) int32 {
+	return int32(int64(x) * int64(c) >> sMulShift)
+}
+
+// addGo writes the wrapping flat int32 add dst[j] = a[j] + b[j] over every lane.
+// Complex addition is a lanewise real add on the interleaved layout, so the flat
+// int32 sum over the lanes is the complex sum; the add wraps in int32 (modulo
+// 2^32), matching a VPADDD or ADD .4S lane. dst may be empty; the len-0 guard
+// protects the len(dst)-1 BCE hints.
+func addGo(dst, a, b []int32) {
+	if len(dst) == 0 {
+		return
+	}
+	_ = a[len(dst)-1]
+	_ = b[len(dst)-1]
+	for i := range dst {
+		dst[i] = a[i] + b[i]
+	}
+}
+
+// subGo writes the wrapping flat int32 sub dst[j] = a[j] - b[j] over every lane,
+// the complex difference on the interleaved layout. The subtract wraps in int32,
+// matching a VPSUBD or SUB .4S lane. dst may be empty; the len-0 guard protects
+// the len(dst)-1 BCE hints.
+func subGo(dst, a, b []int32) {
+	if len(dst) == 0 {
+		return
+	}
+	_ = a[len(dst)-1]
+	_ = b[len(dst)-1]
+	for i := range dst {
+		dst[i] = a[i] - b[i]
+	}
+}
+
+// mulByScalarGo scales every int32 lane in place by the Q15 scalar s:
+// a[j] = S_MUL(a[j], s). It is the flat ScaleQ15 over the interleaved layout, so
+// both the real and imaginary part of each complex sample are scaled. The
+// truncating Q15 arithmetic and the int32 wrap are exactly sMul's.
+func mulByScalarGo(a []int32, s int16) {
+	for i := range a {
+		a[i] = sMul(a[i], s)
+	}
+}
+
+// mulGo writes the C_MUL complex multiply of a by the twiddle tw, over whole
+// complex pairs of the interleaved layout:
+//
+//	dst[2k]   = S_MUL(ar, br) - S_MUL(ai, bi)   // real
+//	dst[2k+1] = S_MUL(ar, bi) + S_MUL(ai, br)   // imag
+//
+// where ar,ai = a[2k],a[2k+1] and br,bi = tw[2k],tw[2k+1]. Each S_MUL is
+// truncated to int32 before the wrapping int32 add/subtract, matching the SIMD
+// lanes. The k+1 < n loop bound processes only whole pairs, so a trailing
+// half-complex (odd length) is never read. dst may alias a exactly: both a lanes
+// of a pair are read into locals before either dst lane is stored, so the
+// in-place update is well defined pair by pair.
+func mulGo(dst, a []int32, tw []int16) {
+	n := len(dst)
+	if n == 0 {
+		return
+	}
+	_ = a[n-1]
+	_ = tw[n-1]
+	for k := 0; k+1 < n; k += 2 {
+		ar, ai := a[k], a[k+1]
+		br, bi := tw[k], tw[k+1]
+		dst[k] = sMul(ar, br) - sMul(ai, bi)
+		dst[k+1] = sMul(ar, bi) + sMul(ai, br)
+	}
+}
+
+// mulConjGo writes the C_MUL complex multiply of a by the conjugated twiddle
+// conj(tw), over whole complex pairs:
+//
+//	dst[2k]   = S_MUL(ar, br) + S_MUL(ai, bi)   // real
+//	dst[2k+1] = S_MUL(ai, br) - S_MUL(ar, bi)   // imag
+//
+// Same truncating Q15 arithmetic, int32 wrap and in-place-alias discipline as
+// mulGo; only the two combine signs differ (the conjugate negates bi).
+func mulConjGo(dst, a []int32, tw []int16) {
+	n := len(dst)
+	if n == 0 {
+		return
+	}
+	_ = a[n-1]
+	_ = tw[n-1]
+	for k := 0; k+1 < n; k += 2 {
+		ar, ai := a[k], a[k+1]
+		br, bi := tw[k], tw[k+1]
+		dst[k] = sMul(ar, br) + sMul(ai, bi)
+		dst[k+1] = sMul(ai, br) - sMul(ar, bi)
+	}
+}

--- a/cint/cint_other.go
+++ b/cint/cint_other.go
@@ -1,0 +1,14 @@
+//go:build !amd64 && !arm64
+
+package cint
+
+// Fallback dispatch for architectures without a SIMD kernel: every operation
+// routes to the pure-Go reference.
+
+func addCint(dst, a, b []int32)          { addGo(dst, a, b) }
+func subCint(dst, a, b []int32)          { subGo(dst, a, b) }
+func mulByScalarCint(a []int32, s int16) { mulByScalarGo(a, s) }
+func mulCint(dst, a []int32, tw []int16) { mulGo(dst, a, tw) }
+func mulConjCint(dst, a []int32, tw []int16) {
+	mulConjGo(dst, a, tw)
+}

--- a/cint/cint_test.go
+++ b/cint/cint_test.go
@@ -153,12 +153,14 @@ func TestMul(t *testing.T) {
 
 // plantExtremes seeds the head and tail complex with the wrap-driving extremes.
 func plantExtremes(a []int32, tw []int16) {
-	n := len(a)
-	if n >= 2 {
+	// Each slice is indexed by its own length so a shorter tw never panics.
+	if len(a) >= 2 {
 		a[0], a[1] = math.MinInt32, math.MaxInt32
+		a[len(a)-2], a[len(a)-1] = math.MaxInt32, math.MinInt32
+	}
+	if len(tw) >= 2 {
 		tw[0], tw[1] = math.MinInt16, math.MaxInt16
-		a[n-2], a[n-1] = math.MaxInt32, math.MinInt32
-		tw[n-2], tw[n-1] = math.MaxInt16, math.MinInt16
+		tw[len(tw)-2], tw[len(tw)-1] = math.MaxInt16, math.MinInt16
 	}
 }
 

--- a/cint/cint_test.go
+++ b/cint/cint_test.go
@@ -1,0 +1,553 @@
+package cint
+
+import (
+	"encoding/binary"
+	"math"
+	"math/big"
+	"testing"
+)
+
+// Tests for the fixed-point complex arithmetic kernels. The load-bearing
+// contract is the TRUNCATING Q15 multiply S_MUL (an arithmetic right shift, no
+// rounding constant) with int32 wraparound on every add and subtract, so the
+// critical cases are (1) truncation vs rounding at small products and (2) the
+// MinInt32 / MinInt16 wraps where a saturating build would diverge. Every SIMD
+// path is validated bit-for-bit against the pure-Go reference AND an independent
+// arbitrary-precision oracle, so a fault cannot hide by agreeing with the
+// reference alone.
+
+// genI32 produces a deterministic spread across the full int32 range from a cheap
+// LCG, so sign and high bits are exercised at every index.
+func genI32(n int, seed uint32) []int32 {
+	s := make([]int32, n)
+	x := seed*2654435761 + 1
+	for i := range s {
+		x = x*1664525 + 1013904223
+		s[i] = int32(x)
+	}
+	return s
+}
+
+// genI16 produces a deterministic spread across the full int16 range for the Q15
+// twiddle, using the high bits of the same LCG so the low-order patterns differ
+// from genI32.
+func genI16(n int, seed uint32) []int16 {
+	s := make([]int16, n)
+	x := seed*40503 + 12345
+	for i := range s {
+		x = x*1664525 + 1013904223
+		s[i] = int16(x >> 16)
+	}
+	return s
+}
+
+// sMulBig computes S_MUL(x, c) in arbitrary precision, fully independent of the
+// int64 arithmetic in sMul and the SIMD kernels. big.Int.Rsh is a floor
+// (arithmetic) shift, matching Go's signed >>, and the final int32() drops the
+// value back to a 32-bit lane exactly as a store does, so 2^31 wraps to MinInt32.
+func sMulBig(x int32, c int16) int32 {
+	p := new(big.Int).Mul(big.NewInt(int64(x)), big.NewInt(int64(c)))
+	p.Rsh(p, sMulShift) // floor shift, matches Go's arithmetic >>
+	return int32(p.Int64())
+}
+
+// mulOracle and mulConjOracle compute one complex product in arbitrary precision.
+// The two S_MULs are truncated to int32 first, then combined with wrapping int32
+// arithmetic (Go int32 add/sub wrap), so the oracle reproduces the kernel's exact
+// two-step contract.
+func mulOracle(ar, ai int32, br, bi int16) (re, im int32) {
+	return sMulBig(ar, br) - sMulBig(ai, bi), sMulBig(ar, bi) + sMulBig(ai, br)
+}
+
+func mulConjOracle(ar, ai int32, br, bi int16) (re, im int32) {
+	return sMulBig(ar, br) + sMulBig(ai, bi), sMulBig(ai, br) - sMulBig(ar, bi)
+}
+
+// evenLengths sweeps whole-complex-pair int32 lengths: every even length 0..80
+// (0..40 complex), covering each vector-block/scalar-tail split of the 4-complex
+// (8 int32) AVX2/NEON blocks, plus a spread of larger ones with non-block tails.
+var evenLengths = func() []int {
+	lens := make([]int, 0, 60)
+	for n := 0; n <= 80; n += 2 {
+		lens = append(lens, n)
+	}
+	return append(lens, 128, 200, 256, 258, 512, 1000, 1024, 2048)
+}()
+
+// checkMul verifies got against the Go reference and the oracle over n int32 lanes
+// (n/2 complex). conj selects the conjugated combine.
+func checkMul(t *testing.T, name string, conj bool, got, a []int32, tw []int16) {
+	t.Helper()
+	n := len(got)
+	ref := make([]int32, n)
+	if conj {
+		mulConjGo(ref, a, tw)
+	} else {
+		mulGo(ref, a, tw)
+	}
+	for k := 0; k+1 < n; k += 2 {
+		var re, im int32
+		if conj {
+			re, im = mulConjOracle(a[k], a[k+1], tw[k], tw[k+1])
+		} else {
+			re, im = mulOracle(a[k], a[k+1], tw[k], tw[k+1])
+		}
+		if got[k] != ref[k] || got[k+1] != ref[k+1] {
+			t.Fatalf("%s n=%d at complex %d: got (%d,%d), reference (%d,%d)", name, n, k/2, got[k], got[k+1], ref[k], ref[k+1])
+		}
+		if got[k] != re || got[k+1] != im {
+			t.Fatalf("%s n=%d at complex %d: got (%d,%d), oracle (%d,%d)", name, n, k/2, got[k], got[k+1], re, im)
+		}
+	}
+}
+
+// TestSMulTruncation pins the truncating contract in isolation, the single most
+// important behavior: S_MUL must arithmetically shift with NO rounding constant.
+// Each case names a product whose >>15 truncation differs from a +(1<<14) rounding
+// build, plus the MinInt32/MinInt16 wraps a saturating build gets wrong.
+func TestSMulTruncation(t *testing.T) {
+	cases := []struct {
+		x    int32
+		c    int16
+		want int32
+	}{
+		{32767, 1, 0},              // 32767/32768 truncates to 0 (rounding -> 1)
+		{1, 16384, 0},              // 0.5 in Q15 truncates to 0 (rounding -> 1)
+		{3, 16384, 1},              // 1.5 truncates to 1 (rounding -> 2)
+		{-1, 16384, -1},            // -0.5 floors to -1 (rounding -> 0)
+		{-3, 1, -1},                // -3/32768 floors to -1
+		{32768, 1, 1},              // exactly 1
+		{math.MinInt32, 1, -65536}, // -2^31 >> 15 = -2^16
+		{math.MaxInt32, 1, 65535},  // (2^31-1) >> 15
+		{math.MinInt32, math.MinInt16, math.MinInt32},     // 2^46 >> 15 = 2^31 -> wraps to MinInt32
+		{math.MinInt32, math.MaxInt16, -2147418112},       // -2^31 * (2^15-1) >> 15
+		{math.MaxInt32, math.MinInt16, math.MinInt32 + 1}, // -(2^46-2^15) >> 15 = -(2^31-1)
+	}
+	for _, c := range cases {
+		if got := sMul(c.x, c.c); got != c.want {
+			t.Errorf("sMul(%d,%d) = %d, want %d", c.x, c.c, got, c.want)
+		}
+		if got := sMulBig(c.x, c.c); got != c.want {
+			t.Errorf("sMulBig(%d,%d) = %d, want %d (oracle disagrees)", c.x, c.c, got, c.want)
+		}
+	}
+}
+
+// TestMul sweeps every whole-pair length against the reference and the oracle.
+// MinInt32/MaxInt32 ride the head and tail complex of a, and MinInt16/MaxInt16 the
+// head and tail of tw, so the wraps run at every length at both ends.
+func TestMul(t *testing.T) {
+	for _, n := range evenLengths {
+		a := genI32(n, 11)
+		tw := genI16(n, 12)
+		plantExtremes(a, tw)
+		dst := make([]int32, n)
+		Mul(dst, a, tw)
+		checkMul(t, "Mul", false, dst, a, tw)
+
+		dst2 := make([]int32, n)
+		MulConj(dst2, a, tw)
+		checkMul(t, "MulConj", true, dst2, a, tw)
+	}
+}
+
+// plantExtremes seeds the head and tail complex with the wrap-driving extremes.
+func plantExtremes(a []int32, tw []int16) {
+	n := len(a)
+	if n >= 2 {
+		a[0], a[1] = math.MinInt32, math.MaxInt32
+		tw[0], tw[1] = math.MinInt16, math.MaxInt16
+		a[n-2], a[n-1] = math.MaxInt32, math.MinInt32
+		tw[n-2], tw[n-1] = math.MaxInt16, math.MinInt16
+	}
+}
+
+// TestMulValueMatrix plants a load-bearing complex pair (data and twiddle) at
+// every complex position across a length that spans a vector block plus a scalar
+// tail on both arches, so a lane error, an index error and a recombine the even/odd
+// blend mishandles are all caught wherever they live. The AVX2 VPMULDQ even/odd
+// split makes the per-position sweep essential.
+func TestMulValueMatrix(t *testing.T) {
+	dataPlant := [][2]int32{
+		{math.MinInt32, math.MaxInt32}, {math.MaxInt32, math.MinInt32},
+		{math.MinInt32, math.MinInt32}, {-1, 1}, {0x12345678, -0x0BADF00D},
+		{1, -1}, {0, 0},
+	}
+	twPlant := [][2]int16{
+		{math.MinInt16, math.MaxInt16}, {math.MaxInt16, math.MinInt16},
+		{math.MinInt16, math.MinInt16}, {-1, 1}, {0x4000, -0x4000}, {1, -1},
+	}
+	const nc = 6 // 6 complex = 12 int32: one 8-int32 block + 2-complex tail
+	const n = nc * 2
+	fillerA := genI32(n, 21)
+	fillerTw := genI16(n, 22)
+	for _, dp := range dataPlant {
+		for _, tp := range twPlant {
+			for pos := range nc {
+				a := append([]int32(nil), fillerA...)
+				tw := append([]int16(nil), fillerTw...)
+				a[2*pos], a[2*pos+1] = dp[0], dp[1]
+				tw[2*pos], tw[2*pos+1] = tp[0], tp[1]
+				dst := make([]int32, n)
+				Mul(dst, a, tw)
+				checkMul(t, "Mul", false, dst, a, tw)
+				MulConj(dst, a, tw)
+				checkMul(t, "MulConj", true, dst, a, tw)
+			}
+		}
+	}
+}
+
+// TestAddSub sweeps the wrapping complex add and subtract against the reference,
+// with a MinInt32+overflow head and a MaxInt32+overflow tail so both wraps run at
+// every length.
+func TestAddSub(t *testing.T) {
+	for _, n := range evenLengths {
+		a := genI32(n, 31)
+		b := genI32(n, 32)
+		if n >= 2 {
+			a[0], b[0] = math.MinInt32, -1    // sum underflows, diff = MinInt32+1
+			a[n-1], b[n-1] = math.MaxInt32, 1 // sum overflows
+		}
+		dst := make([]int32, n)
+		ref := make([]int32, n)
+
+		Add(dst, a, b)
+		addGo(ref, a, b)
+		for i := range dst {
+			want := int32(int64(a[i]) + int64(b[i]))
+			if dst[i] != ref[i] || dst[i] != want {
+				t.Fatalf("Add n=%d at %d: got %d, ref %d, oracle %d", n, i, dst[i], ref[i], want)
+			}
+		}
+
+		Sub(dst, a, b)
+		subGo(ref, a, b)
+		for i := range dst {
+			want := int32(int64(a[i]) - int64(b[i]))
+			if dst[i] != ref[i] || dst[i] != want {
+				t.Fatalf("Sub n=%d at %d: got %d, ref %d, oracle %d", n, i, dst[i], ref[i], want)
+			}
+		}
+	}
+}
+
+// TestMulByScalar sweeps the in-place Q15 scale against the reference and oracle,
+// planting MinInt32 at index 0 and MaxInt32 at the last index so the wrap runs at
+// every length under a MinInt16 coefficient.
+func TestMulByScalar(t *testing.T) {
+	ss := []int16{math.MinInt16, math.MaxInt16, 1, -1, 0x4000, 0x1234}
+	for _, n := range evenLengths {
+		for _, s := range ss {
+			a := genI32(n, 41)
+			if n >= 2 {
+				a[0] = math.MinInt32
+				a[n-1] = math.MaxInt32
+			}
+			orig := append([]int32(nil), a...)
+			MulByScalar(a, s)
+			for i := range a {
+				want := sMulBig(orig[i], s)
+				if a[i] != want {
+					t.Fatalf("MulByScalar n=%d s=%d at %d: got %d, want %d (oracle)", n, s, i, a[i], want)
+				}
+				if ref := sMul(orig[i], s); a[i] != ref {
+					t.Fatalf("MulByScalar n=%d s=%d at %d: got %d, want %d (reference)", n, s, i, a[i], ref)
+				}
+			}
+		}
+	}
+}
+
+// TestOddLengthMasking confirms every operation masks the processed length to a
+// whole number of complex pairs: a trailing lone real lane in an odd-length slice
+// is left untouched and, for Mul/MulConj, its non-existent imaginary partner is
+// never read (the slice is exactly odd-length, so a read of index len would be out
+// of bounds).
+func TestOddLengthMasking(t *testing.T) {
+	for _, nc := range []int{1, 2, 4, 5, 8, 9, 13} {
+		n := 2*nc + 1 // odd int32 length: nc whole complex + 1 lone real
+		const sentinel = int32(0x0BADBEEF)
+
+		a := genI32(n, 51)
+		tw := genI16(n, 52)
+
+		// Mul: dst last lane is the sentinel and must survive; the first n-1 lanes
+		// must match the oracle over the nc whole pairs.
+		dst := genI32(n, 53)
+		dst[n-1] = sentinel
+		Mul(dst, a, tw)
+		for k := 0; k+1 < n-1; k += 2 {
+			re, im := mulOracle(a[k], a[k+1], tw[k], tw[k+1])
+			if dst[k] != re || dst[k+1] != im {
+				t.Fatalf("Mul odd n=%d at complex %d: got (%d,%d), want (%d,%d)", n, k/2, dst[k], dst[k+1], re, im)
+			}
+		}
+		if dst[n-1] != sentinel {
+			t.Errorf("Mul odd n=%d wrote the trailing half-complex: dst[%d]=%d", n, n-1, dst[n-1])
+		}
+
+		dst = genI32(n, 54)
+		dst[n-1] = sentinel
+		MulConj(dst, a, tw)
+		for k := 0; k+1 < n-1; k += 2 {
+			re, im := mulConjOracle(a[k], a[k+1], tw[k], tw[k+1])
+			if dst[k] != re || dst[k+1] != im {
+				t.Fatalf("MulConj odd n=%d at complex %d: got (%d,%d), want (%d,%d)", n, k/2, dst[k], dst[k+1], re, im)
+			}
+		}
+		if dst[n-1] != sentinel {
+			t.Errorf("MulConj odd n=%d wrote the trailing half-complex: dst[%d]=%d", n, n-1, dst[n-1])
+		}
+
+		// Add/Sub: trailing lane untouched.
+		b := genI32(n, 55)
+		dst = make([]int32, n)
+		dst[n-1] = sentinel
+		Add(dst, a, b)
+		if dst[n-1] != sentinel {
+			t.Errorf("Add odd n=%d wrote the trailing half-complex", n)
+		}
+		dst[n-1] = sentinel
+		Sub(dst, a, b)
+		if dst[n-1] != sentinel {
+			t.Errorf("Sub odd n=%d wrote the trailing half-complex", n)
+		}
+
+		// MulByScalar in place: trailing lane unscaled.
+		sc := genI32(n, 56)
+		sc[n-1] = sentinel
+		MulByScalar(sc, 0x1234)
+		if sc[n-1] != sentinel {
+			t.Errorf("MulByScalar odd n=%d scaled the trailing half-complex: got %d", n, sc[n-1])
+		}
+	}
+}
+
+// TestInPlaceAlias runs Mul, MulConj and MulByScalar fully in place (dst aliases a
+// exactly) and confirms every lane matches the oracle computed from the saved
+// originals. Each SIMD block reads its whole input block into registers before
+// storing, so the exact overlay is well defined. MinInt32 rides the head so the
+// wrap is exercised in place.
+func TestInPlaceAlias(t *testing.T) {
+	for _, n := range []int{2, 4, 6, 8, 10, 14, 16, 18, 32, 34, 64, 128, 130} {
+		a := genI32(n, 61)
+		tw := genI16(n, 62)
+		if n >= 2 {
+			a[0], a[1] = math.MinInt32, math.MaxInt32
+			tw[0], tw[1] = math.MinInt16, math.MaxInt16
+		}
+
+		orig := append([]int32(nil), a...)
+		Mul(a, a, tw) // dst == a
+		for k := 0; k+1 < n; k += 2 {
+			re, im := mulOracle(orig[k], orig[k+1], tw[k], tw[k+1])
+			if a[k] != re || a[k+1] != im {
+				t.Fatalf("Mul in place n=%d at complex %d: got (%d,%d), want (%d,%d)", n, k/2, a[k], a[k+1], re, im)
+			}
+		}
+
+		a2 := append([]int32(nil), orig...)
+		MulConj(a2, a2, tw)
+		for k := 0; k+1 < n; k += 2 {
+			re, im := mulConjOracle(orig[k], orig[k+1], tw[k], tw[k+1])
+			if a2[k] != re || a2[k+1] != im {
+				t.Fatalf("MulConj in place n=%d at complex %d: got (%d,%d), want (%d,%d)", n, k/2, a2[k], a2[k+1], re, im)
+			}
+		}
+
+		a3 := append([]int32(nil), orig...)
+		MulByScalar(a3, -0x4000)
+		for i := range a3 {
+			if want := sMulBig(orig[i], -0x4000); a3[i] != want {
+				t.Fatalf("MulByScalar in place n=%d at %d: got %d, want %d", n, i, a3[i], want)
+			}
+		}
+	}
+}
+
+// TestEmpty confirms empty inputs write nothing and short/nil operands are a no-op
+// that leaves the survivor untouched.
+func TestEmpty(t *testing.T) {
+	Mul(nil, nil, nil)
+	MulConj(nil, nil, nil)
+	Add(nil, nil, nil)
+	Sub(nil, nil, nil)
+	MulByScalar(nil, 5)
+
+	one := []int32{42, 43}
+	tw := []int16{}
+	Mul(one, one, tw) // n = 0 after clamp
+	if one[0] != 42 || one[1] != 43 {
+		t.Errorf("Mul with empty tw modified dst: %v", one)
+	}
+	MulByScalar([]int32{7}, 5) // len 1 -> masked to 0
+}
+
+// TestClamp covers mismatched lengths: n is the shortest of the applicable slices,
+// masked to even, and nothing past it is touched.
+func TestClamp(t *testing.T) {
+	a := genI32(40, 71)
+	tw := genI16(30, 72) // tw shortest -> n = 30
+	dst := make([]int32, 50)
+	for i := range dst {
+		dst[i] = -7 // sentinel
+	}
+	Mul(dst, a, tw)
+	checkMul(t, "Mul", false, dst[:30], a[:30], tw)
+	for i := 30; i < len(dst); i++ {
+		if dst[i] != -7 {
+			t.Fatalf("Mul wrote past the clamp at dst[%d] = %d", i, dst[i])
+		}
+	}
+
+	// dst shortest (odd) -> n = 24 (25 &^ 1).
+	short := make([]int32, 25)
+	Mul(short, a, tw)
+	checkMul(t, "Mul", false, short[:24], a[:24], tw[:24])
+	if short[24] != 0 {
+		t.Fatalf("Mul wrote the masked-off lane: short[24] = %d", short[24])
+	}
+}
+
+// TestUnalignedOperands sweeps element offsets so neither dst, a nor tw is reliably
+// aligned; an aligned-load or aligned-store substitution cannot survive.
+func TestUnalignedOperands(t *testing.T) {
+	const span = 400
+	baseA := genI32(span, 81)
+	baseTw := genI16(span, 82)
+	backing := make([]int32, span)
+	for _, n := range []int{8, 10, 16, 18, 34, 66, 130} {
+		for off := range 8 {
+			a := baseA[off+1 : off+1+n]
+			tw := baseTw[off+2 : off+2+n]
+			dst := backing[off+3 : off+3+n]
+			Mul(dst, a, tw)
+			checkMul(t, "Mul", false, dst, a, tw)
+			MulConj(dst, a, tw)
+			checkMul(t, "MulConj", true, dst, a, tw)
+		}
+	}
+}
+
+// TestAllocFree declares the buffers INSIDE the measured closure so only
+// allocations forced by the operation itself are counted. The dispatch is a direct
+// CPU-flag switch precisely so //go:noescape holds and no slice header escapes.
+func TestAllocFree(t *testing.T) {
+	check := func(name string, f func()) {
+		if got := testing.AllocsPerRun(50, f); got != 0 {
+			t.Errorf("%s forces %v allocations per run, want 0", name, got)
+		}
+	}
+	check("Mul", func() {
+		var a, dst [1024]int32
+		var tw [1024]int16
+		Mul(dst[:], a[:], tw[:])
+	})
+	check("MulConj", func() {
+		var a, dst [1024]int32
+		var tw [1024]int16
+		MulConj(dst[:], a[:], tw[:])
+	})
+	check("MulByScalar", func() {
+		var a [1024]int32
+		MulByScalar(a[:], 0x1234)
+	})
+	check("Add", func() {
+		var a, b, dst [1024]int32
+		Add(dst[:], a[:], b[:])
+	})
+	check("Sub", func() {
+		var a, b, dst [1024]int32
+		Sub(dst[:], a[:], b[:])
+	})
+}
+
+// --- Differential fuzzing over data + twiddle bytes ---
+
+// i32sFromBits reinterprets raw bytes as little-endian int32s, reaching the full
+// int32 range including MinInt32/MaxInt32.
+func i32sFromBits(raw []byte) []int32 {
+	out := make([]int32, len(raw)/4)
+	for i := range out {
+		out[i] = int32(binary.LittleEndian.Uint32(raw[i*4:]))
+	}
+	return out
+}
+
+// i16sFromBits reinterprets raw bytes as little-endian int16s for the Q15 twiddle.
+func i16sFromBits(raw []byte) []int16 {
+	out := make([]int16, len(raw)/2)
+	for i := range out {
+		out[i] = int16(binary.LittleEndian.Uint16(raw[i*2:]))
+	}
+	return out
+}
+
+func cintLenSeeds(f *testing.F) {
+	f.Helper()
+	ns := []int{0, 1, 2, 3, 4, 6, 8, 9, 10, 14, 16, 17, 18, 22, 30, 32, 33, 34, 64, 65, 66, 130}
+	for _, n := range ns {
+		da := make([]byte, n*4)
+		db := make([]byte, n*4)
+		tb := make([]byte, n*2)
+		for i := range da {
+			da[i] = byte(i*37 + 11)
+		}
+		for i := range db {
+			db[i] = byte(i*29 + 3)
+		}
+		for i := range tb {
+			tb[i] = byte(i*53 + 7)
+		}
+		f.Add(da, db, tb, int16(0x1234))
+	}
+}
+
+// FuzzCint differentially fuzzes every operation against its pure-Go reference and,
+// for the multiplies, the arbitrary-precision oracle, over arbitrary int32 data and
+// int16 twiddle bytes. Tail handling and the wraps are explored far past the
+// hand-picked seeds.
+func FuzzCint(f *testing.F) {
+	cintLenSeeds(f)
+	f.Fuzz(func(t *testing.T, dataRaw, bRaw, twRaw []byte, s int16) {
+		a := i32sFromBits(dataRaw)
+		b := i32sFromBits(bRaw)
+		tw := i16sFromBits(twRaw)
+		n := min(len(a), len(b), len(tw))
+		n &^= 1
+		a = a[:n]
+		b = b[:n]
+		tw = tw[:n]
+
+		dst := make([]int32, n)
+		Mul(dst, a, tw)
+		checkMul(t, "FuzzMul", false, dst, a, tw)
+		MulConj(dst, a, tw)
+		checkMul(t, "FuzzMulConj", true, dst, a, tw)
+
+		ref := make([]int32, n)
+		Add(dst, a, b)
+		addGo(ref, a, b)
+		for i := range dst {
+			if dst[i] != ref[i] {
+				t.Fatalf("FuzzAdd at %d: got %d want %d (n=%d)", i, dst[i], ref[i], n)
+			}
+		}
+		Sub(dst, a, b)
+		subGo(ref, a, b)
+		for i := range dst {
+			if dst[i] != ref[i] {
+				t.Fatalf("FuzzSub at %d: got %d want %d (n=%d)", i, dst[i], ref[i], n)
+			}
+		}
+
+		scale := append([]int32(nil), a...)
+		MulByScalar(scale, s)
+		for i := range scale {
+			if want := sMulBig(a[i], s); scale[i] != want {
+				t.Fatalf("FuzzMulByScalar at %d: got %d want %d (n=%d, s=%d)", i, scale[i], want, n, s)
+			}
+		}
+	})
+}


### PR DESCRIPTION
## Summary

Adds the `cint` package: fixed-point complex arithmetic for integer FFT butterflies, the integer analog of `c64`/`c128`. Complex data is int32 real/imaginary interleaved `[r0,i0,r1,i1,...]`; twiddles are int16 Q15 interleaved. This is what any fixed-point codec (a pure-Go bit-exact Opus port, kissfft-style FFTs) needs, and float complex cannot substitute for it because the twiddle multiply carries a defined Q15 rounding a float path would not reproduce bit-for-bit.

Operations (element-wise over the complex index, matching libopus `_kiss_fft_guts.h`):

- `Add` / `Sub`: wrapping int32 complex add and subtract (`C_ADD` / `C_SUB`).
- `Mul`: `C_MUL` complex multiply, `dst = a * tw` with `S_MUL(x, c) = int32(int64(x)*int64(c) >> 15)`, a single TRUNCATING Q15 shift per product (no rounding constant, matching go-opus `MULT16_32_Q15` bit-for-bit), the two products combined by a wrapping int32 subtract and add.
- `MulByScalar`: in-place `C_MULBYSCALAR`, every lane `S_MUL`'d by an int16 Q15 scalar.
- `MulConj`: `C_MUL` against the conjugated twiddle.

All ops clamp to the min applicable length and mask to whole complex pairs (`n &^ 1`), so a trailing half-complex is never read or written; `dst` may alias `a` exactly for an in-place transform.

Kernels are bit-identical across amd64 AVX2, arm64 NEON, and the Go fallback. The AVX2 `Mul` keeps data interleaved and reuses the i32 ScaleQ15 recombine: four even-lane `VPMULDQ` half-products (imaginaries slid in with `VPSRLQ $32`), `VPSRLQ $15` truncation, `VPSUBD`/`VPADDD` combine, then `VPSLLQ $32` + `VPBLENDD $0xAA` to re-interleave, avoiding any deinterleave shuffle. The NEON `Mul` deinterleaves with `LD2`, does the `SMULL`/`SSHR`/`XTN` widen-shift-narrow, and re-interleaves with `ST2`. Dispatch is a direct cpu-flag switch (not an init-time function-pointer table), so the ops stay allocation-free.

## Related issues

Closes #180 (element-wise `Add`/`Sub`/`Mul`/`MulByScalar`/`MulConj`; the fused twiddle-apply-plus-gather helper is deferred pending a benchmark of gather cost vs the butterfly stride, as discussed on the issue).

## Test plan

- [x] Parity against the Go references and an independent `math/big` oracle over complex-count sweeps forcing the vector loop and the scalar tail
- [x] Truncation-vs-rounding pin (`sMul(32767, 1) = 0`), the `MinInt32 x MinInt16` wrap, a per-position value matrix, odd-length masking, in-place aliasing (`dst == a` with a MinInt32 wrap), an over-read poison guard (extremes planted past n over a full-block slack), unaligned, alloc-free (0 allocs/op), dispatch-pin
- [x] Differential fuzz over independent data and twiddle bytes
- [x] Verified bit-exact on real AVX2 hardware (i7-1260P) and real NEON hardware (Raspberry Pi 5); `TestArm64WordEncodings` cross-checks every new `WORD` against `arm64asm`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added fixed-point complex-number arithmetic, including addition, subtraction, scaling, multiplication, and conjugate multiplication.
  * Operations support consistent behavior across supported processor architectures and preserve compatibility with non-vectorized systems.
  * Added support for efficient in-place processing with zero-allocation operation paths.

* **Performance**
  * Added hardware-accelerated processing to improve arithmetic performance on compatible systems.

* **Tests**
  * Added comprehensive correctness, safety, fuzz, allocation, and performance benchmark coverage.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->