### PR TITLE
amd64: stop dispatching AVX2-only kernels on CPUs without AVX2

### DIFF
--- a/README.md
+++ b/README.md
@@ -345,7 +345,7 @@ Results are identical to the per-row path either way.
 |            | `MulConjComplex(dstRe,dstIm,aRe,aIm,bRe,bIm)` | Multiply by conjugate      | 8x / 4x          |
 |            | `AbsSqComplex(dst,aRe,aIm)`           | Magnitude squared                  | 8x / 4x          |
 |            | `ButterflyComplex(uRe,uIm,lRe,lIm,twRe,twIm)` | FFT butterfly with twiddle | 8x / 4x          |
-|            | `RealFFTUnpack(outRe,outIm,zRe,zIm,twRe,twIm)` | Real FFT unpack step     | 8x / 4x          |
+|            | `RealFFTUnpack(outRe,outIm,zRe,zIm,twRe,twIm)` | Real FFT unpack step     | 8x (AVX2+FMA) / 4x (NEON)          |
 | **Utility**| `Reverse(dst, src)`                   | Reverse slice order                | 8x / 4x          |
 |            | `AddSub(sum, diff, a, b)`             | Fused sum and difference           | 8x / 4x          |
 

--- a/asmcheck/asmcheck.go
+++ b/asmcheck/asmcheck.go
@@ -1,7 +1,13 @@
-// Package asmcheck validates hand-encoded ARM64 WORD directives against
-// the instruction described in their comment. It decodes each 32-bit word with
-// the same disassembler go tool objdump uses, so it runs on any architecture
-// with no ARM hardware.
+// Package asmcheck validates this repository's hand-written assembly.
+//
+// Two independent checks live here. ARM64 hand-encoded WORD directives are
+// decoded and compared against the instruction their comment claims, using the
+// same disassembler go tool objdump uses. AMD64 kernels are classified by the
+// x86 SIMD feature level their instructions require, so a kernel's body cannot
+// outrun the CPU feature its dispatch guard demands.
+//
+// Both are pure source analysis, so they run on any architecture with no ARM or
+// x86 hardware.
 package asmcheck
 
 import (
@@ -45,8 +51,9 @@ type Directive struct {
 	Source  CommentSource
 }
 
-// ScanSource parses every WORD $0x... directive in src, associating each with
-// its inline comment, or the comment on the line directly above it.
+// ScanSource parses every ARM64 WORD $0x... directive in src, associating each
+// with its inline comment, or the comment on the line directly above it. For the
+// AMD64 feature-level scanner see ScanX86Source.
 func ScanSource(src string) []Directive {
 	lines := strings.Split(src, "\n")
 	out := make([]Directive, 0, len(lines))

--- a/asmcheck/x86isa.go
+++ b/asmcheck/x86isa.go
@@ -1,0 +1,262 @@
+package asmcheck
+
+// This file adds a static ISA-level check for the AMD64 assembly. For every TEXT
+// symbol it reports the instructions that need more than AVX1, so a test can
+// assert that a kernel's body never outruns the CPU feature its dispatch guard
+// requires.
+//
+// The bug class it exists to catch is real and has shipped twice (#196, #197): a
+// kernel named ...AVX, selected behind a plain cpu.X86.AVX guard, whose body in
+// fact contains AVX2-only encodings. Such a kernel faults with #UD (SIGILL) on
+// an AVX1-only CPU (Intel Sandy/Ivy Bridge, AMD Bulldozer) or on an
+// AVX+FMA3-without-AVX2 CPU (AMD Piledriver, Steamroller). The trap is that the
+// offending instruction
+// often looks innocuous: VBROADCASTSS/VBROADCASTSD accept a register source only
+// under AVX2, and every 256-bit integer operation is AVX2 because AVX1's YMM
+// support is float-only.
+//
+// The check is pure source analysis: it needs no x86 hardware, no assembler and
+// no build, so it runs everywhere the test suite does.
+
+import (
+	"regexp"
+	"strings"
+)
+
+// X86Level is the minimum x86 SIMD feature level an instruction requires.
+type X86Level int
+
+const (
+	// X86LevelAVX covers AVX1 and everything below it (SSE, scalar, and any
+	// non-SIMD instruction). It is the zero value, so an unclassified
+	// instruction never inflates a kernel's level.
+	X86LevelAVX X86Level = iota
+	// X86LevelAVX2 means the instruction was introduced by AVX2.
+	X86LevelAVX2
+	// X86LevelAVX512 means the instruction needs an AVX-512 extension.
+	X86LevelAVX512
+)
+
+// String names the feature level as it appears in this repo's kernel suffixes.
+func (l X86Level) String() string {
+	switch l {
+	case X86LevelAVX2:
+		return "AVX2"
+	case X86LevelAVX512:
+		return "AVX512"
+	default:
+		return "AVX"
+	}
+}
+
+// X86Use is one instruction that requires a feature level above AVX1.
+type X86Use struct {
+	Line   int      // 1-based line number in the scanned source
+	Text   string   // the instruction as written, with any comment stripped
+	Level  X86Level // the level the instruction needs
+	Reason string   // why it needs that level
+}
+
+// X86Kernel is one TEXT symbol together with the instructions in it that need
+// more than AVX1.
+type X86Kernel struct {
+	Name  string   // symbol name, without the leading interpunct
+	Line  int      // 1-based line of the TEXT directive
+	Level X86Level // the highest level any instruction in the body needs
+	Uses  []X86Use // instructions above AVX1, in source order; nil when clean
+}
+
+// avx2Mnemonics are AVX2-only in every VEX form, whatever their operands.
+var avx2Mnemonics = map[string]bool{
+	// Cross-lane permutes with an integer or full-width element selector.
+	"VPERMPD": true, "VPERMQ": true, "VPERMD": true, "VPERMPS": true,
+	"VPERM2I128": true, "VINSERTI128": true, "VEXTRACTI128": true,
+	"VBROADCASTI128": true,
+	// Integer broadcasts.
+	"VPBROADCASTB": true, "VPBROADCASTW": true,
+	"VPBROADCASTD": true, "VPBROADCASTQ": true,
+	// Per-element variable shifts, integer blend, masked move.
+	"VPSLLVD": true, "VPSLLVQ": true, "VPSRLVD": true, "VPSRLVQ": true,
+	"VPSRAVD": true, "VPBLENDD": true, "VPMASKMOVD": true, "VPMASKMOVQ": true,
+	// Gathers.
+	"VPGATHERDD": true, "VPGATHERDQ": true, "VPGATHERQD": true, "VPGATHERQQ": true,
+	"VGATHERDPS": true, "VGATHERDPD": true, "VGATHERQPS": true, "VGATHERQPD": true,
+	// AVX2 256-bit integer ops whose mnemonic does not start with VP, so the
+	// VP-on-YMM rule below cannot catch them. Both have a 128-bit SSE4.1 form.
+	"VMPSADBW": true, "VMOVNTDQA": true,
+}
+
+// opaqueDirectives emit instruction bytes the assembler never sees as a
+// mnemonic. This repo hand-encodes on amd64 deliberately: go1.26 assembles
+// VPDPWSSD to the EVEX (AVX-512) form, which faults on Alder Lake, so i16's
+// AVX-VNNI kernel spells it as BYTE directives instead (#169). Such bytes are
+// opaque to source analysis, so treating them as AVX1-legal would let the
+// repo's own documented workaround smuggle an arbitrarily high instruction into
+// a kernel named for a lower tier. They report AVX2 instead: not because the
+// bytes are known to be AVX2, but because a hand encoding always needs an
+// explicit tier claim above plain AVX1.
+var opaqueDirectives = map[string]bool{
+	"BYTE": true, "WORD": true, "LONG": true, "QUAD": true,
+}
+
+// avx1YmmVPMnemonics are the only VP-prefixed instructions AVX1 defines on a YMM
+// operand. AVX1's 256-bit support is float-only, so every other VP... form on a
+// YMM register was introduced by AVX2. Keeping this as a closed whitelist (the
+// AVX1 instruction set is frozen) makes the VP rule fail safe: a 256-bit integer
+// operation nobody thought to enumerate is still reported. That safety is
+// specific to the VP rule; see the scope note on X86LevelAVX for what the
+// classifier as a whole does not model.
+var avx1YmmVPMnemonics = map[string]bool{
+	"VPERM2F128": true, // float lane permute
+	"VPERMILPS":  true, // in-lane float permute
+	"VPERMILPD":  true,
+	"VPTEST":     true, // 256-bit form is AVX1
+}
+
+var (
+	// textRe matches a TEXT directive and captures the symbol name. Go asm
+	// spells the package qualifier with an interpunct; a bare "." is accepted
+	// too so a hand-written or transformed source still parses.
+	textRe = regexp.MustCompile(`^TEXT\s+[·.]([A-Za-z_]\w*)`)
+	// instrRe captures an instruction mnemonic, any EVEX decorator suffix, and
+	// the operand text. Go's assembler spells AVX-512 masking, broadcast and
+	// embedded rounding as a dotted suffix (VADDPD.RN_SAE, VMOVUPS.Z), so the
+	// suffix has to be part of the pattern; without it those lines match nothing
+	// and are skipped as though they were not instructions at all.
+	instrRe = regexp.MustCompile(`^([A-Z][A-Z0-9]*)((?:\.[A-Z0-9_]+)*)(?:\s+(.*))?$`)
+	// ymmRe matches a YMM register operand.
+	ymmRe = regexp.MustCompile(`\bY\d+\b`)
+	// zmmRe matches a ZMM register operand.
+	zmmRe = regexp.MustCompile(`\bZ\d+\b`)
+	// maskOperandRe matches an operand that is exactly an AVX-512 opmask
+	// register. It is applied per operand, not to the whole operand string, so
+	// a symbol that merely happens to be named K1 cannot look like a mask.
+	maskOperandRe = regexp.MustCompile(`^K[0-7]$`)
+	// xmmOperandRe matches an operand that is exactly an XMM register.
+	xmmOperandRe = regexp.MustCompile(`^X\d+$`)
+)
+
+// noFeatureMnemonics are directives and instructions that carry no SIMD feature
+// level, so they are classified without inspecting their operands.
+var noFeatureMnemonics = map[string]bool{
+	"TEXT": true, "DATA": true, "GLOBL": true, "FUNCDATA": true,
+	"PCDATA": true, "RET": true, "NOP": true,
+}
+
+// stripAsmComment removes a trailing // comment and surrounding whitespace from
+// one line of Go assembly.
+func stripAsmComment(line string) string {
+	if i := strings.Index(line, "//"); i >= 0 {
+		line = line[:i]
+	}
+	return strings.TrimSpace(line)
+}
+
+// hasMaskOperand reports whether any operand is an AVX-512 opmask register.
+func hasMaskOperand(operands string) bool {
+	for op := range strings.SplitSeq(operands, ",") {
+		if maskOperandRe.MatchString(strings.TrimSpace(op)) {
+			return true
+		}
+	}
+	return false
+}
+
+// x86InstrLevel classifies one AMD64 instruction, returning the feature level it
+// needs and a short reason. Anything AVX1-legal, and anything that is not an
+// instruction at all, reports X86LevelAVX with an empty reason.
+func x86InstrLevel(instr string) (level X86Level, reason string) {
+	m := instrRe.FindStringSubmatch(instr)
+	if m == nil {
+		return X86LevelAVX, ""
+	}
+	mnem, decorator, operands := m[1], m[2], m[3]
+	if noFeatureMnemonics[mnem] {
+		return X86LevelAVX, ""
+	}
+	if opaqueDirectives[mnem] {
+		return X86LevelAVX2, "hand-encoded " + mnem + " directive (opaque to source analysis)"
+	}
+	if decorator != "" {
+		return X86LevelAVX512, "EVEX decorator " + decorator
+	}
+	if zmmRe.MatchString(operands) {
+		return X86LevelAVX512, "ZMM operand"
+	}
+	if hasMaskOperand(operands) {
+		return X86LevelAVX512, "opmask operand"
+	}
+	if avx2Mnemonics[mnem] {
+		return X86LevelAVX2, "AVX2-only mnemonic"
+	}
+	if strings.HasPrefix(mnem, "VP") && ymmRe.MatchString(operands) && !avx1YmmVPMnemonics[mnem] {
+		return X86LevelAVX2, "256-bit integer operation (AVX1 YMM support is float-only)"
+	}
+	// VBROADCASTSS/VBROADCASTSD take an m32/m64 source under AVX1; the
+	// register-source form was added by AVX2. Go assembly puts the source first.
+	if mnem == "VBROADCASTSS" || mnem == "VBROADCASTSD" {
+		if src, _, ok := strings.Cut(operands, ","); ok && xmmOperandRe.MatchString(strings.TrimSpace(src)) {
+			return X86LevelAVX2, "register-source " + mnem + " (AVX1 defines only the memory-source form)"
+		}
+	}
+	return X86LevelAVX, ""
+}
+
+// ScanX86Source parses every TEXT symbol in an AMD64 assembly source and reports
+// each one's required feature level together with the instructions that set it.
+// Kernels are returned in source order. Content before the first TEXT directive
+// (constant pools, includes) is ignored.
+func ScanX86Source(src string) []X86Kernel {
+	var out []X86Kernel
+	cur := -1
+	for i, raw := range strings.Split(src, "\n") {
+		line := stripAsmComment(raw)
+		if line == "" {
+			continue
+		}
+		if m := textRe.FindStringSubmatch(line); m != nil {
+			out = append(out, X86Kernel{Name: m[1], Line: i + 1})
+			cur = len(out) - 1
+			continue
+		}
+		if cur < 0 {
+			continue
+		}
+		// Go assembly allows several statements on one line separated by ";",
+		// which the hand-encoded byte runs in i16 use. Classifying the raw line
+		// would see only the first statement and treat the rest as operands.
+		for stmt := range strings.SplitSeq(line, ";") {
+			stmt = strings.TrimSpace(stmt)
+			if stmt == "" {
+				continue
+			}
+			level, reason := x86InstrLevel(stmt)
+			if level == X86LevelAVX {
+				continue
+			}
+			k := &out[cur]
+			k.Uses = append(k.Uses, X86Use{Line: i + 1, Text: stmt, Level: level, Reason: reason})
+			if level > k.Level {
+				k.Level = level
+			}
+		}
+	}
+	return out
+}
+
+// DeclaredX86Level reports the feature level a kernel's name claims, from its
+// suffix. Names ending in AVX512 claim AVX-512 and names ending in AVX2 claim
+// AVX2. AVXVNNI also claims AVX2: AVX-VNNI is the VEX-encoded form of the
+// dot-product instructions and every part that implements it also implements
+// AVX2. Everything else (an ...AVX, ...SSE2 or unsuffixed kernel) claims no more
+// than AVX1.
+func DeclaredX86Level(name string) X86Level {
+	switch {
+	case strings.HasSuffix(name, "AVX512"):
+		return X86LevelAVX512
+	case strings.HasSuffix(name, "AVX2"), strings.HasSuffix(name, "AVXVNNI"):
+		return X86LevelAVX2
+	default:
+		return X86LevelAVX
+	}
+}

--- a/asmcheck/x86isa_test.go
+++ b/asmcheck/x86isa_test.go
@@ -1,0 +1,237 @@
+package asmcheck
+
+import "testing"
+
+func TestX86InstrLevelClassification(t *testing.T) {
+	cases := []struct {
+		instr string
+		want  X86Level
+	}{
+		// AVX1-legal, or not SIMD at all.
+		{"VMOVUPS 0(SI), Y0", X86LevelAVX},
+		{"VDIVPS Y0, Y7, Y0", X86LevelAVX},
+		{"VMULPD Y1, Y2, Y3", X86LevelAVX},
+		{"VBROADCASTSS recip32_one<>(SB), Y7", X86LevelAVX},
+		{"VBROADCASTSD s+48(FP), Y1", X86LevelAVX},
+		{"VBROADCASTSS alpha+24(FP), Y3", X86LevelAVX},
+		{"VPERM2F128 $0x01, Y0, Y1, Y2", X86LevelAVX},
+		{"VPERMILPS $0x1B, Y0, Y1", X86LevelAVX},
+		{"VPTEST Y0, Y1", X86LevelAVX},
+		{"VPERMILPD $0x5, Y0, Y1", X86LevelAVX},
+		{"VINSERTF128 $1, X1, Y0, Y0", X86LevelAVX},
+		{"VEXTRACTF128 $1, Y0, X1", X86LevelAVX},
+		{"VPAND X1, X2, X3", X86LevelAVX}, // 128-bit integer VEX op is AVX1
+		{"MOVQ dst_base+0(FP), DX", X86LevelAVX},
+		{"RET", X86LevelAVX},
+		{"recip32_avx_loop32:", X86LevelAVX},
+
+		// AVX2: register-source broadcast.
+		{"VBROADCASTSS X7, Y7", X86LevelAVX2},
+		{"VBROADCASTSD X3, Y3", X86LevelAVX2},
+
+		// AVX2: 256-bit integer operations.
+		{"VPADDD Y10, Y4, Y4", X86LevelAVX2},
+		{"VPCMPEQD Y14, Y14, Y14", X86LevelAVX2},
+		{"VPSLLD $31, Y14, Y14", X86LevelAVX2},
+		{"VPSUBQ log64_off<>(SB), Y0, Y2", X86LevelAVX2},
+		{"VPMOVSXWD (SI), Y0", X86LevelAVX2},
+		{"VPABSB (SI), Y1", X86LevelAVX2},
+
+		// AVX2: mnemonics that are AVX2-only in every form.
+		{"VPERMPD $0x1B, Y2, Y2", X86LevelAVX2},
+		{"VPERMD Y3, Y9, Y3", X86LevelAVX2},
+		{"VPERMPS Y0, Y3, Y12", X86LevelAVX2},
+		{"VPBLENDD $0xAA, Y5, Y4, Y6", X86LevelAVX2},
+		{"VEXTRACTI128 $1, Y0, X3", X86LevelAVX2},
+		{"VPBROADCASTB lo+48(FP), Y3", X86LevelAVX2},
+
+		// AVX2: 256-bit integer ops whose mnemonic does not start with VP, so
+		// only the explicit list can catch them.
+		{"VMPSADBW $0, Y1, Y2, Y3", X86LevelAVX2},
+		{"VMOVNTDQA (SI), Y0", X86LevelAVX2},
+
+		// Hand-encoded bytes are opaque to source analysis, so they must not
+		// read as AVX1-legal. This is how i16 spells AVX-VNNI VPDPWSSD (#169).
+		{"BYTE $0xC4", X86LevelAVX2},
+		{"WORD $0x1234", X86LevelAVX2},
+
+		// AVX-512: ZMM or opmask operands.
+		{"VPBROADCASTD AX, Z7", X86LevelAVX512},
+		{"VMOVUPS 0(SI), Z0", X86LevelAVX512},
+		{"VDIVPS Z0, Z7, Z0", X86LevelAVX512},
+		{"VMOVUPS Y0, Y1, K1", X86LevelAVX512},
+
+		// AVX-512: an EVEX decorator is AVX-512 even with X/Y operands. Without
+		// the decorator in the mnemonic pattern these lines match nothing and
+		// are skipped as though they were not instructions.
+		{"VADDPD.RN_SAE Z1, Z2, Z3", X86LevelAVX512},
+		{"VMOVUPS.Z (SI), K1, Y0", X86LevelAVX512},
+		{"VADDPS.BCST (SI), Y1, Y2", X86LevelAVX512},
+
+		// A symbol that merely happens to be named K1 is not an opmask operand.
+		{"MOVOU K1<>(SB), X1", X86LevelAVX},
+		{"VMOVUPS zmm_const<>(SB), Y1", X86LevelAVX},
+	}
+	for _, c := range cases {
+		got, reason := x86InstrLevel(c.instr)
+		if got != c.want {
+			t.Errorf("x86InstrLevel(%q) = %v (%s), want %v", c.instr, got, reason, c.want)
+		}
+		if got != X86LevelAVX && reason == "" {
+			t.Errorf("x86InstrLevel(%q) reported %v with no reason", c.instr, got)
+		}
+	}
+}
+
+// TestX86InstrLevelIgnoresRegisterNamesInMnemonic guards against a classifier
+// that looks for a YMM register anywhere in the line: only operands count, so a
+// float mnemonic on YMM registers must stay AVX1.
+func TestX86InstrLevelClassificationIgnoresRegisterNamesInMnemonic(t *testing.T) {
+	for _, instr := range []string{"VADDPS Y0, Y1, Y2", "VXORPD Y3, Y3, Y3", "VSHUFPS $0xB1, Y1, Y1, Y4"} {
+		if got, _ := x86InstrLevel(instr); got != X86LevelAVX {
+			t.Errorf("x86InstrLevel(%q) = %v, want %v", instr, got, X86LevelAVX)
+		}
+	}
+}
+
+const scanFixture = `#include "textflag.h"
+
+DATA one<>+0x00(SB)/4, $0x3f800000
+GLOBL one<>(SB), RODATA|NOPTR, $4
+
+TEXT ·cleanAVX(SB), NOSPLIT, $0-48
+    VBROADCASTSS one<>(SB), Y7   // VBROADCASTSS X7, Y7 would be AVX2
+    VDIVPS Y0, Y7, Y0
+    RET
+
+TEXT ·dirtyAVX(SB), NOSPLIT, $0-48
+    VBROADCASTSS X7, Y7
+    VPADDD Y1, Y2, Y3
+    RET
+
+TEXT ·wideAVX512(SB), NOSPLIT, $0-48
+    VPBROADCASTD AX, Z7
+    RET
+`
+
+func TestScanX86Source(t *testing.T) {
+	kernels := ScanX86Source(scanFixture)
+	if len(kernels) != 3 {
+		t.Fatalf("got %d kernels, want 3: %+v", len(kernels), kernels)
+	}
+
+	if got := kernels[0]; got.Name != "cleanAVX" || got.Level != X86LevelAVX || len(got.Uses) != 0 {
+		t.Errorf("kernel 0 = %+v, want cleanAVX at AVX with no uses "+
+			"(the comment naming an AVX2 form must be stripped)", got)
+	}
+
+	dirty := kernels[1]
+	if dirty.Name != "dirtyAVX" || dirty.Level != X86LevelAVX2 {
+		t.Errorf("kernel 1 = %+v, want dirtyAVX at AVX2", dirty)
+	}
+	if len(dirty.Uses) != 2 {
+		t.Fatalf("dirtyAVX uses = %+v, want 2", dirty.Uses)
+	}
+	// Line numbers are 1-based and point at the offending instruction.
+	if dirty.Uses[0].Line != 12 || dirty.Uses[1].Line != 13 {
+		t.Errorf("dirtyAVX use lines = %d, %d; want 12, 13", dirty.Uses[0].Line, dirty.Uses[1].Line)
+	}
+
+	if got := kernels[2]; got.Name != "wideAVX512" || got.Level != X86LevelAVX512 {
+		t.Errorf("kernel 2 = %+v, want wideAVX512 at AVX512", got)
+	}
+}
+
+// TestScanX86SourceEmpty checks a source with no TEXT symbols, and that
+// instructions appearing before the first TEXT are not attributed to a kernel.
+func TestScanX86SourceEmpty(t *testing.T) {
+	if got := ScanX86Source("#include \"textflag.h\"\n    VPADDD Y1, Y2, Y3\n"); len(got) != 0 {
+		t.Errorf("ScanX86Source with no TEXT = %+v, want none", got)
+	}
+}
+
+func TestDeclaredX86Level(t *testing.T) {
+	cases := map[string]X86Level{
+		"reciprocalAVX":    X86LevelAVX,
+		"addScaledSSE":     X86LevelAVX,
+		"interleave2_32":   X86LevelAVX,
+		"minMaxAVX2":       X86LevelAVX2,
+		"xcorr4AVXVNNI":    X86LevelAVX2,
+		"addScaledAVX512":  X86LevelAVX512,
+		"dotProductAVX512": X86LevelAVX512,
+	}
+	for name, want := range cases {
+		if got := DeclaredX86Level(name); got != want {
+			t.Errorf("DeclaredX86Level(%q) = %v, want %v", name, got, want)
+		}
+	}
+}
+
+func TestX86LevelString(t *testing.T) {
+	cases := map[X86Level]string{
+		X86LevelAVX:    "AVX",
+		X86LevelAVX2:   "AVX2",
+		X86LevelAVX512: "AVX512",
+	}
+	for level, want := range cases {
+		if got := level.String(); got != want {
+			t.Errorf("X86Level(%d).String() = %q, want %q", int(level), got, want)
+		}
+	}
+}
+
+func TestStripAsmCommentHelper(t *testing.T) {
+	cases := map[string]string{
+		"    VPADDD Y1, Y2, Y3   // comment": "VPADDD Y1, Y2, Y3",
+		"// whole line":                      "",
+		"    VZEROUPPER":                     "VZEROUPPER",
+		"":                                   "",
+	}
+	for in, want := range cases {
+		if got := stripAsmComment(in); got != want {
+			t.Errorf("stripAsmComment(%q) = %q, want %q", in, got, want)
+		}
+	}
+}
+
+// TestScanX86SourceTakesLevelMaximum pins that a kernel reports the HIGHEST
+// level any instruction needs, not the last one seen. Without the maximum, an
+// AVX-512 instruction followed by an AVX2 one would report AVX2, so an
+// ...AVX2-named kernel containing an AVX-512 instruction would pass.
+func TestScanX86SourceTakesLevelMaximum(t *testing.T) {
+	const src = `TEXT ·mixedAVX2(SB), NOSPLIT, $0-0
+    VPBROADCASTD AX, Z7
+    VPADDD Y1, Y2, Y3
+    RET
+`
+	kernels := ScanX86Source(src)
+	if len(kernels) != 1 {
+		t.Fatalf("got %d kernels, want 1", len(kernels))
+	}
+	if kernels[0].Level != X86LevelAVX512 {
+		t.Errorf("Level = %v, want %v (the AVX-512 use must not be overwritten by "+
+			"the later AVX2 one)", kernels[0].Level, X86LevelAVX512)
+	}
+	if len(kernels[0].Uses) != 2 {
+		t.Errorf("Uses = %d, want 2", len(kernels[0].Uses))
+	}
+}
+
+// TestScanX86SourceSplitsStatements pins that several statements on one line,
+// separated by ";", are each classified. i16 writes its hand-encoded AVX-VNNI
+// instruction that way, so classifying only the first statement would hide the
+// rest as though they were operands.
+func TestScanX86SourceSplitsStatements(t *testing.T) {
+	const src = `TEXT ·joinedAVX(SB), NOSPLIT, $0-0
+    MOVQ AX, BX; VPADDD Y1, Y2, Y3
+    RET
+`
+	kernels := ScanX86Source(src)
+	if len(kernels) != 1 {
+		t.Fatalf("got %d kernels, want 1", len(kernels))
+	}
+	if kernels[0].Level != X86LevelAVX2 {
+		t.Errorf("Level = %v, want %v; the second statement on the line was not "+
+			"classified", kernels[0].Level, X86LevelAVX2)
+	}
+}

--- a/asmcheck_amd64_gate_test.go
+++ b/asmcheck_amd64_gate_test.go
@@ -1,0 +1,382 @@
+package simd
+
+// This test makes the AVX2 dispatch guards enforced rather than documented.
+//
+// TestAmd64KernelISALevel proves each kernel's BODY needs AVX2. It says nothing
+// about the kernel's dispatch, so on its own an exemption table entry is a prose
+// claim: weaken sigmoid32's guard from cpu.X86.AVX2 back to cpu.X86.AVX and the
+// ISA test still passes, silently restoring the #196/#197 SIGILL. This test
+// closes that by reading the guard out of the Go source.
+//
+// It checks every kernel whose body needs AVX2, not only the ones the exemption
+// table lists. A correctly-named ...AVX2 kernel never trips the ISA test, so
+// driving this off the table would have left the 44 correctly-named AVX2 kernels
+// in i8, i16, i32 and cint unchecked, and flipping one package's
+// `var hasAVX2 = cpu.X86.AVX2` to `cpu.X86.AVX` would be the #196 bug class
+// reintroduced wholesale with every test still green.
+//
+// The check is DOMINANCE-based, not "does the word AVX2 appear somewhere in the
+// function". The weaker form passes several unsafe shapes that occur in this
+// repo's own dispatch code: a switch whose sibling arm is AVX2-gated while the
+// arm holding the kernel is not, and a negated guard that runs the kernel on
+// exactly the CPUs that lack the feature.
+
+import (
+	"go/ast"
+	"go/parser"
+	"go/token"
+	"os"
+	"path/filepath"
+	"slices"
+	"testing"
+
+	"github.com/tphakala/simd/asmcheck"
+)
+
+// avx2GateIdents are the identifiers that establish an AVX2-or-better
+// requirement. cpu.X86.AVX2 is the direct test; AVX512F/AVX512VL imply it;
+// AVXVNNI is defined in cpu/cpu_amd64.go as AVX2 AND the VNNI bit, and
+// cpu.clearAVX2 clears it alongside AVX2, so it implies AVX2 in this repo by
+// construction. Package-level caches such as `var hasAVX2 = cpu.X86.AVX2` are
+// resolved to their initializer rather than trusted by name; see gateVars.
+var avx2GateIdents = map[string]bool{
+	"AVX2": true, "AVX512F": true, "AVX512VL": true, "AVXVNNI": true,
+}
+
+// pkgFuncs is one package's amd64 dispatch source, parsed once.
+type pkgFuncs struct {
+	funcs map[string]*ast.FuncDecl
+	// gateVars holds package-level bools whose initializer establishes AVX2,
+	// for example `var hasAVX2 = cpu.X86.AVX2`. Resolving the initializer is
+	// what stops the check trusting a name: redefining hasAVX2 as cpu.X86.AVX
+	// must fail, and by name alone it would not.
+	gateVars map[string]bool
+}
+
+// TestAmd64KernelDispatchRequiresAVX2 asserts that every AMD64 kernel whose body
+// needs AVX2 is dispatched only from a branch whose condition requires AVX2.
+func TestAmd64KernelDispatchRequiresAVX2(t *testing.T) {
+	parsed := map[string]*pkgFuncs{}
+
+	for _, file := range findAmd64Asm(t) {
+		src, err := os.ReadFile(file)
+		if err != nil {
+			t.Fatalf("read %s: %v", file, err)
+		}
+		pkgDir := filepath.Dir(file)
+
+		for _, k := range asmcheck.ScanX86Source(string(src)) {
+			// AVX-512 kernels are selected by whole init tiers rather than by a
+			// per-call branch, which this dominance check does not model. They
+			// are covered by the ISA test's name-versus-body assertion.
+			if k.Level != asmcheck.X86LevelAVX2 {
+				continue
+			}
+			pf := parsed[pkgDir]
+			if pf == nil {
+				pf = parseAmd64Package(t, pkgDir)
+				parsed[pkgDir] = pf
+			}
+			checkKernelGated(t, file, pkgDir, k, pf)
+		}
+	}
+}
+
+// checkKernelGated reports every dispatch of one AVX2-requiring kernel that is
+// not dominated by an AVX2 condition.
+func checkKernelGated(t *testing.T, file, pkgDir string, k asmcheck.X86Kernel, pf *pkgFuncs) {
+	t.Helper()
+	refs := 0
+	for _, name := range sortedFuncNames(pf.funcs) {
+		fn := pf.funcs[name]
+		if name == k.Name || fn.Body == nil {
+			continue
+		}
+		for _, path := range referencePaths(fn, k.Name) {
+			refs++
+			if dominatedByAVX2(path, fn, pf) {
+				continue
+			}
+			t.Errorf("%s: kernel %s needs AVX2, but %s.%s dispatches it from a branch "+
+				"that does not require AVX2.\n"+
+				"\tfirst AVX2 use: %s:%d %s\n"+
+				"An AVX1-only CPU (Intel Sandy/Ivy Bridge, AMD Bulldozer) or an "+
+				"AVX+FMA3-without-AVX2 CPU (AMD Piledriver, Steamroller) reaching this "+
+				"kernel faults with SIGILL. That is #196/#197. Restore the AVX2 guard on "+
+				"this branch, or move the kernel behind one.",
+				file, k.Name, pkgDir, name, file, firstUseLine(k), firstUseText(k))
+		}
+	}
+	if refs == 0 {
+		t.Errorf("%s: kernel %s needs AVX2 but nothing in %s references it. "+
+			"Either it is dead code, or its dispatch lives somewhere this test does not "+
+			"parse (only %s/*_amd64.go is read).", file, k.Name, pkgDir, pkgDir)
+	}
+}
+
+func firstUseLine(k asmcheck.X86Kernel) int {
+	if len(k.Uses) == 0 {
+		return k.Line
+	}
+	return k.Uses[0].Line
+}
+
+func firstUseText(k asmcheck.X86Kernel) string {
+	if len(k.Uses) == 0 {
+		return ""
+	}
+	return k.Uses[0].Text + "  (" + k.Uses[0].Reason + ")"
+}
+
+// parseAmd64Package parses every *_amd64.go file in dir once.
+func parseAmd64Package(t *testing.T, dir string) *pkgFuncs {
+	t.Helper()
+	paths, err := filepath.Glob(filepath.Join(dir, "*_amd64.go"))
+	if err != nil {
+		t.Fatalf("glob %s: %v", dir, err)
+	}
+	if len(paths) == 0 {
+		t.Fatalf("no *_amd64.go in %s, so no dispatch could be checked", dir)
+	}
+	pf := &pkgFuncs{funcs: map[string]*ast.FuncDecl{}, gateVars: map[string]bool{}}
+	fset := token.NewFileSet()
+	for _, p := range paths {
+		f, perr := parser.ParseFile(fset, p, nil, parser.SkipObjectResolution)
+		if perr != nil {
+			t.Fatalf("parse %s: %v", p, perr)
+		}
+		for _, d := range f.Decls {
+			switch decl := d.(type) {
+			case *ast.FuncDecl:
+				if decl.Recv == nil {
+					pf.funcs[decl.Name.Name] = decl
+				}
+			case *ast.GenDecl:
+				collectGateVars(decl, pf.gateVars)
+			}
+		}
+	}
+	return pf
+}
+
+// collectGateVars records package-level vars whose initializer establishes AVX2.
+func collectGateVars(decl *ast.GenDecl, out map[string]bool) {
+	if decl.Tok != token.VAR {
+		return
+	}
+	for _, spec := range decl.Specs {
+		vs, ok := spec.(*ast.ValueSpec)
+		if !ok {
+			continue
+		}
+		for i, name := range vs.Names {
+			if i < len(vs.Values) && mentionsGateIdent(vs.Values[i]) {
+				out[name.Name] = true
+			}
+		}
+	}
+}
+
+// referencePaths returns, for each reference to name inside fn, the chain of
+// enclosing nodes from the function body down to the reference.
+func referencePaths(fn *ast.FuncDecl, name string) [][]ast.Node {
+	var out [][]ast.Node
+	var stack []ast.Node
+	ast.Inspect(fn.Body, func(n ast.Node) bool {
+		if n == nil {
+			stack = stack[:len(stack)-1]
+			return true
+		}
+		stack = append(stack, n)
+		if id, ok := n.(*ast.Ident); ok && id.Name == name {
+			path := make([]ast.Node, len(stack))
+			copy(path, stack)
+			out = append(out, path)
+		}
+		return true
+	})
+	return out
+}
+
+// dominatedByAVX2 reports whether the reference at the end of path is reached
+// only when an AVX2 condition held.
+//
+// Two shapes count, and they are the two this repo uses. First, the reference
+// sits inside the taken branch of an `if` (or a `case`) whose condition requires
+// AVX2 positively. Second, an earlier statement in an enclosing block is an
+// early-out guard, `if !hasAVX2 { return }`, which is a negated gate whose body
+// leaves the function.
+func dominatedByAVX2(path []ast.Node, fn *ast.FuncDecl, pf *pkgFuncs) bool {
+	for i, n := range path {
+		switch node := n.(type) {
+		case *ast.IfStmt:
+			// Only the then-branch is guarded by the condition. A reference in
+			// the else-branch is reached precisely when the condition was false.
+			if i+1 < len(path) && path[i+1] == ast.Node(node.Body) && positiveGate(node.Cond, pf) {
+				return true
+			}
+		case *ast.CaseClause:
+			for _, expr := range node.List {
+				if positiveGate(expr, pf) {
+					return true
+				}
+			}
+		case *ast.BlockStmt:
+			if i+1 < len(path) && earlyOutGuardBefore(node, path[i+1], pf) {
+				return true
+			}
+		}
+	}
+	_ = fn
+	return false
+}
+
+// earlyOutGuardBefore reports whether block contains, before stmt, an
+// `if !<avx2 gate> { ... return ... }` guard.
+func earlyOutGuardBefore(block *ast.BlockStmt, stmt ast.Node, pf *pkgFuncs) bool {
+	for _, s := range block.List {
+		if ast.Node(s) == stmt {
+			return false
+		}
+		ifStmt, ok := s.(*ast.IfStmt)
+		if !ok || !negativeGate(ifStmt.Cond, pf) {
+			continue
+		}
+		if blockExits(ifStmt.Body) {
+			return true
+		}
+	}
+	return false
+}
+
+// blockExits reports whether every path through the block leaves the function.
+// Only the shapes this repo uses are recognised: a trailing return, or a panic.
+func blockExits(b *ast.BlockStmt) bool {
+	if len(b.List) == 0 {
+		return false
+	}
+	switch last := b.List[len(b.List)-1].(type) {
+	case *ast.ReturnStmt:
+		return true
+	case *ast.ExprStmt:
+		call, ok := last.X.(*ast.CallExpr)
+		if !ok {
+			return false
+		}
+		id, ok := call.Fun.(*ast.Ident)
+		return ok && id.Name == "panic"
+	default:
+		return false
+	}
+}
+
+// positiveGate reports whether cond requires AVX2 when true. A gate identifier
+// under a `!` does not count: that is the inverted guard, which runs the kernel
+// on exactly the CPUs that lack the feature.
+func positiveGate(cond ast.Expr, pf *pkgFuncs) bool {
+	return gatePolarity(cond, pf, false)
+}
+
+// negativeGate reports whether cond is true when AVX2 is ABSENT.
+func negativeGate(cond ast.Expr, pf *pkgFuncs) bool {
+	return gatePolarity(cond, pf, true)
+}
+
+// gatePolarity walks cond looking for an AVX2 gate whose sense matches want
+// (want=false: the gate as written; want=true: the gate under a `!`).
+func gatePolarity(cond ast.Expr, pf *pkgFuncs, want bool) bool {
+	found := false
+	var walk func(e ast.Expr, negated bool)
+	walk = func(e ast.Expr, negated bool) {
+		if e == nil || found {
+			return
+		}
+		switch x := e.(type) {
+		case *ast.UnaryExpr:
+			if x.Op == token.NOT {
+				walk(x.X, !negated)
+				return
+			}
+			walk(x.X, negated)
+		case *ast.BinaryExpr:
+			walk(x.X, negated)
+			walk(x.Y, negated)
+		case *ast.ParenExpr:
+			walk(x.X, negated)
+		case *ast.SelectorExpr:
+			if avx2GateIdents[x.Sel.Name] && negated == want {
+				found = true
+			}
+		case *ast.Ident:
+			if (avx2GateIdents[x.Name] || pf.gateVars[x.Name]) && negated == want {
+				found = true
+			}
+		case *ast.CallExpr:
+			// A predicate such as logSIMDOK32(n) whose body returns the gate.
+			if id, ok := x.Fun.(*ast.Ident); ok && negated == want && predicateGates(id.Name, pf) {
+				found = true
+			}
+		}
+	}
+	walk(cond, false)
+	return found
+}
+
+// predicateGates reports whether a same-package function returns an expression
+// that requires AVX2, which is how the log and pow family keeps its guard.
+func predicateGates(name string, pf *pkgFuncs) bool {
+	fn := pf.funcs[name]
+	if fn == nil || fn.Body == nil {
+		return false
+	}
+	found := false
+	ast.Inspect(fn.Body, func(n ast.Node) bool {
+		if found {
+			return false
+		}
+		ret, ok := n.(*ast.ReturnStmt)
+		if !ok {
+			return true
+		}
+		for _, r := range ret.Results {
+			if gatePolarity(r, pf, false) {
+				found = true
+			}
+		}
+		return true
+	})
+	return found
+}
+
+// mentionsGateIdent reports whether e contains an AVX2 feature identifier.
+func mentionsGateIdent(e ast.Expr) bool {
+	found := false
+	ast.Inspect(e, func(n ast.Node) bool {
+		if found {
+			return false
+		}
+		switch x := n.(type) {
+		case *ast.SelectorExpr:
+			if avx2GateIdents[x.Sel.Name] {
+				found = true
+			}
+		case *ast.Ident:
+			if avx2GateIdents[x.Name] {
+				found = true
+			}
+		}
+		return !found
+	})
+	return found
+}
+
+// sortedFuncNames returns the map's keys in a stable order so that a failure
+// reports the same way on every run.
+func sortedFuncNames(m map[string]*ast.FuncDecl) []string {
+	out := make([]string, 0, len(m))
+	for k := range m {
+		out = append(out, k)
+	}
+	slices.Sort(out)
+	return out
+}

--- a/asmcheck_amd64_isa_test.go
+++ b/asmcheck_amd64_isa_test.go
@@ -1,0 +1,157 @@
+package simd
+
+import (
+	"os"
+	"path/filepath"
+	"strconv"
+	"strings"
+	"testing"
+
+	"github.com/tphakala/simd/asmcheck"
+)
+
+// findAmd64Asm returns every *_amd64.s file under the module root.
+func findAmd64Asm(t *testing.T) []string {
+	t.Helper()
+	var files []string
+	err := filepath.WalkDir(".", func(p string, d os.DirEntry, err error) error {
+		if err != nil {
+			return err
+		}
+		if !d.IsDir() && strings.HasSuffix(p, "_amd64.s") {
+			// Normalize to forward slashes so reporting is identical on
+			// Windows (WalkDir yields backslashes).
+			files = append(files, filepath.ToSlash(p))
+		}
+		return nil
+	})
+	if err != nil {
+		t.Fatalf("walk: %v", err)
+	}
+	if len(files) == 0 {
+		t.Fatal("no *_amd64.s files found; is the test running from the module root?")
+	}
+	return files
+}
+
+// avx2GatedAVXKernels lists kernels whose name claims only AVX but whose body
+// needs AVX2, and which are safe anyway because the Go dispatch that selects them
+// gates on cpu.X86.AVX2 (or the package's hasAVX2) rather than cpu.X86.AVX. The
+// value records that gate, so the guard is stated where the exemption is granted.
+//
+// A kernel may be added here ONLY together with its AVX2 gate. Without one, an
+// AVX1-only CPU (Intel Sandy/Ivy Bridge, AMD Bulldozer) or an
+// AVX+FMA3-without-AVX2 CPU (AMD Piledriver, Steamroller) reaches an AVX2
+// encoding and faults with SIGILL;
+// that is exactly what #196 and #197 were. Renaming an entry's kernel to the
+// ...AVX2 suffix its body requires is the better fix and lets the entry go.
+//
+// Keys are "file:kernel", because the same kernel name exists in several packages.
+// The log core and its two pow entry points share one gate per package.
+const (
+	f32LogGate = "f32_amd64.go logSIMDOK32: cpu.X86.AVX2 && cpu.X86.FMA"
+	f64LogGate = "f64_amd64.go logSIMDOK: cpu.X86.AVX2 && cpu.X86.FMA"
+)
+
+var avx2GatedAVXKernels = map[string]string{
+	// f32: 256-bit integer ops and cross-lane permutes, all AVX2-gated.
+	"f32/f32_amd64.s:interleave3AVX":         "f32_amd64.go interleaveN32: cpu.X86.AVX2",
+	"f32/f32_amd64.s:interleave6AVX":         "f32_amd64.go interleaveN32: cpu.X86.AVX2",
+	"f32/f32_amd64.s:deinterleave3AVX":       "f32_amd64.go deinterleaveN32: cpu.X86.AVX2",
+	"f32/f32_amd64.s:deinterleave6AVX":       "f32_amd64.go deinterleaveN32: cpu.X86.AVX2",
+	"f32/f32_amd64.s:sigmoidAVX":             "f32_amd64.go sigmoid32: cpu.X86.AVX2",
+	"f32/f32_amd64.s:tanhAVX":                "f32_amd64.go tanh32: cpu.X86.AVX2",
+	"f32/f32_amd64.s:expAVX":                 "f32_amd64.go exp32: cpu.X86.AVX2",
+	"f32/f32_amd64.s:logAVX":                 f32LogGate,
+	"f32/f32_amd64.s:powAVX":                 f32LogGate,
+	"f32/f32_amd64.s:powElemAVX":             f32LogGate,
+	"f32/f32_amd64.s:int16ToFloat32ScaleAVX": "f32_amd64.go int16ToFloat32Scale: cpu.X86.AVX2",
+	"f32/f32_amd64.s:realFFTUnpackAVX":       "f32_amd64.go realFFTUnpack32: cpu.X86.AVX2 && cpu.X86.FMA",
+
+	// f64: same shape as f32, plus VPERMPD in the autocorrelation and unpack steps.
+	"f64/f64_amd64.s:interleave3AVX":   "f64_amd64.go interleaveN64: cpu.X86.AVX2",
+	"f64/f64_amd64.s:deinterleave3AVX": "f64_amd64.go deinterleaveN64: cpu.X86.AVX2",
+	"f64/f64_amd64.s:deinterleave6AVX": "f64_amd64.go deinterleaveN64: cpu.X86.AVX2",
+	"f64/f64_amd64.s:sigmoidAVX":       "f64_amd64.go sigmoid64: cpu.X86.AVX2",
+	"f64/f64_amd64.s:tanhAVX":          "f64_amd64.go tanh64: cpu.X86.AVX2",
+	"f64/f64_amd64.s:expAVX":           "f64_amd64.go exp64: cpu.X86.AVX2",
+	"f64/f64_amd64.s:logAVX":           f64LogGate,
+	"f64/f64_amd64.s:powAVX":           f64LogGate,
+	"f64/f64_amd64.s:powElemAVX":       f64LogGate,
+	"f64/f64_amd64.s:autocorrStep4AVX": "f64_amd64.go autocorrelate64: hasAVX2 early-out",
+	"f64/f64_amd64.s:realFFTUnpackAVX": "f64_amd64.go realFFTUnpack64: hasAVX2 && cpu.X86.FMA",
+}
+
+// TestAmd64KernelISALevel asserts that no AMD64 kernel uses an instruction above
+// the feature level its name claims, so that a kernel dispatched behind a plain
+// cpu.X86.AVX guard cannot contain an AVX2-only encoding. Kernels that outrun
+// their name must be listed in avx2GatedAVXKernels together with the AVX2 gate
+// that protects them.
+func TestAmd64KernelISALevel(t *testing.T) {
+	usedExemption := map[string]bool{}
+
+	for _, file := range findAmd64Asm(t) {
+		src, err := os.ReadFile(file)
+		if err != nil {
+			t.Fatalf("read %s: %v", file, err)
+		}
+		kernels := asmcheck.ScanX86Source(string(src))
+		if len(kernels) == 0 {
+			t.Errorf("%s: no TEXT symbols found. Every amd64 assembly file in this "+
+				"repo defines kernels, so zero means the scanner stopped recognising "+
+				"this file's TEXT spelling and is silently checking nothing in it.", file)
+		}
+		for _, k := range kernels {
+			declared := asmcheck.DeclaredX86Level(k.Name)
+			key := file + ":" + k.Name
+			if k.Level <= declared {
+				continue
+			}
+			if gate, ok := avx2GatedAVXKernels[key]; ok {
+				usedExemption[key] = true
+				t.Logf("%s: %s needs %s, exempt via %s", file, k.Name, k.Level, gate)
+				continue
+			}
+			t.Errorf("%s:%d: kernel %s is named for %s but its body needs %s.\n"+
+				"%s"+
+				"Fix the assembly to stay within %s, rename the kernel to its real tier, "+
+				"or add %q to avx2GatedAVXKernels with the AVX2 gate that protects it.",
+				file, k.Line, k.Name, declared, k.Level,
+				formatX86Uses(file, k.Uses, declared), declared, key)
+		}
+	}
+
+	for key := range avx2GatedAVXKernels {
+		if !usedExemption[key] {
+			t.Errorf("avx2GatedAVXKernels lists %q, but that kernel no longer needs an "+
+				"exemption (it was fixed, renamed or removed); drop the entry.", key)
+		}
+	}
+}
+
+// formatX86Uses renders the offending instructions as indented, file:line
+// prefixed lines, one per distinct mnemonic and reason.
+func formatX86Uses(file string, uses []asmcheck.X86Use, declared asmcheck.X86Level) string {
+	var b strings.Builder
+	seen := map[string]bool{}
+	for _, u := range uses {
+		if u.Level <= declared {
+			continue
+		}
+		mnem, _, _ := strings.Cut(u.Text, " ")
+		if seen[mnem+u.Reason] {
+			continue
+		}
+		seen[mnem+u.Reason] = true
+		b.WriteString("\t")
+		b.WriteString(file)
+		b.WriteString(":")
+		b.WriteString(strconv.Itoa(u.Line))
+		b.WriteString(": ")
+		b.WriteString(u.Text)
+		b.WriteString("  <- ")
+		b.WriteString(u.Reason)
+		b.WriteString("\n")
+	}
+	return b.String()
+}

--- a/c64/c64_amd64.s
+++ b/c64/c64_amd64.s
@@ -145,11 +145,13 @@ TEXT ·scaleAVX(SB), NOSPLIT, $0-56
     MOVQ dst_len+8(FP), CX
     MOVQ a_base+24(FP), SI
 
-    // Load scalar s and broadcast
-    // s is at offset 48 (complex64 = 8 bytes)
-    VMOVSD s+48(FP), X8      // X8 = [sr, si, ?, ?]
-    // Broadcast to YMM: [sr,si,sr,si,sr,si,sr,si]
-    VBROADCASTSD X8, Y1
+    // Broadcast scalar s to YMM: [sr,si,sr,si,sr,si,sr,si].
+    // s is at offset 48 (complex64 = 8 bytes). Broadcasting straight from the
+    // argument slot keeps VBROADCASTSD on its AVX1 encoding, which only defines
+    // an m64 source; the register-source form is AVX2-only, and this kernel runs
+    // on the AVX+FMA tier that AVX1+FMA3 parts (AMD Piledriver and Steamroller)
+    // also reach. See #196/#197.
+    VBROADCASTSD s+48(FP), Y1
 
     // Create swapped [si,sr,si,sr,...] for cross products
     VSHUFPS $0xB1, Y1, Y1, Y4

--- a/f32/f32.go
+++ b/f32/f32.go
@@ -788,7 +788,8 @@ func ConvolveValidMaxAbsMulti(signal []float32, kernels [][]float32) float32 {
 // This is commonly used as an activation function in neural networks.
 // Processes min(len(dst), len(src)) elements.
 //
-// Uses AVX+FMA on AMD64 (8x float32), NEON on ARM64 (4x float32).
+// Uses AVX2 on AMD64 (8x float32), NEON on ARM64 (4x float32). FMA is not
+// used: the kernel reconstructs 2^k with 256-bit integer ops instead.
 func Sigmoid(dst, src []float32) {
 	n := min(len(dst), len(src))
 	if n == 0 {
@@ -800,7 +801,8 @@ func Sigmoid(dst, src []float32) {
 // SigmoidInPlace computes the sigmoid activation function in-place: a[i] = 1 / (1 + e^(-a[i])).
 // This is commonly used as an activation function in neural networks.
 //
-// Uses AVX+FMA on AMD64 (8x float32), NEON on ARM64 (4x float32).
+// Uses AVX2 on AMD64 (8x float32), NEON on ARM64 (4x float32). FMA is not
+// used: the kernel reconstructs 2^k with 256-bit integer ops instead.
 func SigmoidInPlace(a []float32) {
 	if len(a) == 0 {
 		return
@@ -846,7 +848,7 @@ func ClampScale(dst, src []float32, minVal, maxVal, scale float32) {
 // Uses fast approximation: tanh(x) ≈ x / (1 + |x|) for |x| < 1, sign(x) for |x| >= 2.5, polynomial otherwise.
 // Processes min(len(dst), len(src)) elements.
 //
-// Uses AVX on AMD64 (8x float32), NEON on ARM64 (4x float32).
+// Uses AVX2 on AMD64 (8x float32), NEON on ARM64 (4x float32).
 func Tanh(dst, src []float32) {
 	n := min(len(dst), len(src))
 	if n == 0 {
@@ -1244,7 +1246,7 @@ func ButterflyComplex(upperRe, upperIm, lowerRe, lowerIm, twRe, twIm []float32) 
 //	X[0] = Z[0].real + Z[0].imag  (DC component)
 //	X[n] = Z[0].real - Z[0].imag  (Nyquist component)
 //
-// Uses AVX+FMA on AMD64, NEON on ARM64, with pure Go fallback.
+// Uses AVX2+FMA on AMD64, NEON on ARM64, with pure Go fallback.
 func RealFFTUnpack(outRe, outIm, zRe, zIm, twRe, twIm []float32) {
 	n := len(zRe)
 	if n < realFFTUnpackMinN {

--- a/f32/f32_amd64.go
+++ b/f32/f32_amd64.go
@@ -1300,9 +1300,13 @@ func butterflyComplex32(upperRe, upperIm, lowerRe, lowerIm, twRe, twIm []float32
 }
 
 func realFFTUnpack32(outRe, outIm, zRe, zIm, twRe, twIm []float32, n int) {
-	// Use AVX+FMA if available and have enough elements
+	// realFFTUnpackAVX needs AVX2, not just AVX+FMA: it builds the sign mask with
+	// VPCMPEQD/VPSLLD on YMM and broadcasts with the register-source VBROADCASTSS,
+	// all AVX2-only. Gating on plain AVX let an AVX1+FMA part (e.g. AMD Piledriver)
+	// reach it and SIGILL. This matches realFFTUnpack64, whose reversed load needs
+	// VPERMPD. See #196.
 	// Need at least 9 elements: process k=1..n-1 where n>=9 gives 8+ iterations
-	if cpu.X86.AVX && cpu.X86.FMA && n > minAVXElements {
+	if cpu.X86.AVX2 && cpu.X86.FMA && n > minAVXElements {
 		realFFTUnpackAVX(outRe, outIm, zRe, zIm, twRe, twIm, n)
 		return
 	}

--- a/f32/f32_amd64.s
+++ b/f32/f32_amd64.s
@@ -3426,6 +3426,21 @@ sqrt32_sse_scalar:
 sqrt32_sse_done:
     RET
 
+// 1.0 in IEEE 754 single precision, the broadcast source for reciprocalAVX.
+// It lives in memory rather than being materialized in a register because
+// VBROADCASTSS only takes an m32 source under AVX1; the register-source
+// (ymm, xmm) form was added by AVX2, and this kernel runs on the AVX+FMA tier,
+// which AVX1+FMA3 parts (AMD Piledriver and Steamroller; original Bulldozer
+// has FMA4 but not the FMA3 this tier tests, and Excavator added AVX2) also reach. See #196/#197.
+//
+// A dedicated 4-byte symbol rather than the first dword of the existing 32-byte
+// roundf32_one<> splat: that one belongs to roundAVX, and sharing would make
+// this kernel's correctness depend on a constant it does not own. Broadcast
+// source only, so 4 bytes is the whole symbol; do not turn it into a 256-bit
+// load.
+DATA recip32_one<>+0x00(SB)/4, $0x3f800000
+GLOBL recip32_one<>(SB), RODATA|NOPTR, $4
+
 // func reciprocalAVX(dst, a []float32)
 //
 // Reciprocal via Division with Latency Hiding (float32)
@@ -3449,11 +3464,9 @@ TEXT ·reciprocalAVX(SB), NOSPLIT, $0-48
     MOVQ dst_len+8(FP), CX
     MOVQ a_base+24(FP), SI
 
-    // Broadcast 1.0 to Y7 (preserved across all iterations)
-    // 0x3f800000 is 1.0 in IEEE 754 single precision
-    MOVL $0x3f800000, AX
-    MOVD AX, X7
-    VBROADCASTSS X7, Y7
+    // Broadcast 1.0 to Y7 (preserved across all iterations).
+    // AVX1 encoding: m32 source, not the AVX2-only register source.
+    VBROADCASTSS recip32_one<>(SB), Y7
 
     // Process 32 elements per iteration (4 vectors × 8 floats)
     // This allows 4 independent VDIVPS operations to be in-flight
@@ -3634,11 +3647,13 @@ recip32_sse_done:
 TEXT ·addScaledAVX(SB), NOSPLIT, $0-56
     MOVQ dst_base+0(FP), DX
     MOVQ dst_len+8(FP), CX
-    MOVSS alpha+24(FP), X3
     MOVQ s_base+32(FP), SI
 
-    // Broadcast alpha to Y3
-    VBROADCASTSS X3, Y3
+    // Broadcast alpha to Y3 straight from its argument slot. AVX1 only defines
+    // the m32 source for VBROADCASTSS; the register-source form is AVX2-only,
+    // and this kernel runs on the AVX+FMA tier that AVX1+FMA3 parts (AMD
+    // Piledriver and Steamroller) also reach. See #196/#197.
+    VBROADCASTSS alpha+24(FP), Y3
 
     MOVQ CX, AX
     SHRQ $3, AX

--- a/f64/f64.go
+++ b/f64/f64.go
@@ -685,7 +685,8 @@ func ConvolveValidMaxAbsMulti(signal []float64, kernels [][]float64) float64 {
 // This is commonly used as an activation function in neural networks.
 // Processes min(len(dst), len(src)) elements.
 //
-// Uses AVX+FMA on AMD64 (4x float64), NEON on ARM64 (2x float64).
+// Uses AVX2 on AMD64 (4x float64), NEON on ARM64 (2x float64). FMA is not
+// used: the kernel reconstructs 2^k with 256-bit integer ops instead.
 func Sigmoid(dst, src []float64) {
 	n := min(len(dst), len(src))
 	if n == 0 {
@@ -697,7 +698,8 @@ func Sigmoid(dst, src []float64) {
 // SigmoidInPlace computes the sigmoid activation function in-place: a[i] = 1 / (1 + e^(-a[i])).
 // This is commonly used as an activation function in neural networks.
 //
-// Uses AVX+FMA on AMD64 (4x float64), NEON on ARM64 (2x float64).
+// Uses AVX2 on AMD64 (4x float64), NEON on ARM64 (2x float64). FMA is not
+// used: the kernel reconstructs 2^k with 256-bit integer ops instead.
 func SigmoidInPlace(a []float64) {
 	if len(a) == 0 {
 		return
@@ -743,7 +745,7 @@ func ClampScale(dst, src []float64, minVal, maxVal, scale float64) {
 // Uses fast approximation: tanh(x) ≈ x / (1 + |x|) for |x| < 1, sign(x) for |x| >= 2.5, polynomial otherwise.
 // Processes min(len(dst), len(src)) elements.
 //
-// Uses AVX on AMD64 (4x float64), NEON on ARM64 (2x float64).
+// Uses AVX2 on AMD64 (4x float64), NEON on ARM64 (2x float64).
 func Tanh(dst, src []float64) {
 	n := min(len(dst), len(src))
 	if n == 0 {
@@ -768,7 +770,7 @@ func TanhInPlace(a []float64) {
 // results stay finite (exp(709) is near MaxFloat64); inputs below about -709
 // underflow to 0. This matches the pure-Go fallback's clamping.
 //
-// Uses AVX on AMD64 (2x float64), NEON on ARM64 (2x float64), and falls back
+// Uses AVX2 on AMD64, NEON on ARM64 (2x float64), and falls back
 // to math.Exp otherwise.
 func Exp(dst, src []float64) {
 	n := min(len(dst), len(src))

--- a/f64/f64_amd64.s
+++ b/f64/f64_amd64.s
@@ -863,6 +863,23 @@ sqrt_avx_done:
     VZEROUPPER
     RET
 
+// 1.0 in IEEE 754 double precision, the broadcast source for reciprocalAVX.
+// It lives in memory rather than being materialized in a register because
+// VBROADCASTSD only takes an m64 source under AVX1; the register-source
+// (ymm, xmm) form was added by AVX2. This kernel is selected by BOTH the AVX+FMA
+// tier and the AVX-without-FMA tier, which is what made it the widest of the
+// five: an AVX1-only part reaches it, meaning Sandy Bridge, Ivy Bridge, and
+// original Bulldozer (which has AVX and FMA4 but neither FMA3 nor AVX2). See
+// #197.
+//
+// A dedicated 8-byte symbol rather than the first quadword of the existing
+// 32-byte roundf64_one<>/sigmoid_one64<> splats: those belong to other kernels,
+// and sharing would make this kernel's correctness depend on a constant it does
+// not own. Broadcast source only, so 8 bytes is the whole symbol; do not turn it
+// into a 256-bit load.
+DATA recip64_one<>+0x00(SB)/8, $0x3FF0000000000000
+GLOBL recip64_one<>(SB), RODATA|NOPTR, $8
+
 // func reciprocalAVX(dst, a []float64)
 //
 // Reciprocal via Division with Latency Hiding
@@ -883,11 +900,9 @@ TEXT ·reciprocalAVX(SB), NOSPLIT, $0-48
     MOVQ dst_len+8(FP), CX
     MOVQ a_base+24(FP), SI
 
-    // Broadcast 1.0 to Y3 (preserved across all iterations)
-    // 0x3FF0000000000000 is 1.0 in IEEE 754 double precision
-    MOVQ $0x3FF0000000000000, AX
-    MOVQ AX, X3
-    VBROADCASTSD X3, Y3
+    // Broadcast 1.0 to Y3 (preserved across all iterations).
+    // AVX1 encoding: m64 source, not the AVX2-only register source.
+    VBROADCASTSD recip64_one<>(SB), Y3
 
     // Process 16 elements per iteration (4 vectors × 4 doubles)
     // This allows 4 independent VDIVPD operations to be in-flight


### PR DESCRIPTION
Closes #196. Closes #197.

Both issues asked for a guard fix and both asked for the same follow-up: "sweep the other AVX-gated kernels for AVX2-only instructions". This does the sweep, fixes everything it found, and adds tests so the sweep does not have to be repeated by hand.

## What was wrong

Five kernels whose bodies contain AVX2-only encodings were selected by dispatch guards that do not require AVX2. On an AVX1-only CPU (Intel Sandy/Ivy Bridge, AMD Bulldozer) or an AVX+FMA3-without-AVX2 CPU (AMD Piledriver, Steamroller) they execute an instruction the CPU does not implement and fault with `#UD` (SIGILL).

| API | Kernel | AVX2-only encoding | Reached by |
|---|---|---|---|
| `f32.Reciprocal` | `reciprocalAVX` | `VBROADCASTSS X7, Y7` | AVX+FMA3 without AVX2 |
| `f32.AddScaled` | `addScaledAVX` | `VBROADCASTSS X3, Y3` | AVX+FMA3 without AVX2 |
| `f32.RealFFTUnpack` | `realFFTUnpackAVX` | `VBROADCASTSS X13, Y13`, `VPCMPEQD`/`VPSLLD` on YMM | AVX+FMA3 without AVX2 (#196) |
| `f64.Reciprocal` | `reciprocalAVX` | `VBROADCASTSD X3, Y3` | AVX1-only **and** AVX+FMA3 without AVX2 (#197) |
| `c64.Scale` | `scaleAVX` | `VBROADCASTSD X8, Y1` | AVX+FMA3 without AVX2 |

`f64.Reciprocal` has the widest blast radius, exactly as #197 predicted: it is assigned in both `initAVX` and `initAVXNoFMA`, so a plain Sandy Bridge reaches it.

On the affected AMD parts specifically, since #196's body lists the whole Bulldozer line: the guard tests `cpu.X86.FMA`, which is FMA3. Original Bulldozer has FMA4 but not FMA3, so it never reaches an AVX+FMA tier at all, and Excavator added AVX2. The parts that actually reach these kernels without AVX2 are Piledriver and Steamroller (confirmed against clang's `-march=bdverN` feature macros).

Two things make this class easy to miss in review:

- `VBROADCASTSS`/`VBROADCASTSD` accept a **register** source only under AVX2. AVX1 defines just the `m32`/`m64` form. Same VEX prefix, same opcode; only ModRM's mod field differs.
- Every 256-bit **integer** operation is AVX2, because AVX1's YMM support is float-only.

GNU as confirms both, independently of any reasoning in this PR:

```
$ printf '.arch generic64\n.arch .avx\n.text\nvbroadcastss %%xmm7, %%ymm7\n' | as -
{standard input}:4: Error: operand type mismatch for `vbroadcastss'
$ printf '.arch generic64\n.arch .avx2\n.text\nvbroadcastss %%xmm7, %%ymm7\n' | as -     # accepted
$ printf '.arch generic64\n.arch .avx\n.text\nvbroadcastss 0x20(%%rsp), %%ymm3\n' | as - # accepted
$ printf '.arch generic64\n.arch .avx\n.text\nvpcmpeqd %%ymm14, %%ymm14, %%ymm14\n' | as -
{standard input}:4: Error: operand size mismatch for `vpcmpeqd'
```

## The fix

**Four are fixed in the assembly, not by narrowing a guard.** In each, the value being broadcast was already in memory (an argument slot, or a compile-time constant), so the register-source form was never buying anything. Switching to the memory-source form fixes the ISA level, removes an instruction from the prologue, and keeps the AVX1 and AVX1+FMA3 tiers fully covered instead of demoting them to SSE2.

```
f32 reciprocalAVX  MOVL $0x3f800000,AX + MOVD AX,X7 + VBROADCASTSS X7,Y7  ->  VBROADCASTSS recip32_one<>(SB),Y7
f32 addScaledAVX   MOVSS alpha+24(FP),X3 + VBROADCASTSS X3,Y3             ->  VBROADCASTSS alpha+24(FP),Y3
f64 reciprocalAVX  MOVQ $0x3FF0..,AX + MOVQ AX,X3 + VBROADCASTSD X3,Y3     ->  VBROADCASTSD recip64_one<>(SB),Y3
c64 scaleAVX       VMOVSD s+48(FP),X8 + VBROADCASTSD X8,Y1                ->  VBROADCASTSD s+48(FP),Y1
```

The broadcast writes every lane, so the low lane the scalar tails read (`VDIVSS X0, X7, X0`, `VFMADD231SS X0, X3, X1`, `VDIVSD X0, X3, X0`) still holds the same value. `X8` and `AX` were dead stagers.

**The fifth, `f32.RealFFTUnpack`, takes the guard change #196 asked for**: `cpu.X86.AVX && cpu.X86.FMA` becomes `cpu.X86.AVX2 && cpu.X86.FMA`. This costs Piledriver and Steamroller the vector path for that one function, but those parts previously faulted there, so nothing that worked gets slower. It also makes f32 match `f64.RealFFTUnpack`, whose reversed load genuinely needs `VPERMPD` and was already AVX2-gated.

Worth flagging for your call: review pointed out that this kernel is only three instructions from AVX1-clean. Its whole AVX2 dependency is materialising two constants, and both already exist in the same file as 256-bit RODATA splats (`roundf32_half<>`, `roundf32_signmask<>`) that `roundAVX` already loads on the plain-AVX tier. Replacing the register-source broadcast and the `VPCMPEQD`/`VPSLLD` pair with two `VMOVUPS` loads would keep the tier and need no new data. I left it out because it means editing a hot FFT preamble for a CPU line AMD stopped making in 2016, but say the word and it is a small change.

## Keeping it fixed

The sweep that found these was manual, and nothing stopped a sixth from appearing.

**`TestAmd64KernelISALevel`** scans all 11 `*_amd64.s` files (306 TEXT symbols) and fails when a kernel's body uses an instruction above the feature level its *name* claims. The 23 kernels that legitimately outrun their name are listed in `avx2GatedAVXKernels` with the AVX2 gate that protects them, so adding a 24th forces the author to state its guard. Renaming those to the `...AVX2` suffix their bodies require would let the table go; that is a bigger, separate change.

**`TestAmd64KernelDispatchRequiresAVX2`** checks the guard itself. It covers every kernel whose body needs AVX2, not just the listed ones: a correctly-named `...AVX2` kernel never trips the ISA test, so driving this off the table would have left the 44 AVX2 kernels in i8, i16, i32 and cint unverified, and flipping one package's `var hasAVX2 = cpu.X86.AVX2` to `cpu.X86.AVX` would be this bug class reintroduced wholesale.

It is dominance-based rather than "the token AVX2 appears somewhere in this function". The weaker form is satisfied by shapes this repo actually contains: `interleaveN32` is a four-arm switch where two arms are AVX2-gated and two are not, so weakening one arm leaves a sibling's `cpu.X86.AVX2` in the same body. It also resolves package-level caches like `hasAVX2` to their initializer instead of trusting the name, and rejects an inverted guard.

Both are pure source analysis: no x86 hardware, no assembler, no build, so they run on every CI arch.

## Verification

Full suite green on an i7-1260P (AVX2+FMA, Linux) and on arm64 (Cortex-A76).

GNU objdump on the linked binaries confirms the emitted form. Go's own objdump and `x/arch/x86/x86asm` both mis-decode VEX (they render `vbroadcastss` as `sbb`), so this had to come from binutils:

```
f32.reciprocalAVX  c4 e2 7d 18 3d ...  vbroadcastss 0x100b94(%rip),%ymm7   # <recip32_one>
f32.addScaledAVX   c4 e2 7d 18 5c 24 20 vbroadcastss 0x20(%rsp),%ymm3
f64.reciprocalAVX  c4 e2 7d 19 1d ...  vbroadcastsd 0xfde40(%rip),%ymm3    # <recip64_one>
c64.scaleAVX       c4 e2 7d 19 4c 24 38 vbroadcastsd 0x38(%rsp),%ymm1
```

No `%xmm` source anywhere. The only register-source broadcast left in f32 is inside `realFFTUnpackAVX`, which is now AVX2-gated.

The tests were mutation-checked rather than observed to pass. Fifteen unsafe changes, each of which must fail the suite, and all fifteen do:

| Mutation | Caught |
|---|---|
| Weaken `sigmoid32`'s guard to `cpu.X86.AVX` | yes |
| Weaken **one arm** of the 4-arm `interleaveN32` / `deinterleaveN32` / `interleaveN64` switches (4 variants) | yes |
| Invert `sigmoid32`'s guard to `!cpu.X86.AVX2` | yes |
| Invert `autocorrelate64`'s `!hasAVX2` early-out | yes |
| Redefine `var hasAVX2 = cpu.X86.AVX` in f64 / i8 / i32 | yes |
| Weaken the transitive `logSIMDOK32` guard | yes |
| Revert `realFFTUnpack32` to #196's guard | yes |
| Reintroduce a register-source broadcast in `reciprocalAVX` | yes |
| Hide an instruction in a hand-encoded `BYTE` run | yes |
| Hide an instruction behind an EVEX decorator (`VADDPD.RN_SAE`) | yes |
| *Control: a comment-only edit* | *correctly not caught* |

Benchmarks (i7-1260P, pinned core, `-count 8`, benchstat): f64 `Reciprocal` flat at every size from 128 to 65536 (geomean +0.01%), f32 `Reciprocal_1000` flat, f32 `AddScaled_1000` -6.74%, c64 `Scale/SIMD` +0.83%.

Neither moving number is attributable to the change. No function in any of the three binaries changed address, every loop body is byte-identical, and only each prologue shrank (by 4, 5 and 11 bytes, absorbed by existing inter-function padding), so both are code placement. The two flat kernels are `VDIVPS`/`VDIVPD`-throughput-bound and insensitive to placement, which is consistent. On the merits the new forms are strictly better: one fewer uop each, and two fewer port-5 shuffle slots in the RODATA cases.

## Also in here

Seven public doc comments claimed an ISA tier their guard contradicts, which this PR's own exemption table is what proves: `f32.Sigmoid`, `f32.SigmoidInPlace`, `f32.Tanh`, `f64.Sigmoid`, `f64.SigmoidInPlace`, `f64.Tanh` and `f64.Exp` all gate on `cpu.X86.AVX2`, not on AVX or AVX+FMA. Plus the README row for `f32.RealFFTUnpack`, and the `asmcheck` package doc, which described an ARM64-only package.

## Known scope limits

The classifier models the AVX / AVX2 / AVX-512 axis only, and says so at `X86LevelAVX`. It does not model FMA3, the sub-AVX1 tiers (an `...SSE2`-named kernel using SSE4.1 reads as clean, which is c64's actual shape), or F16C/PCLMULQDQ. The FMA axis is the sibling failure mode worth closing next, since `f64` and `c128` hand-maintain an `initAVXNoFMA` tier. Filed as follow-ups rather than folded in here.
