### PR TITLE
f64: add RealFFTUnpack, the AVX2/NEON real-FFT even/odd unpack

### DIFF
--- a/f64/f64.go
+++ b/f64/f64.go
@@ -899,3 +899,54 @@ func ButterflyComplex(upperRe, upperIm, lowerRe, lowerIm, twRe, twIm []float64) 
 	}
 	butterflyComplex64(upperRe[:n], upperIm[:n], lowerRe[:n], lowerIm[:n], twRe[:n], twIm[:n])
 }
+
+// realFFTUnpackMinN is the minimum n required for RealFFTUnpack (need at least 2 bins).
+const realFFTUnpackMinN = 2
+
+// RealFFTUnpack performs the unpacking step of a real-valued FFT.
+//
+// Given Z = FFT(packed real data of size 2n), this computes the real FFT output X
+// for bins k = 1 to n-1. The formula for each bin is:
+//
+//	conj_z = conj(Z[n-k])
+//	even = 0.5 * (Z[k] + conj_z)
+//	diff = Z[k] - conj_z
+//	odd  = W[k] * (-0.5i) * diff
+//	X[k] = even + odd
+//
+// Expanding the complex arithmetic:
+//
+//	evenRe = 0.5 * (zRe[k] + zRe[n-k])
+//	evenIm = 0.5 * (zIm[k] - zIm[n-k])
+//	diffRe = zRe[k] - zRe[n-k]
+//	diffIm = zIm[k] + zIm[n-k]
+//	oddRe  = 0.5 * (twRe[k]*diffIm + twIm[k]*diffRe)
+//	oddIm  = 0.5 * (twIm[k]*diffIm - twRe[k]*diffRe)
+//	outRe[k] = evenRe + oddRe
+//	outIm[k] = evenIm + oddIm
+//
+// Parameters:
+//   - outRe, outIm: Output arrays, X[k] written to index k for k in [1, n-1]
+//   - zRe, zIm: Input Z array of length n
+//   - twRe, twIm: Twiddle factors W[k] at index k-1 (length n-1)
+//
+// The DC bin (k=0) and Nyquist bin (k=n) must be handled separately by the caller.
+// Typical real FFT post-processing:
+//
+//	X[0] = Z[0].real + Z[0].imag  (DC component)
+//	X[n] = Z[0].real - Z[0].imag  (Nyquist component)
+//
+// It is the float64 counterpart of f32.RealFFTUnpack.
+//
+// Uses AVX2+FMA on AMD64, NEON on ARM64, with a pure Go fallback.
+func RealFFTUnpack(outRe, outIm, zRe, zIm, twRe, twIm []float64) {
+	n := len(zRe)
+	if n < realFFTUnpackMinN {
+		return
+	}
+	// Validate slice lengths
+	if len(zIm) < n || len(outRe) < n || len(outIm) < n || len(twRe) < n-1 || len(twIm) < n-1 {
+		return
+	}
+	realFFTUnpack64(outRe, outIm, zRe, zIm, twRe, twIm, n)
+}

--- a/f64/f64_amd64.go
+++ b/f64/f64_amd64.go
@@ -665,6 +665,20 @@ func butterflyComplex64(upperRe, upperIm, lowerRe, lowerIm, twRe, twIm []float64
 	butterflyComplex64Go(upperRe, upperIm, lowerRe, lowerIm, twRe, twIm)
 }
 
