### PR TITLE
f32,f64: use the VEX convert in the variance divide epilogue

### DIFF
--- a/README.md
+++ b/README.md
@@ -1009,10 +1009,10 @@ All int32 kernels are zero-allocation and bit-exact against the pure-Go referenc
   `*Go` reference; each pair reports the best of repeated runs. Displayed nanoseconds
   are rounded to whole ns, so the speedup column (computed from the raw timings) may
   differ from a recomputation using the rounded ns shown. The float32 and float64
-  Variance/StdDev rows are the exception on both counts, having been re-measured
-  under a stricter protocol with #214: medians of 9 rounds, one process per point
-  with the order alternated each round, pinned to one P-core, and speedups computed
-  from the rounded nanoseconds shown so a reader can check the division.
+  Variance/StdDev rows were re-measured with #214 under a stricter protocol:
+  medians of 9 rounds, one process per point with the order alternated each round,
+  pinned to one P-core, and speedups computed from the rounded nanoseconds shown,
+  so for those four rows the division can be checked by hand.
 
 ## Known Limitations
 

--- a/README.md
+++ b/README.md
@@ -763,14 +763,15 @@ i8.ToInt16(w16, a) // sign-extend to int16 (exact)
 |                 | Min               | 148       | 350     | **2.4x**  |
 |                 | Max               | 151       | 370     | **2.5x**  |
 | **Statistical** | Mean              | 33        | 419     | **12.7x** |
-|                 | Variance\*        | 552       | 3893    | **7.1x**  |
-|                 | StdDev\*          | 556       | 3900    | **7.0x**  |
+|                 | Variance\*        | 419       | 3483    | **8.3x**  |
+|                 | StdDev\*          | 421       | 3481    | **8.3x**  |
 | **Vector**      | EuclideanDistance | 76        | 1173    | **15.4x** |
 |                 | Normalize         | 536       | 692     | **1.3x**  |
 |                 | CumulativeSum     | 472       | 457     | 1.0x      |
 | **Range**       | Clamp             | 83        | 880     | **10.6x** |
 
