### PR TITLE
f32,f64: hoist the realFFTUnpack scalar-tail constants out of the loop (#208)

### DIFF
--- a/f32/f32_amd64.s
+++ b/f32/f32_amd64.s
@@ -5371,33 +5371,42 @@ realfft_remainder:
     ADDQ BX, R12                     // R12 = &twIm[k-1]
     INCQ AX                          // Restore AX = k
 
-realfft_scalar:
-    // Calculate mirror index: nk = n - k
+    // Mirror pointers for the tail. nk = n-k falls by one as k rises, so R9 and
+    // R10 walk backwards through zRe/zIm instead of being recomputed from the
+    // frame on every iteration. Both are dead here: the 8-wide loop above has
+    // finished with them, and this block sets both unconditionally, so the
+    // AX == 0 entry that skips the vector preamble is covered too.
     MOVQ CX, BX
-    SUBQ AX, BX                      // BX = n - k = nk
+    SUBQ AX, BX                      // BX = n - k = nk of the first tail element
+    SHLQ $2, BX                      // BX = nk * 4 = byte offset
+    MOVQ zRe_base+48(FP), R9
+    ADDQ BX, R9                      // R9 = &zRe[nk]
+    MOVQ zIm_base+72(FP), R10
+    ADDQ BX, R10                     // R10 = &zIm[nk]
 
+    // Tail constants, hoisted out of the loop and loaded from RODATA with VEX.
+    // Whenever the 8-wide loop ran, the upper YMM halves are dirty here (the
+    // only VZEROUPPER is at realfft_done), so a legacy-SSE MOVD in the loop
+    // body pays an AVX-SSE transition: MEASURED at 2 assists.sse_avx_mix per
+    // iteration on an i7-1260P, about 213 cycles each, which is essentially the
+    // whole per-element tail cost. Dropping them took n=64 from 662 ns to
+    // 27 ns. See #208.
+    VMOVSS roundf32_half<>(SB), X13     // X13 = 0.5f
+    VMOVSS roundf32_signmask<>(SB), X14 // X14 = 0x80000000 (sign bit only)
+
+realfft_scalar:
     // Load Z[k]
     VMOVSS (DI), X0                  // X0 = zRe[k]
     VMOVSS (R8), X1                  // X1 = zIm[k]
 
     // Load conj(Z[n-k])
-    MOVQ zRe_base+48(FP), R15
-    MOVQ BX, R9
-    SHLQ $2, R9
-    ADDQ R9, R15
-    VMOVSS (R15), X2                 // X2 = zRe[nk]
+    VMOVSS (R9), X2                  // X2 = zRe[nk]
+    VMOVSS (R10), X3                 // X3 = zIm[nk]
 
-    MOVQ zIm_base+72(FP), R15
-    ADDQ R9, R15
-    VMOVSS (R15), X3                 // X3 = zIm[nk]
-
-    // Load 0.5 constant (0x3F000000 = 0.5f)
-    MOVL $0x3F000000, BX
-    MOVD BX, X13
-
-    // Negate X3 for conjugate: znkIm = -zIm[nk]
-    VXORPS X14, X14, X14
-    VSUBSS X3, X14, X3               // X3 = -zIm[nk] = znkIm
+    // Negate X3 for conjugate: znkIm = -zIm[nk]. The sign-bit flip matches the
+    // 8-wide body above and realFFTUnpack32Go, both of which negate; a 0 - x
+    // subtract returns +0 for zIm[nk] == +0 where -x returns -0.
+    VXORPS X14, X3, X3               // X3 = -zIm[nk] = znkIm
 
     // evenRe = 0.5 * (zkRe + znkRe)
     VADDSS X0, X2, X4
@@ -5438,11 +5447,12 @@ realfft_scalar:
     // Advance pointers
     ADDQ $4, DI
     ADDQ $4, R8
+    SUBQ $4, R9                      // mirror zRe: nk--
+    SUBQ $4, R10                     // mirror zIm: nk--
     ADDQ $4, R11
     ADDQ $4, R12
     ADDQ $4, DX
     ADDQ $4, SI
-    INCQ AX                          // k++
 
     DECQ R13
     JNZ  realfft_scalar

--- a/f32/f32_test.go
+++ b/f32/f32_test.go
@@ -3447,8 +3447,105 @@ func TestRealFFTUnpack_KnownValues(t *testing.T) {
 	}
 }
 