+func realFFTUnpack64(outRe, outIm, zRe, zIm, twRe, twIm []float64, n int) {
+	// realFFTUnpackAVX needs AVX2, not just AVX+FMA: the reversed load uses VPERMPD
+	// and the constants use register-source VBROADCASTSD plus VPCMPEQD/VPSLLQ on
+	// YMM, all AVX2-only. Gating on plain AVX would let an AVX1+FMA part (e.g. AMD
+	// Piledriver) reach it and SIGILL. hasAVX2 is the same guard the other VPERMPD
+	// users in this package use (autocorrelate, interleaveN).
+	// n > minAVXElements means n >= 5, so (n-1) >= 4 = one full 4-wide AVX pass.
+	if hasAVX2 && cpu.X86.FMA && n > minAVXElements {
+		realFFTUnpackAVX(outRe, outIm, zRe, zIm, twRe, twIm, n)
+		return
+	}
+	realFFTUnpack64Go(outRe, outIm, zRe, zIm, twRe, twIm, n)
+}
+
 func sigmoid64(dst, src []float64) {
 	// Requires AVX2: sigmoidAVX reconstructs 2^k with 256-bit YMM integer ops
 	// (VCVTTPD2DQ/VPMOVSXDQ/VPSLLQ/VPADDQ) that do not exist on AVX1-only CPUs.
@@ -1059,3 +1073,8 @@ func cubicInterpDotAVX(hist, a, b, c, d []float64, x float64) float64
 //
 //go:noescape
 func butterflyComplexAVX(upperRe, upperIm, lowerRe, lowerIm, twRe, twIm []float64)
+
+// RealFFTUnpack assembly function declaration
+//
+//go:noescape
+func realFFTUnpackAVX(outRe, outIm, zRe, zIm, twRe, twIm []float64, n int)

--- a/f64/f64_amd64.s
+++ b/f64/f64_amd64.s
@@ -6102,3 +6102,244 @@ butterfly_scalar:
 butterfly_done:
     VZEROUPPER
     RET
+
+// func realFFTUnpackAVX(outRe, outIm, zRe, zIm, twRe, twIm []float64, n int)
+// Real-FFT unpack step, 4 float64 lanes per YMM (AVX+FMA). The float64
+// counterpart of f32's realFFTUnpackAVX: 4 lanes/iter instead of 8, so the
+// 256-bit byte stride ($32) is identical while the loop counter halves. For
+// k in [1, n-1] with nk = n-k:
+//   znk    = conj(Z[nk]) = (zRe[nk], -zIm[nk])
+//   even   = 0.5*(Z[k] + znk) ; diff = Z[k] - znk
+//   oddRe  = 0.5*(wr*diffIm + wi*diffRe) ; oddIm = 0.5*(wi*diffIm - wr*diffRe)
+//   X[k]   = even + odd
+// The mirror slice is read in reverse (highest index first) and permuted so a
+// forward vector Z[k:k+4] pairs with Z[nk:nk-3]. Frame:
+// outRe(24)+outIm(24)+zRe(24)+zIm(24)+twRe(24)+twIm(24)+n(8) = 152 bytes.
+TEXT ·realFFTUnpackAVX(SB), NOSPLIT, $0-152
+    // Load parameters
+    MOVQ outRe_base+0(FP), DX        // DX = outRe pointer
+    MOVQ outIm_base+24(FP), SI       // SI = outIm pointer
+    MOVQ zRe_base+48(FP), DI         // DI = zRe pointer (forward)
+    MOVQ zIm_base+72(FP), R8         // R8 = zIm pointer (forward)
+    MOVQ twRe_base+96(FP), R11       // R11 = twRe pointer
+    MOVQ twIm_base+120(FP), R12      // R12 = twIm pointer
+    MOVQ n+144(FP), CX               // CX = n
+
+    // Calculate number of iterations: (n-1) / 4
+    MOVQ CX, AX
+    DECQ AX                          // AX = n - 1
+    MOVQ AX, R13                     // R13 = n - 1 (save for remainder)
+    SHRQ $2, AX                      // AX = (n-1) / 4 = number of SIMD iterations
+    JZ   realfft64_remainder         // Skip SIMD loop if < 4 elements
+
+    // Set up reverse pointers: R9 = &zRe[n-4], R10 = &zIm[n-4].
+    // BX (not R14) holds byte offsets: R14 is the goroutine g pointer on Go amd64.
+    MOVQ CX, BX                      // BX = n
+    SUBQ $4, BX                      // BX = n - 4
+    SHLQ $3, BX                      // BX = (n-4) * 8 = byte offset
+    MOVQ DI, R9
+    ADDQ BX, R9                      // R9 = &zRe[n-4]
+    MOVQ R8, R10
+    ADDQ BX, R10                     // R10 = &zIm[n-4]
+
+    // Offset forward pointers to start at index 1
+    ADDQ $8, DI                      // DI = &zRe[1]
+    ADDQ $8, R8                      // R8 = &zIm[1]
+    ADDQ $8, DX                      // DX = &outRe[1]
+    ADDQ $8, SI                      // SI = &outIm[1]
+
+    // Broadcast 0.5 (0x3FE0000000000000 = 0.5)
+    MOVQ $0x3FE0000000000000, BX
+    MOVQ BX, X13
+    VBROADCASTSD X13, Y13            // Y13 = 0.5 broadcast
+
+    // Sign mask for negation (0x8000000000000000 = the float64 sign bit).
+    // VPSLLQ $63 gives 0x8000000000000000; VPSLLD $31 would give
+    // 0x8000000080000000 and corrupt the double.
+    VPCMPEQD Y14, Y14, Y14           // Y14 = all 1s
+    VPSLLQ $63, Y14, Y14             // Y14 = 0x8000000000000000
+
+realfft64_loop4:
+    // Load forward Z[k:k+4]
+    VMOVUPD (DI), Y0                 // Y0 = zRe[k:k+4] (forward)
+    VMOVUPD (R8), Y1                 // Y1 = zIm[k:k+4] (forward)
+
+    // Load reverse Z[n-k-3:n-k+1] and reverse the order
+    // Memory has: z[n-k-3], z[n-k-2], z[n-k-1], z[n-k]
+    // We need:    z[n-k], z[n-k-1], z[n-k-2], z[n-k-3]
+    VMOVUPD (R9), Y2                 // Y2 = zRe[n-k-3:n-k+1] (to be reversed)
+    VMOVUPD (R10), Y3                // Y3 = zIm[n-k-3:n-k+1] (to be reversed)
+
+    // Reverse Y2 and Y3 with a single VPERMPD: [a b c d] -> [d c b a].
+    // 0x1B = 0b00011011 = [3,2,1,0] over 4 qwords. The f32 kernel needs a two-step
+    // reverse because VPERMILPS permutes 32-bit lanes within each 128-bit half, so
+    // it cannot reverse 4 doubles; VPERMPD does the full cross-lane qword reverse.
+    VPERMPD $0x1B, Y2, Y2
+    VPERMPD $0x1B, Y3, Y3
+
+    // Now Y2 = znkRe (reversed), Y3 = zIm[n-k] (reversed, not yet negated)
+    // For conjugate: znkIm = -zIm[n-k]
+    VXORPD Y14, Y3, Y3               // Y3 = znkIm = -zIm[n-k] (conjugate)
+
+    // Compute even = 0.5 * (Z[k] + conj(Z[n-k]))
+    VADDPD Y0, Y2, Y4                // Y4 = zkRe + znkRe
+    VMULPD Y4, Y13, Y4               // Y4 = evenRe = 0.5 * (zkRe + znkRe)
+    VADDPD Y1, Y3, Y5                // Y5 = zkIm + znkIm (znkIm already negated)
+    VMULPD Y5, Y13, Y5               // Y5 = evenIm = 0.5 * (zkIm + znkIm)
+
+    // Compute diff = Z[k] - conj(Z[n-k])
+    VSUBPD Y2, Y0, Y6                // Y6 = diffRe = zkRe - znkRe
+    VSUBPD Y3, Y1, Y7                // Y7 = diffIm = zkIm - znkIm
+
+    // Load twiddles W[k]
+    VMOVUPD (R11), Y8                // Y8 = twRe (wr)
+    VMOVUPD (R12), Y9                // Y9 = twIm (wi)
+
+    // Compute odd = W[k] * (-0.5i) * diff
+    // oddRe = 0.5 * (wr*diffIm + wi*diffRe)
+    VMULPD Y8, Y7, Y10               // Y10 = wr * diffIm
+    VFMADD231PD Y9, Y6, Y10          // Y10 = wr*diffIm + wi*diffRe
+    VMULPD Y10, Y13, Y10             // Y10 = oddRe = 0.5 * (wr*diffIm + wi*diffRe)
+
+    // oddIm = 0.5 * (wi*diffIm - wr*diffRe)
+    VMULPD Y9, Y7, Y11               // Y11 = wi * diffIm
+    VFNMADD231PD Y8, Y6, Y11         // Y11 = wi*diffIm - wr*diffRe
+    VMULPD Y11, Y13, Y11             // Y11 = oddIm = 0.5 * (wi*diffIm - wr*diffRe)
+
+    // Compute output X[k] = even + odd
+    VADDPD Y4, Y10, Y0               // Y0 = outRe = evenRe + oddRe
+    VADDPD Y5, Y11, Y1               // Y1 = outIm = evenIm + oddIm
+
+    // Store results
+    VMOVUPD Y0, (DX)                 // store outRe[k:k+4]
+    VMOVUPD Y1, (SI)                 // store outIm[k:k+4]
+
+    // Advance pointers
+    ADDQ $32, DI                     // forward zRe += 4
+    ADDQ $32, R8                     // forward zIm += 4
+    SUBQ $32, R9                     // reverse zRe -= 4
+    SUBQ $32, R10                    // reverse zIm -= 4
+    ADDQ $32, R11                    // twRe += 4
+    ADDQ $32, R12                    // twIm += 4
+    ADDQ $32, DX                     // outRe += 4
+    ADDQ $32, SI                     // outIm += 4
+
+    DECQ AX
+    JNZ  realfft64_loop4
+
+realfft64_remainder:
+    // Handle remaining elements (n-1) % 4
+    ANDQ $3, R13                     // R13 = remainder count
+    JZ   realfft64_done
+
+    // Reload base pointers for remainder (need to recalculate positions)
+    MOVQ outRe_base+0(FP), DX
+    MOVQ outIm_base+24(FP), SI
+    MOVQ zRe_base+48(FP), DI
+    MOVQ zIm_base+72(FP), R8
+    MOVQ twRe_base+96(FP), R11
+    MOVQ twIm_base+120(FP), R12
+    MOVQ n+144(FP), CX
+
+    // Calculate starting k for remainder: 1 + 4 * num_full_iterations
+    MOVQ CX, AX
+    DECQ AX                          // AX = n - 1
+    SHRQ $2, AX                      // AX = num_full_iterations
+    SHLQ $2, AX                      // AX = 4 * num_full_iterations
+    INCQ AX                          // AX = 1 + 4 * num_full_iterations = starting k
+
+    // Offset pointers to starting k
+    MOVQ AX, BX
+    SHLQ $3, BX                      // BX = k * 8 bytes
+    ADDQ BX, DX                      // DX = &outRe[k]
+    ADDQ BX, SI                      // SI = &outIm[k]
+    ADDQ BX, DI                      // DI = &zRe[k]
+    ADDQ BX, R8                      // R8 = &zIm[k]
+
+    // Twiddle offset is (k-1)
+    DECQ AX
+    MOVQ AX, BX
+    SHLQ $3, BX
+    ADDQ BX, R11                     // R11 = &twRe[k-1]
+    ADDQ BX, R12                     // R12 = &twIm[k-1]
+    INCQ AX                          // Restore AX = k
+
+realfft64_scalar:
+    // Calculate mirror index: nk = n - k
+    MOVQ CX, BX
+    SUBQ AX, BX                      // BX = n - k = nk
+
+    // Load Z[k]
+    VMOVSD (DI), X0                  // X0 = zRe[k]
+    VMOVSD (R8), X1                  // X1 = zIm[k]
+
+    // Load conj(Z[n-k])
+    MOVQ zRe_base+48(FP), R15
+    MOVQ BX, R9
+    SHLQ $3, R9
+    ADDQ R9, R15
+    VMOVSD (R15), X2                 // X2 = zRe[nk]
+
+    MOVQ zIm_base+72(FP), R15
+    ADDQ R9, R15
+    VMOVSD (R15), X3                 // X3 = zIm[nk]
+
+    // Load 0.5 constant (0x3FE0000000000000 = 0.5)
+    MOVQ $0x3FE0000000000000, BX
+    MOVQ BX, X13
+
+    // Negate X3 for conjugate: znkIm = -zIm[nk]
+    VXORPD X14, X14, X14
+    VSUBSD X3, X14, X3               // X3 = -zIm[nk] = znkIm
+
+    // evenRe = 0.5 * (zkRe + znkRe)
+    VADDSD X0, X2, X4
+    VMULSD X4, X13, X4               // X4 = evenRe
+
+    // evenIm = 0.5 * (zkIm + znkIm)
+    VADDSD X1, X3, X5
+    VMULSD X5, X13, X5               // X5 = evenIm
+
+    // diffRe = zkRe - znkRe
+    VSUBSD X2, X0, X6                // X6 = diffRe
+
+    // diffIm = zkIm - znkIm
+    VSUBSD X3, X1, X7                // X7 = diffIm
+
+    // Load twiddles
+    VMOVSD (R11), X8                 // X8 = wr
+    VMOVSD (R12), X9                 // X9 = wi
+
+    // oddRe = 0.5 * (wr*diffIm + wi*diffRe)
+    VMULSD X8, X7, X10               // X10 = wr * diffIm
+    VFMADD231SD X9, X6, X10          // X10 = wr*diffIm + wi*diffRe
+    VMULSD X10, X13, X10             // X10 = oddRe
+
+    // oddIm = 0.5 * (wi*diffIm - wr*diffRe)
+    VMULSD X9, X7, X11               // X11 = wi * diffIm
+    VFNMADD231SD X8, X6, X11         // X11 = wi*diffIm - wr*diffRe
+    VMULSD X11, X13, X11             // X11 = oddIm
+
+    // output = even + odd
+    VADDSD X4, X10, X0               // X0 = outRe
+    VADDSD X5, X11, X1               // X1 = outIm
+
+    // Store
+    VMOVSD X0, (DX)
+    VMOVSD X1, (SI)
+
+    // Advance pointers
+    ADDQ $8, DI
+    ADDQ $8, R8
+    ADDQ $8, R11
+    ADDQ $8, R12
+    ADDQ $8, DX
+    ADDQ $8, SI
+    INCQ AX                          // k++
+
+    DECQ R13
+    JNZ  realfft64_scalar
+
+realfft64_done:
+    VZEROUPPER
+    RET

--- a/f64/f64_arm64.go
+++ b/f64/f64_arm64.go
@@ -512,6 +512,18 @@ func butterflyComplex64(upperRe, upperIm, lowerRe, lowerIm, twRe, twIm []float64
 //go:noescape
 func butterflyComplexNEON(upperRe, upperIm, lowerRe, lowerIm, twRe, twIm []float64)
 
+func realFFTUnpack64(outRe, outIm, zRe, zIm, twRe, twIm []float64, n int) {
+	// One NEON iteration needs 2 float64 lanes; n > 2 means (n-1) >= 2.
+	if hasNEON && n > 2 {
+		realFFTUnpackNEON(outRe, outIm, zRe, zIm, twRe, twIm, n)
+		return
+	}
+	realFFTUnpack64Go(outRe, outIm, zRe, zIm, twRe, twIm, n)
+}
+
+//go:noescape
+func realFFTUnpackNEON(outRe, outIm, zRe, zIm, twRe, twIm []float64, n int)
+
 func sigmoid64(dst, src []float64) {
 	// Assumes len(src) >= len(dst); caller ensures this via public API
 	if hasNEON && len(dst) >= 2 {

--- a/f64/f64_arm64.s
+++ b/f64/f64_arm64.s
@@ -2828,3 +2828,223 @@ butterfly_neon_scalar_loop:
 
 butterfly_neon_done:
     RET
+
+// func realFFTUnpackNEON(outRe, outIm, zRe, zIm, twRe, twIm []float64, n int)
+// Real-FFT unpack step, 2 float64 lanes (.2D) per vector register, the float64
+// counterpart of f32's realFFTUnpackNEON: 2 lanes/iter instead of 4, so the
+// 16-byte stride is identical while the loop counter halves. For k in [1, n-1]
+// with nk = n-k:
+//   znk    = conj(Z[nk]) = (zRe[nk], -zIm[nk])
+//   even   = 0.5*(Z[k] + znk) ; diff = Z[k] - znk
+//   oddRe  = 0.5*(wr*diffIm + wi*diffRe) ; oddIm = 0.5*(wi*diffIm - wr*diffRe)
+//   X[k]   = even + odd
+// The mirror slice is read in reverse; EXT #8 swaps the two f64 lanes, which is
+// the full reverse for 2 doubles (REV64 has no .2D form and is not used here).
+// Frame: outRe(24)+outIm(24)+zRe(24)+zIm(24)+twRe(24)+twIm(24)+n(8) = 152 bytes.
+TEXT ·realFFTUnpackNEON(SB), NOSPLIT, $0-152
+    // Load parameters
+    MOVD outRe_base+0(FP), R0        // R0 = outRe pointer
+    MOVD outIm_base+24(FP), R1       // R1 = outIm pointer
+    MOVD zRe_base+48(FP), R2         // R2 = zRe pointer (forward)
+    MOVD zIm_base+72(FP), R3         // R3 = zIm pointer (forward)
+    MOVD twRe_base+96(FP), R4        // R4 = twRe pointer
+    MOVD twIm_base+120(FP), R5       // R5 = twIm pointer
+    MOVD n+144(FP), R6               // R6 = n
+
+    // Calculate number of iterations: (n-1) / 2
+    SUB $1, R6, R7                   // R7 = n - 1
+    MOVD R7, R14                     // R14 = n - 1 (save for remainder; R14 is a temp on arm64, g is R28)
+    LSR $1, R7                       // R7 = (n-1) / 2 = number of SIMD iterations
+    CBZ R7, realfft64_neon_remainder // Skip SIMD loop if < 2 elements
+
+    // Set up reverse pointers: zRe[n-2], zIm[n-2]
+    SUB $2, R6, R8                   // R8 = n - 2
+    LSL $3, R8                       // R8 = (n-2) * 8 = byte offset
+    MOVD zRe_base+48(FP), R9
+    ADD R8, R9                       // R9 = &zRe[n-2]
+    MOVD zIm_base+72(FP), R10
+    ADD R8, R10                      // R10 = &zIm[n-2]
+
+    // Offset forward pointers to start at index 1
+    ADD $8, R2                       // R2 = &zRe[1]
+    ADD $8, R3                       // R3 = &zIm[1]
+    ADD $8, R0                       // R0 = &outRe[1]
+    ADD $8, R1                       // R1 = &outIm[1]
+
+    // Load 0.5 constant into V30
+    MOVD $0x3FE0000000000000, R11    // 0.5 in IEEE 754 double
+    FMOVD R11, F30
+    WORD $0x4E0807DE                 // DUP V30.2D, V30.D[0]
+
+realfft64_neon_loop2:
+    // Load forward Z[k:k+2]
+    VLD1.P 16(R2), [V0.D2]           // V0 = zRe[k:k+2] (forward)
+    VLD1.P 16(R3), [V1.D2]           // V1 = zIm[k:k+2] (forward)
+
+    // Load reverse Z[n-k-1:n-k+1] and reverse the order
+    VLD1 (R9), [V2.D2]               // V2 = zRe[n-k-1:n-k+1] (to be reversed)
+    VLD1 (R10), [V3.D2]              // V3 = zIm[n-k-1:n-k+1] (to be reversed)
+
+    // Reverse V2 and V3: swap the two f64 lanes ([0,1] -> [1,0]) via EXT #8
+    WORD $0x6E024042                 // EXT V2.16B, V2.16B, V2.16B, #8
+    WORD $0x6E034063                 // EXT V3.16B, V3.16B, V3.16B, #8
+
+    // For conjugate: znkIm = -zIm[n-k]
+    WORD $0x6EE0F863                 // FNEG V3.2D, V3.2D  (negate for conjugate)
+
+    // Compute even = 0.5 * (Z[k] + conj(Z[n-k]))
+    // evenRe = 0.5 * (zkRe + znkRe)
+    WORD $0x4E62D404                 // FADD V4.2D, V0.2D, V2.2D  (zkRe + znkRe)
+    WORD $0x6E7EDC84                 // FMUL V4.2D, V4.2D, V30.2D  (evenRe)
+
+    // evenIm = 0.5 * (zkIm + znkIm)
+    WORD $0x4E63D425                 // FADD V5.2D, V1.2D, V3.2D  (zkIm + znkIm)
+    WORD $0x6E7EDCA5                 // FMUL V5.2D, V5.2D, V30.2D  (evenIm)
+
+    // Compute diff = Z[k] - conj(Z[n-k])
+    // diffRe = zkRe - znkRe
+    WORD $0x4EE2D406                 // FSUB V6.2D, V0.2D, V2.2D  (diffRe)
+    // diffIm = zkIm - znkIm
+    WORD $0x4EE3D427                 // FSUB V7.2D, V1.2D, V3.2D  (diffIm)
+
+    // Load twiddles W[k] (not post-increment, need them for computation first)
+    VLD1.P 16(R4), [V8.D2]           // V8 = twRe (wr)
+    VLD1.P 16(R5), [V9.D2]           // V9 = twIm (wi)
+
+    // Compute odd = W[k] * (-0.5i) * diff
+    // oddRe = 0.5 * (wr*diffIm + wi*diffRe)
+    WORD $0x6E67DD0A                 // FMUL V10.2D, V8.2D, V7.2D   (wr * diffIm)
+    WORD $0x4E66CD2A                 // FMLA V10.2D, V9.2D, V6.2D   (V10 += wi * diffRe)
+    WORD $0x6E7EDD4A                 // FMUL V10.2D, V10.2D, V30.2D (oddRe)
+
+    // oddIm = 0.5 * (wi*diffIm - wr*diffRe)
+    WORD $0x6E67DD2B                 // FMUL V11.2D, V9.2D, V7.2D   (wi * diffIm)
+    WORD $0x4EE6CD0B                 // FMLS V11.2D, V8.2D, V6.2D   (V11 -= wr * diffRe)
+    WORD $0x6E7EDD6B                 // FMUL V11.2D, V11.2D, V30.2D (oddIm)
+
+    // Compute output X[k] = even + odd
+    WORD $0x4E6AD480                 // FADD V0.2D, V4.2D, V10.2D  (outRe)
+    WORD $0x4E6BD4A1                 // FADD V1.2D, V5.2D, V11.2D  (outIm)
+
+    // Store results
+    VST1.P [V0.D2], 16(R0)           // Store outRe[k:k+2]
+    VST1.P [V1.D2], 16(R1)           // Store outIm[k:k+2]
+
+    // Move reverse pointers backward
+    SUB $16, R9                      // reverse zRe -= 2
+    SUB $16, R10                     // reverse zIm -= 2
+
+    SUB $1, R7
+    CBNZ R7, realfft64_neon_loop2
+
+realfft64_neon_remainder:
+    // Handle remaining element (n-1) % 2
+    AND $1, R14
+    CBZ R14, realfft64_neon_done
+
+    // Reload base pointers for remainder
+    MOVD outRe_base+0(FP), R0
+    MOVD outIm_base+24(FP), R1
+    MOVD zRe_base+48(FP), R2
+    MOVD zIm_base+72(FP), R3
+    MOVD twRe_base+96(FP), R4
+    MOVD twIm_base+120(FP), R5
+    MOVD n+144(FP), R6
+
+    // Calculate starting k for remainder: 1 + 2 * num_full_iterations
+    SUB $1, R6, R7                   // R7 = n - 1
+    LSR $1, R7                       // R7 = num_full_iterations
+    LSL $1, R7                       // R7 = 2 * num_full_iterations
+    ADD $1, R7                       // R7 = starting k
+
+    // Offset pointers to starting k
+    LSL $3, R7, R8                   // R8 = k * 8 bytes
+    ADD R8, R0                       // R0 = &outRe[k]
+    ADD R8, R1                       // R1 = &outIm[k]
+    ADD R8, R2                       // R2 = &zRe[k]
+    ADD R8, R3                       // R3 = &zIm[k]
+
+    // Twiddle offset is (k-1)
+    SUB $1, R7
+    LSL $3, R7, R8
+    ADD R8, R4                       // R4 = &twRe[k-1]
+    ADD R8, R5                       // R5 = &twIm[k-1]
+    ADD $1, R7                       // Restore R7 = k
+
+realfft64_neon_scalar:
+    // Calculate mirror index: nk = n - k
+    SUB R7, R6, R8                   // R8 = n - k = nk
+
+    // Load Z[k]
+    FMOVD (R2), F0                   // F0 = zRe[k]
+    FMOVD (R3), F1                   // F1 = zIm[k]
+
+    // Load conj(Z[n-k])
+    MOVD zRe_base+48(FP), R9
+    LSL $3, R8, R10
+    ADD R10, R9
+    FMOVD (R9), F2                   // F2 = zRe[nk]
+
+    MOVD zIm_base+72(FP), R9
+    ADD R10, R9
+    FMOVD (R9), F3                   // F3 = zIm[nk]
+
+    // Negate F3 for conjugate: znkIm = -zIm[nk]
+    FNEGD F3, F3                     // F3 = -zIm[nk] = znkIm
+
+    // Load 0.5 constant
+    MOVD $0x3FE0000000000000, R11
+    FMOVD R11, F13                   // F13 = 0.5
+
+    // evenRe = 0.5 * (zkRe + znkRe)
+    FADDD F0, F2, F4                 // F4 = zkRe + znkRe
+    FMULD F4, F13, F4                // F4 = evenRe
+
+    // evenIm = 0.5 * (zkIm + znkIm)
+    FADDD F1, F3, F5                 // F5 = zkIm + znkIm
+    FMULD F5, F13, F5                // F5 = evenIm
+
+    // diffRe = zkRe - znkRe
+    FSUBD F2, F0, F6                 // F6 = diffRe
+
+    // diffIm = zkIm - znkIm
+    FSUBD F3, F1, F7                 // F7 = diffIm
+
+    // Load twiddles
+    FMOVD (R4), F8                   // F8 = wr
+    FMOVD (R5), F9                   // F9 = wi
+
+    // oddRe = 0.5 * (wr*diffIm + wi*diffRe)
+    FMULD F8, F7, F10                // F10 = wr * diffIm
+    FMULD F9, F6, F11                // F11 = wi * diffRe
+    FADDD F10, F11, F10              // F10 = wr*diffIm + wi*diffRe
+    FMULD F10, F13, F10              // F10 = oddRe
+
+    // oddIm = 0.5 * (wi*diffIm - wr*diffRe)
+    FMULD F9, F7, F11                // F11 = wi * diffIm
+    FMULD F8, F6, F12                // F12 = wr * diffRe
+    FSUBD F12, F11, F11              // F11 = wi*diffIm - wr*diffRe
+    FMULD F11, F13, F11              // F11 = oddIm
+
+    // output = even + odd
+    FADDD F4, F10, F0                // F0 = outRe
+    FADDD F5, F11, F1                // F1 = outIm
+
+    // Store
+    FMOVD F0, (R0)
+    FMOVD F1, (R1)
+
+    // Advance pointers
+    ADD $8, R2
+    ADD $8, R3
+    ADD $8, R4
+    ADD $8, R5
+    ADD $8, R0
+    ADD $8, R1
+    ADD $1, R7                       // k++
+
+    SUB $1, R14
+    CBNZ R14, realfft64_neon_scalar
+
+realfft64_neon_done:
+    RET

--- a/f64/f64_go.go
+++ b/f64/f64_go.go
@@ -713,3 +713,43 @@ func butterflyComplex64Go(upperRe, upperIm, lowerRe, lowerIm, twRe, twIm []float
 		lowerIm[i] = ui - tempIm
 	}
 }
+
+// realFFTUnpackHalf is the constant 0.5 used in real FFT unpack computation.
+const realFFTUnpackHalf = 0.5
+
+// realFFTUnpack64Go performs the unpacking step of real FFT.
+// For k in [1, n-1]:
+//
+//	X[k] = 0.5*(Z[k] + conj(Z[n-k])) + W[k]*(-0.5i)*(Z[k] - conj(Z[n-k]))
+func realFFTUnpack64Go(outRe, outIm, zRe, zIm, twRe, twIm []float64, n int) {
+	// Process k from 1 to n-1
+	// For each k, we need Z[k] and Z[n-k] (mirrored)
+	for k := 1; k < n; k++ {
+		nk := n - k // Mirror index
+
+		// Load Z[k] and conj(Z[n-k])
+		zkRe, zkIm := zRe[k], zIm[k]
+		znkRe, znkIm := zRe[nk], -zIm[nk] // Conjugate
+
+		// even = 0.5 * (Z[k] + conj(Z[n-k]))
+		evenRe := realFFTUnpackHalf * (zkRe + znkRe)
+		evenIm := realFFTUnpackHalf * (zkIm + znkIm)
+
+		// diff = Z[k] - conj(Z[n-k])
+		diffRe := zkRe - znkRe
+		diffIm := zkIm - znkIm
+
+		// odd = W[k] * (-0.5i) * diff
+		// W[k] is at twRe[k-1], twIm[k-1]
+		wr, wi := twRe[k-1], twIm[k-1]
+		// (-0.5i) * diff = 0.5*diffIm - 0.5i*diffRe
+		// W * (-0.5i * diff) = (wr + i*wi) * (0.5*diffIm - 0.5i*diffRe)
+		//   = 0.5*(wr*diffIm + wi*diffRe) + 0.5i*(wi*diffIm - wr*diffRe)
+		oddRe := realFFTUnpackHalf * (wr*diffIm + wi*diffRe)
+		oddIm := realFFTUnpackHalf * (wi*diffIm - wr*diffRe)
+
+		// X[k] = even + odd
+		outRe[k] = evenRe + oddRe
+		outIm[k] = evenIm + oddIm
+	}
+}

--- a/f64/f64_other.go
+++ b/f64/f64_other.go
@@ -73,3 +73,6 @@ func powElem64(dst, base, exp []float64)    { powElemGo(dst, base, exp) }
 func butterflyComplex64(upperRe, upperIm, lowerRe, lowerIm, twRe, twIm []float64) {
 	butterflyComplex64Go(upperRe, upperIm, lowerRe, lowerIm, twRe, twIm)
 }
+func realFFTUnpack64(outRe, outIm, zRe, zIm, twRe, twIm []float64, n int) {
+	realFFTUnpack64Go(outRe, outIm, zRe, zIm, twRe, twIm, n)
+}

--- a/f64/realfftunpack_test.go
+++ b/f64/realfftunpack_test.go
@@ -1,0 +1,380 @@
+package f64
+
+import (
+	"fmt"
+	"math"
+	"testing"
+)
+
+// =============================================================================
+// REAL FFT UNPACK TESTS (float64)
+// =============================================================================
+
+// realFFTUnpackRef is a test-local scalar reference, transcribed independently
+// from the unpack formula. It is an oracle independent of realFFTUnpack64Go, so a
+// mistake copied into both the kernel and its Go reference would still be caught.
+// It matches realFFTUnpack64Go numerically (both use separate multiply and add,
+// no FMA); the ~1 ULP FMA difference shows up only against the SIMD kernels. For
+// k in [1, n-1] with nk = n-k it computes X[k].
+func realFFTUnpackRef(outRe, outIm, zRe, zIm, twRe, twIm []float64, n int) {
+	for k := 1; k < n; k++ {
+		nk := n - k
+
+		// Load Z[k] and conj(Z[n-k])
+		zkRe, zkIm := zRe[k], zIm[k]
+		znkRe, znkIm := zRe[nk], -zIm[nk] // Conjugate
+
+		// even = 0.5 * (Z[k] + conj(Z[n-k]))
+		evenRe := 0.5 * (zkRe + znkRe)
+		evenIm := 0.5 * (zkIm + znkIm)
+
+		// diff = Z[k] - conj(Z[n-k])
+		diffRe := zkRe - znkRe
+		diffIm := zkIm - znkIm
+
+		// odd = W[k] * (-0.5i) * diff
+		wr, wi := twRe[k-1], twIm[k-1]
+		oddRe := 0.5 * (wr*diffIm + wi*diffRe)
+		oddIm := 0.5 * (wi*diffIm - wr*diffRe)
+
+		// X[k] = even + odd
+		outRe[k] = evenRe + oddRe
+		outIm[k] = evenIm + oddIm
+	}
+}
+
+// realFFTUnpackClose reports whether got is within the tight float64 tolerance
+// of want. Float64 FMA divergence is ~1e-13, so an absolute floor plus a
+// relative band comfortably covers it.
+func realFFTUnpackClose(got, want float64) bool {
+	diff := math.Abs(got - want)
+	return diff <= 1e-9 || diff <= math.Abs(want)*1e-11
+}
+
+func TestRealFFTUnpack(t *testing.T) {
+	// 6 and 10 give (n-1) % 4 == 1, the only AVX scalar-tail length not otherwise hit.
+	sizes := []int{2, 3, 4, 5, 6, 8, 9, 10, 16, 17, 31, 32, 33, 63, 64, 65, 128, 256, 512, 1000}
+
+	for _, n := range sizes {
+		t.Run(fmt.Sprintf("n=%d", n), func(t *testing.T) {
+			// Allocate arrays
+			zRe := make([]float64, n)
+			zIm := make([]float64, n)
+			twRe := make([]float64, n-1)
+			twIm := make([]float64, n-1)
+			outRe := make([]float64, n)
+			outIm := make([]float64, n)
+			outReRef := make([]float64, n)
+			outImRef := make([]float64, n)
+
+			// Initialize with test data
+			for i := range n {
+				zRe[i] = float64(i+1) * 0.1
+				zIm[i] = float64(i+2) * 0.2
+			}
+
+			// Generate twiddle factors
+			for k := 1; k < n; k++ {
+				angle := -2 * math.Pi * float64(k) / float64(2*n)
+				twRe[k-1] = math.Cos(angle)
+				twIm[k-1] = math.Sin(angle)
+			}
+
+			// Apply SIMD version
+			RealFFTUnpack(outRe, outIm, zRe, zIm, twRe, twIm)
+
+			// Apply reference
+			realFFTUnpackRef(outReRef, outImRef, zRe, zIm, twRe, twIm, n)
+
+			// Compare results
+			for k := 1; k < n; k++ {
+				if !realFFTUnpackClose(outRe[k], outReRef[k]) {
+					t.Errorf("outRe[%d] = %v, want %v, diff=%v", k, outRe[k], outReRef[k], outRe[k]-outReRef[k])
+				}
+				if !realFFTUnpackClose(outIm[k], outImRef[k]) {
+					t.Errorf("outIm[%d] = %v, want %v, diff=%v", k, outIm[k], outImRef[k], outIm[k]-outImRef[k])
+				}
+			}
+		})
+	}
+}
+
+func TestRealFFTUnpack_EdgeCases(t *testing.T) {
+	// Test with n < 2 (should return without doing anything)
+	t.Run("n=0", func(_ *testing.T) {
+		RealFFTUnpack(nil, nil, nil, nil, nil, nil)
+	})
+
+	t.Run("n=1", func(t *testing.T) {
+		outRe := []float64{7}
+		outIm := []float64{8}
+		zRe := []float64{1}
+		zIm := []float64{0}
+		// No twiddles needed for n=1; below realFFTUnpackMinN so it must return.
+		RealFFTUnpack(outRe, outIm, zRe, zIm, nil, nil)
+		// Should return without modifying anything since n < 2.
+		if outRe[0] != 7 || outIm[0] != 8 {
+			t.Errorf("n=1 modified output: outRe=%v outIm=%v, want unchanged", outRe[0], outIm[0])
+		}
+	})
+}
+
+func TestRealFFTUnpack_GoVsSIMD(t *testing.T) {
+	// Test that Go and SIMD implementations produce identical results.
+	// n=3 exercises the arm64 NEON path (n>2); the larger sizes exercise the
+	// amd64 AVX path (n>4).
+	sizes := []int{3, 5, 9, 16, 17, 32, 64, 128, 256, 512}
+
+	for _, n := range sizes {
+		t.Run(fmt.Sprintf("n=%d", n), func(t *testing.T) {
+			zRe := make([]float64, n)
+			zIm := make([]float64, n)
+			twRe := make([]float64, n-1)
+			twIm := make([]float64, n-1)
+			outReSIMD := make([]float64, n)
+			outImSIMD := make([]float64, n)
+			outReGo := make([]float64, n)
+			outImGo := make([]float64, n)
+
+			// Use varied test data
+			for i := range n {
+				zRe[i] = math.Sin(float64(i)*0.7) * 10
+				zIm[i] = math.Cos(float64(i)*0.9) * 10
+			}
+
+			for k := 1; k < n; k++ {
+				angle := -2 * math.Pi * float64(k) / float64(2*n)
+				twRe[k-1] = math.Cos(angle)
+				twIm[k-1] = math.Sin(angle)
+			}
+
+			// Run both implementations
+			RealFFTUnpack(outReSIMD, outImSIMD, zRe, zIm, twRe, twIm)
+			realFFTUnpack64Go(outReGo, outImGo, zRe, zIm, twRe, twIm, n)
+
+			// Compare with tight tolerance for FMA precision differences
+			for k := 1; k < n; k++ {
+				if !realFFTUnpackClose(outReSIMD[k], outReGo[k]) {
+					t.Errorf("k=%d outRe: SIMD=%v, Go=%v, diff=%v", k, outReSIMD[k], outReGo[k], outReSIMD[k]-outReGo[k])
+				}
+				if !realFFTUnpackClose(outImSIMD[k], outImGo[k]) {
+					t.Errorf("k=%d outIm: SIMD=%v, Go=%v, diff=%v", k, outImSIMD[k], outImGo[k], outImSIMD[k]-outImGo[k])
+				}
+			}
+		})
+	}
+}
+
+func TestRealFFTUnpack_KnownValues(t *testing.T) {
+	// Test with known values for a small case.
+	// n=4: process k=1,2,3
+	n := 4
+	zRe := []float64{1, 2, 3, 4}
+	zIm := []float64{0.1, 0.2, 0.3, 0.4}
+
+	// Twiddles for k=1,2,3: W[k] = exp(-i*2*pi*k/(2*4)) = exp(-i*pi*k/4)
+	twRe := []float64{
+		math.Cos(-math.Pi / 4),     // k=1
+		math.Cos(-math.Pi / 2),     // k=2
+		math.Cos(-3 * math.Pi / 4), // k=3
+	}
+	twIm := []float64{
+		math.Sin(-math.Pi / 4),     // k=1
+		math.Sin(-math.Pi / 2),     // k=2
+		math.Sin(-3 * math.Pi / 4), // k=3
+	}
+
+	outRe := make([]float64, n)
+	outIm := make([]float64, n)
+	outReRef := make([]float64, n)
+	outImRef := make([]float64, n)
+
+	RealFFTUnpack(outRe, outIm, zRe, zIm, twRe, twIm)
+	realFFTUnpackRef(outReRef, outImRef, zRe, zIm, twRe, twIm, n)
+
+	for k := 1; k < n; k++ {
+		if math.Abs(outRe[k]-outReRef[k]) > 1e-12 {
+			t.Errorf("k=%d outRe = %v, want %v", k, outRe[k], outReRef[k])
+		}
+		if math.Abs(outIm[k]-outImRef[k]) > 1e-12 {
+			t.Errorf("k=%d outIm = %v, want %v", k, outIm[k], outImRef[k])
+		}
+	}
+}
+
+// TestRealFFTUnpack_AllocFree pins the zero-allocation guarantee. The direct
+// cpu-flag dispatch keeps //go:noescape effective; routing through an init-time
+// function-pointer table would reintroduce heap allocations here.
+func TestRealFFTUnpack_AllocFree(t *testing.T) {
+	const n = 256
+	zRe := make([]float64, n)
+	zIm := make([]float64, n)
+	twRe := make([]float64, n-1)
+	twIm := make([]float64, n-1)
+	outRe := make([]float64, n)
+	outIm := make([]float64, n)
+	for i := range n {
+		zRe[i] = float64(i+1) * 0.1
+		zIm[i] = float64(i+2) * 0.2
+	}
+	for k := 1; k < n; k++ {
+		angle := -2 * math.Pi * float64(k) / float64(2*n)
+		twRe[k-1] = math.Cos(angle)
+		twIm[k-1] = math.Sin(angle)
+	}
+	fn := func() { RealFFTUnpack(outRe, outIm, zRe, zIm, twRe, twIm) }
+	if a := testing.AllocsPerRun(50, fn); a != 0 {
+		t.Errorf("RealFFTUnpack allocated %v times per run, want 0", a)
+	}
+}
+
+// TestRealFFTUnpack_OverRead guards the reversed mirror load. The kernel reads
+// Z[n-k] descending against Z[k] ascending; a reverse pointer sized one block too
+// far (or a forward load past the end) would read outside [0,n). zRe/zIm are
+// backed by padded arrays whose guard bands hold NaN (two AVX blocks = 8 float64
+// on each side, comfortably over one widest-kernel vector), then sliced to exactly
+// length n. Any out-of-range read pulls a NaN into an output lane, which the parity
+// check catches deterministically instead of a SIGSEGV or a coincidental match.
+// NaN is used because it is not an algebraic identity for the add/mul in the
+// unpack and can never be swallowed by the tolerance.
+func TestRealFFTUnpack_OverRead(t *testing.T) {
+	const pad = 8 // two AVX blocks of NaN guard band on each side of z
+	// Sizes vary (n-1)%4 and (n-1)%2 so both the AVX and NEON reverse paths, at
+	// their minimum reverse index and every tail length, are stressed.
+	for _, n := range []int{5, 6, 16, 17, 18, 31, 32, 33, 64, 65} {
+		t.Run(fmt.Sprintf("n=%d", n), func(t *testing.T) {
+			nan := math.NaN()
+			zReBack := make([]float64, pad+n+pad)
+			zImBack := make([]float64, pad+n+pad)
+			for i := range zReBack {
+				zReBack[i], zImBack[i] = nan, nan
+			}
+			zRe := zReBack[pad : pad+n]
+			zIm := zImBack[pad : pad+n]
+			for i := range n {
+				zRe[i] = math.Sin(float64(i)*0.7) * 10
+				zIm[i] = math.Cos(float64(i)*0.9) * 10
+			}
+			twRe := make([]float64, n-1)
+			twIm := make([]float64, n-1)
+			for k := 1; k < n; k++ {
+				angle := -2 * math.Pi * float64(k) / float64(2*n)
+				twRe[k-1] = math.Cos(angle)
+				twIm[k-1] = math.Sin(angle)
+			}
+			outRe := make([]float64, n)
+			outIm := make([]float64, n)
+			outReRef := make([]float64, n)
+			outImRef := make([]float64, n)
+
+			RealFFTUnpack(outRe, outIm, zRe, zIm, twRe, twIm)
+			realFFTUnpackRef(outReRef, outImRef, zRe, zIm, twRe, twIm, n)
+
+			for k := 1; k < n; k++ {
+				if math.IsNaN(outRe[k]) || math.IsNaN(outIm[k]) {
+					t.Fatalf("k=%d: NaN in output -> kernel over-read the zRe/zIm guard band", k)
+				}
+				if !realFFTUnpackClose(outRe[k], outReRef[k]) {
+					t.Errorf("k=%d outRe = %v, want %v", k, outRe[k], outReRef[k])
+				}
+				if !realFFTUnpackClose(outIm[k], outImRef[k]) {
+					t.Errorf("k=%d outIm = %v, want %v", k, outIm[k], outImRef[k])
+				}
+			}
+		})
+	}
+}
+
+// TestRealFFTUnpack_ShortSlices exercises the length-validation guards: with n
+// taken from len(zRe), any operand shorter than required (zIm/outRe/outIm < n, or
+// twRe/twIm < n-1) must make the call return without writing output or panicking.
+func TestRealFFTUnpack_ShortSlices(t *testing.T) {
+	const n = 8
+	makeZ := func() ([]float64, []float64) {
+		zRe := make([]float64, n)
+		zIm := make([]float64, n)
+		for i := range n {
+			zRe[i], zIm[i] = float64(i+1)*0.1, float64(i+2)*0.2
+		}
+		return zRe, zIm
+	}
+	makeTw := func(m int) ([]float64, []float64) {
+		a, b := make([]float64, m), make([]float64, m)
+		for i := range m {
+			a[i], b[i] = 0.5, -0.5
+		}
+		return a, b
+	}
+	allZero := func(t *testing.T, name string, s []float64) {
+		t.Helper()
+		for i, v := range s {
+			if v != 0 {
+				t.Errorf("%s written at [%d]=%v, want untouched (guard should have returned)", name, i, v)
+			}
+		}
+	}
+
+	cases := []struct {
+		name                              string
+		zImLen, outReLen, outImLen, twLen int
+	}{
+		{"shortZIm", n - 1, n, n, n - 1},
+		{"shortOutRe", n, n - 1, n, n - 1},
+		{"shortOutIm", n, n, n - 1, n - 1},
+		{"shortTwiddles", n, n, n, n - 2},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			zRe, zImFull := makeZ()
+			zIm := zImFull[:c.zImLen]
+			twRe, twIm := makeTw(c.twLen)
+			outRe := make([]float64, c.outReLen)
+			outIm := make([]float64, c.outImLen)
+			RealFFTUnpack(outRe, outIm, zRe, zIm, twRe, twIm)
+			allZero(t, "outRe", outRe)
+			allZero(t, "outIm", outIm)
+		})
+	}
+}
+
+func BenchmarkRealFFTUnpack(b *testing.B) {
+	sizes := []int{64, 128, 256, 512, 1024, 4096}
+
+	benchFn := func(b *testing.B, n int, fn func(outRe, outIm, zRe, zIm, twRe, twIm []float64, n int)) {
+		b.Helper()
+		zRe := make([]float64, n)
+		zIm := make([]float64, n)
+		twRe := make([]float64, n-1)
+		twIm := make([]float64, n-1)
+		outRe := make([]float64, n)
+		outIm := make([]float64, n)
+
+		for i := range n {
+			zRe[i] = float64(i) * 0.1
+			zIm[i] = float64(i) * 0.2
+		}
+		for k := 1; k < n; k++ {
+			angle := -2 * math.Pi * float64(k) / float64(2*n)
+			twRe[k-1] = math.Cos(angle)
+			twIm[k-1] = math.Sin(angle)
+		}
+
+		b.ResetTimer()
+		b.SetBytes(int64(n * 8 * 6)) // 6 float64 slices touched (in/out re/im + twiddles)
+
+		for range b.N {
+			fn(outRe, outIm, zRe, zIm, twRe, twIm, n)
+		}
+	}
+
+	for _, n := range sizes {
+		b.Run(fmt.Sprintf("SIMD_%d", n), func(b *testing.B) {
+			benchFn(b, n, func(outRe, outIm, zRe, zIm, twRe, twIm []float64, _ int) {
+				RealFFTUnpack(outRe, outIm, zRe, zIm, twRe, twIm)
+			})
+		})
+		b.Run(fmt.Sprintf("Go_%d", n), func(b *testing.B) {
+			benchFn(b, n, realFFTUnpack64Go)
+		})
+	}
+}


### PR DESCRIPTION
Adds `f64.RealFFTUnpack`, the float64 counterpart of `f32.RealFFTUnpack`, with an AVX2/FMA kernel on amd64, a NEON kernel on arm64, and a pure-Go fallback. This is the second of the f64 FFT building blocks issue #192 calls out (the first, `f64.ButterflyComplex`, shipped in #193). Together they are the two kernels `f64/stft.go`'s scalar `unravelBin` and `fftHalf` are hand-rolling; wiring them in is the next step.

`RealFFTUnpack` recombines the even/odd half-spectra of a half-length real FFT: for each bin k in [1, n-1] it computes `X[k] = 0.5*(Z[k] + conj(Z[n-k])) + W[k]*(-0.5i)*(Z[k] - conj(Z[n-k]))`. On arm64 this is the bigger win of the two kernels, because `unravelBin` is a scalar loop over bins that profiles disproportionately high on the Pi.

The kernel is a lane-width port of the proven f32 version, with the reversed/mirror load (`Z[n-k]` descending against `Z[k]` ascending) being the one part that is not a mechanical suffix swap: on AVX the 8-lane `VPERM2F128`+`VPERMILPS` reverse becomes a single `VPERMPD $0x1B` (a `VPERMILPS $0x1B` mask is invalid across 4 doubles), and on NEON the `REV64`+`EXT` pair collapses to a single `EXT #8` (there is no `.2D` form of `REV64`; swapping the two doublewords IS the reverse for two float64 lanes). The 0.5 broadcast and the conjugate sign mask use the float64 bit patterns (`0x3FE0…`, `VPSLLQ $63`). Byte strides are unchanged from f32 (4 float64 == 8 float32 == 32 bytes on AVX; 2 == 4 == 16 bytes on NEON); only lane counts and element strides change. Dispatch is a direct cpu-flag switch, keeping the operation allocation-free.

### Verification

- Parity vs a non-FMA scalar reference and vs the pure-Go path, hand-computed known values, edge cases (n below the 2-bin minimum, empty slices), and a zero-alloc assertion.
- `asmcheck` cross-verifies every new NEON `WORD` encoding against `golang.org/x/arch/arm64asm`; the goroutine-register-clobber guard passes.
- Ran the full `f64` package on real hardware: amd64 i7-1260P (AVX2) and arm64 Raspberry Pi 5 (Cortex-A76 NEON), green on both.

Refs #192.
