### PR TITLE
f64: add ButterflyComplexStage, the stage-level radix-2 DIT butterfly

### DIFF
--- a/README.md
+++ b/README.md
@@ -156,11 +156,18 @@ sum := crc.Checksum16(p) // bit-identical to the scalar reference, zero-alloc
 
 **Scope:** `f64` carries the FLAC/LPC and scientific double-precision surface,
 including `Autocorrelate` (lag-vectorized LPC autocorrelation) and the split-format
-FFT butterfly building blocks (`ButterflyComplex`, `RealFFTUnpack`) that a
-double-precision FFT/STFT path needs. The broader audio/ML helpers (PCM
-conversions, the general split-format complex ops such as `MulComplex` /
-`AbsSqComplex`, indexed/strided dot products) live in `f32` instead, so the two
-float surfaces remain intentionally asymmetric.
+FFT butterfly building blocks (`ButterflyComplex`, `ButterflyComplexStage`,
+`RealFFTUnpack`) that a double-precision FFT/STFT path needs. The broader
+audio/ML helpers (PCM conversions, the general split-format complex ops such as
+`MulComplex` / `AbsSqComplex`, indexed/strided dot products) live in `f32`
+instead, so the two float surfaces remain intentionally asymmetric.
+
+Prefer `ButterflyComplexStage` over `ButterflyComplex` when driving a whole
+transform. It takes the stage rather than one block, so the per-block call
+overhead disappears and the short spans, which cannot fill a vector along `j`,
+vectorize across blocks instead. Measured over one stage of a 1024-point
+transform on an x86 core, that collapses the cost spread across spans from
+roughly 30x to under 2x, so the small-span stages stop dominating the transform.
 
 | Category        | Function                            | Description                   | SIMD Width                          |
 | --------------- | ----------------------------------- | ----------------------------- | ----------------------------------- |
@@ -212,6 +219,7 @@ float surfaces remain intentionally asymmetric.
 |                 | `AccumulateAdd(dst, src, off)`      | Overlap-add: dst[off:] += src | 8x / 4x / 2x                        |
 |                 | `Autocorrelate(autoc, x, maxLag)`   | LPC autocorrelation Σ x[i]·x[i-lag] (bit-exact) | 4x (AVX2) / 2x (NEON)     |
 | **Complex/FFT** | `ButterflyComplex(uRe,uIm,lRe,lIm,twRe,twIm)` | FFT butterfly with twiddle multiply | 4x (AVX+FMA) / 2x (NEON)   |
+|                 | `ButterflyComplexStage(re,im,span,twRe,twIm)` | One whole radix-2 DIT stage (any span) | 4x (AVX+FMA) / 2x (NEON)   |
 |                 | `RealFFTUnpack(outRe,outIm,zRe,zIm,twRe,twIm)` | Real-FFT even/odd unpack step | 4x (AVX2) / 2x (NEON)       |
 | **Audio**       | `Interleave2(dst, a, b)`            | Pack stereo: [L,R,L,R,...]    | 4x / 2x                             |
 |                 | `Deinterleave2(a, b, src)`          | Unpack stereo to channels     | 4x / 2x                             |

--- a/f64/butterfly_complex_stage_test.go
+++ b/f64/butterfly_complex_stage_test.go
@@ -81,12 +81,21 @@ func stageTestData(n, span int) (re, im, twRe, twIm []float64) {
 // 1e-3 in magnitude.
 const stageTwiddlePhase = 0.4
 
+// Tolerances for closeEnough. The absolute floor carries values near zero, where a
+// relative bound is meaningless because the butterfly's sum and difference can
+// cancel to nearly nothing; the relative bound carries everything else. Both match
+// TestButterflyComplex's relTol.
+const (
+	stageAbsTol = 1e-9
+	stageRelTol = 1e-11
+)
+
 // closeEnough is the tolerance used throughout: the vector and scalar paths fuse
 // their multiply-adds differently, so they agree to within rounding rather than
-// exactly. It matches TestButterflyComplex's relTol.
+// exactly.
 func closeEnough(got, want float64) bool {
 	diff := math.Abs(got - want)
-	return diff <= 1e-9 || diff <= math.Abs(want)*1e-11
+	return diff <= stageAbsTol || diff <= math.Abs(want)*stageRelTol
 }
 
 // stageSpans covers every dispatch path: span 1 and 2 are the block-axis AVX

--- a/f64/butterfly_complex_stage_test.go
+++ b/f64/butterfly_complex_stage_test.go
@@ -174,6 +174,13 @@ func TestButterflyComplexStage_MatchesPerBlockLoop(t *testing.T) {
 	}
 }
 
