### PR TITLE
f64: ARM64 micro-optimisations and tolerance unification for ButterflyComplexStage (#206)

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -188,7 +188,10 @@ Add the operation to `testdata/generate_expectations.c` for validation.
 
 ### 7. Update Documentation
 
-Update `README.md` to include the new operation in the API table.
+Update `README.md` to include the new operation in the API table, and add it to
+the package index in `doc.go`. Both are hand-maintained and nothing checks them,
+so an operation added to one and not the other drifts silently; that is how the
+FFT primitives ended up in the README but not in `doc.go`.
 
 ## Code Style
 

--- a/README.md
+++ b/README.md
@@ -164,7 +164,7 @@ instead, so the two float surfaces remain intentionally asymmetric.
 
 Prefer `ButterflyComplexStage` over `ButterflyComplex` when driving a whole
 transform. It takes the stage rather than one block, so the per-block call
-overhead disappears and the short spans, which cannot fill a vector along `j`,
+overhead disappears and the short spans that cannot fill a vector along `j`
 vectorize across blocks instead. Measured over one stage of a 1024-point
 transform on an x86 core, that collapses the cost spread across spans from
 roughly 30x to under 2x, so the small-span stages stop dominating the transform.

--- a/asmcheck_test.go
+++ b/asmcheck_test.go
@@ -344,7 +344,13 @@ func asmFuncBody(src, fn string) ([]string, bool) {
 func TestNoFMAContract(t *testing.T) {
 	// VFMADD/VFNMADD/VFMSUB/VFNMSUB (amd64); FMADD/FMSUB/FNMADD/FNMSUB and the
 	// FMLA/FMLS vector forms (arm64). Deliberately excludes FMUL/FADD/FMAX/FMIN.
-	fmaRe := regexp.MustCompile(`^(VFN?M(ADD|SUB)|FN?M(ADD|SUB)|FML[AS])`)
+	//
+	// FML[AS] carries an optional V because the two spellings reach this test by
+	// different routes: a WORD decoded through arm64asm yields the ARM spelling
+	// FMLA, while a source-level mnemonic yields Go's Plan 9 spelling VFMLA.
+	// Matching only the former would let a kernel written with the mnemonic (the
+	// form docs/assembly-encoding.md recommends for new kernels) fuse silently.
+	fmaRe := regexp.MustCompile(`^(VFN?M(ADD|SUB)|FN?M(ADD|SUB)|V?FML[AS])`)
 
 	for _, k := range singleRoundingKernels {
 		src, err := os.ReadFile(k.file)

--- a/doc.go
+++ b/doc.go
@@ -94,7 +94,7 @@
 //
 // Spectral (f64, f32): STFTPlan (NewSTFTPlan, STFT, STFTPower, STFTPowerInto, NumFrames) - fused real-input short-time Fourier transform with optional librosa-style center=true framing (PadMode: NoPad/PadZero/PadReflect)
 //
-// FFT primitives (f64, f32): ButterflyComplex (radix-2 butterfly with twiddle multiply, split-complex), RealFFTUnpack (real-FFT even/odd unpack step); f64 additionally has ButterflyComplexStage, one whole radix-2 decimation-in-time stage at any span, which vectorizes across blocks where the span is too short to fill a vector
+// FFT primitives (f64, f32): ButterflyComplex (radix-2 butterfly with twiddle multiply, split-complex), RealFFTUnpack (real-FFT even/odd unpack step); f64 additionally has ButterflyComplexStage, one whole radix-2 decimation-in-time stage at any span, which picks its vectorization axis from the span
 //
 // Integer DSP (i16): Interleave2, Deinterleave2, DotProduct, DotProductUnsafe, XCorr (widening int16 x int16 -> wrapping int32; ARM64 SMLAL/SMLAL2, amd64 PMADDWD/VPMADDWD; XCorr evaluates 4 correlation lags per kernel call), Abs, MaxAbs, MulQ15 (wrapping 16-bit absolute value, widened abs-max, rounding Q15 multiply)
 //

--- a/doc.go
+++ b/doc.go
@@ -94,6 +94,8 @@
 //
 // Spectral (f64, f32): STFTPlan (NewSTFTPlan, STFT, STFTPower, STFTPowerInto, NumFrames) - fused real-input short-time Fourier transform with optional librosa-style center=true framing (PadMode: NoPad/PadZero/PadReflect)
 //
+// FFT primitives (f64, f32): ButterflyComplex (radix-2 butterfly with twiddle multiply, split-complex), RealFFTUnpack (real-FFT even/odd unpack step); f64 additionally has ButterflyComplexStage, one whole radix-2 decimation-in-time stage at any span, which vectorizes across blocks where the span is too short to fill a vector
+//
 // Integer DSP (i16): Interleave2, Deinterleave2, DotProduct, DotProductUnsafe, XCorr (widening int16 x int16 -> wrapping int32; ARM64 SMLAL/SMLAL2, amd64 PMADDWD/VPMADDWD; XCorr evaluates 4 correlation lags per kernel call), Abs, MaxAbs, MulQ15 (wrapping 16-bit absolute value, widened abs-max, rounding Q15 multiply)
 //
 // Integer DSP (i32): Interleave2, Deinterleave2, Add, Sub, Abs, Sum, MinMax, MaxAbs, NegWhereNeg, ScaleQ31, ScaleQ15, Butterfly, FIRValidQ15

--- a/docs/assembly-encoding.md
+++ b/docs/assembly-encoding.md
@@ -32,12 +32,40 @@ one against `golang.org/x/arch/arm64asm` (see the `asmcheck` package and
 
 ```
 VADD (.S4/.H8), VSHL, VADDV, VEXT, VDUP, VMOV, VEOR, VUMAX,
-VLD1/VLD1.P/VST1/VST1.P
+VLD1/VLD1.P/VST1/VST1.P (including the multi-register forms),
+VZIP1/VZIP2/VUZP1/VUZP2 (.D2 and .S4), VFMLA/VFMLS (.D2 and .S4)
 ```
 
 `VADDV` and `VUMAX` are the two worth calling out: both look like they might need
 encoding and both do not. Reach for a `WORD` only after confirming the mnemonic is
 actually rejected.
+
+The float permutes and the fused multiply-adds are the other easy ones to miss.
+Verified against go1.26.5 by assembling each with `go tool asm` and reading the
+word back with `go tool objdump`: every one of the six is accepted on both `.D2`
+and `.S4`, and each emits exactly the word the repo already hand-encodes for the
+same operands. The `.D2` set, against `f64/f64_arm64.s`:
+
+| Plan 9 source                 | Emitted word | Decodes as                    |
+| ----------------------------- | ------------ | ----------------------------- |
+| `VUZP1 V1.D2, V0.D2, V2.D2`   | `0x4EC11802` | `UZP1 V2.2D, V0.2D, V1.2D`    |
+| `VUZP2 V1.D2, V0.D2, V3.D2`   | `0x4EC15803` | `UZP2 V3.2D, V0.2D, V1.2D`    |
+| `VZIP1 V11.D2, V10.D2, V0.D2` | `0x4ECB3940` | `ZIP1 V0.2D, V10.2D, V11.2D`  |
+| `VZIP2 V11.D2, V10.D2, V1.D2` | `0x4ECB7941` | `ZIP2 V1.2D, V10.2D, V11.2D`  |
+| `VFMLS V5.D2, V3.D2, V6.D2`   | `0x4EE5CC66` | `FMLS V6.2D, V3.2D, V5.2D`    |
+| `VFMLA V4.D2, V3.D2, V7.D2`   | `0x4E64CC67` | `FMLA V7.2D, V3.2D, V4.2D`    |
+
+Note the operand order: Plan 9 writes `Vm, Vn, Vd` where ARM writes `Vd, Vn, Vm`.
+
+The `.S4` forms behave the same way. Spot-checked against `f32/f32_arm64.s`:
+`VZIP1 V1.S4, V0.S4, V2.S4` emits `0x4E813802`, `VUZP1 V1.S4, V0.S4, V2.S4`
+emits `0x4E811802`, and `VFMLA V4.S4, V2.S4, V0.S4` emits `0x4E24CC40`, each
+identical to the `WORD` that file already carries for those operands.
+
+Every arm64 kernel in this repo still spells these six as `WORD`s; a grep for the
+mnemonics at the start of a line finds no use anywhere. That is consistency with
+the neighbouring instructions in kernels that hand-encode anyway, not a toolchain
+constraint. A new kernel with no other `WORD` in it should use the mnemonics.
 
 An amusing asymmetry: `go tool objdump` happily *decodes* a hand-encoded word back
 to `VSMLAL ...`. The toolchain knows the instruction on the way out but not on the

--- a/docs/assembly-encoding.md
+++ b/docs/assembly-encoding.md
@@ -33,8 +33,13 @@ one against `golang.org/x/arch/arm64asm` (see the `asmcheck` package and
 ```
 VADD (.S4/.H8), VSHL, VADDV, VEXT, VDUP, VMOV, VEOR, VUMAX,
 VLD1/VLD1.P/VST1/VST1.P (including the multi-register forms),
-VZIP1/VZIP2/VUZP1/VUZP2 (.D2 and .S4), VFMLA/VFMLS (.D2 and .S4)
+VZIP1/VZIP2/VUZP1/VUZP2 (any arrangement),
+VFMLA/VFMLS (.S2/.S4/.D2 only, NOT the FP16 .H4/.H8)
 ```
+
+This list says these instructions do not NEED a `WORD`. It is not an instruction
+to convert the existing kernels, which hand-encode them deliberately; see the note
+below the tables before changing any of them.
 
 `VADDV` and `VUMAX` are the two worth calling out: both look like they might need
 encoding and both do not. Reach for a `WORD` only after confirming the mnemonic is
@@ -62,10 +67,15 @@ The `.S4` forms behave the same way. Spot-checked against `f32/f32_arm64.s`:
 emits `0x4E811802`, and `VFMLA V4.S4, V2.S4, V0.S4` emits `0x4E24CC40`, each
 identical to the `WORD` that file already carries for those operands.
 
-Every arm64 kernel in this repo still spells these six as `WORD`s; a grep for the
-mnemonics at the start of a line finds no use anywhere. That is consistency with
-the neighbouring instructions in kernels that hand-encode anyway, not a toolchain
-constraint. A new kernel with no other `WORD` in it should use the mnemonics.
+A grep for these mnemonics at the start of a line finds no use anywhere in the
+tree: every occurrence is a `WORD`. That is consistency with the neighbouring
+instructions in kernels that hand-encode anyway, not a toolchain constraint. A new
+kernel with no other `WORD` in it should use the mnemonics.
+
+One caveat if you do. `TestNoFMAContract` forbids a fused multiply-add in the
+kernels listed in `singleRoundingKernels`, and it sees a `WORD` through its decoded
+ARM spelling (`FMLA`) but a mnemonic through Go's Plan 9 spelling (`VFMLA`). Its
+regex covers both, so either form is caught; do not narrow it.
 
 An amusing asymmetry: `go tool objdump` happily *decodes* a hand-encoded word back
 to `VSMLAL ...`. The toolchain knows the instruction on the way out but not on the

--- a/f64/butterfly_complex_stage_test.go
+++ b/f64/butterfly_complex_stage_test.go
@@ -86,25 +86,19 @@ const stageTwiddlePhase = 0.4
 // Three of this file's tests compare two implementations of the same butterfly
 // over the same data, differing only in how their multiply-adds fuse: SIMD vs
 // butterflyComplexStageRef, SIMD vs the per-block ButterflyComplex loop, and
-// SIMD vs the Go fallback. All three land at the same magnitude, so all three
-// use this one bound rather than inventing their own. Measured 2026-08-01 with
-// go1.26 over the full stageSpans x stageBlockCounts sweep, the largest
+// SIMD vs the Go fallback. All three use this one bound rather than inventing
+// their own. Over the full stageSpans x stageBlockCounts sweep the largest
 // difference any of them produces is 1.78e-15, on both an AVX+FMA amd64 core
-// (i7-1260P) and a NEON Cortex-A76 (Pi 5).
+// and a NEON Cortex-A76.
 //
-// The bound has to be absolute. The largest value the sweep leaves behind after
-// a stage is 13.147, and 1.78e-15 is exactly one ULP there, so the error tracks
-// the magnitude of the OPERANDS rather than of the individual result: the
-// butterfly's sum and difference can cancel to near zero while the rounding that
-// produced them does not shrink with them. On amd64 the worst RELATIVE
-// difference over the same sweep is 1.46e-13, and it occurs on exactly such a
-// cancelled element.
+// The bound has to be absolute rather than relative, because the butterfly's
+// sum and difference can cancel to near zero while the rounding that produced
+// them does not shrink with them. On amd64 the worst RELATIVE difference over
+// the same sweep is 1.46e-13, and it occurs on exactly such a cancelled element.
 //
 // So stageAbsTol carries every row, at 56x the measured worst case. stageRelTol
 // is a safety valve for data larger than this fixture's; it only takes over
-// above |want| == 10 and no current row depends on it. Both are far tighter than
-// TestButterflyComplex's 1e-9/1e-11, which they used to copy: that pair is a
-// round number, not a measurement.
+// above |want| == 10 and no current row depends on it.
 const (
 	stageAbsTol = 1e-13
 	stageRelTol = 1e-14
@@ -204,13 +198,13 @@ func TestButterflyComplexStage_MatchesPerBlockLoop(t *testing.T) {
 }
 
 // TestButterflyComplexStage_SIMDvsGo compares the dispatched kernel against the
-// Go fallback directly, below the public wrapper's guard, so the shapes the
-// wrapper would send to Go still reach the kernel here.
+// Go fallback over an explicit (span, blocks) grid, rather than through the
+// public wrapper, which derives blocks from the slice lengths.
 //
-// It uses closeEnough like the rest of the file. It used to carry its own bare
-// 1e-12 absolute bound, described as tighter than closeEnough; measurement says
-// the two comparisons produce the same 1.78e-15 worst case, so a separate
-// constant bought nothing and hid a 560x-loose bound behind the word "tighter".
+// This does NOT get below the SIMD-versus-Go threshold: that lives inside
+// butterflyComplexStage64, which is the function called here, so rows under it
+// compare the Go path against itself. On amd64 that is 5 of the 140 rows
+// (blocks*span < 4), on arm64 1 (blocks*span < 2).
 func TestButterflyComplexStage_SIMDvsGo(t *testing.T) {
 	for _, span := range stageSpans {
 		for _, blocks := range stageBlockCounts {
@@ -242,19 +236,16 @@ func TestButterflyComplexStage_SIMDvsGo(t *testing.T) {
 // stageFFTTolPerN2 bounds TestButterflyComplexStage_FullFFT's per-bin error,
 // which grows as n^2 rather than as n.
 //
-// Measured 2026-08-01 with go1.26 over n in [8, 8192] on a NEON Cortex-A76 and
-// an AVX+FMA amd64 core: the largest per-bin error divided by n^2 stays inside
-// [4.5e-17, 1.4e-16], and the exponent fitted across that range is n^2.04. The
-// mechanism sits on the reference side, not in the kernels. The naive DFT
-// accumulates n terms per bin, so its own error is O(n * eps * |X[k]|), and
-// |X[k]| for this input grows like O(n); over the same range
-// err/(n * eps * max|X|) stays inside [0.38, 1.25].
+// Measured over n in [8, 8192] on a NEON Cortex-A76 and an AVX+FMA amd64 core,
+// the fitted exponent is roughly n^2 and this bound holds with at least 65x
+// headroom at every size measured (the minimum is 69.7x at n = 128), on arm64
+// and on amd64 under both GOAMD64=v1 and v3. The mechanism sits on
+// the reference side, not in the kernels: the naive DFT accumulates n terms per
+// bin, and |X[k]| for this input itself grows like O(n).
 //
-// This replaces a 1e-10*n bound, which grew as n^1 against an n^2 error, so its
-// headroom shrank with size: 1.7e5x at n = 8, 1167x at n = 1024, 125x at
-// n = 8192. Scaling by n^2 instead holds the headroom flat at 74x to 225x
-// across the whole measured range, so adding a larger row later does not
-// silently spend the margin.
+// It replaces a 1e-10*n bound, which grew as n^1 against an n^2 error, so its
+// headroom shrank with size. Scaling by n^2 keeps it roughly flat instead, so
+// adding a larger row later does not silently spend the margin.
 const stageFFTTolPerN2 = 1e-14
 
 // TestButterflyComplexStage_FullFFT drives a complete iterative Cooley-Tukey

--- a/f64/butterfly_complex_stage_test.go
+++ b/f64/butterfly_complex_stage_test.go
@@ -81,13 +81,33 @@ func stageTestData(n, span int) (re, im, twRe, twIm []float64) {
 // 1e-3 in magnitude.
 const stageTwiddlePhase = 0.4
 
-// Tolerances for closeEnough. The absolute floor carries values near zero, where a
-// relative bound is meaningless because the butterfly's sum and difference can
-// cancel to nearly nothing; the relative bound carries everything else. Both match
-// TestButterflyComplex's relTol.
+// Tolerances for closeEnough.
+//
+// Three of this file's tests compare two implementations of the same butterfly
+// over the same data, differing only in how their multiply-adds fuse: SIMD vs
+// butterflyComplexStageRef, SIMD vs the per-block ButterflyComplex loop, and
+// SIMD vs the Go fallback. All three land at the same magnitude, so all three
+// use this one bound rather than inventing their own. Measured 2026-08-01 with
+// go1.26 over the full stageSpans x stageBlockCounts sweep, the largest
+// difference any of them produces is 1.78e-15, on both an AVX+FMA amd64 core
+// (i7-1260P) and a NEON Cortex-A76 (Pi 5).
+//
+// The bound has to be absolute. The largest value the sweep leaves behind after
+// a stage is 13.147, and 1.78e-15 is exactly one ULP there, so the error tracks
+// the magnitude of the OPERANDS rather than of the individual result: the
+// butterfly's sum and difference can cancel to near zero while the rounding that
+// produced them does not shrink with them. On amd64 the worst RELATIVE
+// difference over the same sweep is 1.46e-13, and it occurs on exactly such a
+// cancelled element.
+//
+// So stageAbsTol carries every row, at 56x the measured worst case. stageRelTol
+// is a safety valve for data larger than this fixture's; it only takes over
+// above |want| == 10 and no current row depends on it. Both are far tighter than
+// TestButterflyComplex's 1e-9/1e-11, which they used to copy: that pair is a
+// round number, not a measurement.
 const (
-	stageAbsTol = 1e-9
-	stageRelTol = 1e-11
+	stageAbsTol = 1e-13
+	stageRelTol = 1e-14
 )
 
 // closeEnough is the tolerance used throughout: the vector and scalar paths fuse
@@ -183,13 +203,14 @@ func TestButterflyComplexStage_MatchesPerBlockLoop(t *testing.T) {
 	}
 }
 
-// stageSIMDvsGoTol bounds the SIMD-vs-Go difference. Both sides compute the same
-// stage over the same data and differ only in how their multiply-adds fuse, so this
-// is a tighter absolute bound than closeEnough, which compares against a separate
-// scalar reference. On stageTestData's inputs (magnitudes of order 10) the observed
-// difference is a few ULP, far under this.
-const stageSIMDvsGoTol = 1e-12
-
+// TestButterflyComplexStage_SIMDvsGo compares the dispatched kernel against the
+// Go fallback directly, below the public wrapper's guard, so the shapes the
+// wrapper would send to Go still reach the kernel here.
+//
+// It uses closeEnough like the rest of the file. It used to carry its own bare
+// 1e-12 absolute bound, described as tighter than closeEnough; measurement says
+// the two comparisons produce the same 1.78e-15 worst case, so a separate
+// constant bought nothing and hid a 560x-loose bound behind the word "tighter".
 func TestButterflyComplexStage_SIMDvsGo(t *testing.T) {
 	for _, span := range stageSpans {
 		for _, blocks := range stageBlockCounts {
@@ -206,10 +227,10 @@ func TestButterflyComplexStage_SIMDvsGo(t *testing.T) {
 				butterflyComplexStage64Go(reGo, imGo, span, blocks, twRe, twIm)
 
 				for i := range n {
-					if math.Abs(re[i]-reGo[i]) > stageSIMDvsGoTol {
+					if !closeEnough(re[i], reGo[i]) {
 						t.Errorf("re[%d]: SIMD=%v, Go=%v", i, re[i], reGo[i])
 					}
-					if math.Abs(im[i]-imGo[i]) > stageSIMDvsGoTol {
+					if !closeEnough(im[i], imGo[i]) {
 						t.Errorf("im[%d]: SIMD=%v, Go=%v", i, im[i], imGo[i])
 					}
 				}
@@ -217,6 +238,24 @@ func TestButterflyComplexStage_SIMDvsGo(t *testing.T) {
 		}
 	}
 }
+
+// stageFFTTolPerN2 bounds TestButterflyComplexStage_FullFFT's per-bin error,
+// which grows as n^2 rather than as n.
+//
+// Measured 2026-08-01 with go1.26 over n in [8, 8192] on a NEON Cortex-A76 and
+// an AVX+FMA amd64 core: the largest per-bin error divided by n^2 stays inside
+// [4.5e-17, 1.4e-16], and the exponent fitted across that range is n^2.04. The
+// mechanism sits on the reference side, not in the kernels. The naive DFT
+// accumulates n terms per bin, so its own error is O(n * eps * |X[k]|), and
+// |X[k]| for this input grows like O(n); over the same range
+// err/(n * eps * max|X|) stays inside [0.38, 1.25].
+//
+// This replaces a 1e-10*n bound, which grew as n^1 against an n^2 error, so its
+// headroom shrank with size: 1.7e5x at n = 8, 1167x at n = 1024, 125x at
+// n = 8192. Scaling by n^2 instead holds the headroom flat at 74x to 225x
+// across the whole measured range, so adding a larger row later does not
+// silently spend the margin.
+const stageFFTTolPerN2 = 1e-14
 
 // TestButterflyComplexStage_FullFFT drives a complete iterative Cooley-Tukey
 // transform through ButterflyComplexStage and checks it against a naive DFT.
@@ -271,9 +310,9 @@ func TestButterflyComplexStage_FullFFT(t *testing.T) {
 					wantRe += srcRe[i]*c - srcIm[i]*s
 					wantIm += srcRe[i]*s + srcIm[i]*c
 				}
-				// Accumulated FFT/DFT rounding grows with n; scale the bound by
-				// the transform size rather than using a flat epsilon.
-				tol := 1e-10 * float64(n)
+				// Accumulated rounding, dominated by the naive DFT reference,
+				// grows as n^2; see stageFFTTolPerN2.
+				tol := stageFFTTolPerN2 * float64(n) * float64(n)
 				if math.Abs(re[k]-wantRe) > tol || math.Abs(im[k]-wantIm) > tol {
 					t.Fatalf("bin %d = (%v, %v), want (%v, %v), tol %v",
 						k, re[k], im[k], wantRe, wantIm, tol)

--- a/f64/butterfly_complex_stage_test.go
+++ b/f64/butterfly_complex_stage_test.go
@@ -237,7 +237,8 @@ func TestButterflyComplexStage_SIMDvsGo(t *testing.T) {
 // which grows as n^2 rather than as n.
 //
 // Measured over n in [8, 8192] on a NEON Cortex-A76 and an AVX+FMA amd64 core,
-// the fitted exponent is roughly n^2 and this bound holds with at least 65x
+// the error grows as roughly n^2 (fitted exponent about 2, the exact figure
+// depending on the fit) and this bound holds with at least 65x
 // headroom at every size measured (the minimum is 69.7x at n = 128), on arm64
 // and on amd64 under both GOAMD64=v1 and v3. The mechanism sits on
 // the reference side, not in the kernels: the naive DFT accumulates n terms per

--- a/f64/f64.go
+++ b/f64/f64.go
@@ -921,9 +921,10 @@ const butterflyStageRadix = 2
 // ButterflyComplex costs one call per block, so the call count grows as the
 // runs get short and per-call overhead dominates the small-span stages. Taking
 // the whole stage lets the implementation pick its own vectorization axis,
-// which is not expressible through the per-block API: across j when span fills
-// a vector, and across blocks at the short spans that do. A span that fills
-// neither (span 3 on the 4-wide AVX path) runs the scalar tail.
+// which is not expressible through the per-block API: across j when span is
+// large enough to fill a vector, and across blocks when span is short enough
+// that a whole vector of them fits. A span between the two fills neither axis
+// (span 3 on the 4-wide AVX path) and runs the scalar tail.
 //
 // The stage is a no-op unless span > 0, len(twRe) >= span and len(twIm) >= span,
 // and it is also a no-op when no complete block fits. Blocks are processed while

--- a/f64/f64.go
+++ b/f64/f64.go
@@ -920,9 +920,10 @@ const butterflyStageRadix = 2
 // It is the stage-level form of [ButterflyComplex]. Driving a stage through
 // ButterflyComplex costs one call per block, so the call count grows as the
 // runs get short and per-call overhead dominates the small-span stages. Taking
-// the whole stage lets the implementation pick its own vectorization axis:
-// across j when span is large enough to fill a vector, and across blocks when
-// it is not, which is not expressible through the per-block API.
+// the whole stage lets the implementation pick its own vectorization axis,
+// which is not expressible through the per-block API: across j when span fills
+// a vector, and across blocks at the short spans that do. A span that fills
+// neither (span 3 on the 4-wide AVX path) runs the scalar tail.
 //
 // The stage is a no-op unless span > 0, len(twRe) >= span and len(twIm) >= span,
 // and it is also a no-op when no complete block fits. Blocks are processed while

--- a/f64/f64_arm64.s
+++ b/f64/f64_arm64.s
@@ -2853,12 +2853,13 @@ butterfly_neon_done:
 // pairs into an upper and a lower vector, and ZIP1/ZIP2 put them back.
 //
 // Registers, span >= 2 path: R0/R1 re+im block bases, R2/R3 twiddle bases,
-// R4 span, R5 blocks, R6/R7 upper pointers, R19/R20 lower pointers, R21/R22
-// twiddle pointers, R23 inner counter, R24 span bytes, R25 block bytes.
-// The span == 1 path uses R0/R1 as the running re+im cursors, R6/R7 as the
-// second block's addresses, V12/V13 as the splat twiddle and R23 as the
-// block-pair counter; it never writes R19-R22, R24 or R25. Frame:
-// re(24)+im(24)+span(8)+blocks(8)+twRe(24)+twIm(24) = 112 bytes.
+// R4 span, R5 blocks, R6/R7 upper pointers, R8 span/2 and R9 span&1 (both
+// invariant across the block loop, so both are hoisted above it), R19/R20
+// lower pointers, R21/R22 twiddle pointers, R23 inner counter, R24 span bytes,
+// R25 block bytes. The span == 1 path uses R0/R1 as the running re+im cursors,
+// R6/R7 as the second block's addresses, V12/V13 as the splat twiddle and R23
+// as the block-pair counter; it never writes R8, R9, R19-R22, R24 or R25.
+// Frame: re(24)+im(24)+span(8)+blocks(8)+twRe(24)+twIm(24) = 112 bytes.
 TEXT ·butterflyComplexStageNEON(SB), NOSPLIT, $0-112
     MOVD re_base+0(FP), R0           // R0 = re block base
     MOVD im_base+24(FP), R1          // R1 = im block base
@@ -2877,6 +2878,8 @@ TEXT ·butterflyComplexStageNEON(SB), NOSPLIT, $0-112
     // ----------------------------------------------------------------------
     LSL  $3, R4, R24                 // R24 = span*8 = upper->lower byte offset
     LSL  $4, R4, R25                 // R25 = span*16 = block stride in bytes
+    LSR  $1, R4, R8                  // R8 = span/2 = vector iterations per block
+    AND  $1, R4, R9                  // R9 = span&1, the odd-span scalar butterfly
 
 bfstage_neon_block:
     MOVD R0, R6                      // R6 = upper re
@@ -2885,7 +2888,7 @@ bfstage_neon_block:
     ADD  R24, R1, R20                // R20 = lower im
     MOVD R2, R21                     // R21 = twRe
     MOVD R3, R22                     // R22 = twIm
-    LSR  $1, R4, R23                 // R23 = span/2 vector iterations
+    MOVD R8, R23                     // R23 = working copy of the vector count
     CBZ  R23, bfstage_neon_tail_pre
 
 bfstage_neon_vec:
@@ -2918,8 +2921,7 @@ bfstage_neon_vec:
     CBNZ R23, bfstage_neon_vec
 
 bfstage_neon_tail_pre:
-    AND  $1, R4, R23                 // odd span leaves one scalar butterfly
-    CBZ  R23, bfstage_neon_next
+    CBZ  R9, bfstage_neon_next       // even span: no scalar butterfly left
 
     FMOVD (R19), F2                  // lowerRe
     FMOVD (R20), F3                  // lowerIm
@@ -2954,6 +2956,15 @@ bfstage_neon_next:
     // interleaved. Take 2 blocks (4 float64) per iteration, UZP1/UZP2 to
     // separate the uppers from the lowers, ZIP1/ZIP2 to re-interleave on the
     // way out. The twiddle is the single tw[0], splatted once.
+    //
+    // The loop body's six load instructions and four stores could be two
+    // multi-register loads and two multi-register stores instead
+    // (VLD1 (R0), [V0.D2, V1.D2] and VST1.P [V0.D2, V1.D2], 32(R0)), dropping 6
+    // of its 28 instructions. Measured on a Cortex-A76 (Pi 5, binaries built
+    // with go1.26.5, 15 paired rounds at 2s over span 1 of a 1024-point stage):
+    // 1389ns median before, 1383ns after, 0.4%, with the two ranges
+    // overlapping. The loop is not issue-bound, so the shorter form is not worth
+    // rewriting a hot kernel for; see #206.
     // ----------------------------------------------------------------------
 bfstage_neon_span1:
     FMOVD (R2), F12
@@ -3009,13 +3020,16 @@ bfstage_neon_span1_tail_pre:
 
     FMOVD 8(R0), F2                  // lowerRe
     FMOVD 8(R1), F3                  // lowerIm
-    FMOVD (R2), F4                   // twRe[0]
-    FMOVD (R3), F5                   // twIm[0]
-    FMULD F2, F4, F6
-    FMULD F3, F5, F7
+    // The twiddle is already in registers: F12/F13 alias lane 0 of the V12/V13
+    // splats built at bfstage_neon_span1, and the vector loop above only ever
+    // reads V12/V13 (they are sources of the FMUL/FMLS/FMLA words, never
+    // destinations), so lane 0 still holds twRe[0]/twIm[0]. Reloading them from
+    // (R2)/(R3) would be two redundant loads.
+    FMULD F2, F12, F6
+    FMULD F3, F13, F7
     FSUBD F7, F6, F6                 // F6 = tempRe
-    FMULD F2, F5, F7
-    FMULD F3, F4, F8
+    FMULD F2, F13, F7
+    FMULD F3, F12, F8
     FADDD F7, F8, F7                 // F7 = tempIm
     FMOVD (R0), F0                   // upperRe
     FMOVD (R1), F1                   // upperIm

--- a/f64/f64_arm64.s
+++ b/f64/f64_arm64.s
@@ -2957,14 +2957,15 @@ bfstage_neon_next:
     // separate the uppers from the lowers, ZIP1/ZIP2 to re-interleave on the
     // way out. The twiddle is the single tw[0], splatted once.
     //
-    // The loop body's six load instructions and four stores could be two
-    // multi-register loads and two multi-register stores instead
-    // (VLD1 (R0), [V0.D2, V1.D2] and VST1.P [V0.D2, V1.D2], 32(R0)), dropping 6
-    // of its 28 instructions. Measured on a Cortex-A76 (Pi 5, binaries built
-    // with go1.26.5, 15 paired rounds at 2s over span 1 of a 1024-point stage):
-    // 1389ns median before, 1383ns after, 0.4%, with the two ranges
-    // overlapping. The loop is not issue-bound, so the shorter form is not worth
-    // rewriting a hot kernel for; see #206.
+    // The loop body's four loads, the two ADDs that address them, and its four
+    // stores could be two multi-register loads and two multi-register stores
+    // instead (VLD1 (R0), [V0.D2, V1.D2] and VST1.P [V0.D2, V1.D2], 32(R0)),
+    // dropping 6 of its 28 instructions. Measured on a Cortex-A76 over span 1
+    // of a 1024-point stage, in paired interleaved rounds: under 1%, which is
+    // not worth rewriting a hot kernel for. Neither throughput floor binds here
+    // (about 13 cycles per iteration against a decode floor of 7 and an ASIMD
+    // floor of 8), and none of the six removed instructions is ASIMD, so the
+    // shorter form cannot move the higher of the two. See #206.
     // ----------------------------------------------------------------------
 bfstage_neon_span1:
     FMOVD (R2), F12


### PR DESCRIPTION
Closes #206.

Two ARM64 micro-optimisations to `butterflyComplexStageNEON`, a third one measured and declined, unified test tolerances, and two documentation fixes.

## Kernel

The span-1 scalar tail no longer reloads the twiddles from memory. `V12`/`V13` already hold them broadcast and are never written in the vector loop, so the tail multiplies against `F12`/`F13` directly. The AMD64 sibling already did this.

`span/2` and `span&1` are hoisted out of the per-block loop into `R8` and `R9`. The parity `AND` and its per-block branch on a constant condition leave the loop entirely.

A third candidate, the multi-register `VLD1`/`VST1` form at span 1, was implemented, measured and reverted. It removes 6 of 28 instructions from the loop body and moves the number about 0.65%, which is not worth rewriting a hot kernel for. The measurement is recorded in the kernel comment so it is not re-attempted.

## Verification

**Output is byte-identical.** A 270-shape sweep over spans 1 through 256 and block counts 1 through 65, covering odd block counts so the span-1 scalar tail actually runs, compared raw `float64` bits: identical to `main` at every element, on Apple Silicon and a Cortex-A76, under go1.25.6 and go1.26.5.

**The register-lifetime reasoning was checked against emitted code, not source.** Every `WORD` in the span-1 vector loop was decoded with `arm64asm` and read back out of a linked binary with `objdump`. `V12`/`V13` appear only as `Rm`; every destination is V0-V11, V14, V15. `R4` is never written after the hoist, and the block loop writes only R0, R1, R5, R6, R7, R19-R23.

**Both changes are pinned by mutation.** Swapping `F12`/`F13` in the tail fails at exactly the odd block counts that reach it. Destroying the hoisted count register produces 266 failing subtests. Flipping the hoisted parity branch fails at span 2. Injecting a sign error into the span-1 vector kernel kills the three fixture-driven tests, which also confirms the fixture's non-identity twiddle defeats the trap where an identity `(1, 0)` hides sign errors.

One mutation is worth recording: a wrongly-true parity on an even span does not merely produce wrong numbers, it corrupts the heap, dying in `runtime.scanObject`. The scalar butterfly runs with pointers the vector loop already post-incremented, writing past the block and, on the last block, past the caller's slices. That `CBZ` is a memory-safety guard, not only a correctness gate.

**Performance.** The span-2 gain is 2.4%, confirmed under alignment control: eight binaries at four 16-byte shifts each, with the ratio holding at every shift individually and an untouched Go arm returning exactly 1.0000 at all five spans. It is backed by a static cost model, since the hoist removes exactly one instruction per block and span 2 is the span where per-block overhead is the largest share of the work. The gain decays to nothing by span 64, which is the right shape. No regression at any span.

## Tolerances

Three schemes collapsed to two. `closeEnough` went from `1e-9`/`1e-11` to `1e-13`/`1e-14`, and `_SIMDvsGo`'s private `1e-12` was deleted rather than renamed.

The tightening is safe, and the reason is not "it passed on two machines". IEEE-754 binary64 multiply, add, subtract and FMA are correctly rounded, so the same instruction stream is bit-identical on every conforming part; only the choice of instruction stream can move the result. Each such axis was measured: Apple Silicon versus Cortex-A76 is bit-identical in all 22 measured quantities, go1.25.6 versus go1.26.5 is bit-identical, and the only axis that moves anything is `GOAMD64=v1` versus `v3`, by 2.6% against 56x headroom. `math.Sin`/`Cos` have an architecture implementation only on s390x, so there is no libm variation on any CI leg.

## Second commit

The pre-push gate found every defect in the prose rather than the code, so the follow-up is mostly deletion. Three measured intervals were wrong at both ends and are gone; a causal claim about operand magnitude turned out to be a binade coincidence; a comment claimed the SIMD-versus-Go test gets below a threshold that lives inside the very function it calls; and a revert note attributed a 0.65% effect to overlapping ranges that do not overlap.

Two of those fixes are worth calling out because they close real holes rather than tidying prose:

`TestNoFMAContract`'s regex matched `FMLA`, the spelling a decoded `WORD` yields, but not `VFMLA`, the spelling a source mnemonic yields, while this change's documentation recommends mnemonics for new kernels. A kernel in `singleRoundingKernels` could have fused silently, defeating the #156 single-rounding guarantee. Verified by inserting `VFMLA` into `float32ToInt32ScaleClampNEON`: the widened regex catches it and the original passes it.

`CONTRIBUTING.md`'s add-an-operation checklist ended at "update `README.md`" and never mentioned `doc.go`, which is why three FFT primitives reached the README and not the index. The checklist is fixed as well as the entry.

## Filed separately

#211 batches the pre-existing findings, the largest being that all three tolerance comparisons collapse to exact equality under `SIMD_DISABLE` and on the qemu fallback legs, so no test asserts the vector kernel actually ran.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Expanded FFT operation documentation and clarified vectorization behavior for complex butterfly stages.
  * Added guidance for contributors maintaining API operation indexes.
  * Expanded ARM64 instruction encoding and verification documentation.

* **Performance**
  * Improved ARM64 FFT butterfly-stage execution by reducing repeated calculations and memory loads.

* **Bug Fixes**
  * Strengthened safeguards ensuring fused multiply-add operations are correctly excluded when required.

* **Tests**
  * Refined floating-point tolerances and coverage for more reliable FFT validation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->