### PR TITLE
f64: add ButterflyComplex, the AVX2/NEON complex FFT butterfly

### DIFF
--- a/f64/butterfly_complex_test.go
+++ b/f64/butterfly_complex_test.go
@@ -1,0 +1,458 @@
+package f64
+
+import (
+	"fmt"
+	"math"
+	"testing"
+)
+
+// =============================================================================
+// BUTTERFLY COMPLEX TESTS (float64)
+// =============================================================================
+
+// butterflyComplexRef is a reference implementation of the fused butterfly
+// operation using separate multiply and add (no FMA), so it is the numerically
+// distinct scalar baseline the SIMD FMA path is compared against.
+func butterflyComplexRef(upperRe, upperIm, lowerRe, lowerIm, twRe, twIm []float64) {
+	for i := range upperRe {
+		// Complex multiply: temp = lower * twiddle
+		lr, li := lowerRe[i], lowerIm[i]
+		tr, ti := twRe[i], twIm[i]
+		tempRe := lr*tr - li*ti
+		tempIm := lr*ti + li*tr
+
+		// Butterfly: upper' = upper + temp, lower' = upper - temp
+		ur, ui := upperRe[i], upperIm[i]
+		upperRe[i] = ur + tempRe
+		upperIm[i] = ui + tempIm
+		lowerRe[i] = ur - tempRe
+		lowerIm[i] = ui - tempIm
+	}
+}
+
+func TestButterflyComplex(t *testing.T) {
+	sizes := []int{0, 1, 2, 3, 4, 8, 9, 16, 17, 31, 32, 33, 63, 64, 65, 128, 256, 512, 1000}
+
+	for _, n := range sizes {
+		t.Run(fmt.Sprintf("n=%d", n), func(t *testing.T) {
+			if n == 0 {
+				ButterflyComplex(nil, nil, nil, nil, nil, nil)
+				return
+			}
+
+			upperRe := make([]float64, n)
+			upperIm := make([]float64, n)
+			lowerRe := make([]float64, n)
+			lowerIm := make([]float64, n)
+			twRe := make([]float64, n)
+			twIm := make([]float64, n)
+
+			// Reference copies
+			upperReRef := make([]float64, n)
+			upperImRef := make([]float64, n)
+			lowerReRef := make([]float64, n)
+			lowerImRef := make([]float64, n)
+
+			// Initialize with test data
+			for i := range n {
+				angle := 2 * math.Pi * float64(i) / float64(n)
+				upperRe[i] = float64(i+1) * 0.1
+				upperIm[i] = float64(i+2) * 0.2
+				lowerRe[i] = float64(i+3) * 0.3
+				lowerIm[i] = float64(i+4) * 0.4
+				twRe[i] = math.Cos(angle)
+				twIm[i] = math.Sin(angle)
+			}
+
+			// Copy for reference
+			copy(upperReRef, upperRe)
+			copy(upperImRef, upperIm)
+			copy(lowerReRef, lowerRe)
+			copy(lowerImRef, lowerIm)
+
+			// Apply SIMD version
+			ButterflyComplex(upperRe, upperIm, lowerRe, lowerIm, twRe, twIm)
+
+			// Apply reference
+			butterflyComplexRef(upperReRef, upperImRef, lowerReRef, lowerImRef, twRe, twIm)
+
+			// Compare results - relative tolerance for FMA vs separate mul+add
+			// rounding differences (float64 FMA divergence is ~1 ULP).
+			relTol := func(got, want float64) bool {
+				diff := math.Abs(got - want)
+				return diff <= 1e-9 || diff <= math.Abs(want)*1e-11
+			}
+			for i := range n {
+				if !relTol(upperRe[i], upperReRef[i]) {
+					t.Errorf("upperRe[%d] = %v, want %v", i, upperRe[i], upperReRef[i])
+				}
+				if !relTol(upperIm[i], upperImRef[i]) {
+					t.Errorf("upperIm[%d] = %v, want %v", i, upperIm[i], upperImRef[i])
+				}
+				if !relTol(lowerRe[i], lowerReRef[i]) {
+					t.Errorf("lowerRe[%d] = %v, want %v", i, lowerRe[i], lowerReRef[i])
+				}
+				if !relTol(lowerIm[i], lowerImRef[i]) {
+					t.Errorf("lowerIm[%d] = %v, want %v", i, lowerIm[i], lowerImRef[i])
+				}
+			}
+		})
+	}
+}
+
+func TestButterflyComplex_KnownValues(t *testing.T) {
+	// upper = 1+2i, lower = 3+4i, twiddle = cos(π/4)+i*sin(π/4)
+	// temp = lower * twiddle
+	// upper' = upper + temp, lower' = upper - temp
+	cos45 := math.Cos(math.Pi / 4)
+	sin45 := math.Sin(math.Pi / 4)
+
+	upperRe := []float64{1}
+	upperIm := []float64{2}
+	lowerRe := []float64{3}
+	lowerIm := []float64{4}
+	twRe := []float64{cos45}
+	twIm := []float64{sin45}
+
+	ButterflyComplex(upperRe, upperIm, lowerRe, lowerIm, twRe, twIm)
+
+	// Expected values computed manually
+	tempRe := 3*cos45 - 4*sin45
+	tempIm := 3*sin45 + 4*cos45
+	wantUpperRe := 1 + tempRe
+	wantUpperIm := 2 + tempIm
+	wantLowerRe := 1 - tempRe
+	wantLowerIm := 2 - tempIm
+
+	if math.Abs(upperRe[0]-wantUpperRe) > 1e-12 {
+		t.Errorf("upperRe = %v, want %v", upperRe[0], wantUpperRe)
+	}
+	if math.Abs(upperIm[0]-wantUpperIm) > 1e-12 {
+		t.Errorf("upperIm = %v, want %v", upperIm[0], wantUpperIm)
+	}
+	if math.Abs(lowerRe[0]-wantLowerRe) > 1e-12 {
+		t.Errorf("lowerRe = %v, want %v", lowerRe[0], wantLowerRe)
+	}
+	if math.Abs(lowerIm[0]-wantLowerIm) > 1e-12 {
+		t.Errorf("lowerIm = %v, want %v", lowerIm[0], wantLowerIm)
+	}
+}
+
+// TestButterflyComplex_KnownValuesSIMD pins the SIMD kernels to hand-derived
+// absolute values, not just a differential comparison against the Go path. n=9
+// enters the AVX 4-wide and NEON 2-wide main loops AND their scalar tails; every
+// element uses the same inputs, so every output (main-loop and tail) must equal
+// the same hand-computed result.
+func TestButterflyComplex_KnownValuesSIMD(t *testing.T) {
+	const n = 9 // >= 4: exercises the SIMD main loop plus the scalar remainder
+	cos45 := math.Cos(math.Pi / 4)
+	sin45 := math.Sin(math.Pi / 4)
+
+	upperRe := make([]float64, n)
+	upperIm := make([]float64, n)
+	lowerRe := make([]float64, n)
+	lowerIm := make([]float64, n)
+	twRe := make([]float64, n)
+	twIm := make([]float64, n)
+	for i := range n {
+		upperRe[i], upperIm[i] = 1, 2
+		lowerRe[i], lowerIm[i] = 3, 4
+		twRe[i], twIm[i] = cos45, sin45
+	}
+
+	ButterflyComplex(upperRe, upperIm, lowerRe, lowerIm, twRe, twIm)
+
+	tempRe := 3*cos45 - 4*sin45
+	tempIm := 3*sin45 + 4*cos45
+	wantUpperRe, wantUpperIm := 1+tempRe, 2+tempIm
+	wantLowerRe, wantLowerIm := 1-tempRe, 2-tempIm
+
+	for i := range n {
+		if math.Abs(upperRe[i]-wantUpperRe) > 1e-12 {
+			t.Errorf("upperRe[%d] = %v, want %v", i, upperRe[i], wantUpperRe)
+		}
+		if math.Abs(upperIm[i]-wantUpperIm) > 1e-12 {
+			t.Errorf("upperIm[%d] = %v, want %v", i, upperIm[i], wantUpperIm)
+		}
+		if math.Abs(lowerRe[i]-wantLowerRe) > 1e-12 {
+			t.Errorf("lowerRe[%d] = %v, want %v", i, lowerRe[i], wantLowerRe)
+		}
+		if math.Abs(lowerIm[i]-wantLowerIm) > 1e-12 {
+			t.Errorf("lowerIm[%d] = %v, want %v", i, lowerIm[i], wantLowerIm)
+		}
+	}
+}
+
+// TestButterflyComplex_LengthMismatch verifies the minLen6 clamp: with unequal
+// slice lengths, only the first min(len) elements are processed and the tails of
+// the longer, written slices are left untouched.
+func TestButterflyComplex_LengthMismatch(t *testing.T) {
+	const long, short = 16, 6 // twIm (length short) drives n = 6
+
+	upperRe := make([]float64, long)
+	upperIm := make([]float64, long)
+	lowerRe := make([]float64, long)
+	lowerIm := make([]float64, long)
+	twRe := make([]float64, long)
+	twIm := make([]float64, short) // shortest slice clamps n
+
+	for i := range long {
+		angle := 2 * math.Pi * float64(i) / float64(long)
+		upperRe[i] = float64(i+1) * 0.1
+		upperIm[i] = float64(i+2) * 0.2
+		lowerRe[i] = float64(i+3) * 0.3
+		lowerIm[i] = float64(i+4) * 0.4
+		twRe[i] = math.Cos(angle)
+	}
+	for i := range short {
+		twIm[i] = math.Sin(2 * math.Pi * float64(i) / float64(short))
+	}
+
+	// Snapshot the tails of the four written slices (indices [short, long)).
+	upReTail := append([]float64(nil), upperRe[short:]...)
+	upImTail := append([]float64(nil), upperIm[short:]...)
+	loReTail := append([]float64(nil), lowerRe[short:]...)
+	loImTail := append([]float64(nil), lowerIm[short:]...)
+
+	// Independent reference over the first `short` elements only.
+	wantUpRe := append([]float64(nil), upperRe[:short]...)
+	wantUpIm := append([]float64(nil), upperIm[:short]...)
+	wantLoRe := append([]float64(nil), lowerRe[:short]...)
+	wantLoIm := append([]float64(nil), lowerIm[:short]...)
+	butterflyComplexRef(wantUpRe, wantUpIm, wantLoRe, wantLoIm, twRe[:short], twIm[:short])
+
+	ButterflyComplex(upperRe, upperIm, lowerRe, lowerIm, twRe, twIm)
+
+	// The first `short` elements must match the reference.
+	for i := range short {
+		if math.Abs(upperRe[i]-wantUpRe[i]) > 1e-12 {
+			t.Errorf("upperRe[%d] = %v, want %v", i, upperRe[i], wantUpRe[i])
+		}
+		if math.Abs(upperIm[i]-wantUpIm[i]) > 1e-12 {
+			t.Errorf("upperIm[%d] = %v, want %v", i, upperIm[i], wantUpIm[i])
+		}
+		if math.Abs(lowerRe[i]-wantLoRe[i]) > 1e-12 {
+			t.Errorf("lowerRe[%d] = %v, want %v", i, lowerRe[i], wantLoRe[i])
+		}
+		if math.Abs(lowerIm[i]-wantLoIm[i]) > 1e-12 {
+			t.Errorf("lowerIm[%d] = %v, want %v", i, lowerIm[i], wantLoIm[i])
+		}
+	}
+	// Elements past n must be untouched in all four written slices.
+	for i := range upReTail {
+		k := short + i
+		if upperRe[k] != upReTail[i] {
+			t.Errorf("upperRe[%d] modified past clamp: got %v, want %v", k, upperRe[k], upReTail[i])
+		}
+		if upperIm[k] != upImTail[i] {
+			t.Errorf("upperIm[%d] modified past clamp: got %v, want %v", k, upperIm[k], upImTail[i])
+		}
+		if lowerRe[k] != loReTail[i] {
+			t.Errorf("lowerRe[%d] modified past clamp: got %v, want %v", k, lowerRe[k], loReTail[i])
+		}
+		if lowerIm[k] != loImTail[i] {
+			t.Errorf("lowerIm[%d] modified past clamp: got %v, want %v", k, lowerIm[k], loImTail[i])
+		}
+	}
+}
+
+func TestButterflyComplex_SIMDvsGo(t *testing.T) {
+	sizes := []int{1, 2, 3, 4, 5, 6, 7, 8, 9, 15, 16, 17, 31, 32, 33, 64, 128, 256, 512, 1024}
+
+	for _, n := range sizes {
+		t.Run(fmt.Sprintf("n=%d", n), func(t *testing.T) {
+			upperRe := make([]float64, n)
+			upperIm := make([]float64, n)
+			lowerRe := make([]float64, n)
+			lowerIm := make([]float64, n)
+			twRe := make([]float64, n)
+			twIm := make([]float64, n)
+
+			// Go copies
+			upperReGo := make([]float64, n)
+			upperImGo := make([]float64, n)
+			lowerReGo := make([]float64, n)
+			lowerImGo := make([]float64, n)
+
+			// Initialize with varied data to catch bugs
+			for i := range n {
+				angle := 2 * math.Pi * float64(i) / float64(n)
+				upperRe[i] = math.Sin(float64(i) * 0.123)
+				upperIm[i] = math.Cos(float64(i) * 0.456)
+				lowerRe[i] = math.Sin(float64(i) * 0.789)
+				lowerIm[i] = math.Cos(float64(i) * 0.012)
+				twRe[i] = math.Cos(angle)
+				twIm[i] = math.Sin(angle)
+			}
+
+			copy(upperReGo, upperRe)
+			copy(upperImGo, upperIm)
+			copy(lowerReGo, lowerRe)
+			copy(lowerImGo, lowerIm)
+
+			// SIMD version
+			ButterflyComplex(upperRe, upperIm, lowerRe, lowerIm, twRe, twIm)
+
+			// Pure Go version
+			butterflyComplex64Go(upperReGo, upperImGo, lowerReGo, lowerImGo, twRe, twIm)
+
+			// Compare (only difference is FMA vs separate mul+add, ~1 ULP)
+			for i := range n {
+				if math.Abs(upperRe[i]-upperReGo[i]) > 1e-12 {
+					t.Errorf("upperRe[%d]: SIMD=%v, Go=%v", i, upperRe[i], upperReGo[i])
+				}
+				if math.Abs(upperIm[i]-upperImGo[i]) > 1e-12 {
+					t.Errorf("upperIm[%d]: SIMD=%v, Go=%v", i, upperIm[i], upperImGo[i])
+				}
+				if math.Abs(lowerRe[i]-lowerReGo[i]) > 1e-12 {
+					t.Errorf("lowerRe[%d]: SIMD=%v, Go=%v", i, lowerRe[i], lowerReGo[i])
+				}
+				if math.Abs(lowerIm[i]-lowerImGo[i]) > 1e-12 {
+					t.Errorf("lowerIm[%d]: SIMD=%v, Go=%v", i, lowerIm[i], lowerImGo[i])
+				}
+			}
+		})
+	}
+}
+
+func TestButterflyComplex_FFTPattern(t *testing.T) {
+	// Test the exact FFT butterfly pattern at different stages.
+	fftSizes := []int{8, 16, 32, 64, 128, 256, 512, 1024}
+
+	for _, fftSize := range fftSizes {
+		t.Run(fmt.Sprintf("fft=%d", fftSize), func(t *testing.T) {
+			// Precompute twiddle factors
+			twRe := make([]float64, fftSize/2)
+			twIm := make([]float64, fftSize/2)
+			for k := range fftSize / 2 {
+				angle := -2 * math.Pi * float64(k) / float64(fftSize)
+				twRe[k] = math.Cos(angle)
+				twIm[k] = math.Sin(angle)
+			}
+
+			// Test at different stages
+			for stage := 0; (1 << stage) < fftSize; stage++ {
+				halfSize := 1 << stage
+				fullSize := halfSize * 2
+				twStep := fftSize / fullSize
+
+				t.Run(fmt.Sprintf("stage=%d", stage), func(t *testing.T) {
+					// Create test data
+					upperRe := make([]float64, halfSize)
+					upperIm := make([]float64, halfSize)
+					lowerRe := make([]float64, halfSize)
+					lowerIm := make([]float64, halfSize)
+					gatheredTwRe := make([]float64, halfSize)
+					gatheredTwIm := make([]float64, halfSize)
+
+					// Copy data for reference
+					upperReRef := make([]float64, halfSize)
+					upperImRef := make([]float64, halfSize)
+					lowerReRef := make([]float64, halfSize)
+					lowerImRef := make([]float64, halfSize)
+
+					for k := range halfSize {
+						angle := 2 * math.Pi * float64(k) / float64(halfSize)
+						upperRe[k] = math.Cos(angle)
+						upperIm[k] = math.Sin(angle)
+						lowerRe[k] = math.Sin(angle * 2)
+						lowerIm[k] = math.Cos(angle * 2)
+						gatheredTwRe[k] = twRe[k*twStep]
+						gatheredTwIm[k] = twIm[k*twStep]
+					}
+
+					copy(upperReRef, upperRe)
+					copy(upperImRef, upperIm)
+					copy(lowerReRef, lowerRe)
+					copy(lowerImRef, lowerIm)
+
+					// Apply SIMD butterfly
+					ButterflyComplex(upperRe, upperIm, lowerRe, lowerIm, gatheredTwRe, gatheredTwIm)
+
+					// Apply reference butterfly
+					butterflyComplex64Go(upperReRef, upperImRef, lowerReRef, lowerImRef, gatheredTwRe, gatheredTwIm)
+
+					// Compare
+					for k := range halfSize {
+						if math.Abs(upperRe[k]-upperReRef[k]) > 1e-12 {
+							t.Errorf("stage=%d k=%d upperRe: SIMD=%v, ref=%v", stage, k, upperRe[k], upperReRef[k])
+						}
+						if math.Abs(upperIm[k]-upperImRef[k]) > 1e-12 {
+							t.Errorf("stage=%d k=%d upperIm: SIMD=%v, ref=%v", stage, k, upperIm[k], upperImRef[k])
+						}
+						if math.Abs(lowerRe[k]-lowerReRef[k]) > 1e-12 {
+							t.Errorf("stage=%d k=%d lowerRe: SIMD=%v, ref=%v", stage, k, lowerRe[k], lowerReRef[k])
+						}
+						if math.Abs(lowerIm[k]-lowerImRef[k]) > 1e-12 {
+							t.Errorf("stage=%d k=%d lowerIm: SIMD=%v, ref=%v", stage, k, lowerIm[k], lowerImRef[k])
+						}
+					}
+				})
+			}
+		})
+	}
+}
+
+// TestButterflyComplex_AllocFree pins the zero-allocation guarantee. The direct
+// cpu-flag dispatch keeps //go:noescape effective; routing through an init-time
+// function-pointer table would reintroduce heap allocations here.
+func TestButterflyComplex_AllocFree(t *testing.T) {
+	const n = 256
+	upperRe := make([]float64, n)
+	upperIm := make([]float64, n)
+	lowerRe := make([]float64, n)
+	lowerIm := make([]float64, n)
+	twRe := make([]float64, n)
+	twIm := make([]float64, n)
+	for i := range n {
+		angle := 2 * math.Pi * float64(i) / float64(n)
+		upperRe[i] = float64(i) * 0.1
+		lowerRe[i] = float64(i) * 0.3
+		twRe[i] = math.Cos(angle)
+		twIm[i] = math.Sin(angle)
+	}
+	fn := func() { ButterflyComplex(upperRe, upperIm, lowerRe, lowerIm, twRe, twIm) }
+	if a := testing.AllocsPerRun(50, fn); a != 0 {
+		t.Errorf("ButterflyComplex allocated %v times per run, want 0", a)
+	}
+}
+
+func BenchmarkButterflyComplex(b *testing.B) {
+	sizes := []int{64, 128, 256, 512, 1024, 4096}
+
+	benchFn := func(b *testing.B, n int, fn func(upperRe, upperIm, lowerRe, lowerIm, twRe, twIm []float64)) {
+		b.Helper()
+		upperRe := make([]float64, n)
+		upperIm := make([]float64, n)
+		lowerRe := make([]float64, n)
+		lowerIm := make([]float64, n)
+		twRe := make([]float64, n)
+		twIm := make([]float64, n)
+
+		for i := range n {
+			angle := 2 * math.Pi * float64(i) / float64(n)
+			upperRe[i] = float64(i) * 0.1
+			upperIm[i] = float64(i) * 0.2
+			lowerRe[i] = float64(i) * 0.3
+			lowerIm[i] = float64(i) * 0.4
+			twRe[i] = math.Cos(angle)
+			twIm[i] = math.Sin(angle)
+		}
+
+		b.ResetTimer()
+		b.SetBytes(int64(n * 8 * 6)) // 6 slices of float64
+
+		for i := 0; i < b.N; i++ {
+			fn(upperRe, upperIm, lowerRe, lowerIm, twRe, twIm)
+		}
+	}
+
+	for _, n := range sizes {
+		b.Run(fmt.Sprintf("SIMD_%d", n), func(b *testing.B) {
+			benchFn(b, n, ButterflyComplex)
+		})
+		b.Run(fmt.Sprintf("Go_%d", n), func(b *testing.B) {
+			benchFn(b, n, butterflyComplex64Go)
+		})
+	}
+}

