### PR TITLE
f32: restore the AVX+FMA tier for RealFFTUnpack (#202)

### DIFF
--- a/README.md
+++ b/README.md
@@ -349,7 +349,7 @@ Results are identical to the per-row path either way.
 
 | Category   | Function                              | Description                        | SIMD Width       |
 | ---------- | ------------------------------------- | ---------------------------------- | ---------------- |
-| **Complex**| `MulComplex(dstRe,dstIm,aRe,aIm,bRe,bIm)` | Split-format complex multiply  | 8x (AVX) / 4x (NEON) |
+| **Complex**| `MulComplex(dstRe,dstIm,aRe,aIm,bRe,bIm)` | Split-format complex multiply  | 8x (AVX+FMA) / 4x (NEON) |
 |            | `MulConjComplex(dstRe,dstIm,aRe,aIm,bRe,bIm)` | Multiply by conjugate      | 8x / 4x          |
 |            | `AbsSqComplex(dst,aRe,aIm)`           | Magnitude squared                  | 8x / 4x          |
 |            | `ButterflyComplex(uRe,uIm,lRe,lIm,twRe,twIm)` | FFT butterfly with twiddle | 8x / 4x          |

--- a/README.md
+++ b/README.md
@@ -353,7 +353,7 @@ Results are identical to the per-row path either way.
 |            | `MulConjComplex(dstRe,dstIm,aRe,aIm,bRe,bIm)` | Multiply by conjugate      | 8x / 4x          |
 |            | `AbsSqComplex(dst,aRe,aIm)`           | Magnitude squared                  | 8x / 4x          |
 |            | `ButterflyComplex(uRe,uIm,lRe,lIm,twRe,twIm)` | FFT butterfly with twiddle | 8x / 4x          |
-|            | `RealFFTUnpack(outRe,outIm,zRe,zIm,twRe,twIm)` | Real FFT unpack step     | 8x (AVX2+FMA) / 4x (NEON)          |
+|            | `RealFFTUnpack(outRe,outIm,zRe,zIm,twRe,twIm)` | Real FFT unpack step     | 8x / 4x          |
 | **Utility**| `Reverse(dst, src)`                   | Reverse slice order                | 8x / 4x          |
 |            | `AddSub(sum, diff, a, b)`             | Fused sum and difference           | 8x / 4x          |
 

--- a/asmcheck_amd64_isa_test.go
+++ b/asmcheck_amd64_isa_test.go
@@ -66,7 +66,6 @@ var avx2GatedAVXKernels = map[string]string{
 	"f32/f32_amd64.s:powAVX":                 f32LogGate,
 	"f32/f32_amd64.s:powElemAVX":             f32LogGate,
 	"f32/f32_amd64.s:int16ToFloat32ScaleAVX": "f32_amd64.go int16ToFloat32Scale: cpu.X86.AVX2",
-	"f32/f32_amd64.s:realFFTUnpackAVX":       "f32_amd64.go realFFTUnpack32: cpu.X86.AVX2 && cpu.X86.FMA",
 
 	// f64: same shape as f32, plus VPERMPD in the autocorrelation and unpack steps.
 	"f64/f64_amd64.s:interleave3AVX":   "f64_amd64.go interleaveN64: cpu.X86.AVX2",

--- a/f32/f32.go
+++ b/f32/f32.go
@@ -1246,7 +1246,7 @@ func ButterflyComplex(upperRe, upperIm, lowerRe, lowerIm, twRe, twIm []float32) 
 //	X[0] = Z[0].real + Z[0].imag  (DC component)
 //	X[n] = Z[0].real - Z[0].imag  (Nyquist component)
 //
-// Uses AVX2+FMA on AMD64, NEON on ARM64, with pure Go fallback.
+// Uses AVX+FMA on AMD64, NEON on ARM64, with pure Go fallback.
 func RealFFTUnpack(outRe, outIm, zRe, zIm, twRe, twIm []float32) {
 	n := len(zRe)
 	if n < realFFTUnpackMinN {

--- a/f32/f32_amd64.go
+++ b/f32/f32_amd64.go
@@ -1300,13 +1300,12 @@ func butterflyComplex32(upperRe, upperIm, lowerRe, lowerIm, twRe, twIm []float32
 }
 
 func realFFTUnpack32(outRe, outIm, zRe, zIm, twRe, twIm []float32, n int) {
-	// realFFTUnpackAVX needs AVX2, not just AVX+FMA: it builds the sign mask with
-	// VPCMPEQD/VPSLLD on YMM and broadcasts with the register-source VBROADCASTSS,
-	// all AVX2-only. Gating on plain AVX let an AVX1+FMA part (e.g. AMD Piledriver)
-	// reach it and SIGILL. This matches realFFTUnpack64, whose reversed load needs
-	// VPERMPD. See #196.
+	// Use AVX+FMA if available and have enough elements. realFFTUnpackAVX needs
+	// nothing above AVX1+FMA3; TestAmd64KernelISALevel enforces the AVX2 half of
+	// that claim, and the cpu.X86.FMA conjunct below covers the rest. See #202,
+	// and #196 for the SIGILL an AVX2 encoding here would cause.
 	// Need at least 9 elements: process k=1..n-1 where n>=9 gives 8+ iterations
-	if cpu.X86.AVX2 && cpu.X86.FMA && n > minAVXElements {
+	if cpu.X86.AVX && cpu.X86.FMA && n > minAVXElements {
 		realFFTUnpackAVX(outRe, outIm, zRe, zIm, twRe, twIm, n)
 		return
 	}

--- a/f32/f32_amd64.s
+++ b/f32/f32_amd64.s
@@ -13,8 +13,11 @@ DATA absf32mask<>+0x18(SB)/4, $0x7fffffff
 DATA absf32mask<>+0x1c(SB)/4, $0x7fffffff
 GLOBL absf32mask<>(SB), RODATA|NOPTR, $32
 
-// Constants for roundAVX (round-half-away-from-zero). absf32mask above doubles
-// as the |frac| mask; these supply the sign bit, the 0.5 threshold and 1.0.
+// Shared float32 constants, added for roundAVX (round-half-away-from-zero).
+// absf32mask above doubles as the |frac| mask; these supply the sign bit, 0.5
+// and 1.0. roundf32_signmask and roundf32_half are read by other kernels too,
+// so grep for a symbol before changing its value. roundf32_one is roundAVX's
+// alone.
 DATA roundf32_signmask<>+0x00(SB)/4, $0x80000000
 DATA roundf32_signmask<>+0x04(SB)/4, $0x80000000
 DATA roundf32_signmask<>+0x08(SB)/4, $0x80000000
@@ -5251,15 +5254,12 @@ TEXT ·realFFTUnpackAVX(SB), NOSPLIT, $0-152
 
     // Load constants. The reverse permutation is performed per iteration in the
     // loop with VPERM2F128 + VPERMILPS, so no permutation mask is needed here.
-
-    // Broadcast 0.5 (0x3F000000 = 0.5f)
-    MOVL $0x3F000000, BX
-    MOVD BX, X13
-    VBROADCASTSS X13, Y13            // Y13 = 0.5 broadcast
-
-    // Sign mask for negation (0x80000000)
-    VPCMPEQD Y14, Y14, Y14           // Y14 = all 1s
-    VPSLLD $31, Y14, Y14             // Y14 = 0x80000000 (sign bit only)
+    // The 8-wide loop's constants come from RODATA rather than being
+    // materialised in registers: a register-source VBROADCASTSS and 256-bit
+    // VPCMPEQD/VPSLLD are AVX2, and this kernel is dispatched on the plain
+    // AVX+FMA tier, which AMD Piledriver and Steamroller reach. See #202.
+    VMOVUPS roundf32_half<>(SB), Y13     // Y13 = 0.5f x8
+    VMOVUPS roundf32_signmask<>(SB), Y14 // Y14 = 0x80000000 x8 (sign bit only)
 
 realfft_loop8:
     // Load forward Z[k:k+8]

--- a/f32/f32_test.go
+++ b/f32/f32_test.go
@@ -3327,7 +3327,10 @@ func TestRealFFTUnpack_EdgeCases(t *testing.T) {
 }
 
 func TestRealFFTUnpack_GoVsSIMD(t *testing.T) {
-	// Test that Go and SIMD implementations produce identical results
+	// Test that Go and SIMD agree within the tolerance below. They are not
+	// bit-identical in general: the two paths can make different FMA contraction
+	// choices, and which of them fuses depends on GOARCH and on the dispatched
+	// CPU tier.
 	sizes := []int{9, 16, 17, 32, 64, 128, 256, 512}
 
 	for _, n := range sizes {

--- a/f32/f32_test.go
+++ b/f32/f32_test.go
@@ -3382,6 +3382,34 @@ func TestRealFFTUnpack_GoVsSIMD(t *testing.T) {
 	}
 }
 
+// TestRealFFTUnpack_AllocFree pins the package convention that every operation
+// writes into caller-provided slices and allocates nothing. n = 67 gives
+// (n-1)%8 == 2, so the run covers eight full AVX blocks and a two-iteration
+// scalar remainder; a tail that allocated would go unnoticed at a size where
+// (n-1)%8 is zero.
+func TestRealFFTUnpack_AllocFree(t *testing.T) {
+	const n = 67
+	zRe := make([]float32, n)
+	zIm := make([]float32, n)
+	twRe := make([]float32, n-1)
+	twIm := make([]float32, n-1)
+	outRe := make([]float32, n)
+	outIm := make([]float32, n)
+	for i := range n {
+		zRe[i] = float32(i+1) * 0.1
+		zIm[i] = float32(i+2) * 0.2
+	}
+	for k := 1; k < n; k++ {
+		angle := -2 * math.Pi * float64(k) / float64(2*n)
+		twRe[k-1] = float32(math.Cos(angle))
+		twIm[k-1] = float32(math.Sin(angle))
+	}
+	fn := func() { RealFFTUnpack(outRe, outIm, zRe, zIm, twRe, twIm) }
+	if a := testing.AllocsPerRun(50, fn); a != 0 {
+		t.Errorf("RealFFTUnpack allocated %v times per run, want 0", a)
+	}
+}
+
 func TestRealFFTUnpack_KnownValues(t *testing.T) {
 	// Test with known values for a small case
 	// n=4: process k=1,2,3


### PR DESCRIPTION
Closes #202.

`realFFTUnpackAVX`'s only dependency above AVX1 was three constant-materialisation instructions in its loop preamble. Replacing them with loads of RODATA that already existed in the same file makes the body AVX1+FMA3 clean, so the dispatch guard goes back to `cpu.X86.AVX && cpu.X86.FMA` and AMD Piledriver and Steamroller keep the vector path.

```
-    MOVL $0x3F000000, BX
-    MOVD BX, X13
-    VBROADCASTSS X13, Y13            // register-source form: AVX2
-    VPCMPEQD Y14, Y14, Y14           // 256-bit integer: AVX2
-    VPSLLD $31, Y14, Y14
+    VMOVUPS roundf32_half<>(SB), Y13     // Y13 = 0.5f x8
+    VMOVUPS roundf32_signmask<>(SB), Y14 // Y14 = 0x80000000 x8 (sign bit only)
```

No new RODATA is needed: `roundAVX` already loads both symbols with this exact instruction form while being dispatched on the plain-AVX tier, so the pattern is already shipping to those CPUs through another kernel.

## This completes #200 rather than reversing part of it

#200 found five kernels containing AVX2-only encodings behind guards that did not require AVX2. It fixed four in the assembly and kept their full tier coverage, and narrowed exactly one guard, this one, noting at the time: "the kernel is only three instructions from AVX1-clean and could keep the tier; that is filed as a follow-up rather than folded in here, since it means editing a hot FFT preamble."

This is that follow-up. It takes the count of guard-narrowed kernels from #200 down to zero, so every kernel that sweep touched now keeps the tier it had.

## Verification

**The body is AVX1+FMA3 clean, proved by reassembly with controls.** All 133 instructions of the compiled kernel, disassembled and reassembled under `.arch generic64` plus `.arch .avx` plus `.arch .fma`: zero errors, with round-trip fidelity confirmed so nothing was dropped in transcription. The controls are what make that mean something:

| control | result |
|---|---|
| the 3 removed instructions at `generic64+avx+fma` | rejected, 3 errors |
| the same 3 with `.avx2` added | accepted |
| the full kernel with `.fma` removed | rejected, exactly 4 errors (the four FMA3 ops) |
| the full kernel with `.avx` removed | rejected, 54 errors |

**The constants are bit-identical.** Read from the linked binary rather than the source: both symbols are `0x20` bytes, 32-byte aligned, holding 8 lanes of `0x80000000` and `0x3f000000` respectively, so a YMM load consumes the symbol and nothing after it.

**Output is unchanged on AVX2 hardware.** A differential over identical PRNG input across 17 sizes compared 6021 output float32s as raw bit patterns between the base and this branch: byte-for-byte identical. That matters because the package's own parity tests use a relative tolerance and would not have caught a subtly wrong constant.

**Executed on the target hardware class.** Under `qemu-x86_64 -cpu Opteron_G5`, which reports `AVX=true AVX2=false FMA=true` and enforces #UD for out-of-baseline instructions:

| binary | result |
|---|---|
| v1.6.0, the last release | SIGILL at `c4 41 0d 76 f6`, that is `VPCMPEQD ymm14,ymm14,ymm14` |
| `main` today | pass, on the pure-Go path |
| this branch | pass, running the vector kernel |

Sizes with a non-zero scalar remainder (n = 31, 33, 63, 65, 1000) were included, so the tail path is covered too.

**Register liveness.** The removed sequence used `BX` as scratch, so `BX` now carries `(n-8)*4` into the loop. Nothing in the loop reads it, and both later consumers write before reading. `R14` and `BP` appear nowhere in the compiled kernel.

**The safety net gets stronger, not weaker.** The exemption entry had to be deleted because the ISA test fails on an unused exemption. Under the old AVX2 guard only that test could trip; with a plain AVX guard, any future AVX2 encoding in this kernel trips both it and `TestAmd64KernelDispatchRequiresAVX2`. Confirmed by mutation: reinstating either removed instruction, or re-adding the exemption entry, turns the suite red with the right diagnostic.

Full suites pass on an i7-1260P (AVX2+FMA) and a Cortex-A76, plus `go vet` and per-GOARCH lint for both architectures. `golangci-lint` reports the same 131 pre-existing goconst findings on this branch as on `main`, none in a changed file.

## Behaviour change worth knowing

On an AVX+FMA3-without-AVX2 part, results move by 1 ULP, because the kernel's `VFMADD231PS` rounds once where the Go path rounds twice. Measured: `outRe[9]` goes `40ea98db` to `40ea98dc` at n=64. Nothing regresses, since #200's narrowing was never tagged into a release and those parts crashed in v1.6.0, but the next release notes should mention it. AVX2 parts are bit-identical, as above.

## Comment fixes folded in

The pre-push gate found four comment-accuracy defects, all fixed here and all comment-only. The one that mattered: the dispatch comment justified the widened guard by saying the kernel loads its constants from RODATA, but the scalar tail still materialises its own 0.5, so the premise covered only half the kernel. Since that comment is the only justification a future maintainer will find for a guard whose failure mode is a shipped SIGILL, it now states only what was verified, and says which half of it `TestAmd64KernelISALevel` actually enforces: asmcheck models the AVX1/AVX2/AVX-512 axis and does not model FMA3, so the `cpu.X86.FMA` conjunct is guarded by nothing but itself. That gap is #201.

Worth recording that the first attempt at those fixes was rejected by review. It replaced four overclaiming comments with four fresh ones and introduced more findings than it closed, including a single-cause claim about `VPERMPD` that the f64 kernel's own comment disproves. The fixes here are the minimal deletive form instead: a deleted clause cannot be wrong.

## Filed from the same gate run

* #208, Critical and pre-existing: the scalar tail pays two AVX-SSE microcode assists per iteration (confirmed with `assists.sse_avx_mix`, about 501 cycles per tail element), which makes the vector path slower than the Go fallback at every benchmarked size below 512. A three-line hoist fixes it, measured 21.6x at n=64. Independent of this change; the assist counts are identical on the base.
* #209, batched Low findings.
* Evidence added to #201 (the FMA3 axis is unmodelled, demonstrated by mutation) and #203 (`Opteron_G5` verified as the right qemu model).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Performance**
  * Improved real FFT unpacking on supported AMD64 processors by enabling SIMD acceleration with AVX and FMA, including systems without AVX2.
  * Maintained existing fallback behavior for unsupported hardware and smaller inputs.

* **Documentation**
  * Clarified SIMD support details and platform-specific behavior.
  * Updated testing guidance to reflect acceptable architecture- and CPU-dependent numerical differences.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->