+// stageSIMDvsGoTol bounds the SIMD-vs-Go difference. Both sides compute the same
+// stage over the same data and differ only in how their multiply-adds fuse, so this
+// is a tighter absolute bound than closeEnough, which compares against a separate
+// scalar reference. On stageTestData's inputs (magnitudes of order 10) the observed
+// difference is a few ULP, far under this.
+const stageSIMDvsGoTol = 1e-12
+
 func TestButterflyComplexStage_SIMDvsGo(t *testing.T) {
 	for _, span := range stageSpans {
 		for _, blocks := range stageBlockCounts {
@@ -190,10 +197,10 @@ func TestButterflyComplexStage_SIMDvsGo(t *testing.T) {
 				butterflyComplexStage64Go(reGo, imGo, span, blocks, twRe, twIm)
 
 				for i := range n {
-					if math.Abs(re[i]-reGo[i]) > 1e-12 {
+					if math.Abs(re[i]-reGo[i]) > stageSIMDvsGoTol {
 						t.Errorf("re[%d]: SIMD=%v, Go=%v", i, re[i], reGo[i])
 					}
-					if math.Abs(im[i]-imGo[i]) > 1e-12 {
+					if math.Abs(im[i]-imGo[i]) > stageSIMDvsGoTol {
 						t.Errorf("im[%d]: SIMD=%v, Go=%v", i, im[i], imGo[i])
 					}
 				}

--- a/f64/butterfly_complex_stage_test.go
+++ b/f64/butterfly_complex_stage_test.go
@@ -1,0 +1,485 @@
+package f64
+
+import (
+	"fmt"
+	"math"
+	"testing"
+)
+
+// =============================================================================
+// BUTTERFLY COMPLEX STAGE TESTS (float64)
+// =============================================================================
+
+// butterflyComplexStageRef is an independent reference for one radix-2
+// decimation-in-time stage. It indexes re/im directly rather than delegating to
+// butterflyComplex64Go, so it does not share code with the implementation under
+// test.
+//
+// It is not an unfused baseline: whether these expressions fuse is the Go
+// compiler's choice, and it makes different choices per architecture (it
+// contracts them on ARM64, not on AMD64). Comparisons against it are therefore
+// tolerance-based, never bit-exact.
+func butterflyComplexStageRef(re, im []float64, span int, twRe, twIm []float64) {
+	if span <= 0 || len(twRe) < span || len(twIm) < span {
+		return
+	}
+	n := min(len(re), len(im))
+	for k := 0; k+2*span <= n; k += 2 * span {
+		for j := range span {
+			u, l := k+j, k+span+j
+
+			lr, li := re[l], im[l]
+			tr, ti := twRe[j], twIm[j]
+			tempRe := lr*tr - li*ti
+			tempIm := lr*ti + li*tr
+
+			ur, ui := re[u], im[u]
+			re[u] = ur + tempRe
+			im[u] = ui + tempIm
+			re[l] = ur - tempRe
+			im[l] = ui - tempIm
+		}
+	}
+}
+
+// stageTestData fills split-complex arrays and a twiddle pair with varied,
+// non-degenerate values. n is the element count, span the twiddle count.
+func stageTestData(n, span int) (re, im, twRe, twIm []float64) {
+	re = make([]float64, n)
+	im = make([]float64, n)
+	twRe = make([]float64, span)
+	twIm = make([]float64, span)
+	for i := range n {
+		re[i] = math.Sin(float64(i)*0.317) * float64(i%7+1)
+		im[i] = math.Cos(float64(i)*0.523) * float64(i%5+1)
+	}
+	for j := range span {
+		ang := -math.Pi * (float64(j) + stageTwiddlePhase) / float64(span)
+		sin, cos := math.Sincos(ang)
+		twRe[j] = cos
+		twIm[j] = sin
+	}
+	return re, im, twRe, twIm
+}
+
+// stageTwiddlePhase offsets the twiddle angle so that j == 0 is not the identity
+// twiddle (1, 0).
+//
+// This is load-bearing, not cosmetic. At span == 1 there is exactly one twiddle,
+// so an unoffset generator hands every span == 1 test tw = (1, 0), under which the
+// complex multiply collapses to a pass-through: temp_re = lr*1 - li*0 computes the
+// same bits as lr*1 + li*0. Any sign error in the span == 1 block-axis kernels is
+// then unobservable, and those two kernels are the whole point of the primitive.
+// Verified: before this offset existed, flipping VSUBPD to VADDPD in the AMD64
+// span == 1 path and FMLS to FMLA in the ARM64 one both passed the entire suite on
+// real hardware. A real radix-2 stage-1 twiddle IS 1+0i, so TestButterflyComplexStage_FullFFT
+// cannot cover this either; only a synthetic twiddle can.
+//
+// The phase must be non-integral, or sin lands on zero at j == 0; and 2*(j+phase)
+// must never be an odd multiple of span, or cos lands on zero. 0.4 satisfies both
+// for every span in stageSpans, keeps |tw| == 1, and leaves both components above
+// 1e-3 in magnitude.
+const stageTwiddlePhase = 0.4
+
+// closeEnough is the tolerance used throughout: the vector and scalar paths fuse
+// their multiply-adds differently, so they agree to within rounding rather than
+// exactly. It matches TestButterflyComplex's relTol.
+func closeEnough(got, want float64) bool {
+	diff := math.Abs(got - want)
+	return diff <= 1e-9 || diff <= math.Abs(want)*1e-11
+}
+
+// stageSpans covers every dispatch path: span 1 and 2 are the block-axis AVX
+// paths, span 3 is the only span that fills neither axis and so runs entirely in
+// the j-axis path's scalar tail, and 4..64 walk that path with and without a
+// tail (span%4 != 0).
+var stageSpans = []int{1, 2, 3, 4, 5, 6, 7, 8, 9, 15, 16, 17, 32, 64}
+
+// stageBlockCounts exercise the block-axis remainder tails: span 1 consumes 4
+// blocks per iteration and span 2 consumes 2, so counts 1..7 cover every
+// leftover case for both.
+var stageBlockCounts = []int{1, 2, 3, 4, 5, 6, 7, 8, 16, 33}
+
+func TestButterflyComplexStage(t *testing.T) {
+	for _, span := range stageSpans {
+		for _, blocks := range stageBlockCounts {
+			t.Run(fmt.Sprintf("span=%d/blocks=%d", span, blocks), func(t *testing.T) {
+				n := 2 * span * blocks
+				re, im, twRe, twIm := stageTestData(n, span)
+
+				reRef := make([]float64, n)
+				imRef := make([]float64, n)
+				copy(reRef, re)
+				copy(imRef, im)
+
+				ButterflyComplexStage(re, im, span, twRe, twIm)
+				butterflyComplexStageRef(reRef, imRef, span, twRe, twIm)
+
+				for i := range n {
+					if !closeEnough(re[i], reRef[i]) {
+						t.Errorf("re[%d] = %v, want %v", i, re[i], reRef[i])
+					}
+					if !closeEnough(im[i], imRef[i]) {
+						t.Errorf("im[%d] = %v, want %v", i, im[i], imRef[i])
+					}
+				}
+			})
+		}
+	}
+}
+
+// TestButterflyComplexStage_MatchesPerBlockLoop pins the migration contract that
+// motivates the API: a consumer replacing its per-block ButterflyComplex loop
+// with one ButterflyComplexStage call must get the same spectrum back.
+//
+// Exact equality is not required. The stage and the per-block wrapper can reach
+// different code for the same span (below its SIMD threshold ButterflyComplex
+// runs the scalar fallback while the stage still vectorizes), and the two do not
+// round identically. Which side is fused is not uniform either: the Go compiler
+// contracts the fallback's multiply-add on ARM64 but not on AMD64, so the
+// direction of the difference is arch-dependent and only the tolerance is
+// portable.
+func TestButterflyComplexStage_MatchesPerBlockLoop(t *testing.T) {
+	for _, span := range stageSpans {
+		for _, blocks := range []int{1, 3, 8} {
+			t.Run(fmt.Sprintf("span=%d/blocks=%d", span, blocks), func(t *testing.T) {
+				n := 2 * span * blocks
+				re, im, twRe, twIm := stageTestData(n, span)
+
+				reLoop := make([]float64, n)
+				imLoop := make([]float64, n)
+				copy(reLoop, re)
+				copy(imLoop, im)
+
+				ButterflyComplexStage(re, im, span, twRe, twIm)
+
+				for k := 0; k+2*span <= n; k += 2 * span {
+					ButterflyComplex(
+						reLoop[k:k+span], imLoop[k:k+span],
+						reLoop[k+span:k+2*span], imLoop[k+span:k+2*span],
+						twRe, twIm,
+					)
+				}
+
+				for i := range n {
+					if !closeEnough(re[i], reLoop[i]) {
+						t.Errorf("re[%d]: stage=%v, per-block loop=%v", i, re[i], reLoop[i])
+					}
+					if !closeEnough(im[i], imLoop[i]) {
+						t.Errorf("im[%d]: stage=%v, per-block loop=%v", i, im[i], imLoop[i])
+					}
+				}
+			})
+		}
+	}
+}
+
+func TestButterflyComplexStage_SIMDvsGo(t *testing.T) {
+	for _, span := range stageSpans {
+		for _, blocks := range stageBlockCounts {
+			t.Run(fmt.Sprintf("span=%d/blocks=%d", span, blocks), func(t *testing.T) {
+				n := 2 * span * blocks
+				re, im, twRe, twIm := stageTestData(n, span)
+
+				reGo := make([]float64, n)
+				imGo := make([]float64, n)
+				copy(reGo, re)
+				copy(imGo, im)
+
+				butterflyComplexStage64(re, im, span, blocks, twRe, twIm)
+				butterflyComplexStage64Go(reGo, imGo, span, blocks, twRe, twIm)
+
+				for i := range n {
+					if math.Abs(re[i]-reGo[i]) > 1e-12 {
+						t.Errorf("re[%d]: SIMD=%v, Go=%v", i, re[i], reGo[i])
+					}
+					if math.Abs(im[i]-imGo[i]) > 1e-12 {
+						t.Errorf("im[%d]: SIMD=%v, Go=%v", i, im[i], imGo[i])
+					}
+				}
+			})
+		}
+	}
+}
+
+// TestButterflyComplexStage_FullFFT drives a complete iterative Cooley-Tukey
+// transform through ButterflyComplexStage and checks it against a naive DFT.
+// Every stage of an n-point transform uses a different span (1, 2, 4, ... n/2),
+// so one run walks every vectorization path in sequence and would catch a path
+// that is individually self-consistent but wrong relative to the others.
+func TestButterflyComplexStage_FullFFT(t *testing.T) {
+	for _, n := range []int{8, 16, 32, 64, 256, 1024} {
+		t.Run(fmt.Sprintf("n=%d", n), func(t *testing.T) {
+			srcRe := make([]float64, n)
+			srcIm := make([]float64, n)
+			for i := range n {
+				srcRe[i] = math.Sin(float64(i)*0.21) + 0.5*math.Cos(float64(i)*1.7)
+				srcIm[i] = math.Cos(float64(i) * 0.13)
+			}
+
+			// Bit-reversal permutation into the working buffers.
+			re := make([]float64, n)
+			im := make([]float64, n)
+			bits := 0
+			for 1<<bits < n {
+				bits++
+			}
+			for i := range n {
+				r := 0
+				for b := range bits {
+					if i&(1<<b) != 0 {
+						r |= 1 << (bits - 1 - b)
+					}
+				}
+				re[r] = srcRe[i]
+				im[r] = srcIm[i]
+			}
+
+			twRe := make([]float64, n/2)
+			twIm := make([]float64, n/2)
+			for span := 1; span < n; span *= 2 {
+				for j := range span {
+					ang := -math.Pi * float64(j) / float64(span)
+					twRe[j] = math.Cos(ang)
+					twIm[j] = math.Sin(ang)
+				}
+				ButterflyComplexStage(re, im, span, twRe[:span], twIm[:span])
+			}
+
+			// Naive DFT reference.
+			for k := range n {
+				var wantRe, wantIm float64
+				for i := range n {
+					ang := -2 * math.Pi * float64(k) * float64(i) / float64(n)
+					c, s := math.Cos(ang), math.Sin(ang)
+					wantRe += srcRe[i]*c - srcIm[i]*s
+					wantIm += srcRe[i]*s + srcIm[i]*c
+				}
+				// Accumulated FFT/DFT rounding grows with n; scale the bound by
+				// the transform size rather than using a flat epsilon.
+				tol := 1e-10 * float64(n)
+				if math.Abs(re[k]-wantRe) > tol || math.Abs(im[k]-wantIm) > tol {
+					t.Fatalf("bin %d = (%v, %v), want (%v, %v), tol %v",
+						k, re[k], im[k], wantRe, wantIm, tol)
+				}
+			}
+		})
+	}
+}
+
+// TestButterflyComplexStage_PartialBlockUntouched pins the documented boundary:
+// blocks are processed while k+2*span <= n, so a trailing run shorter than a
+// full block must be left exactly as it was.
+func TestButterflyComplexStage_PartialBlockUntouched(t *testing.T) {
+	const sentinel = -12345.5
+
+	for _, span := range stageSpans {
+		// Dedupe: for small spans the candidates collapse onto the same value, and
+		// Go silently disambiguates the duplicate subtest names as #01/#02, which
+		// reads as coverage that is not there.
+		seen := map[int]bool{}
+		extras := make([]int, 0, 4)
+		for _, extra := range []int{1, 2, span, 2*span - 1} {
+			if extra <= 0 || extra >= 2*span || seen[extra] {
+				continue
+			}
+			seen[extra] = true
+			extras = append(extras, extra)
+		}
+
+		// blocks 4 as well as 3: the AMD64 span == 1 path consumes four blocks per
+		// vector iteration, so at blocks == 3 it never runs its vector loop at all
+		// and a trailing partial block would only ever be seen by the scalar tail.
+		for _, blocks := range []int{3, 4} {
+			for _, extra := range extras {
+				t.Run(fmt.Sprintf("span=%d/blocks=%d/extra=%d", span, blocks, extra), func(t *testing.T) {
+					checkPartialBlockUntouched(t, span, blocks, extra, sentinel)
+				})
+			}
+		}
+	}
+}
+
+// checkPartialBlockUntouched runs one shape of the partial-block boundary check:
+// the trailing `extra` elements must be untouched, and the complete blocks must
+// have been transformed.
+func checkPartialBlockUntouched(t *testing.T, span, blocks, extra int, sentinel float64) {
+	t.Helper()
+
+	used := 2 * span * blocks
+	n := used + extra
+	re, im, twRe, twIm := stageTestData(n, span)
+	beforeRe := append([]float64(nil), re...)
+	beforeIm := append([]float64(nil), im...)
+	for i := used; i < n; i++ {
+		re[i] = sentinel
+		im[i] = sentinel
+	}
+
+	ButterflyComplexStage(re, im, span, twRe, twIm)
+
+	for i := used; i < n; i++ {
+		if re[i] != sentinel {
+			t.Errorf("re[%d] = %v, want untouched sentinel %v", i, re[i], sentinel)
+		}
+		if im[i] != sentinel {
+			t.Errorf("im[%d] = %v, want untouched sentinel %v", i, im[i], sentinel)
+		}
+	}
+
+	// Assert the complete blocks WERE transformed. Without this the test passes
+	// against a stage that does nothing at all, which is exactly what its name
+	// promises to rule out.
+	for i := range used {
+		if re[i] != beforeRe[i] || im[i] != beforeIm[i] {
+			return
+		}
+	}
+	t.Errorf("no element in the %d complete-block elements changed; the stage did nothing", used)
+}
+
+// TestButterflyComplexStage_Degenerate covers every input the public wrapper is
+// documented to reject, and asserts it is a no-op rather than a panic.
+func TestButterflyComplexStage_Degenerate(t *testing.T) {
+	const span = 4
+	n := 2 * span * 2
+	_, _, twRe, twIm := stageTestData(n, span)
+
+	// nTwRe and nTwIm are separate on purpose. Driving both twiddle slices from a
+	// single field makes len(twRe) < span short-circuit first in every row, so the
+	// len(twIm) < span clause is never the one that fires and deleting it from the
+	// wrapper leaves the suite green. What it costs a caller passing a short twIm
+	// is worse than a lost no-op: the Go fallback would panic slicing twIm[:span],
+	// but the asm kernels derive every address from span and blocks, so they would
+	// read out of bounds silently. Each clause needs its own row.
+	cases := []struct {
+		name  string
+		span  int
+		nRe   int
+		nIm   int
+		nTwRe int
+		nTwIm int
+	}{
+		{"span=0", 0, n, n, span, span},
+		{"span=-1", -1, n, n, span, span},
+		{"nil slices", span, 0, 0, span, span},
+		{"nil twiddles", span, n, n, 0, 0},
+		{"twRe short", span, n, n, span - 1, span},
+		{"twIm short", span, n, n, span, span - 1},
+		{"twRe nil, twIm ok", span, n, n, 0, span},
+		{"twIm nil, twRe ok", span, n, n, span, 0},
+		{"re shorter than one block", span, 2*span - 1, n, span, span},
+		{"im shorter than one block", span, n, 2*span - 1, span, span},
+		{"exactly one element", span, 1, 1, span, span},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			// Build re and im at exactly the requested lengths, independently,
+			// so "re shorter" and "im shorter" really are distinct cases.
+			full, _, _, _ := stageTestData(n, span)
+			re := append([]float64(nil), full[:tc.nRe]...)
+			im := append([]float64(nil), full[:tc.nIm]...)
+
+			wantRe := append([]float64(nil), re...)
+			wantIm := append([]float64(nil), im...)
+
+			// Must not panic.
+			ButterflyComplexStage(re, im, tc.span, twRe[:tc.nTwRe], twIm[:tc.nTwIm])
+
+			// Every case here is a no-op: either the guard rejects it outright, or
+			// it clears the guard but contains no complete 2*span block.
+			for i := range im {
+				if im[i] != wantIm[i] {
+					t.Errorf("im[%d] = %v, want unchanged %v", i, im[i], wantIm[i])
+				}
+			}
+			for i := range re {
+				if re[i] != wantRe[i] {
+					t.Errorf("re[%d] = %v, want unchanged %v", i, re[i], wantRe[i])
+				}
+			}
+		})
+	}
+}
+
+func TestButterflyComplexStage_AllocFree(t *testing.T) {
+	// One case per vectorization path, so an allocation introduced in any of
+	// them fails here rather than only in the one shape a single case happens
+	// to take.
+	for _, span := range []int{1, 2, 3, 8} {
+		t.Run(fmt.Sprintf("span=%d", span), func(t *testing.T) {
+			n := 2 * span * 16
+			re, im, twRe, twIm := stageTestData(n, span)
+			fn := func() { ButterflyComplexStage(re, im, span, twRe, twIm) }
+			if a := testing.AllocsPerRun(50, fn); a != 0 {
+				t.Errorf("ButterflyComplexStage allocated %v times per run, want 0", a)
+			}
+		})
+	}
+}
+
+func BenchmarkButterflyComplexStage(b *testing.B) {
+	// A fixed 1024-point transform's worth of butterflies per stage, swept over
+	// span. Work is identical in every row: blocks*span is constant at 512, so the
+	// only variable is how short the runs are. This is the shape issue #198 measured.
+	//
+	// Measure on an IDLE host, and interleave by running one full sweep per process
+	// invocation at -test.count=1 rather than using -test.count=N. Two reasons:
+	// -count=N repeats each sub-benchmark N times consecutively rather than
+	// alternating the arms, and sustained benchmarking on a laptop-class part drops
+	// the sustained-load P-state, which has been observed to halve the reported
+	// rate for a whole run and to recover only after the machine idles. Both inflate
+	// absolutes without touching the Stage-vs-PerBlock ratio, so prefer the ratio.
+	//
+	// Two things the PerBlock row is NOT. At span 1 it does not reach the per-block
+	// SIMD kernel on either architecture, and at span 2 it does not on AMD64, because
+	// ButterflyComplex vectorizes only from len >= 4 there (len >= 2 on ARM64); those
+	// rows compare the stage against a scalar loop plus call overhead rather than
+	// against vector code, so they measure a new vector path as well as removed call
+	// overhead. And the in-place butterfly grows its operands, so every variant
+	// saturates to non-finite within a few thousand iterations and spends almost the
+	// whole run there; that costs nothing (Inf and NaN are full rate, and since the
+	// butterfly doubles energy per application the data grows away from the denormal
+	// range rather than into it), and it hits all three variants identically.
+	const n = 1024
+
+	// 6 and 10 are in the sweep because both leave span%4 == 2, so they are the only
+	// rows that measure the j-axis scalar tail; every power-of-two span skips it.
+	// They also give non-power-of-two block counts (85 and 51). The two block-axis
+	// remainders stay unmeasured here: they need blocks%4 != 0 at span 1 or
+	// blocks%2 != 0 at span 2, which n = 1024 cannot produce. Those are covered by
+	// stageBlockCounts in the correctness tests, not by this benchmark.
+	for _, span := range []int{1, 2, 4, 6, 8, 10, 16, 32, 64, 128, 256, 512} {
+		blocks := n / (2 * span)
+
+		// Fresh buffers per sub-benchmark so every variant starts from the same
+		// data rather than from whatever the previous one left behind.
+		b.Run(fmt.Sprintf("Stage/span=%d", span), func(b *testing.B) {
+			re, im, twRe, twIm := stageTestData(n, span)
+			for b.Loop() {
+				ButterflyComplexStage(re, im, span, twRe, twIm)
+			}
+		})
+
+		b.Run(fmt.Sprintf("PerBlock/span=%d", span), func(b *testing.B) {
+			re, im, twRe, twIm := stageTestData(n, span)
+			for b.Loop() {
+				for k := 0; k < blocks*2*span; k += 2 * span {
+					ButterflyComplex(
+						re[k:k+span], im[k:k+span],
+						re[k+span:k+2*span], im[k+span:k+2*span],
+						twRe, twIm,
+					)
+				}
+			}
+		})
+
+		b.Run(fmt.Sprintf("Go/span=%d", span), func(b *testing.B) {
+			re, im, twRe, twIm := stageTestData(n, span)
+			for b.Loop() {
+				butterflyComplexStage64Go(re, im, span, blocks, twRe, twIm)
+			}
+		})
+	}
+}

--- a/f64/f64.go
+++ b/f64/f64.go
@@ -902,6 +902,51 @@ func ButterflyComplex(upperRe, upperIm, lowerRe, lowerIm, twRe, twIm []float64) 
 	butterflyComplex64(upperRe[:n], upperIm[:n], lowerRe[:n], lowerIm[:n], twRe[:n], twIm[:n])
 }
 
+// butterflyStageRadix is the radix of a decimation-in-time stage: every block
+// holds exactly one upper half and one lower half, each span elements long, so
+// a block is butterflyStageRadix*span elements wide.
+const butterflyStageRadix = 2
+
+// ButterflyComplexStage applies one complete radix-2 decimation-in-time stage
+// in place over split-complex data. For every block k in steps of 2*span, and
+// every j in [0, span), it performs the ButterflyComplex operation on the pair
+// (k+j, k+span+j) with twiddle (twRe[j], twIm[j]):
+//
+//	temp_re = re[k+span+j]*twRe[j] - im[k+span+j]*twIm[j]
+//	temp_im = re[k+span+j]*twIm[j] + im[k+span+j]*twRe[j]
+//	re[k+j], re[k+span+j] = re[k+j]+temp_re, re[k+j]-temp_re
+//	im[k+j], im[k+span+j] = im[k+j]+temp_im, im[k+j]-temp_im
+//
+// It is the stage-level form of [ButterflyComplex]. Driving a stage through
+// ButterflyComplex costs one call per block, so the call count grows as the
+// runs get short and per-call overhead dominates the small-span stages. Taking
+// the whole stage lets the implementation pick its own vectorization axis:
+// across j when span is large enough to fill a vector, and across blocks when
+// it is not, which is not expressible through the per-block API.
+//
+// The stage is a no-op unless span > 0, len(twRe) >= span and len(twIm) >= span,
+// and it is also a no-op when no complete block fits. Blocks are processed while
+// k+2*span <= n, where n = min(len(re), len(im)); a trailing partial block is
+// left untouched.
+//
+// Uses AVX+FMA on AMD64, NEON on ARM64, with a pure Go fallback. As with
+// [ButterflyComplex], results are not guaranteed bit-identical between the
+// vector and fallback paths, so do not depend on exact equality across build
+// targets or across spans.
+func ButterflyComplexStage(re, im []float64, span int, twRe, twIm []float64) {
+	if span <= 0 || len(twRe) < span || len(twIm) < span {
+		return
+	}
+	n := min(len(re), len(im))
+	blockLen := butterflyStageRadix * span
+	blocks := n / blockLen
+	if blocks == 0 {
+		return
+	}
+	used := blocks * blockLen
+	butterflyComplexStage64(re[:used], im[:used], span, blocks, twRe[:span], twIm[:span])
+}
+
 // realFFTUnpackMinN is the minimum n required for RealFFTUnpack (need at least 2 bins).
 const realFFTUnpackMinN = 2
 

--- a/f64/f64_amd64.go
+++ b/f64/f64_amd64.go
@@ -666,11 +666,18 @@ func butterflyComplex64(upperRe, upperIm, lowerRe, lowerIm, twRe, twIm []float64
 }
 
 func butterflyComplexStage64(re, im []float64, span, blocks int, twRe, twIm []float64) {
-	// butterflyComplexStageAVX handles every span: across j when span fills a
+	// butterflyComplexStageAVX is correct for every span: across j when span fills a
 	// 4-wide YMM, across blocks for span 1 and 2. span == 3 fills neither and runs
 	// through the kernel's scalar tail, which still beats the Go fallback by roughly
 	// 2-3x because the kernel absorbs the whole block loop into one call while the
 	// Go path pays a call per block that is over the inliner's budget.
+	//
+	// The guard below is about total work, not about span: a stage carrying fewer
+	// than minAVXElements butterflies goes to Go regardless of its span. So "every
+	// span" describes what the kernel handles, not what always reaches it. The
+	// threshold is conservative rather than load-bearing, since the kernel is
+	// correct below it too; see #206 for relaxing it, which needs coverage first
+	// because every current test enters through this guard.
 	//
 	// AVX+FMA is the whole requirement, with no AVX2 anywhere: the block-axis paths
 	// shuffle with VUNPCKLPD/VUNPCKHPD and VPERM2F128 and splat their twiddles with

--- a/f64/f64_amd64.go
+++ b/f64/f64_amd64.go
@@ -665,6 +665,25 @@ func butterflyComplex64(upperRe, upperIm, lowerRe, lowerIm, twRe, twIm []float64
 	butterflyComplex64Go(upperRe, upperIm, lowerRe, lowerIm, twRe, twIm)
 }
 
+func butterflyComplexStage64(re, im []float64, span, blocks int, twRe, twIm []float64) {
+	// butterflyComplexStageAVX handles every span: across j when span fills a
+	// 4-wide YMM, across blocks for span 1 and 2. span == 3 fills neither and runs
+	// through the kernel's scalar tail, which still beats the Go fallback by roughly
+	// 2-3x because the kernel absorbs the whole block loop into one call while the
+	// Go path pays a call per block that is over the inliner's budget.
+	//
+	// AVX+FMA is the whole requirement, with no AVX2 anywhere: the block-axis paths
+	// shuffle with VUNPCKLPD/VUNPCKHPD and VPERM2F128 and splat their twiddles with
+	// the memory-source forms of VBROADCASTSD and VBROADCASTF128. The register-source
+	// VBROADCASTSD would be AVX2, which is the trap #196/#197 swept for; see the
+	// realFFTUnpack64 comment below.
+	if cpu.X86.AVX && cpu.X86.FMA && blocks*span >= minAVXElements {
+		butterflyComplexStageAVX(re, im, span, blocks, twRe, twIm)
+		return
+	}
+	butterflyComplexStage64Go(re, im, span, blocks, twRe, twIm)
+}
+
 func realFFTUnpack64(outRe, outIm, zRe, zIm, twRe, twIm []float64, n int) {
 	// realFFTUnpackAVX needs AVX2, not just AVX+FMA: the reversed load uses VPERMPD
 	// and the constants use register-source VBROADCASTSD plus VPCMPEQD/VPSLLQ on
@@ -1073,6 +1092,17 @@ func cubicInterpDotAVX(hist, a, b, c, d []float64, x float64) float64
 //
 //go:noescape
 func butterflyComplexAVX(upperRe, upperIm, lowerRe, lowerIm, twRe, twIm []float64)
+
+// ButterflyComplexStage assembly function declaration.
+//
+// Callers MUST satisfy len(re) == len(im) == 2*span*blocks and
+// len(twRe) == len(twIm) >= span, with span >= 1 and blocks >= 1. Every address
+// the kernel forms is derived from span and blocks, never from the slice headers,
+// so a violated precondition reads and writes out of bounds silently rather than
+// panicking the way the Go fallback would. ButterflyComplexStage establishes it.
+//
+//go:noescape
+func butterflyComplexStageAVX(re, im []float64, span, blocks int, twRe, twIm []float64)
 
 // RealFFTUnpack assembly function declaration
 //

--- a/f64/f64_amd64.s
+++ b/f64/f64_amd64.s
@@ -6123,7 +6123,11 @@ butterfly_done:
 // float64. For every block k in steps of 2*span and every j in [0, span), the
 // butterfly at (k+j, k+span+j) with twiddle tw[j]. Same arithmetic sequence as
 // butterflyComplexAVX above (VMULPD/VMULPD/VSUBPD then VMULPD/VFMADD231PD), so
-// a stage produces the same bits as driving butterflyComplexAVX per block.
+// a stage produces the same bits as driving THAT KERNEL per block, for every span
+// and block count tested. That is a kernel-to-kernel statement, not a claim about
+// the exported ButterflyComplex: its dispatch withholds short slices from this
+// kernel, so a per-block loop through the public API can land on the Go path and
+// round differently. Compare kernels, not entry points.
 //
 // The stage form exists to pick its own vectorization axis. Long spans vectorize
 // across j, where the twiddles and both halves of the block are contiguous. Spans

--- a/f64/f64_amd64.s
+++ b/f64/f64_amd64.s
@@ -6118,6 +6118,292 @@ butterfly_done:
     VZEROUPPER
     RET
 
+// func butterflyComplexStageAVX(re, im []float64, span, blocks int, twRe, twIm []float64)
+// One complete radix-2 decimation-in-time stage, in place over split-complex
+// float64. For every block k in steps of 2*span and every j in [0, span), the
+// butterfly at (k+j, k+span+j) with twiddle tw[j]. Same arithmetic sequence as
+// butterflyComplexAVX above (VMULPD/VMULPD/VSUBPD then VMULPD/VFMADD231PD), so
+// a stage produces the same bits as driving butterflyComplexAVX per block.
+//
+// The stage form exists to pick its own vectorization axis. Long spans vectorize
+// across j, where the twiddles and both halves of the block are contiguous. Spans
+// of 1 and 2 cannot fill a 4-wide YMM along j at all, so they vectorize across
+// blocks instead, gathering 4 (span 1) or 2 (span 2) blocks per iteration with
+// in-register shuffles. That is what a per-block API cannot express, and it is
+// where the per-call overhead used to dominate.
+//
+// span 3 is the one span with neither axis: it enters the j-axis path, whose
+// 4-wide bound (span &^ 3) is 0 there, so every butterfly runs in that path's
+// scalar tail. It is still dispatched here, because absorbing the block loop into
+// one call beats the Go fallback's call per block.
+//
+// AVX+FMA only, no AVX2: the block-axis shuffles are VUNPCKLPD/VUNPCKHPD and
+// VPERM2F128, the twiddle splats are the memory-source forms of VBROADCASTSD and
+// VBROADCASTF128 (the register-source VBROADCASTSD would be AVX2), and all vector
+// arithmetic is floating point, in 256-bit, 128-bit and scalar widths. Frame:
+// re(24)+im(24)+span(8)+blocks(8)+twRe(24)+twIm(24) = 112 bytes.
+TEXT ·butterflyComplexStageAVX(SB), NOSPLIT, $0-112
+    MOVQ re_base+0(FP), DX           // DX = re block base
+    MOVQ im_base+24(FP), R8          // R8 = im block base
+    MOVQ span+48(FP), CX             // CX = span
+    MOVQ blocks+56(FP), AX           // AX = block count
+    MOVQ twRe_base+64(FP), R9        // R9 = twRe base
+    MOVQ twIm_base+88(FP), R10       // R10 = twIm base
+
+    TESTQ AX, AX
+    JZ    bfstage_done
+    CMPQ  CX, $1
+    JEQ   bfstage_span1
+    CMPQ  CX, $2
+    JEQ   bfstage_span2
+
+// ---------------------------------------------------------------------------
+// Long span: vectorize across j. Per block, span/4 full YMM iterations over the
+// contiguous run, then a scalar tail for span%4. Twiddles restart at j=0 for
+// every block, so they are addressed by the same j index as the data.
+// ---------------------------------------------------------------------------
+    MOVQ CX, R11
+    SHLQ $3, R11                     // R11 = span*8 = upper->lower byte offset
+    MOVQ CX, R12
+    SHLQ $4, R12                     // R12 = span*16 = block stride in bytes
+    MOVQ CX, R13
+    ANDQ $-4, R13                    // R13 = span &^ 3 = 4-wide loop bound
+
+bfstage_block:
+    LEAQ (DX)(R11*1), SI             // SI = lower re for this block
+    LEAQ (R8)(R11*1), DI             // DI = lower im for this block
+    XORQ BX, BX                      // BX = j
+    CMPQ BX, R13
+    JGE  bfstage_tail_pre
+
+bfstage_vec:
+    VMOVUPD (SI)(BX*8), Y0           // Y0 = lower_re[j:j+4]
+    VMOVUPD (DI)(BX*8), Y1           // Y1 = lower_im[j:j+4]
+    VMOVUPD (R9)(BX*8), Y2           // Y2 = tw_re[j:j+4]
+    VMOVUPD (R10)(BX*8), Y3          // Y3 = tw_im[j:j+4]
+
+    VMULPD Y0, Y2, Y4                // Y4 = lr*tr
+    VMULPD Y1, Y3, Y5                // Y5 = li*ti
+    VSUBPD Y5, Y4, Y4                // Y4 = temp_re = lr*tr - li*ti
+    VMULPD Y0, Y3, Y5                // Y5 = lr*ti
+    VFMADD231PD Y1, Y2, Y5           // Y5 = temp_im = lr*ti + li*tr
+
+    VMOVUPD (DX)(BX*8), Y0           // Y0 = upper_re[j:j+4]
+    VMOVUPD (R8)(BX*8), Y1           // Y1 = upper_im[j:j+4]
+
+    VADDPD Y0, Y4, Y2                // upper_re + temp_re
+    VSUBPD Y4, Y0, Y3                // upper_re - temp_re
+    VMOVUPD Y2, (DX)(BX*8)
+    VMOVUPD Y3, (SI)(BX*8)
+    VADDPD Y1, Y5, Y2                // upper_im + temp_im
+    VSUBPD Y5, Y1, Y3                // upper_im - temp_im
+    VMOVUPD Y2, (R8)(BX*8)
+    VMOVUPD Y3, (DI)(BX*8)
+
+    ADDQ $4, BX
+    CMPQ BX, R13
+    JLT  bfstage_vec
+
+bfstage_tail_pre:
+    CMPQ BX, CX
+    JGE  bfstage_next
+
+bfstage_tail:
+    VMOVSD (SI)(BX*8), X0            // X0 = lower_re[j]
+    VMOVSD (DI)(BX*8), X1            // X1 = lower_im[j]
+    VMOVSD (R9)(BX*8), X2            // X2 = tw_re[j]
+    VMOVSD (R10)(BX*8), X3           // X3 = tw_im[j]
+
+    VMULSD X0, X2, X4
+    VMULSD X1, X3, X5
+    VSUBSD X5, X4, X4                // X4 = temp_re
+    VMULSD X0, X3, X5
+    VFMADD231SD X1, X2, X5           // X5 = temp_im
+
+    VMOVSD (DX)(BX*8), X0            // X0 = upper_re[j]
+    VMOVSD (R8)(BX*8), X1            // X1 = upper_im[j]
+
+    VADDSD X0, X4, X2
+    VSUBSD X4, X0, X3
+    VMOVSD X2, (DX)(BX*8)
+    VMOVSD X3, (SI)(BX*8)
+    VADDSD X1, X5, X2
+    VSUBSD X5, X1, X3
+    VMOVSD X2, (R8)(BX*8)
+    VMOVSD X3, (DI)(BX*8)
+
+    INCQ BX
+    CMPQ BX, CX
+    JLT  bfstage_tail
+
+bfstage_next:
+    ADDQ R12, DX
+    ADDQ R12, R8
+    DECQ AX
+    JNZ  bfstage_block
+    JMP  bfstage_done
+
+// ---------------------------------------------------------------------------
+// span == 1: each block is one pair [u, l], so the array is fully interleaved.
+// Take 4 blocks (8 float64) at a time and split them with VUNPCKLPD/VUNPCKHPD.
+// Those unpacks work inside each 128-bit half, so the four uppers land in lane
+// order (b0, b2, b1, b3) rather than (b0, b1, b2, b3). That permutation is
+// harmless: the lowers land in the SAME order, the twiddle is one broadcast
+// scalar, and the inverse unpack on the way out puts every lane back where it
+// came from. Keeping the permuted order is what avoids needing VPERMPD (AVX2).
+// ---------------------------------------------------------------------------
+bfstage_span1:
+    VBROADCASTSD (R9), Y6            // Y6 = tw_re[0] in all lanes
+    VBROADCASTSD (R10), Y7           // Y7 = tw_im[0] in all lanes
+
+    MOVQ AX, BX
+    SHRQ $2, BX                      // BX = blocks/4 = 4-block iterations
+    JZ   bfstage_span1_tail_pre
+
+bfstage_span1_vec:
+    VMOVUPD (DX), Y0                 // [u0,l0,u1,l1] re
+    VMOVUPD 32(DX), Y1               // [u2,l2,u3,l3] re
+    VUNPCKLPD Y1, Y0, Y4             // Y4 = upper_re = [u0,u2,u1,u3]
+    VUNPCKHPD Y1, Y0, Y5             // Y5 = lower_re = [l0,l2,l1,l3]
+    VMOVUPD (R8), Y2                 // [u0,l0,u1,l1] im
+    VMOVUPD 32(R8), Y3               // [u2,l2,u3,l3] im
+    VUNPCKLPD Y3, Y2, Y8             // Y8 = upper_im, same lane order
+    VUNPCKHPD Y3, Y2, Y9             // Y9 = lower_im, same lane order
+
+    VMULPD Y5, Y6, Y10               // lr*tr
+    VMULPD Y9, Y7, Y11               // li*ti
+    VSUBPD Y11, Y10, Y10             // Y10 = temp_re
+    VMULPD Y5, Y7, Y11               // lr*ti
+    VFMADD231PD Y9, Y6, Y11          // Y11 = temp_im
+
+    VADDPD Y4, Y10, Y0               // new upper_re
+    VSUBPD Y10, Y4, Y1               // new lower_re
+    VADDPD Y8, Y11, Y2               // new upper_im
+    VSUBPD Y11, Y8, Y3               // new lower_im
+
+    VUNPCKLPD Y1, Y0, Y12            // [U0,L0,U1,L1] re
+    VUNPCKHPD Y1, Y0, Y13            // [U2,L2,U3,L3] re
+    VMOVUPD Y12, (DX)
+    VMOVUPD Y13, 32(DX)
+    VUNPCKLPD Y3, Y2, Y12            // [U0,L0,U1,L1] im
+    VUNPCKHPD Y3, Y2, Y13            // [U2,L2,U3,L3] im
+    VMOVUPD Y12, (R8)
+    VMOVUPD Y13, 32(R8)
+
+    ADDQ $64, DX
+    ADDQ $64, R8
+    DECQ BX
+    JNZ  bfstage_span1_vec
+
+bfstage_span1_tail_pre:
+    ANDQ $3, AX                      // AX = leftover blocks (0..3)
+    JZ   bfstage_done
+
+bfstage_span1_tail:
+    VMOVSD 8(DX), X0                 // lower_re
+    VMOVSD 8(R8), X1                 // lower_im
+    VMULSD X0, X6, X4
+    VMULSD X1, X7, X5
+    VSUBSD X5, X4, X4                // temp_re
+    VMULSD X0, X7, X5
+    VFMADD231SD X1, X6, X5           // temp_im
+
+    VMOVSD (DX), X0                  // upper_re
+    VMOVSD (R8), X1                  // upper_im
+    VADDSD X0, X4, X2
+    VSUBSD X4, X0, X3
+    VMOVSD X2, (DX)
+    VMOVSD X3, 8(DX)
+    VADDSD X1, X5, X2
+    VSUBSD X5, X1, X3
+    VMOVSD X2, (R8)
+    VMOVSD X3, 8(R8)
+
+    ADDQ $16, DX
+    ADDQ $16, R8
+    DECQ AX
+    JNZ  bfstage_span1_tail
+    JMP  bfstage_done
+
+// ---------------------------------------------------------------------------
+// span == 2: each block is [u0,u1,l0,l1], exactly one 128-bit half per side.
+// Take 2 blocks (8 float64) at a time; VPERM2F128 collects the two upper halves
+// into one YMM and the two lower halves into another, so the 4 lanes carry 2
+// blocks x 2 j values. The twiddle pair repeats per block, which is one
+// memory-source VBROADCASTF128.
+// ---------------------------------------------------------------------------
+bfstage_span2:
+    VBROADCASTF128 (R9), Y6          // Y6 = [tr0,tr1,tr0,tr1]
+    VBROADCASTF128 (R10), Y7         // Y7 = [ti0,ti1,ti0,ti1]
+
+    MOVQ AX, BX
+    SHRQ $1, BX                      // BX = blocks/2 = 2-block iterations
+    JZ   bfstage_span2_tail_pre
+
+bfstage_span2_vec:
+    VMOVUPD (DX), Y0                 // block0 re = [u0,u1,l0,l1]
+    VMOVUPD 32(DX), Y1               // block1 re
+    VPERM2F128 $0x20, Y1, Y0, Y4     // Y4 = upper_re = [u0,u1,u0',u1']
+    VPERM2F128 $0x31, Y1, Y0, Y5     // Y5 = lower_re = [l0,l1,l0',l1']
+    VMOVUPD (R8), Y2                 // block0 im
+    VMOVUPD 32(R8), Y3               // block1 im
+    VPERM2F128 $0x20, Y3, Y2, Y8     // Y8 = upper_im
+    VPERM2F128 $0x31, Y3, Y2, Y9     // Y9 = lower_im
+
+    VMULPD Y5, Y6, Y10
+    VMULPD Y9, Y7, Y11
+    VSUBPD Y11, Y10, Y10             // Y10 = temp_re
+    VMULPD Y5, Y7, Y11
+    VFMADD231PD Y9, Y6, Y11          // Y11 = temp_im
+
+    VADDPD Y4, Y10, Y0               // new upper_re
+    VSUBPD Y10, Y4, Y1               // new lower_re
+    VADDPD Y8, Y11, Y2               // new upper_im
+    VSUBPD Y11, Y8, Y3               // new lower_im
+
+    VPERM2F128 $0x20, Y1, Y0, Y12    // block0 re = [U0,U1,L0,L1]
+    VPERM2F128 $0x31, Y1, Y0, Y13    // block1 re
+    VMOVUPD Y12, (DX)
+    VMOVUPD Y13, 32(DX)
+    VPERM2F128 $0x20, Y3, Y2, Y12    // block0 im
+    VPERM2F128 $0x31, Y3, Y2, Y13    // block1 im
+    VMOVUPD Y12, (R8)
+    VMOVUPD Y13, 32(R8)
+
+    ADDQ $64, DX
+    ADDQ $64, R8
+    DECQ BX
+    JNZ  bfstage_span2_vec
+
+bfstage_span2_tail_pre:
+    ANDQ $1, AX                      // one leftover block at most
+    JZ   bfstage_done
+
+    // Single block, 2 lanes wide: XMM halves of the same broadcast twiddles.
+    VMOVUPD (DX), X4                 // [u0,u1] re
+    VMOVUPD 16(DX), X5               // [l0,l1] re
+    VMOVUPD (R8), X8                 // [u0,u1] im
+    VMOVUPD 16(R8), X9               // [l0,l1] im
+
+    VMULPD X5, X6, X10
+    VMULPD X9, X7, X11
+    VSUBPD X11, X10, X10             // temp_re
+    VMULPD X5, X7, X11
+    VFMADD231PD X9, X6, X11          // temp_im
+
+    VADDPD X4, X10, X0
+    VSUBPD X10, X4, X1
+    VMOVUPD X0, (DX)
+    VMOVUPD X1, 16(DX)
+    VADDPD X8, X11, X2
+    VSUBPD X11, X8, X3
+    VMOVUPD X2, (R8)
+    VMOVUPD X3, 16(R8)
+
+bfstage_done:
+    VZEROUPPER
+    RET
+
 // func realFFTUnpackAVX(outRe, outIm, zRe, zIm, twRe, twIm []float64, n int)
 // Real-FFT unpack step, 4 float64 lanes per YMM (AVX+FMA). The float64
 // counterpart of f32's realFFTUnpackAVX: 4 lanes/iter instead of 8, so the

--- a/f64/f64_arm64.go
+++ b/f64/f64_arm64.go
@@ -512,6 +512,26 @@ func butterflyComplex64(upperRe, upperIm, lowerRe, lowerIm, twRe, twIm []float64
 //go:noescape
 func butterflyComplexNEON(upperRe, upperIm, lowerRe, lowerIm, twRe, twIm []float64)
 
+func butterflyComplexStage64(re, im []float64, span, blocks int, twRe, twIm []float64) {
+	// butterflyComplexStageNEON vectorizes across j for span >= 2 and across
+	// blocks for span == 1, so every span has a vector path. One iteration needs
+	// 2 float64 lanes, so anything below 2 total butterflies falls to Go.
+	if hasNEON && blocks*span >= 2 {
+		butterflyComplexStageNEON(re, im, span, blocks, twRe, twIm)
+		return
+	}
+	butterflyComplexStage64Go(re, im, span, blocks, twRe, twIm)
+}
+
+// Callers MUST satisfy len(re) == len(im) == 2*span*blocks and
+// len(twRe) == len(twIm) >= span, with span >= 1 and blocks >= 1. Every address
+// the kernel forms is derived from span and blocks, never from the slice headers,
+// so a violated precondition reads and writes out of bounds silently rather than
+// panicking the way the Go fallback would. ButterflyComplexStage establishes it.
+//
+//go:noescape
+func butterflyComplexStageNEON(re, im []float64, span, blocks int, twRe, twIm []float64)
+
 func realFFTUnpack64(outRe, outIm, zRe, zIm, twRe, twIm []float64, n int) {
 	// One NEON iteration needs 2 float64 lanes; n > 2 means (n-1) >= 2.
 	if hasNEON && n > 2 {

--- a/f64/f64_arm64.s
+++ b/f64/f64_arm64.s
@@ -2829,6 +2829,208 @@ butterfly_neon_scalar_loop:
 butterfly_neon_done:
     RET
 
+// func butterflyComplexStageNEON(re, im []float64, span, blocks int, twRe, twIm []float64)
+// One complete radix-2 decimation-in-time stage, in place over split-complex
+// float64. For every block k in steps of 2*span and every j in [0, span), the
+// butterfly at (k+j, k+span+j) with twiddle tw[j]. The arithmetic is the same
+// sequence butterflyComplexNEON uses: FMUL+FMLS for temp_re and FMUL+FMLA for
+// temp_im in the vector body, unfused FMUL/FMUL/FSUB and FMUL/FMUL/FADD in the
+// scalar tail.
+//
+// That makes a stage bit-identical to driving butterflyComplexNEON per block for
+// span >= 2, where both take their vector body (verified across every span and
+// block count the tests sweep). It does NOT extend to span 1: this kernel fuses
+// across blocks there, while butterflyComplexNEON handed a length-1 slice falls
+// to its unfused scalar tail, so the two are not the same computation even though
+// they agree for some inputs. The combination is unreachable through
+// butterflyComplex64, which gates NEON on len >= 2.
+//
+// Two vectorization axes, picked by span. span >= 2 vectorizes across j, where
+// the twiddles and both halves of a block are contiguous, and the block loop is
+// folded into the kernel so short runs no longer pay a call each. span == 1
+// cannot fill a .2D vector along j at all (there is exactly one butterfly per
+// block), so it vectorizes across blocks: UZP1/UZP2 split two interleaved [u,l]
+// pairs into an upper and a lower vector, and ZIP1/ZIP2 put them back.
+//
+// Registers, span >= 2 path: R0/R1 re+im block bases, R2/R3 twiddle bases,
+// R4 span, R5 blocks, R6/R7 upper pointers, R19/R20 lower pointers, R21/R22
+// twiddle pointers, R23 inner counter, R24 span bytes, R25 block bytes.
+// The span == 1 path uses R0/R1 as the running re+im cursors, R6/R7 as the
+// second block's addresses, V12/V13 as the splat twiddle and R23 as the
+// block-pair counter; it never writes R19-R22, R24 or R25. Frame:
+// re(24)+im(24)+span(8)+blocks(8)+twRe(24)+twIm(24) = 112 bytes.
+TEXT ·butterflyComplexStageNEON(SB), NOSPLIT, $0-112
+    MOVD re_base+0(FP), R0           // R0 = re block base
+    MOVD im_base+24(FP), R1          // R1 = im block base
+    MOVD span+48(FP), R4             // R4 = span
+    MOVD blocks+56(FP), R5           // R5 = block count
+    MOVD twRe_base+64(FP), R2        // R2 = twRe base
+    MOVD twIm_base+88(FP), R3        // R3 = twIm base
+
+    CBZ  R5, bfstage_neon_done
+    CMP  $1, R4
+    BEQ  bfstage_neon_span1
+
+    // ----------------------------------------------------------------------
+    // span >= 2: vectorize across j, two lanes per iteration, scalar tail when
+    // span is odd. Pointers are reset from the block bases on every block.
+    // ----------------------------------------------------------------------
+    LSL  $3, R4, R24                 // R24 = span*8 = upper->lower byte offset
+    LSL  $4, R4, R25                 // R25 = span*16 = block stride in bytes
+
+bfstage_neon_block:
+    MOVD R0, R6                      // R6 = upper re
+    MOVD R1, R7                      // R7 = upper im
+    ADD  R24, R0, R19                // R19 = lower re
+    ADD  R24, R1, R20                // R20 = lower im
+    MOVD R2, R21                     // R21 = twRe
+    MOVD R3, R22                     // R22 = twIm
+    LSR  $1, R4, R23                 // R23 = span/2 vector iterations
+    CBZ  R23, bfstage_neon_tail_pre
+
+bfstage_neon_vec:
+    VLD1   (R19), [V2.D2]            // V2 = lowerRe[j:j+2]
+    VLD1   (R20), [V3.D2]            // V3 = lowerIm[j:j+2]
+    VLD1.P 16(R21), [V4.D2]          // V4 = twRe[j:j+2]
+    VLD1.P 16(R22), [V5.D2]          // V5 = twIm[j:j+2]
+    VLD1   (R6), [V0.D2]             // V0 = upperRe[j:j+2]
+    VLD1   (R7), [V1.D2]             // V1 = upperIm[j:j+2]
+
+    // tempRe = lowerRe*twRe - lowerIm*twIm
+    WORD $0x6E64DC46                 // FMUL V6.2D, V2.2D, V4.2D
+    WORD $0x4EE5CC66                 // FMLS V6.2D, V3.2D, V5.2D
+
+    // tempIm = lowerRe*twIm + lowerIm*twRe
+    WORD $0x6E65DC47                 // FMUL V7.2D, V2.2D, V5.2D
+    WORD $0x4E64CC67                 // FMLA V7.2D, V3.2D, V4.2D
+
+    WORD $0x4E66D408                 // FADD V8.2D, V0.2D, V6.2D  (new upperRe)
+    WORD $0x4EE6D40A                 // FSUB V10.2D, V0.2D, V6.2D (new lowerRe)
+    WORD $0x4E67D429                 // FADD V9.2D, V1.2D, V7.2D  (new upperIm)
+    WORD $0x4EE7D42B                 // FSUB V11.2D, V1.2D, V7.2D (new lowerIm)
+
+    VST1.P [V8.D2], 16(R6)
+    VST1.P [V9.D2], 16(R7)
+    VST1.P [V10.D2], 16(R19)
+    VST1.P [V11.D2], 16(R20)
+
+    SUB  $1, R23
+    CBNZ R23, bfstage_neon_vec
+
+bfstage_neon_tail_pre:
+    AND  $1, R4, R23                 // odd span leaves one scalar butterfly
+    CBZ  R23, bfstage_neon_next
+
+    FMOVD (R19), F2                  // lowerRe
+    FMOVD (R20), F3                  // lowerIm
+    FMOVD (R21), F4                  // twRe
+    FMOVD (R22), F5                  // twIm
+    FMULD F2, F4, F6
+    FMULD F3, F5, F7
+    FSUBD F7, F6, F6                 // F6 = tempRe
+    FMULD F2, F5, F7
+    FMULD F3, F4, F8
+    FADDD F7, F8, F7                 // F7 = tempIm
+    FMOVD (R6), F0                   // upperRe
+    FMOVD (R7), F1                   // upperIm
+    FADDD F0, F6, F8
+    FSUBD F6, F0, F9
+    FADDD F1, F7, F10
+    FSUBD F7, F1, F11
+    FMOVD F8, (R6)
+    FMOVD F10, (R7)
+    FMOVD F9, (R19)
+    FMOVD F11, (R20)
+
+bfstage_neon_next:
+    ADD  R25, R0, R0
+    ADD  R25, R1, R1
+    SUB  $1, R5
+    CBNZ R5, bfstage_neon_block
+    RET
+
+    // ----------------------------------------------------------------------
+    // span == 1: every block is one [u, l] pair, so re/im are fully
+    // interleaved. Take 2 blocks (4 float64) per iteration, UZP1/UZP2 to
+    // separate the uppers from the lowers, ZIP1/ZIP2 to re-interleave on the
+    // way out. The twiddle is the single tw[0], splatted once.
+    // ----------------------------------------------------------------------
+bfstage_neon_span1:
+    FMOVD (R2), F12
+    VDUP  V12.D[0], V12.D2           // V12 = twRe[0] in both lanes
+    FMOVD (R3), F13
+    VDUP  V13.D[0], V13.D2           // V13 = twIm[0] in both lanes
+
+    LSR  $1, R5, R23                 // R23 = blocks/2 = 2-block iterations
+    CBZ  R23, bfstage_neon_span1_tail_pre
+
+bfstage_neon_span1_vec:
+    VLD1 (R0), [V0.D2]               // V0 = [u0, l0] re
+    ADD  $16, R0, R6
+    VLD1 (R6), [V1.D2]               // V1 = [u1, l1] re
+    VLD1 (R1), [V4.D2]               // V4 = [u0, l0] im
+    ADD  $16, R1, R7
+    VLD1 (R7), [V5.D2]               // V5 = [u1, l1] im
+
+    WORD $0x4EC11802                 // UZP1 V2.2D, V0.2D, V1.2D -> upperRe [u0,u1]
+    WORD $0x4EC15803                 // UZP2 V3.2D, V0.2D, V1.2D -> lowerRe [l0,l1]
+    WORD $0x4EC51886                 // UZP1 V6.2D, V4.2D, V5.2D -> upperIm
+    WORD $0x4EC55887                 // UZP2 V7.2D, V4.2D, V5.2D -> lowerIm
+
+    // tempRe = lowerRe*twRe - lowerIm*twIm
+    WORD $0x6E6CDC68                 // FMUL V8.2D, V3.2D, V12.2D
+    WORD $0x4EEDCCE8                 // FMLS V8.2D, V7.2D, V13.2D
+
+    // tempIm = lowerRe*twIm + lowerIm*twRe
+    WORD $0x6E6DDC69                 // FMUL V9.2D, V3.2D, V13.2D
+    WORD $0x4E6CCCE9                 // FMLA V9.2D, V7.2D, V12.2D
+
+    WORD $0x4E68D44A                 // FADD V10.2D, V2.2D, V8.2D  (new upperRe)
+    WORD $0x4EE8D44B                 // FSUB V11.2D, V2.2D, V8.2D  (new lowerRe)
+    WORD $0x4E69D4CE                 // FADD V14.2D, V6.2D, V9.2D  (new upperIm)
+    WORD $0x4EE9D4CF                 // FSUB V15.2D, V6.2D, V9.2D  (new lowerIm)
+
+    WORD $0x4ECB3940                 // ZIP1 V0.2D, V10.2D, V11.2D -> [U0,L0] re
+    WORD $0x4ECB7941                 // ZIP2 V1.2D, V10.2D, V11.2D -> [U1,L1] re
+    WORD $0x4ECF39C4                 // ZIP1 V4.2D, V14.2D, V15.2D -> [U0,L0] im
+    WORD $0x4ECF79C5                 // ZIP2 V5.2D, V14.2D, V15.2D -> [U1,L1] im
+
+    VST1.P [V0.D2], 16(R0)
+    VST1.P [V1.D2], 16(R0)
+    VST1.P [V4.D2], 16(R1)
+    VST1.P [V5.D2], 16(R1)
+
+    SUB  $1, R23
+    CBNZ R23, bfstage_neon_span1_vec
+
+bfstage_neon_span1_tail_pre:
+    AND  $1, R5, R23                 // one leftover block at most
+    CBZ  R23, bfstage_neon_done
+
+    FMOVD 8(R0), F2                  // lowerRe
+    FMOVD 8(R1), F3                  // lowerIm
+    FMOVD (R2), F4                   // twRe[0]
+    FMOVD (R3), F5                   // twIm[0]
+    FMULD F2, F4, F6
+    FMULD F3, F5, F7
+    FSUBD F7, F6, F6                 // F6 = tempRe
+    FMULD F2, F5, F7
+    FMULD F3, F4, F8
+    FADDD F7, F8, F7                 // F7 = tempIm
+    FMOVD (R0), F0                   // upperRe
+    FMOVD (R1), F1                   // upperIm
+    FADDD F0, F6, F8
+    FSUBD F6, F0, F9
+    FADDD F1, F7, F10
+    FSUBD F7, F1, F11
+    FMOVD F8, (R0)
+    FMOVD F10, (R1)
+    FMOVD F9, 8(R0)
+    FMOVD F11, 8(R1)
+
+bfstage_neon_done:
+    RET
+
 // func realFFTUnpackNEON(outRe, outIm, zRe, zIm, twRe, twIm []float64, n int)
 // Real-FFT unpack step, 2 float64 lanes (.2D) per vector register, the float64
 // counterpart of f32's realFFTUnpackNEON: 2 lanes/iter instead of 4, so the

--- a/f64/f64_go.go
+++ b/f64/f64_go.go
@@ -714,6 +714,20 @@ func butterflyComplex64Go(upperRe, upperIm, lowerRe, lowerIm, twRe, twIm []float
 	}
 }
 
+// butterflyComplexStage64Go applies one radix-2 decimation-in-time stage in
+// place over split-complex data. blocks is the number of complete 2*span
+// blocks; the caller has already reconciled it against len(re)/len(im).
+func butterflyComplexStage64Go(re, im []float64, span, blocks int, twRe, twIm []float64) {
+	tr, ti := twRe[:span], twIm[:span]
+	for b := range blocks {
+		k := b * butterflyStageRadix * span
+		mid, end := k+span, k+butterflyStageRadix*span
+		upRe, upIm := re[k:mid:mid], im[k:mid:mid]
+		loRe, loIm := re[mid:end:end], im[mid:end:end]
+		butterflyComplex64Go(upRe, upIm, loRe, loIm, tr, ti)
+	}
+}
+
 // realFFTUnpackHalf is the constant 0.5 used in real FFT unpack computation.
 const realFFTUnpackHalf = 0.5
 

--- a/f64/f64_other.go
+++ b/f64/f64_other.go
@@ -73,6 +73,10 @@ func powElem64(dst, base, exp []float64)    { powElemGo(dst, base, exp) }
 func butterflyComplex64(upperRe, upperIm, lowerRe, lowerIm, twRe, twIm []float64) {
 	butterflyComplex64Go(upperRe, upperIm, lowerRe, lowerIm, twRe, twIm)
 }
+func butterflyComplexStage64(re, im []float64, span, blocks int, twRe, twIm []float64) {
+	butterflyComplexStage64Go(re, im, span, blocks, twRe, twIm)
+}
+
 func realFFTUnpack64(outRe, outIm, zRe, zIm, twRe, twIm []float64, n int) {
 	realFFTUnpack64Go(outRe, outIm, zRe, zIm, twRe, twIm, n)
 }


### PR DESCRIPTION
Refs #198 (first of its two parts; the `RealFFTPower` variant is not in this PR, so this does not close the issue).

Adds `f64.ButterflyComplexStage`, the stage-level form of the existing `f64.ButterflyComplex`.

## Why

`ButterflyComplex` takes one contiguous run of pairs, so driving a full radix-2 stage at span `s` over an `n`-point transform costs `n/(2s)` separate calls. The butterflies per stage are constant at `n/2`, so the call count explodes exactly where the runs get short. Worse, the per-block API cannot vectorize a short span at all: at span 1 and 2 the slices are 1 and 2 elements long, below the width a vector needs, so those stages fall to scalar code however the caller drives them. Half the stages of a decimation-in-time transform have span below `sqrt(n)`.

Taking the whole stage lets the implementation choose its own vectorization axis: across `j` when span fills a vector, and across blocks when it does not. So the win at short spans is two things at once, the removed per-call overhead and a vector path that was previously unreachable.

## Implementation

On AMD64 the block-axis paths gather 4 blocks (span 1) or 2 blocks (span 2) per iteration. The span-1 split uses `VUNPCKLPD`/`VUNPCKHPD`, whose in-lane behaviour leaves the four blocks in the order (b0, b2, b1, b3); keeping that permuted order rather than correcting it is what avoids needing `VPERMPD`, so the kernel stays **AVX+FMA and does not narrow to AVX2**. Span 2 uses `VPERM2F128`. On ARM64 the span-1 path splits with `UZP1`/`UZP2` and re-interleaves with `ZIP1`/`ZIP2`.

Every span is dispatched to the kernel, including span 3, which fills neither axis and runs entirely in the j-axis path's scalar tail. That still beats the Go fallback by 2-3x, because the kernel absorbs the block loop into one call while the Go path pays a per-block call that is over the inliner's budget.

## Measurements

Idle i7-1260P (AVX2+FMA) and Raspberry Pi 5 (Cortex-A76), one complete stage over `n = 1024` split-complex float64, 20 rounds with one sweep per process invocation so the two arms interleave in time. Work is identical in every row (`blocks*span` is 512 throughout). All rows p <= 0.001.

| span | amd64 per-block | amd64 stage | x | arm64 per-block | arm64 stage | x |
|---|---|---|---|---|---|---|
| 1 | 4347.5n | 225.5n | 19.3 | 10424n | 1405n | 7.4 |
| 2 | 2487.5n | 224.7n | 11.1 | 5808n | 1086n | 5.3 |
| 4 | 1165.0n | 151.7n | 7.7 | 3178n | 901n | 3.5 |
| 8 | 658.3n | 134.4n | 4.9 | 2142n | 859n | 2.5 |
| 16 | 399.4n | 124.6n | 3.2 | 1518n | 839n | 1.8 |
| 32 | 268.1n | 133.7n | 2.0 | 1220n | 842n | 1.4 |
| 64 | 193.6n | 129.1n | 1.5 | 1073n | 824n | 1.3 |
| 128 | 162.0n | 129.8n | 1.2 | 995n | 824n | 1.2 |
| 256 | 145.9n | 129.2n | 1.1 | 948n | 813n | 1.2 |
| 512 | 138.5n | 124.5n | 1.1 | 928n | 816n | 1.1 |

Summed over the ten stages of a 1024-point transform: **6.6x on amd64, 3.1x on arm64** for the transform core.

Two method caveats, both learned the hard way in this PR. `-test.count=N` does not interleave, it repeats each sub-benchmark consecutively. And sustained benchmarking on this part drops the sustained-load P-state enough to halve the reported rate until the machine idles. Earlier numbers taken without accounting for both were wrong by up to a third, so the benchmark now documents the protocol.

## Verification

Full `f64` suite passes on the AVX2 host and on the Pi 5 (447 subtests each). `TestArm64WordEncodings` cross-checks the 12 new hand-encoded WORDs against `arm64asm`; `TestAmd64KernelISALevel` confirms the AVX kernel stays within AVX1+FMA, and an instruction census of the linked kernel shows zero EVEX prefixes with both twiddle splats in their memory-source AVX1 form. Bounds were checked empirically as well as by derivation: canary-guarded sweeps over ten thousand shape combinations, with span and length varied independently so most cases are not block-aligned, moved no byte outside the slices on either architecture.

One test detail worth flagging for review. The test twiddles carry a deliberate phase offset, because without it span 1 gets the identity twiddle (1, 0), under which the complex multiply collapses to a pass-through and a sign error in either block-axis kernel is invisible. Sign-flip mutants in both kernels were confirmed to survive the whole suite before the offset was added, and to die after.

## Not in this PR

- `RealFFTPower`, the other half of #198.
- Wiring `f64/stft.go` onto the new primitive: filed as #205, since `fftHalf` reads its twiddles strided while this API needs them contiguous, so it needs per-stage tables rather than a call-site swap.
- Low-severity findings batched into #206.
- No `f32` twin; this is f64-scoped, matching the issue.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added `ButterflyComplexStage` operation with optimized implementations for AMD64 and ARM64 architectures, including fallback Go implementation.

* **Documentation**
  * Updated documentation describing the new FFT stage operation and performance characteristics.

* **Tests**
  * Added comprehensive test suite with unit tests, benchmarks, and cross-implementation equivalence checks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->