--- a/f64/f64.go
+++ b/f64/f64.go
@@ -872,3 +872,30 @@ func PowElem(dst, base, exp []float64) {
 	}
 	powElem64(dst[:n], base[:n], exp[:n])
 }
+
+func minLen6(a, b, c, d, e, f int) int {
+	return min(a, b, c, d, e, f)
+}
+
+// ButterflyComplex performs the FFT butterfly operation with twiddle factor multiply:
+//
+//	temp_re = lower_re[i]*tw_re[i] - lower_im[i]*tw_im[i]
+//	temp_im = lower_re[i]*tw_im[i] + lower_im[i]*tw_re[i]
+//	upper_re[i], lower_re[i] = upper_re[i]+temp_re, upper_re[i]-temp_re
+//	upper_im[i], lower_im[i] = upper_im[i]+temp_im, upper_im[i]-temp_im
+//
+// This fused operation avoids intermediate memory writes, keeping temp values
+// in registers for significant speedup in FFT inner loops. It is the float64
+// counterpart of f32.ButterflyComplex.
+//
+// Processes min(len(upperRe), len(upperIm), len(lowerRe), len(lowerIm), len(twRe), len(twIm)) elements.
+// All slices are modified in-place: upper receives upper+temp, lower receives upper-temp.
+//
+// Uses AVX+FMA on AMD64, NEON on ARM64, with a pure Go fallback.
+func ButterflyComplex(upperRe, upperIm, lowerRe, lowerIm, twRe, twIm []float64) {
+	n := minLen6(len(upperRe), len(upperIm), len(lowerRe), len(lowerIm), len(twRe), len(twIm))
+	if n == 0 {
+		return
+	}
+	butterflyComplex64(upperRe[:n], upperIm[:n], lowerRe[:n], lowerIm[:n], twRe[:n], twIm[:n])
+}