+// TestRealFFTUnpack_SignedZero pins the sign of a zero result. Every input is a
+// signed zero and every twiddle is +1 or -1, so every intermediate is an exact
+// zero and nothing rounds: the comparison can be bit-for-bit. The AVX scalar
+// tail used to negate for the conjugate with 0 - x, which returns +0 where -x
+// returns -0, so it disagreed with both its own 8-wide body and the Go
+// reference on these inputs (#208).
+//
+// Both comparisons are needed and neither covers the other. Dispatched-vs-Go
+// pins the kernel, but wherever the dispatcher declines SIMD it CALLS
+// realFFTUnpack32Go, so that arm degenerates to comparing a value with itself.
+// Go-vs-realFFTUnpackRef pins the fallback against an independently written
+// oracle and holds on every tier. Swapping the first arm to the oracle instead
+// of adding the second would just move the blind spot onto the AVX path, where
+// realFFTUnpack32Go stops being reachable from RealFFTUnpack.
+func TestRealFFTUnpack_SignedZero(t *testing.T) {
+	// (n-1)%8 runs 0..7 over 9..16, so the AVX scalar tail is exercised at every
+	// length it can have; the NEON tail is (n-1)%4 and this list sweeps that too.
+	// 64 and 65 add a size with several full 8-wide blocks ahead of a full tail
+	// and one with no tail at all.
+	sizes := []int{9, 10, 11, 12, 13, 14, 15, 16, 64, 65}
+
+	for _, n := range sizes {
+		t.Run(fmt.Sprintf("n=%d", n), func(t *testing.T) {
+			zRe := make([]float32, n)
+			zIm := make([]float32, n)
+			twRe := make([]float32, n-1)
+			twIm := make([]float32, n-1)
+			outRe := make([]float32, n)
+			outIm := make([]float32, n)
+			outReGo := make([]float32, n)
+			outImGo := make([]float32, n)
+			outReRef := make([]float32, n)
+			outImRef := make([]float32, n)
+
+			// Six independent sign bits. zRe and zIm each get one sign for the low
+			// half of the input and one for the high half: a tail element has k in
+			// the high half and its mirror index nk = n-k in the low half, so the
+			// split lets the sweep drive the two ends of a mirrored pair apart.
+			// The two twiddles take one sign each. 64 patterns covers every
+			// combination.
+			const signBits = 6
+			for pat := range 1 << signBits {
+				sign := func(bit uint) float64 {
+					if pat&(1<<bit) != 0 {
+						return -1
+					}
+					return 1
+				}
+				half := n / 2
+				for i := range n {
+					reBit, imBit := uint(0), uint(1)
+					if i >= half {
+						reBit, imBit = 2, 3
+					}
+					zRe[i] = float32(math.Copysign(0, sign(reBit)))
+					zIm[i] = float32(math.Copysign(0, sign(imBit)))
+				}
+				for k := 1; k < n; k++ {
+					twRe[k-1] = float32(sign(4))
+					twIm[k-1] = float32(sign(5))
+				}
+
+				RealFFTUnpack(outRe, outIm, zRe, zIm, twRe, twIm)
+				realFFTUnpack32Go(outReGo, outImGo, zRe, zIm, twRe, twIm, n)
+				realFFTUnpackRef(outReRef, outImRef, zRe, zIm, twRe, twIm, n)
+
+				for k := 1; k < n; k++ {
+					if math.Float32bits(outRe[k]) != math.Float32bits(outReGo[k]) {
+						t.Errorf("pat=%#02x k=%d: outRe = %v (%#08x), Go = %v (%#08x)",
+							pat, k, outRe[k], math.Float32bits(outRe[k]),
+							outReGo[k], math.Float32bits(outReGo[k]))
+					}
+					if math.Float32bits(outIm[k]) != math.Float32bits(outImGo[k]) {
+						t.Errorf("pat=%#02x k=%d: outIm = %v (%#08x), Go = %v (%#08x)",
+							pat, k, outIm[k], math.Float32bits(outIm[k]),
+							outImGo[k], math.Float32bits(outImGo[k]))
+					}
+					if math.Float32bits(outReGo[k]) != math.Float32bits(outReRef[k]) {
+						t.Errorf("pat=%#02x k=%d: Go outRe = %v (%#08x), ref = %v (%#08x)",
+							pat, k, outReGo[k], math.Float32bits(outReGo[k]),
+							outReRef[k], math.Float32bits(outReRef[k]))
+					}
+					if math.Float32bits(outImGo[k]) != math.Float32bits(outImRef[k]) {
+						t.Errorf("pat=%#02x k=%d: Go outIm = %v (%#08x), ref = %v (%#08x)",
+							pat, k, outImGo[k], math.Float32bits(outImGo[k]),
+							outImRef[k], math.Float32bits(outImRef[k]))
+					}
+				}
+			}
+		})
+	}
+}
+
 func BenchmarkRealFFTUnpack(b *testing.B) {
-	sizes := []int{64, 128, 256, 512, 1024, 4096}
+	// 513 sits next to 512 because every power of two in this list has
+	// (n-1)%8 == 7, the longest AVX scalar tail (and (n-1)%4 == 3, the longest
+	// NEON one). Without a size where the tail is empty its cost is charged to
+	// every row and reads as the kernel's baseline.
+	sizes := []int{64, 128, 256, 512, 513, 1024, 4096}
 
 	benchFn := func(b *testing.B, n int, fn func(outRe, outIm, zRe, zIm, twRe, twIm []float32, n int)) {
 		b.Helper()

--- a/f64/f64_amd64.s
+++ b/f64/f64_amd64.s
@@ -6569,33 +6569,42 @@ realfft64_remainder:
     ADDQ BX, R12                     // R12 = &twIm[k-1]
     INCQ AX                          // Restore AX = k
 
-realfft64_scalar:
-    // Calculate mirror index: nk = n - k
+    // Mirror pointers for the tail. nk = n-k falls by one as k rises, so R9 and
+    // R10 walk backwards through zRe/zIm instead of being recomputed from the
+    // frame on every iteration. Both are dead here: the 4-wide loop above has
+    // finished with them, and this block sets both unconditionally, so the
+    // AX == 0 entry that skips the vector preamble is covered too.
     MOVQ CX, BX
-    SUBQ AX, BX                      // BX = n - k = nk
+    SUBQ AX, BX                      // BX = n - k = nk of the first tail element
+    SHLQ $3, BX                      // BX = nk * 8 = byte offset
+    MOVQ zRe_base+48(FP), R9
+    ADDQ BX, R9                      // R9 = &zRe[nk]
+    MOVQ zIm_base+72(FP), R10
+    ADDQ BX, R10                     // R10 = &zIm[nk]
 
+    // Tail constants, hoisted out of the loop and loaded from RODATA with VEX.
+    // Whenever the 4-wide loop ran, the upper YMM halves are dirty here (the
+    // only VZEROUPPER is at realfft64_done), so a legacy-SSE MOVQ in the loop
+    // body pays an AVX-SSE transition: MEASURED at 2 assists.sse_avx_mix per
+    // iteration on an i7-1260P, about 213 cycles each, which is essentially the
+    // whole per-element tail cost. Dropping them took n=64 from 314 ns to
+    // 32 ns. See #208.
+    VMOVSD roundf64_half<>(SB), X13     // X13 = 0.5
+    VMOVSD roundf64_signmask<>(SB), X14 // X14 = 0x8000000000000000 (sign bit)
+
+realfft64_scalar:
     // Load Z[k]
     VMOVSD (DI), X0                  // X0 = zRe[k]
     VMOVSD (R8), X1                  // X1 = zIm[k]
 
     // Load conj(Z[n-k])
-    MOVQ zRe_base+48(FP), R15
-    MOVQ BX, R9
-    SHLQ $3, R9
-    ADDQ R9, R15
-    VMOVSD (R15), X2                 // X2 = zRe[nk]
+    VMOVSD (R9), X2                  // X2 = zRe[nk]
+    VMOVSD (R10), X3                 // X3 = zIm[nk]
 
-    MOVQ zIm_base+72(FP), R15
-    ADDQ R9, R15
-    VMOVSD (R15), X3                 // X3 = zIm[nk]
-
-    // Load 0.5 constant (0x3FE0000000000000 = 0.5)
-    MOVQ $0x3FE0000000000000, BX
-    MOVQ BX, X13
-
-    // Negate X3 for conjugate: znkIm = -zIm[nk]
-    VXORPD X14, X14, X14
-    VSUBSD X3, X14, X3               // X3 = -zIm[nk] = znkIm
+    // Negate X3 for conjugate: znkIm = -zIm[nk]. The sign-bit flip matches the
+    // 4-wide body above and realFFTUnpack64Go, both of which negate; a 0 - x
+    // subtract returns +0 for zIm[nk] == +0 where -x returns -0.
+    VXORPD X14, X3, X3               // X3 = -zIm[nk] = znkIm
 
     // evenRe = 0.5 * (zkRe + znkRe)
     VADDSD X0, X2, X4
@@ -6636,11 +6645,12 @@ realfft64_scalar:
     // Advance pointers
     ADDQ $8, DI
     ADDQ $8, R8
+    SUBQ $8, R9                      // mirror zRe: nk--
+    SUBQ $8, R10                     // mirror zIm: nk--
     ADDQ $8, R11
     ADDQ $8, R12
     ADDQ $8, DX
     ADDQ $8, SI
-    INCQ AX                          // k++
 
     DECQ R13
     JNZ  realfft64_scalar

--- a/f64/realfftunpack_test.go
+++ b/f64/realfftunpack_test.go
@@ -337,8 +337,105 @@ func TestRealFFTUnpack_ShortSlices(t *testing.T) {
 	}
 }
 
+// TestRealFFTUnpack_SignedZero pins the sign of a zero result. Every input is a
+// signed zero and every twiddle is +1 or -1, so every intermediate is an exact
+// zero and nothing rounds: the comparison can be bit-for-bit. The AVX scalar
+// tail used to negate for the conjugate with 0 - x, which returns +0 where -x
+// returns -0, so it disagreed with both its own 4-wide body and the Go
+// reference on these inputs (#208).
+//
+// Both comparisons are needed and neither covers the other. Dispatched-vs-Go
+// pins the kernel, but wherever the dispatcher declines SIMD it CALLS
+// realFFTUnpack64Go, so that arm degenerates to comparing a value with itself.
+// Go-vs-realFFTUnpackRef pins the fallback against an independently written
+// oracle and holds on every tier. Swapping the first arm to the oracle instead
+// of adding the second would just move the blind spot onto the AVX path, where
+// realFFTUnpack64Go stops being reachable from RealFFTUnpack.
+func TestRealFFTUnpack_SignedZero(t *testing.T) {
+	// (n-1)%4 runs 0..3 over 5..8, so the AVX scalar tail is exercised at every
+	// length it can have; the NEON tail is (n-1)%2 and this list sweeps that too.
+	// 16, 64 and 65 add sizes with several full 4-wide blocks ahead of the tail,
+	// including one with no tail at all.
+	sizes := []int{5, 6, 7, 8, 16, 64, 65}
+
+	for _, n := range sizes {
+		t.Run(fmt.Sprintf("n=%d", n), func(t *testing.T) {
+			zRe := make([]float64, n)
+			zIm := make([]float64, n)
+			twRe := make([]float64, n-1)
+			twIm := make([]float64, n-1)
+			outRe := make([]float64, n)
+			outIm := make([]float64, n)
+			outReGo := make([]float64, n)
+			outImGo := make([]float64, n)
+			outReRef := make([]float64, n)
+			outImRef := make([]float64, n)
+
+			// Six independent sign bits. zRe and zIm each get one sign for the low
+			// half of the input and one for the high half: a tail element has k in
+			// the high half and its mirror index nk = n-k in the low half, so the
+			// split lets the sweep drive the two ends of a mirrored pair apart.
+			// The two twiddles take one sign each. 64 patterns covers every
+			// combination.
+			const signBits = 6
+			for pat := range 1 << signBits {
+				sign := func(bit uint) float64 {
+					if pat&(1<<bit) != 0 {
+						return -1
+					}
+					return 1
+				}
+				half := n / 2
+				for i := range n {
+					reBit, imBit := uint(0), uint(1)
+					if i >= half {
+						reBit, imBit = 2, 3
+					}
+					zRe[i] = math.Copysign(0, sign(reBit))
+					zIm[i] = math.Copysign(0, sign(imBit))
+				}
+				for k := 1; k < n; k++ {
+					twRe[k-1] = sign(4)
+					twIm[k-1] = sign(5)
+				}
+
+				RealFFTUnpack(outRe, outIm, zRe, zIm, twRe, twIm)
+				realFFTUnpack64Go(outReGo, outImGo, zRe, zIm, twRe, twIm, n)
+				realFFTUnpackRef(outReRef, outImRef, zRe, zIm, twRe, twIm, n)
+
+				for k := 1; k < n; k++ {
+					if math.Float64bits(outRe[k]) != math.Float64bits(outReGo[k]) {
+						t.Errorf("pat=%#02x k=%d: outRe = %v (%#016x), Go = %v (%#016x)",
+							pat, k, outRe[k], math.Float64bits(outRe[k]),
+							outReGo[k], math.Float64bits(outReGo[k]))
+					}
+					if math.Float64bits(outIm[k]) != math.Float64bits(outImGo[k]) {
+						t.Errorf("pat=%#02x k=%d: outIm = %v (%#016x), Go = %v (%#016x)",
+							pat, k, outIm[k], math.Float64bits(outIm[k]),
+							outImGo[k], math.Float64bits(outImGo[k]))
+					}
+					if math.Float64bits(outReGo[k]) != math.Float64bits(outReRef[k]) {
+						t.Errorf("pat=%#02x k=%d: Go outRe = %v (%#016x), ref = %v (%#016x)",
+							pat, k, outReGo[k], math.Float64bits(outReGo[k]),
+							outReRef[k], math.Float64bits(outReRef[k]))
+					}
+					if math.Float64bits(outImGo[k]) != math.Float64bits(outImRef[k]) {
+						t.Errorf("pat=%#02x k=%d: Go outIm = %v (%#016x), ref = %v (%#016x)",
+							pat, k, outImGo[k], math.Float64bits(outImGo[k]),
+							outImRef[k], math.Float64bits(outImRef[k]))
+					}
+				}
+			}
+		})
+	}
+}
+
 func BenchmarkRealFFTUnpack(b *testing.B) {
-	sizes := []int{64, 128, 256, 512, 1024, 4096}
+	// 513 sits next to 512 because every power of two in this list has
+	// (n-1)%4 == 3, the longest AVX scalar tail (and (n-1)%2 == 1, the longest
+	// NEON one). Without a size where the tail is empty its cost is charged to
+	// every row and reads as the kernel's baseline.
+	sizes := []int{64, 128, 256, 512, 513, 1024, 4096}
 
 	benchFn := func(b *testing.B, n int, fn func(outRe, outIm, zRe, zIm, twRe, twIm []float64, n int)) {
 		b.Helper()


### PR DESCRIPTION
Closes #208.

`realFFTUnpackAVX`'s scalar remainder loop contained one non-VEX vector instruction, `MOVD BX, X13`, executed with the upper YMM halves dirty because the only `VZEROUPPER` is at `realfft_done`. That is an AVX-SSE transition, and it cost two microcode assists per tail iteration at roughly 213 cycles each.

Because every size in `BenchmarkRealFFTUnpack` was a power of two, and every power of two has the maximum tail length in both packages, **every benchmarked size sat at maximum tail cost**, and the accelerated path was slower than the pure-Go fallback it replaces at f32 n=64, 128 and 256.

## Measured

`cpu_core/assists.sse_avx_mix`, i7-1260P, pinned, one process per point. The per-size model is exact: 2 assists per tail iteration, 0 when the tail is empty, across all eight f32 tail lengths and all four f64 ones. That pins the entire cost to one loop rather than inferring it.

Interleaved medians, 11 rounds with the order swapped each round, with the untouched pure-Go path and the new tail-free size 513 as controls:

| bench | f32 before | f32 after | f64 before | f64 after |
|---|---|---|---|---|
| SIMD_64 | 663.2 ns | **26.77** | 314.3 ns | **32.05** |
| SIMD_512 | 764.2 | **118.8** | 471.0 | **190.2** |
| SIMD_4096 | 2189 | 1556 | 3466 | 3168 |
| **SIMD_513** (no tail, control) | 112.9 | 112.6 | 188.7 | 188.7 |

Assists go to 0 at every size, and IPC at f32 n=64 goes from 0.25 to 5.8. The saving is a constant per call equal to the tail length times about 425 cycles: 639 ns for f32's 7 elements and 277 ns for f64's 3, a ratio of 2.31 against the 2.33 the tail lengths predict. After the fix the tail loop sits at the FP-port throughput floor.

The empty-tail path is not merely unchanged but unreachable by the new code: `ANDQ $7, R13; JZ realfft_done` runs before the added setup, confirmed by instruction counts at n=513 being identical between builds.

## The negation change

The conjugate negation moves from `0 - x` to a sign-bit flip. The two differ on `+0`, so the old tail agreed with neither its own vector body (already `VXORPS`) nor the Go reference (`-zIm[nk]`). It also disagreed with **this function's own godoc**, whose stated formula `evenIm = 0.5 * (zIm[k] - zIm[n-k])` yields `-0` for the case the old tail returned `+0`.

Checked over two independent corpora sweeping every tail residue with NaN, Inf and signed-zero generators. Every changed component is in the scalar tail, at a size with a non-empty tail, and differs only in a sign bit; no payload bit and no magnitude changes. Signed zeros are strictly fixed. NaN signs are a net but not a strict improvement: most stop disagreeing with the reference and a few start, all sign-only, and IEEE 754 specifies neither which NaN propagates nor the sign of a NaN result. The 8-wide body already disagreed with Go on NaN signs before this change, unchanged by it.

Release note for whoever cuts the next one: outputs in the last `(n-1)%8` (f32) or `(n-1)%4` (f64) bins can change in the sign of a zero result and in NaN sign bits. Finite values are unaffected and no API changed.

## The new test's third arm is load-bearing

`TestRealFFTUnpack_SignedZero` compares three ways. Dispatched-vs-Go pins the kernel, but wherever the dispatcher declines SIMD it *calls* the function it is being compared against, so that arm goes inert. Which tiers those are differs by package, since f32 gates on AVX+FMA and f64 on AVX2.

Verified by regressing the Go reference's own negation: with only the first arm the regression is missed on two of four tiers in f32 and three of four in f64; with the Go-vs-`realFFTUnpackRef` arm added it is caught on all four in both. The obvious alternative was measured and rejected: simply swapping the oracle closes that hole but opens an identical one on the AVX path, where the Go function stops being reachable from `RealFFTUnpack`.

Benchmarks gain n=513, where the tail is empty on both the AVX and NEON widths, so the tail cost is no longer charged to every row.

## arm64 untouched

The NEON tails re-materialise the constant and reload frame pointers per iteration too, but AArch64 has no VEX/SSE mode split so there is no assist to remove. Measured kernel-direct, NEON beats the Go fallback at every size from 5 to 64.

## Found by the same gate run, filed separately

* **#214**, the same defect class in `varianceAVX` and `varianceAVX512`: a `CVTSQ2SS`/`CVTSQ2SD` in the divide epilogue. `f64.Variance`'s AVX kernel is currently **2.6x slower than its own Go fallback at n=128**, and one instruction fixes it (106.6 ns to 7.88 ns).
* **#215**, replacing the scalar remainder with an overlapping vector block, worth a further ~32% at f32 n=64, blocked on documenting an aliasing precondition that `RealFFTUnpack`'s godoc currently does not state.

The sweep that found #214 is worth recording: a search for legacy *moves* found 7 sites and concluded this fix was complete; a search for the general hazard, any legacy non-VEX XMM write with dirty upper state, found three more. The hazard class is the latter.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Performance**
  * Improved real FFT unpacking efficiency, especially for scalar tail processing.
  * Reduced overhead for mirrored spectrum calculations across supported numeric precisions.

* **Bug Fixes**
  * Preserved signed-zero values correctly during real FFT unpacking.

* **Tests**
  * Added comprehensive signed-zero coverage across SIMD and fallback implementations.
  * Expanded benchmarks to include additional input sizes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->