-\*Variance/StdDev benchmarked at 4096 elements (SIMD benefits at larger sizes)
+\*Variance/StdDev benchmarked at 4096 elements (SIMD benefits at larger sizes),
+and re-measured after the variance divide-epilogue fix (#214)
 
 #### float32 Operations - SIMD vs Pure Go (1024 elements)
 
@@ -789,13 +790,15 @@ i8.ToInt16(w16, a) // sign-extend to int16 (exact)
 |                | Sum        | 18        | 416     | **22.6x** |
 |                | Min        | 66        | 347     | **5.2x**  |
 |                | Max        | 120       | 382     | **3.2x**  |
-| **Statistical**| Variance\*  | 164       | 921     | **5.6x**  |
-|                | StdDev\*    | 164       | 903     | **5.5x**  |
+| **Statistical**| Variance\*  | 54        | 842     | **15.6x** |
+|                | StdDev\*    | 54        | 842     | **15.6x** |
 | **Vector**     | EuclideanDistance\* | 35 | 434     | **12.4x** |
 | **Range**      | Clamp      | 45        | 753     | **16.6x** |
 
 \*Variance/StdDev/EuclideanDistance use their own fixed 1000-element benchmark
-(the other rows are at 1024 elements); all numbers come from one run on this host.
+(the other rows are at 1024 elements). The Variance and StdDev rows were
+re-measured after the variance divide-epilogue fix (#214); the other rows come
+from one earlier run on this host.
 
 #### Activation Functions - SIMD vs Pure Go
 

--- a/README.md
+++ b/README.md
@@ -798,7 +798,9 @@ and re-measured after the variance divide-epilogue fix (#214)
 \*Variance/StdDev/EuclideanDistance use their own fixed 1000-element benchmark
 (the other rows are at 1024 elements). The Variance and StdDev rows were
 re-measured after the variance divide-epilogue fix (#214); the other rows come
-from one earlier run on this host.
+from one earlier run on this host. `BenchmarkVariance_1000` and
+`BenchmarkStdDev_1000` have no Go sub-benchmark, so those two Go figures come
+from running the same benchmarks under `SIMD_DISABLE=all`.
 
 #### Activation Functions - SIMD vs Pure Go
 

--- a/README.md
+++ b/README.md
@@ -1008,7 +1008,11 @@ All int32 kernels are zero-allocation and bit-exact against the pure-Go referenc
   Pure-Go baselines use the same binary via `SIMD_DISABLE=all` or each operation's
   `*Go` reference; each pair reports the best of repeated runs. Displayed nanoseconds
   are rounded to whole ns, so the speedup column (computed from the raw timings) may
-  differ from a recomputation using the rounded ns shown.
+  differ from a recomputation using the rounded ns shown. The float32 and float64
+  Variance/StdDev rows are the exception on both counts, having been re-measured
+  under a stricter protocol with #214: medians of 9 rounds, one process per point
+  with the order alternated each round, pinned to one P-core, and speedups computed
+  from the rounded nanoseconds shown so a reader can check the division.
 
 ## Known Limitations
 

--- a/f32/f32_amd64.s
+++ b/f32/f32_amd64.s
@@ -6582,8 +6582,15 @@ var32_avx_scalar:
     JNZ  var32_avx_scalar
 
 var32_avx_divide:
+    // VEX convert, not CVTSQ2SS. The upper YMM halves are always dirty here:
+    // VBROADCASTSS and the VXORPS accumulator init run unconditionally at entry
+    // and the kernel's only VZEROUPPER is below, so the legacy-SSE write to X1
+    // paid an AVX-SSE transition. MEASURED at 2 assists.sse_avx_mix per call
+    // on an i7-1260P, at eight lengths from 0 to 4096, and 0 after this change.
+    // X1's bits 127:32 are dead (VDIVSS takes them from X0), so the merge source
+    // is free; X1 keeps this a one-instruction drop-in. See #214.
     MOVQ a_len+8(FP), CX
-    CVTSQ2SS CX, X1
+    VCVTSI2SSQ CX, X1, X1
     VDIVSS X1, X0, X0
     VMOVSS X0, ret+32(FP)
     VZEROUPPER

--- a/f32/f32_amd64.s
+++ b/f32/f32_amd64.s
@@ -6503,12 +6503,10 @@ var32_sse_divide:
     // Keep the legacy CVTSQ2SS. Do not copy the VEX convert from
     // var32_avx_divide below: varianceSSE is dispatched on CPUs without AVX,
     // where VCVTSI2SSQ is a SIGILL. TestAmd64KernelISALevel will not stop you.
-    // It gives any kernel whose name does not end in AVX2/AVX512 the AVX floor
-    // and a VEX-128 instruction classifies at that same floor, so the mutant
-    // leaves it green, while a genuine AVX2 instruction here does fail it. Both
-    // MEASURED. What does catch it is the cross-isa CI, where the Conroe and
-    // qemu64 SSE2 legs die on this line. #214 measured this kernel at 0
-    // assists, so there is nothing to fix here in the first place.
+    // It gives varianceSSE the AVX floor, and VCVTSI2SSQ classifies at that
+    // same floor, so the mutant leaves it green, while a genuine AVX2
+    // instruction here does fail it. Both MEASURED. What does catch it is the
+    // cross-isa CI, where the Conroe and qemu64 SSE2 legs die on this line.
     MOVQ a_len+8(FP), CX
     CVTSQ2SS CX, X1
     DIVSS X1, X0

--- a/f32/f32_amd64.s
+++ b/f32/f32_amd64.s
@@ -6500,6 +6500,12 @@ var32_sse_scalar:
     JNZ  var32_sse_scalar
 
 var32_sse_divide:
+    // Keep the legacy CVTSQ2SS. Do not copy the VEX convert from
+    // var32_avx_divide below: initSSE dispatches varianceSSE on CPUs without
+    // AVX, where VCVTSI2SSQ is a SIGILL. Nothing would catch that edit.
+    // MEASURED: making it leaves TestAmd64KernelISALevel green, while a genuine
+    // AVX2 instruction at this line does fail it. There is also nothing to fix
+    // here, since this kernel writes no YMM. See #214.
     MOVQ a_len+8(FP), CX
     CVTSQ2SS CX, X1
     DIVSS X1, X0

--- a/f32/f32_amd64.s
+++ b/f32/f32_amd64.s
@@ -6501,11 +6501,14 @@ var32_sse_scalar:
 
 var32_sse_divide:
     // Keep the legacy CVTSQ2SS. Do not copy the VEX convert from
-    // var32_avx_divide below: initSSE dispatches varianceSSE on CPUs without
-    // AVX, where VCVTSI2SSQ is a SIGILL. Nothing would catch that edit.
-    // MEASURED: making it leaves TestAmd64KernelISALevel green, while a genuine
-    // AVX2 instruction at this line does fail it. There is also nothing to fix
-    // here, since this kernel writes no YMM. See #214.
+    // var32_avx_divide below: varianceSSE is dispatched on CPUs without AVX,
+    // where VCVTSI2SSQ is a SIGILL. TestAmd64KernelISALevel will not stop you.
+    // It gives any kernel whose name does not end in AVX2/AVX512 the AVX floor
+    // and a VEX-128 instruction classifies at that same floor, so the mutant
+    // leaves it green, while a genuine AVX2 instruction here does fail it. Both
+    // MEASURED. What does catch it is the cross-isa CI, where the Conroe and
+    // qemu64 SSE2 legs die on this line. #214 measured this kernel at 0
+    // assists, so there is nothing to fix here in the first place.
     MOVQ a_len+8(FP), CX
     CVTSQ2SS CX, X1
     DIVSS X1, X0

--- a/f64/benchmark_test.go
+++ b/f64/benchmark_test.go
@@ -2,6 +2,7 @@ package f64
 
 import (
 	"fmt"
+	"math"
 	"testing"
 )
 
@@ -440,6 +441,29 @@ func BenchmarkVariance(b *testing.B) {
 		b.Run(fmt.Sprintf("Go_%d", size), func(b *testing.B) {
 			for i := 0; i < b.N; i++ {
 				sink64 = varianceFullGo(a)
+			}
+			// Two passes: mean + variance, so 2x data read
+			reportThroughput64(b, size*2)
+		})
+	}
+}
+
+// BenchmarkStdDev mirrors BenchmarkVariance. StdDev is Variance plus one
+// math.Sqrt, so this is not an independent kernel; it exists because the README
+// publishes a float64 StdDev row and nothing here could reproduce it.
+func BenchmarkStdDev(b *testing.B) {
+	for _, size := range benchSizes {
+		a, _, _, _ := makeBenchData64(size)
+		b.Run(fmt.Sprintf("SIMD_%d", size), func(b *testing.B) {
+			for i := 0; i < b.N; i++ {
+				sink64 = StdDev(a)
+			}
+			// Two passes: mean + variance, so 2x data read
+			reportThroughput64(b, size*2)
+		})
+		b.Run(fmt.Sprintf("Go_%d", size), func(b *testing.B) {
+			for i := 0; i < b.N; i++ {
+				sink64 = math.Sqrt(varianceFullGo(a))
 			}
 			// Two passes: mean + variance, so 2x data read
 			reportThroughput64(b, size*2)

--- a/f64/f64_amd64.s
+++ b/f64/f64_amd64.s
@@ -3181,6 +3181,12 @@ var_sse2_remainder:
     ADDSD X1, X0
 
 var_sse2_divide:
+    // Keep the legacy CVTSQ2SD. Do not copy the VEX convert from
+    // var_avx_divide above: initSSE2 dispatches varianceSSE2 on CPUs without
+    // AVX, where VCVTSI2SDQ is a SIGILL. Nothing would catch that edit.
+    // MEASURED: making it leaves TestAmd64KernelISALevel green, while a genuine
+    // AVX2 instruction at this line does fail it. There is also nothing to fix
+    // here, since this kernel writes no YMM. See #214.
     MOVQ a_len+8(FP), CX
     CVTSQ2SD CX, X1
     DIVSD X1, X0

--- a/f64/f64_amd64.s
+++ b/f64/f64_amd64.s
@@ -3184,12 +3184,10 @@ var_sse2_divide:
     // Keep the legacy CVTSQ2SD. Do not copy the VEX convert from
     // var_avx_divide above: varianceSSE2 is dispatched on CPUs without AVX,
     // where VCVTSI2SDQ is a SIGILL. TestAmd64KernelISALevel will not stop you.
-    // It gives any kernel whose name does not end in AVX2/AVX512 the AVX floor
-    // and a VEX-128 instruction classifies at that same floor, so the mutant
-    // leaves it green, while a genuine AVX2 instruction here does fail it. Both
-    // MEASURED. What does catch it is the cross-isa CI, where the Conroe and
-    // qemu64 SSE2 legs die on this line. #214 measured this kernel at 0
-    // assists, so there is nothing to fix here in the first place.
+    // It gives varianceSSE2 the AVX floor, and VCVTSI2SDQ classifies at that
+    // same floor, so the mutant leaves it green, while a genuine AVX2
+    // instruction here does fail it. Both MEASURED. What does catch it is the
+    // cross-isa CI, where the Conroe and qemu64 SSE2 legs die on this line.
     MOVQ a_len+8(FP), CX
     CVTSQ2SD CX, X1
     DIVSD X1, X0

--- a/f64/f64_amd64.s
+++ b/f64/f64_amd64.s
@@ -3182,11 +3182,14 @@ var_sse2_remainder:
 
 var_sse2_divide:
     // Keep the legacy CVTSQ2SD. Do not copy the VEX convert from
-    // var_avx_divide above: initSSE2 dispatches varianceSSE2 on CPUs without
-    // AVX, where VCVTSI2SDQ is a SIGILL. Nothing would catch that edit.
-    // MEASURED: making it leaves TestAmd64KernelISALevel green, while a genuine
-    // AVX2 instruction at this line does fail it. There is also nothing to fix
-    // here, since this kernel writes no YMM. See #214.
+    // var_avx_divide above: varianceSSE2 is dispatched on CPUs without AVX,
+    // where VCVTSI2SDQ is a SIGILL. TestAmd64KernelISALevel will not stop you.
+    // It gives any kernel whose name does not end in AVX2/AVX512 the AVX floor
+    // and a VEX-128 instruction classifies at that same floor, so the mutant
+    // leaves it green, while a genuine AVX2 instruction here does fail it. Both
+    // MEASURED. What does catch it is the cross-isa CI, where the Conroe and
+    // qemu64 SSE2 legs die on this line. #214 measured this kernel at 0
+    // assists, so there is nothing to fix here in the first place.
     MOVQ a_len+8(FP), CX
     CVTSQ2SD CX, X1
     DIVSD X1, X0

--- a/f64/f64_amd64.s
+++ b/f64/f64_amd64.s
@@ -1042,9 +1042,16 @@ var_avx_scalar:
     JNZ  var_avx_scalar
 
 var_avx_divide:
-    // Divide by n
+    // Divide by n. VEX convert, not CVTSQ2SD. The upper YMM halves are always
+    // dirty here: VBROADCASTSD and the VXORPD accumulator init run
+    // unconditionally at entry and the kernel's only VZEROUPPER is below, so the
+    // legacy-SSE write to X1 paid an AVX-SSE transition. MEASURED at 2
+    // assists.sse_avx_mix per call on an i7-1260P, at eight lengths from 0 to
+    // 4096, and 0 after this change. X1's bits 127:64 are dead (VDIVSD takes
+    // them from X0), so the merge source is free; X1 keeps this a
+    // one-instruction drop-in. See #214.
     MOVQ a_len+8(FP), CX
-    CVTSQ2SD CX, X1
+    VCVTSI2SDQ CX, X1, X1
     VDIVSD X1, X0, X0
     VMOVSD X0, ret+32(FP)
     VZEROUPPER
@@ -2394,8 +2401,15 @@ var_512_scalar:
     JNZ  var_512_scalar
 
 var_512_divide:
+    // The same legacy-SSE write in the same position as var_avx_divide, fixed
+    // the same way; X1's bits 127:64 are dead here too, so the merge source is
+    // free. The assembler emits the VEX form of VCVTSI2SDQ (c4 e1 f3 2a c9,
+    // checked with objdump), which every AVX-512 CPU supports, so the kernel's
+    // tier does not change. NOT MEASURED: no AVX-512 hardware is available to
+    // this project (#75/#96), so unlike var_avx_divide the assist count and the
+    // bit-for-bit output of this kernel are unverified. See #214.
     MOVQ a_len+8(FP), CX
-    CVTSQ2SD CX, X1
+    VCVTSI2SDQ CX, X1, X1
     VDIVSD X1, X0, X0
     VMOVSD X0, ret+32(FP)
     VZEROUPPER


### PR DESCRIPTION
Fixes #214.

`varianceAVX` (f32 and f64) and `varianceAVX512` (f64) ended their divide epilogue with a legacy `CVTSQ2SS/SD CX, X1`. That is a non-VEX write to an XMM register at a point where the upper YMM halves are always dirty, since the prologue's broadcast and accumulator init run unconditionally before any length test. It cost an AVX-SSE transition on every call. Switching the three sites to the VEX form `VCVTSI2SSQ/SDQ CX, X1, X1` removes it. X1's upper bits are dead at that point because the following `VDIVSS/SD` takes them from X0, so the merge source is free and this stays a one-instruction drop-in.

The effect is large at small n, because the penalty is per call rather than per element. `f64.Variance` at n=128 goes from 106.4 ns to 7.724 ns, which takes it from 2.6x **slower** than its own pure-Go fallback to 5.3x faster. This is the same defect class as #208 (PR #216).

## Evidence

Measured on the i7-1260P, pinned to one P-core, one process per point, order alternated across rounds, medians.

* **Encodings are three-byte VEX, not EVEX**, read back with objdump: `c4 e1 f3 2a c9` (f64) and `c4 e1 f2 2a c9` (f32). #169 is the prior case in this repo where a mnemonic silently assembled to the EVEX form and faulted on hardware without AVX-512, so this was checked rather than assumed.
* Both encodings are 5 bytes, so no code moved. Every symbol sits at an identical address in both binaries and the full `.text` disassembly differs in exactly three instructions. Alignment is excluded as a benchmark confound by construction.
* **Assists**: `cpu_core/assists.sse_avx_mix` measures exactly 2 per call before and 0 after, at every length tested from n=0 to n=4096, in both packages. The n=0 point is the one that pins the cost as per-call rather than per-element.
* **Output is bit-identical**: 38052 raw bit patterns per package over 12 input families crossed with 7 means (NaN, +Inf, denormal, MaxFloat included) and 151 lengths straddling every dispatch boundary. Sabotage-checked, injecting `INCQ CX` turns 5168 rows red.
* Full suites green on amd64 native, arm64 (Pi 5), and under `qemu -cpu SandyBridge` and `-cpu Opteron_G5`, plus the `SIMD_DISABLE=avx2` and `SIMD_DISABLE=all` legs.

The AVX-512 site could not be measured, since no AVX-512 hardware is available to this project (#75, #96). It is fixed by inspection with the VEX encoding confirmed by objdump, and the comment at that site says `NOT MEASURED` explicitly.

## The two SSE siblings are deliberately untouched, and now say so

`f32 varianceSSE` and `f64 varianceSSE2` keep the legacy convert. Both measured 0 assists in both trees, so there is nothing at these sites to remove, and their encodings are byte-identical in the new binaries.

That needed a comment, because the invited "make it consistent" edit is a hard SIGILL rather than a style regression: both kernels are dispatched on CPUs without AVX, where a VEX convert does not exist.

The static ISA test does not object. `DeclaredX86Level` gives any kernel whose name does not end in `AVX2`/`AVX512` the AVX floor, and a VEX-128 instruction classifies at that same floor, so the comparison `k.Level <= declared` passes. Measured in both packages and both directions:

| mutation at the SSE divide epilogue | `TestAmd64KernelISALevel` |
| --- | --- |
| VEX convert (the invited mistake) | **passes**, and the package still builds |
| a genuine AVX2 instruction | fails, naming the kernel and line |

What does catch it is the `cross-isa` CI job from #203/#213. Under `-cpu Conroe` and `-cpu qemu64` with AVX stripped, the mutant dies on the instruction with a stack trace naming the line. An earlier revision of this PR claimed nothing in the suite would catch it, which was wrong, and the comments now name both the check that misses it and the one that catches it.

The comments also no longer name a single init function as the dispatch path. `varianceSSE2` is selected by `initAVXNoFMA` as well as `initSSE2`, and f32's `initSSE` is itself the AVX-without-FMA fallthrough, so both kernels also run on AVX-capable CPUs. The instruction stands, since the reachable set still includes genuinely pre-AVX parts, but "SSE-named kernel implies non-AVX CPU" is not true here and the comment should not teach it.

## Four published README rows moved

The change invalidates the numbers this repo publishes for Variance and StdDev on both float surfaces. Re-measured on the i7-1260P that the README names, 9 rounds, alternated order, 2 s idle gap between processes, medians. Run-to-run spread was at most 1.6% and mostly under 0.5%.

| row | previously published | re-measured | Go | speedup |
| --- | --- | --- | --- | --- |
| f32 `Variance_1000` | 164 | **54** | 842 | 15.6x |
| f32 `StdDev_1000` | 164 | **54** | 842 | 15.6x |
| f64 `Variance/4096` | 552 | **419** | 3483 | 8.3x |
| f64 `StdDev/4096` | 556 | **421** | 3481 | 8.3x |

The left column is what the README used to publish, not a paired measurement from this run: the old figures predate this work and, in f64 `StdDev`'s case, had no benchmark behind them at all.

Both Go columns were re-measured alongside the SIMD ones rather than carried over from the old table, so each published speedup is that row's own Go/SIMD ratio and a reader can check the division. The float32 footnote previously claimed every row in that table came from one run, which this change made false, so it now says which rows were re-measured.

The README's Methodology bullet now records the protocol these four rows were measured under: medians of 9 rounds rather than a best-of, and speedups computed from the rounded nanoseconds so the division can be checked by hand.

While doing this I found that f64 had no `StdDev` benchmark at all, so the README row it backs was not reproducible by anyone. Added one mirroring `BenchmarkVariance`.

## Not addressed here

Nothing pins the VEX form against a future revert. The change is bit-identical by construction, so every existing test passes with either encoding, and `asmcheck`'s objdump support is arm64-WORD-only. A guard asserting that the three `variance*` divide epilogues contain no non-VEX mnemonic would close it, and `ScanX86Source` already parses what that needs. Worth a follow-up rather than a blocker.

One pre-existing sibling site of this class remains open at `f32/f32_amd64.s:3697` (`MOVSS alpha+24(FP), X3` in `addScaledAVX512`). It sits at function entry before the kernel dirties anything, and the prologue position was measured at 0 assists during #208, so it is not this defect.