--- a/f64/f64_amd64.go
+++ b/f64/f64_amd64.go
@@ -656,6 +656,15 @@ func cubicInterpDot64(hist, a, b, c, d []float64, x float64) float64 {
 	return cubicInterpDotGo(hist, a, b, c, d, x)
 }
 
+func butterflyComplex64(upperRe, upperIm, lowerRe, lowerIm, twRe, twIm []float64) {
+	// Use AVX+FMA if available and have at least one full 4-wide vector.
+	if cpu.X86.AVX && cpu.X86.FMA && len(upperRe) >= minAVXElements {
+		butterflyComplexAVX(upperRe, upperIm, lowerRe, lowerIm, twRe, twIm)
+		return
+	}
+	butterflyComplex64Go(upperRe, upperIm, lowerRe, lowerIm, twRe, twIm)
+}
+
 func sigmoid64(dst, src []float64) {
 	// Requires AVX2: sigmoidAVX reconstructs 2^k with 256-bit YMM integer ops
 	// (VCVTTPD2DQ/VPMOVSXDQ/VPSLLQ/VPADDQ) that do not exist on AVX1-only CPUs.
@@ -1045,3 +1054,8 @@ func deinterleave2SSE2(a, b, src []float64)
 //
 //go:noescape
 func cubicInterpDotAVX(hist, a, b, c, d []float64, x float64) float64
+
+// ButterflyComplex assembly function declaration
+//
+//go:noescape
+func butterflyComplexAVX(upperRe, upperIm, lowerRe, lowerIm, twRe, twIm []float64)

--- a/f64/f64_amd64.s
+++ b/f64/f64_amd64.s
@@ -5991,3 +5991,114 @@ DATA log64_powclamp_lo<>+0x08(SB)/8, $0xc087500000000000
 DATA log64_powclamp_lo<>+0x10(SB)/8, $0xc087500000000000
 DATA log64_powclamp_lo<>+0x18(SB)/8, $0xc087500000000000
 GLOBL log64_powclamp_lo<>(SB), RODATA|NOPTR, $32
+
+// func butterflyComplexAVX(upperRe, upperIm, lowerRe, lowerIm, twRe, twIm []float64)
+// FFT butterfly with twiddle multiply, 4 float64 lanes per YMM (AVX+FMA). The
+// float64 counterpart of f32's butterflyComplexAVX: 4 lanes/iter instead of 8,
+// so the 256-bit byte stride ($32) is identical while the loop counter halves.
+//   temp_re = lower_re*tw_re - lower_im*tw_im
+//   temp_im = lower_re*tw_im + lower_im*tw_re
+//   upper' = upper + temp ; lower' = upper - temp   (independently for re/im)
+TEXT ·butterflyComplexAVX(SB), NOSPLIT, $0-144
+    MOVQ upperRe_base+0(FP), DX      // DX = upperRe pointer
+    MOVQ upperRe_len+8(FP), CX       // CX = length
+    MOVQ upperIm_base+24(FP), R8     // R8 = upperIm pointer
+    MOVQ lowerRe_base+48(FP), SI     // SI = lowerRe pointer
+    MOVQ lowerIm_base+72(FP), DI     // DI = lowerIm pointer
+    MOVQ twRe_base+96(FP), R9        // R9 = twRe pointer
+    MOVQ twIm_base+120(FP), R10      // R10 = twIm pointer
+
+    // Process 4 float64 per iteration
+    MOVQ CX, AX
+    SHRQ $2, AX
+    JZ   butterfly_remainder
+
+butterfly_loop4:
+    // Load lower and twiddle
+    VMOVUPD (SI), Y0                 // Y0 = lower_re[0:4]
+    VMOVUPD (DI), Y1                 // Y1 = lower_im[0:4]
+    VMOVUPD (R9), Y2                 // Y2 = tw_re[0:4]
+    VMOVUPD (R10), Y3                // Y3 = tw_im[0:4]
+
+    // Complex multiply: temp = lower * twiddle
+    // temp_re = lower_re*tw_re - lower_im*tw_im
+    // temp_im = lower_re*tw_im + lower_im*tw_re
+    VMULPD Y0, Y2, Y4                // Y4 = lower_re * tw_re
+    VMULPD Y1, Y3, Y5                // Y5 = lower_im * tw_im
+    VSUBPD Y5, Y4, Y4                // Y4 = temp_re = lr*tr - li*ti
+
+    VMULPD Y0, Y3, Y5                // Y5 = lower_re * tw_im
+    VFMADD231PD Y1, Y2, Y5           // Y5 = temp_im = lr*ti + li*tr
+
+    // Load upper
+    VMOVUPD (DX), Y0                 // Y0 = upper_re[0:4]
+    VMOVUPD (R8), Y1                 // Y1 = upper_im[0:4]
+
+    // Butterfly: upper' = upper + temp, lower' = upper - temp
+    VADDPD Y0, Y4, Y2                // Y2 = upper_re + temp_re
+    VSUBPD Y4, Y0, Y3                // Y3 = upper_re - temp_re
+    VMOVUPD Y2, (DX)                 // store upper_re'
+    VMOVUPD Y3, (SI)                 // store lower_re'
+
+    VADDPD Y1, Y5, Y2                // Y2 = upper_im + temp_im
+    VSUBPD Y5, Y1, Y3                // Y3 = upper_im - temp_im
+    VMOVUPD Y2, (R8)                 // store upper_im'
+    VMOVUPD Y3, (DI)                 // store lower_im'
+
+    // Advance pointers (4 float64 = 32 bytes)
+    ADDQ $32, DX
+    ADDQ $32, R8
+    ADDQ $32, SI
+    ADDQ $32, DI
+    ADDQ $32, R9
+    ADDQ $32, R10
+    DECQ AX
+    JNZ  butterfly_loop4
+
+butterfly_remainder:
+    ANDQ $3, CX
+    JZ   butterfly_done
+
+butterfly_scalar:
+    // Load lower and twiddle (scalar)
+    VMOVSD (SI), X0                  // X0 = lower_re
+    VMOVSD (DI), X1                  // X1 = lower_im
+    VMOVSD (R9), X2                  // X2 = tw_re
+    VMOVSD (R10), X3                 // X3 = tw_im
+
+    // Complex multiply: temp = lower * twiddle
+    VMULSD X0, X2, X4                // X4 = lower_re * tw_re
+    VMULSD X1, X3, X5                // X5 = lower_im * tw_im
+    VSUBSD X5, X4, X4                // X4 = temp_re
+
+    VMULSD X0, X3, X5                // X5 = lower_re * tw_im
+    VFMADD231SD X1, X2, X5           // X5 = temp_im
+
+    // Load upper
+    VMOVSD (DX), X0                  // X0 = upper_re
+    VMOVSD (R8), X1                  // X1 = upper_im
+
+    // Butterfly
+    VADDSD X0, X4, X2                // X2 = upper_re + temp_re
+    VSUBSD X4, X0, X3                // X3 = upper_re - temp_re
+    VMOVSD X2, (DX)
+    VMOVSD X3, (SI)
+
+    VADDSD X1, X5, X2                // X2 = upper_im + temp_im
+    VSUBSD X5, X1, X3                // X3 = upper_im - temp_im
+    VMOVSD X2, (R8)
+    VMOVSD X3, (DI)
+
+    // Advance pointers (1 float64 = 8 bytes)
+    ADDQ $8, DX
+    ADDQ $8, R8
+    ADDQ $8, SI
+    ADDQ $8, DI
+    ADDQ $8, R9
+    ADDQ $8, R10
+    DECQ CX
+    JNZ  butterfly_scalar
+
+butterfly_done:
+    VZEROUPPER
+    RET

--- a/f64/f64_arm64.go
+++ b/f64/f64_arm64.go
@@ -500,6 +500,18 @@ func cubicInterpDot64(hist, a, b, c, d []float64, x float64) float64 {
 //go:noescape
 func cubicInterpDotNEON(hist, a, b, c, d []float64, x float64) float64
 
+func butterflyComplex64(upperRe, upperIm, lowerRe, lowerIm, twRe, twIm []float64) {
+	// One NEON iteration needs 2 float64 lanes; anything shorter falls to Go.
+	if hasNEON && len(upperRe) >= 2 {
+		butterflyComplexNEON(upperRe, upperIm, lowerRe, lowerIm, twRe, twIm)
+		return
+	}
+	butterflyComplex64Go(upperRe, upperIm, lowerRe, lowerIm, twRe, twIm)
+}
+
+//go:noescape
+func butterflyComplexNEON(upperRe, upperIm, lowerRe, lowerIm, twRe, twIm []float64)
+
 func sigmoid64(dst, src []float64) {
 	// Assumes len(src) >= len(dst); caller ensures this via public API
 	if hasNEON && len(dst) >= 2 {

--- a/f64/f64_arm64.s
+++ b/f64/f64_arm64.s
@@ -18,6 +18,7 @@
 // FNEG Vd.2D, Vn.2D:        0x6EE0F800 | (Vn << 5) | Vd
 // FRINTN Vd.2D, Vn.2D:      0x4E618800 | (Vn << 5) | Vd  (round to nearest, ties to even)
 // FMLA Vd.2D, Vn.2D, Vm.2D: 0x4E60CC00 | (Vm << 16) | (Vn << 5) | Vd
+// FMLS Vd.2D, Vn.2D, Vm.2D: 0x4EE0CC00 | (Vm << 16) | (Vn << 5) | Vd
 // FADDP Dd, Vn.2D:          0x7E70D800 | (Vn << 5) | Vd
 
 // func dotProductNEON(a, b []float64) float64
@@ -2718,4 +2719,112 @@ powelem64_neon_scalar_normal:
     CBNZ R3, powelem64_neon_scalar_loop
 
 powelem64_neon_done:
+    RET
+
+// func butterflyComplexNEON(upperRe, upperIm, lowerRe, lowerIm, twRe, twIm []float64)
+// Computes FFT butterfly with twiddle factor multiply using split arrays, the
+// float64 counterpart of f32's butterflyComplexNEON: 2 float64 lanes (.2D) per
+// vector register instead of 4 float32 (.4S), so the 16-byte stride is identical
+// while the loop counter halves.
+//   temp_re = lower_re[i]*tw_re[i] - lower_im[i]*tw_im[i]
+//   temp_im = lower_re[i]*tw_im[i] + lower_im[i]*tw_re[i]
+//   upper_re[i], lower_re[i] = upper_re[i]+temp_re, upper_re[i]-temp_re
+//   upper_im[i], lower_im[i] = upper_im[i]+temp_im, upper_im[i]-temp_im
+// Frame: upperRe(24) + upperIm(24) + lowerRe(24) + lowerIm(24) + twRe(24) + twIm(24) = 144 bytes
+TEXT ·butterflyComplexNEON(SB), NOSPLIT, $0-144
+    MOVD upperRe_base+0(FP), R0      // R0 = upperRe pointer
+    MOVD upperRe_len+8(FP), R3       // R3 = length
+    MOVD upperIm_base+24(FP), R1     // R1 = upperIm pointer
+    MOVD lowerRe_base+48(FP), R4     // R4 = lowerRe pointer
+    MOVD lowerIm_base+72(FP), R5     // R5 = lowerIm pointer
+    MOVD twRe_base+96(FP), R6        // R6 = twRe pointer
+    MOVD twIm_base+120(FP), R7       // R7 = twIm pointer
+
+    // Process 2 float64 per iteration
+    LSR $1, R3, R8
+    CBZ R8, butterfly_neon_scalar
+
+butterfly_neon_loop2:
+    // Load inputs
+    VLD1.P 16(R0), [V0.D2]           // V0 = upperRe[0:2]
+    VLD1.P 16(R1), [V1.D2]           // V1 = upperIm[0:2]
+    VLD1.P 16(R4), [V2.D2]           // V2 = lowerRe[0:2]
+    VLD1.P 16(R5), [V3.D2]           // V3 = lowerIm[0:2]
+    VLD1.P 16(R6), [V4.D2]           // V4 = twRe[0:2]
+    VLD1.P 16(R7), [V5.D2]           // V5 = twIm[0:2]
+
+    // tempRe = lowerRe*twRe - lowerIm*twIm
+    WORD $0x6E64DC46                  // FMUL V6.2D, V2.2D, V4.2D  (lowerRe * twRe)
+    WORD $0x4EE5CC66                  // FMLS V6.2D, V3.2D, V5.2D  (V6 -= lowerIm * twIm)
+
+    // tempIm = lowerRe*twIm + lowerIm*twRe
+    WORD $0x6E65DC47                  // FMUL V7.2D, V2.2D, V5.2D  (lowerRe * twIm)
+    WORD $0x4E64CC67                  // FMLA V7.2D, V3.2D, V4.2D  (V7 += lowerIm * twRe)
+
+    // new upperRe = upperRe + tempRe, new lowerRe = upperRe - tempRe
+    WORD $0x4E66D408                  // FADD V8.2D, V0.2D, V6.2D  (upperRe + tempRe)
+    WORD $0x4EE6D40A                  // FSUB V10.2D, V0.2D, V6.2D (upperRe - tempRe)
+
+    // new upperIm = upperIm + tempIm, new lowerIm = upperIm - tempIm
+    WORD $0x4E67D429                  // FADD V9.2D, V1.2D, V7.2D  (upperIm + tempIm)
+    WORD $0x4EE7D42B                  // FSUB V11.2D, V1.2D, V7.2D (upperIm - tempIm)
+
+    // Store results (need to rewind pointers since we post-incremented during load)
+    SUB $16, R0
+    SUB $16, R1
+    SUB $16, R4
+    SUB $16, R5
+    VST1.P [V8.D2], 16(R0)           // Store new upperRe
+    VST1.P [V9.D2], 16(R1)           // Store new upperIm
+    VST1.P [V10.D2], 16(R4)          // Store new lowerRe
+    VST1.P [V11.D2], 16(R5)          // Store new lowerIm
+
+    SUB $1, R8
+    CBNZ R8, butterfly_neon_loop2
+
+butterfly_neon_scalar:
+    AND $1, R3
+    CBZ R3, butterfly_neon_done
+
+butterfly_neon_scalar_loop:
+    // Load scalar values
+    FMOVD (R0), F0                   // F0 = upperRe
+    FMOVD (R1), F1                   // F1 = upperIm
+    FMOVD (R4), F2                   // F2 = lowerRe
+    FMOVD (R5), F3                   // F3 = lowerIm
+    FMOVD (R6), F4                   // F4 = twRe
+    FMOVD (R7), F5                   // F5 = twIm
+
+    // tempRe = lowerRe*twRe - lowerIm*twIm
+    FMULD F2, F4, F6                 // F6 = lowerRe * twRe
+    FMULD F3, F5, F7                 // F7 = lowerIm * twIm
+    FSUBD F7, F6, F6                 // F6 = tempRe (F6 - F7)
+
+    // tempIm = lowerRe*twIm + lowerIm*twRe
+    FMULD F2, F5, F7                 // F7 = lowerRe * twIm
+    FMULD F3, F4, F8                 // F8 = lowerIm * twRe
+    FADDD F7, F8, F7                 // F7 = tempIm
+
+    // Butterfly: upper' = upper + temp, lower' = upper - temp
+    FADDD F0, F6, F8                 // F8 = new upperRe
+    FSUBD F6, F0, F9                 // F9 = new lowerRe (F0 - F6)
+    FADDD F1, F7, F10                // F10 = new upperIm
+    FSUBD F7, F1, F11                // F11 = new lowerIm (F1 - F7)
+
+    // Store results
+    FMOVD F8, (R0)
+    FMOVD F10, (R1)
+    FMOVD F9, (R4)
+    FMOVD F11, (R5)
+
+    ADD $8, R0
+    ADD $8, R1
+    ADD $8, R4
+    ADD $8, R5
+    ADD $8, R6
+    ADD $8, R7
+    SUB $1, R3
+    CBNZ R3, butterfly_neon_scalar_loop
+
+butterfly_neon_done:
     RET

--- a/f64/f64_go.go
+++ b/f64/f64_go.go
@@ -692,3 +692,24 @@ func powElemGo(dst, base, exp []float64) {
 		dst[i] = math.Pow(base[i], exp[i])
 	}
 }
+
+// butterflyComplex64Go performs FFT butterfly with twiddle multiply:
+//
+//	temp = lower * twiddle (complex multiply)
+//	upper, lower = upper + temp, upper - temp
+func butterflyComplex64Go(upperRe, upperIm, lowerRe, lowerIm, twRe, twIm []float64) {
+	for i := range upperRe {
+		// Complex multiply: temp = lower * twiddle
+		lr, li := lowerRe[i], lowerIm[i]
+		tr, ti := twRe[i], twIm[i]
+		tempRe := lr*tr - li*ti
+		tempIm := lr*ti + li*tr
+
+		// Butterfly: upper' = upper + temp, lower' = upper - temp
+		ur, ui := upperRe[i], upperIm[i]
+		upperRe[i] = ur + tempRe
+		upperIm[i] = ui + tempIm
+		lowerRe[i] = ur - tempRe
+		lowerIm[i] = ui - tempIm
+	}
+}

--- a/f64/f64_other.go
+++ b/f64/f64_other.go
@@ -70,3 +70,6 @@ func log2_64(dst, src []float64)            { log2Go(dst, src) }
 func log10_64(dst, src []float64)           { log10Go(dst, src) }
 func pow64(dst, src []float64, exp float64) { powGo(dst, src, exp) }
 func powElem64(dst, base, exp []float64)    { powElemGo(dst, base, exp) }
+func butterflyComplex64(upperRe, upperIm, lowerRe, lowerIm, twRe, twIm []float64) {
+	butterflyComplex64Go(upperRe, upperIm, lowerRe, lowerIm, twRe, twIm)
+}


### PR DESCRIPTION
Adds `f64.ButterflyComplex`, the float64 counterpart of the existing `f32.ButterflyComplex`, with an AVX2/FMA kernel on amd64, a NEON kernel on arm64, and a pure-Go fallback. This is the first of the f64 primitives that issue #192 calls out as a prerequisite: the FFT building blocks (`ButterflyComplex`, `RealFFTUnpack`) existed only in `f32`, so a float64 consumer (the bit-exact SoX/STFT path) had nothing to reach for. `RealFFTUnpack` and the `stft.go` wiring follow in separate PRs, mirroring how the f32 versions shipped (#12, #13).

The kernel is a direct lane-width port of the proven f32 version: 4 float64 per YMM on AVX (vs 8 float32), 2 per `.2D` on NEON (vs 4 `.4S`). The 256-bit/128-bit byte strides are unchanged (8*f32 == 4*f64 == 32B; 4*f32 == 2*f64 == 16B); only the loop counters and element strides change. Dispatch is a direct cpu-flag switch (not the init-time function-pointer table), which keeps `//go:noescape` effective and the operation allocation-free.

### Semantics (identical to f32)

For each element of the six split-format slices:

```
temp_re = lower_re*tw_re - lower_im*tw_im
temp_im = lower_re*tw_im + lower_im*tw_re
upper_re', lower_re' = upper_re + temp_re, upper_re - temp_re
upper_im', lower_im' = upper_im + temp_im, upper_im - temp_im
```

All six slices are modified in place; the call processes `min` of the six lengths.

### Verification

- Parity vs a non-FMA scalar reference and vs the pure-Go path, hand-computed known values, and the realistic multi-stage FFT twiddle-gather pattern, across sizes that exercise the SIMD main loop, the scalar tail, and the sub-threshold Go path.
- `testing.AllocsPerRun == 0`.
- `asmcheck` cross-verifies every new NEON `WORD` encoding against `golang.org/x/arch/arm64asm`; the goroutine-register-clobber guard passes (no R14/R28 use).
- Ran on real hardware, not just locally: amd64 i7-1260P (genuine AVX2) and arm64 Raspberry Pi 5 (Cortex-A76 NEON), full `f64` package green on both.
- Benchmark on the i7-1260P (P-core pinned) shows the AVX kernel doing real work: ~4x over the Go path (256: 76 ns vs 311 ns; 1024: 294 ns vs 1190 ns).

Refs #192.
