### PR TITLE
f32,f64: close the four test gaps kept from the #209 and #211 triage

### DIFF
--- a/f32/f32_test.go
+++ b/f32/f32_test.go
@@ -3447,6 +3447,161 @@ func TestRealFFTUnpack_KnownValues(t *testing.T) {
 	}
 }
 
+// realFFTUnpack32Close is the tolerance for the two tests below, which compare
+// the dispatched kernel against realFFTUnpackRef. The two differ only in how
+// their multiply-adds fuse, so they agree to within float32 rounding rather than
+// exactly.
+//
+// MEASURED over the size sweep below plus 128/256/512/1000: the largest absolute
+// difference is 1.907e-06 on an AVX+FMA amd64 core and 9.537e-07 on a NEON
+// Cortex-A76, so realFFTUnpack32AbsTol carries every row at about 52x the worst
+// case.
+//
+// Do not delete the absolute arm in favour of the relative one. The worst
+// RELATIVE difference over the same sweep is 2.017e-05 on amd64, which is above
+// realFFTUnpack32RelTol, and it occurs on an element where the unpack's sum and
+// difference cancel to near zero while the rounding that produced them does not
+// shrink with them. The relative arm is a safety valve for data larger than this
+// fixture's; it only takes over above |want| == 10.
+const (
+	realFFTUnpack32AbsTol = 1e-4
+	realFFTUnpack32RelTol = 1e-5
+)
+
+func realFFTUnpack32Close(got, want float32) bool {
+	diff := math.Abs(float64(got - want))
+	return diff <= realFFTUnpack32AbsTol || diff <= math.Abs(float64(want))*realFFTUnpack32RelTol
+}
+
+// TestRealFFTUnpack_OverRead guards the reversed mirror load, mirroring the f64
+// test of the same name. The kernel reads Z[n-k] descending against Z[k]
+// ascending, so a reverse pointer sized one block too far, or a forward load past
+// the end, reads outside [0,n). zRe/zIm are backed by padded arrays whose guard
+// bands hold NaN, then sliced to exactly length n, so an out-of-range read pulls
+// a NaN into an output lane and reports itself.
+//
+// What this adds over the other RealFFTUnpack tests is a defined value next to
+// the slice and a diagnostic that names the cause. MEASURED: shifting the reverse
+// pointer to &zRe[n-7] is caught here AND by TestRealFFTUnpack,
+// TestRealFFTUnpack_GoVsSIMD and TestRealFFTUnpack_SignedZero, so this is not the
+// only net under that particular mutation. Those three depend on whatever the
+// allocator happens to leave after the slice; this one does not.
+//
+// Three things make the guard band work, and checking only the first two reads as
+// thorough. It is non-zero; NaN is not an algebraic identity for the add or the
+// multiply in the unpack, so it can never be swallowed; and the pad is two full
+// blocks of the widest kernel reachable here, the 8-wide AVX path (f32 has no
+// AVX-512 realFFTUnpack kernel, and NEON is 4-wide).
+func TestRealFFTUnpack_OverRead(t *testing.T) {
+	const pad = 16 // two 8-wide AVX blocks of NaN guard band on each side of z
+	// n > minAVXElements (8) is what dispatches to AVX, and these sizes vary
+	// (n-1)%8 and (n-1)%4 so both the AVX and NEON reverse paths are stressed at
+	// their minimum reverse index and at every tail length.
+	for _, n := range []int{9, 10, 16, 17, 18, 31, 32, 33, 64, 65} {
+		t.Run(fmt.Sprintf("n=%d", n), func(t *testing.T) {
+			nan := float32(math.NaN())
+			zReBack := make([]float32, pad+n+pad)
+			zImBack := make([]float32, pad+n+pad)
+			for i := range zReBack {
+				zReBack[i], zImBack[i] = nan, nan
+			}
+			zRe := zReBack[pad : pad+n]
+			zIm := zImBack[pad : pad+n]
+			for i := range n {
+				zRe[i] = float32(math.Sin(float64(i)*0.7) * 10)
+				zIm[i] = float32(math.Cos(float64(i)*0.9) * 10)
+			}
+			twRe := make([]float32, n-1)
+			twIm := make([]float32, n-1)
+			for k := 1; k < n; k++ {
+				angle := -2 * math.Pi * float64(k) / float64(2*n)
+				twRe[k-1] = float32(math.Cos(angle))
+				twIm[k-1] = float32(math.Sin(angle))
+			}
+			outRe := make([]float32, n)
+			outIm := make([]float32, n)
+			outReRef := make([]float32, n)
+			outImRef := make([]float32, n)
+
+			RealFFTUnpack(outRe, outIm, zRe, zIm, twRe, twIm)
+			realFFTUnpackRef(outReRef, outImRef, zRe, zIm, twRe, twIm, n)
+
+			for k := 1; k < n; k++ {
+				if math.IsNaN(float64(outRe[k])) || math.IsNaN(float64(outIm[k])) {
+					t.Fatalf("k=%d: NaN in output -> kernel over-read the zRe/zIm guard band", k)
+				}
+				if !realFFTUnpack32Close(outRe[k], outReRef[k]) {
+					t.Errorf("k=%d outRe = %v, want %v", k, outRe[k], outReRef[k])
+				}
+				if !realFFTUnpack32Close(outIm[k], outImRef[k]) {
+					t.Errorf("k=%d outIm = %v, want %v", k, outIm[k], outImRef[k])
+				}
+			}
+		})
+	}
+}
+
+// TestRealFFTUnpack_ShortSlices exercises the length-validation guard. With n
+// taken from len(zRe), any operand shorter than required must make the call
+// return without writing output or panicking.
+//
+// Each case shortens exactly one operand, so every clause of the guard is pinned
+// on its own. Shortening twRe and twIm together would leave either clause
+// deletable, since the other would still catch it.
+func TestRealFFTUnpack_ShortSlices(t *testing.T) {
+	const n = 16 // above minAVXElements, so a missing guard reaches the AVX kernel
+	makeZ := func() ([]float32, []float32) {
+		zRe := make([]float32, n)
+		zIm := make([]float32, n)
+		for i := range n {
+			zRe[i], zIm[i] = float32(i+1)*0.1, float32(i+2)*0.2
+		}
+		return zRe, zIm
+	}
+	makeTw := func(reLen, imLen int) ([]float32, []float32) {
+		twRe := make([]float32, reLen)
+		twIm := make([]float32, imLen)
+		for k := range twRe {
+			twRe[k] = float32(math.Cos(-2 * math.Pi * float64(k+1) / float64(2*n)))
+		}
+		for k := range twIm {
+			twIm[k] = float32(math.Sin(-2 * math.Pi * float64(k+1) / float64(2*n)))
+		}
+		return twRe, twIm
+	}
+	allZero := func(t *testing.T, name string, s []float32) {
+		t.Helper()
+		for i, v := range s {
+			if v != 0 {
+				t.Errorf("%s written at [%d]=%v, want untouched (guard should have returned)", name, i, v)
+			}
+		}
+	}
+
+	cases := []struct {
+		name                                         string
+		zImLen, outReLen, outImLen, twReLen, twImLen int
+	}{
+		{"shortZIm", n - 1, n, n, n - 1, n - 1},
+		{"shortOutRe", n, n - 1, n, n - 1, n - 1},
+		{"shortOutIm", n, n, n - 1, n - 1, n - 1},
+		{"shortTwRe", n, n, n, n - 2, n - 1},
+		{"shortTwIm", n, n, n, n - 1, n - 2},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			zRe, zImFull := makeZ()
+			zIm := zImFull[:c.zImLen]
+			twRe, twIm := makeTw(c.twReLen, c.twImLen)
+			outRe := make([]float32, c.outReLen)
+			outIm := make([]float32, c.outImLen)
+			RealFFTUnpack(outRe, outIm, zRe, zIm, twRe, twIm)
+			allZero(t, "outRe", outRe)
+			allZero(t, "outIm", outIm)
+		})
+	}
+}
+
 // TestRealFFTUnpack_SignedZero pins the sign of a zero result. Every input is a
 // signed zero and every twiddle is +1 or -1, so every intermediate is an exact
 // zero and nothing rounds: the comparison can be bit-for-bit. The AVX scalar

--- a/f32/f32_test.go
+++ b/f32/f32_test.go
@@ -3452,10 +3452,11 @@ func TestRealFFTUnpack_KnownValues(t *testing.T) {
 // only in how their multiply-adds fuse, so they agree to within float32 rounding
 // rather than exactly.
 //
-// MEASURED by instrumenting this predicate and running the whole f32 suite on a
-// default build: over its 690 comparisons the worst absolute difference is
-// 1.907e-06 on an AVX+FMA amd64 core and 9.537e-07 on a NEON Cortex-A76, so
-// realFFTUnpack32AbsTol carries every row at about 52x the worst case.
+// MEASURED by instrumenting this predicate and running the whole f32 suite. On a
+// default amd64 build, over its 690 comparisons, the worst absolute difference is
+// 1.907e-06 on an AVX+FMA core. A separate run on a NEON Cortex-A76 reached
+// 9.537e-07. So realFFTUnpack32AbsTol carries every row at about 52x the worst
+// case.
 //
 // Keep the absolute arm. On that build the worst relative difference, 1.425e-05,
 // is above realFFTUnpack32RelTol, so deleting the absolute arm fails
@@ -3469,7 +3470,9 @@ const (
 )
 
 func realFFTUnpack32Close(got, want float32) bool {
-	diff := math.Abs(float64(got - want))
+	// Widen before subtracting. float32(got-want) would round the difference in
+	// float32 before it is ever compared, which is the quantity under test.
+	diff := math.Abs(float64(got) - float64(want))
 	return diff <= realFFTUnpack32AbsTol || diff <= math.Abs(float64(want))*realFFTUnpack32RelTol
 }
 
@@ -3570,10 +3573,22 @@ func TestRealFFTUnpack_ShortSlices(t *testing.T) {
 		}
 		return twRe, twIm
 	}
-	allZero := func(t *testing.T, name string, s []float32) {
+	// Outputs are prefilled with a sentinel rather than left zero. A zero-filled
+	// buffer cannot distinguish "the guard returned without writing" from "the
+	// kernel ran and wrote a zero", so the assertion would not catch the case it
+	// is named for.
+	const sentinel = float32(-1.5)
+	makeOut := func(n int) []float32 {
+		s := make([]float32, n)
+		for i := range s {
+			s[i] = sentinel
+		}
+		return s
+	}
+	untouched := func(t *testing.T, name string, s []float32) {
 		t.Helper()
 		for i, v := range s {
-			if v != 0 {
+			if v != sentinel {
 				t.Errorf("%s written at [%d]=%v, want untouched (guard should have returned)", name, i, v)
 			}
 		}
@@ -3594,11 +3609,11 @@ func TestRealFFTUnpack_ShortSlices(t *testing.T) {
 			zRe, zImFull := makeZ()
 			zIm := zImFull[:c.zImLen]
 			twRe, twIm := makeTw(c.twReLen, c.twImLen)
-			outRe := make([]float32, c.outReLen)
-			outIm := make([]float32, c.outImLen)
+			outRe := makeOut(c.outReLen)
+			outIm := makeOut(c.outImLen)
 			RealFFTUnpack(outRe, outIm, zRe, zIm, twRe, twIm)
-			allZero(t, "outRe", outRe)
-			allZero(t, "outIm", outIm)
+			untouched(t, "outRe", outRe)
+			untouched(t, "outIm", outIm)
 		})
 	}
 }

--- a/f32/f32_test.go
+++ b/f32/f32_test.go
@@ -3447,22 +3447,21 @@ func TestRealFFTUnpack_KnownValues(t *testing.T) {
 	}
 }
 
-// realFFTUnpack32Close is the tolerance for the two tests below, which compare
-// the dispatched kernel against realFFTUnpackRef. The two differ only in how
-// their multiply-adds fuse, so they agree to within float32 rounding rather than
-// exactly.
+// realFFTUnpack32Close is the tolerance for TestRealFFTUnpack_OverRead below,
+// which compares the dispatched kernel against realFFTUnpackRef. The two differ
+// only in how their multiply-adds fuse, so they agree to within float32 rounding
+// rather than exactly.
 //
-// MEASURED over the size sweep below plus 128/256/512/1000: the largest absolute
-// difference is 1.907e-06 on an AVX+FMA amd64 core and 9.537e-07 on a NEON
-// Cortex-A76, so realFFTUnpack32AbsTol carries every row at about 52x the worst
-// case.
+// MEASURED by instrumenting this predicate and running the whole f32 suite: over
+// its 690 comparisons the worst absolute difference is 1.907e-06 on an AVX+FMA
+// amd64 core and 9.537e-07 on a NEON Cortex-A76, so realFFTUnpack32AbsTol carries
+// every row at about 52x the worst case.
 //
-// Do not delete the absolute arm in favour of the relative one. The worst
-// RELATIVE difference over the same sweep is 2.017e-05 on amd64, which is above
-// realFFTUnpack32RelTol, and it occurs on an element where the unpack's sum and
-// difference cancel to near zero while the rounding that produced them does not
-// shrink with them. The relative arm is a safety valve for data larger than this
-// fixture's; it only takes over above |want| == 10.
+// Do not delete the absolute arm in favour of the relative one. It is the
+// deciding arm for 592 of those 690 comparisons, and the worst relative
+// difference, 1.425e-05, is above realFFTUnpack32RelTol. The relative band is a
+// safety valve for data larger than this fixture's; it only takes over above
+// |want| == 10.
 const (
 	realFFTUnpack32AbsTol = 1e-4
 	realFFTUnpack32RelTol = 1e-5
@@ -3484,8 +3483,8 @@ func realFFTUnpack32Close(got, want float32) bool {
 // the slice and a diagnostic that names the cause. MEASURED: shifting the reverse
 // pointer to &zRe[n-7] is caught here AND by TestRealFFTUnpack,
 // TestRealFFTUnpack_GoVsSIMD and TestRealFFTUnpack_SignedZero, so this is not the
-// only net under that particular mutation. Those three depend on whatever the
-// allocator happens to leave after the slice; this one does not.
+// only net under that particular mutation. It is the only one that reports the
+// over-read as such rather than as a value mismatch.
 //
 // Three things make the guard band work, and checking only the first two reads as
 // thorough. It is non-zero; NaN is not an algebraic identity for the add or the
@@ -3494,10 +3493,11 @@ func realFFTUnpack32Close(got, want float32) bool {
 // AVX-512 realFFTUnpack kernel, and NEON is 4-wide).
 func TestRealFFTUnpack_OverRead(t *testing.T) {
 	const pad = 16 // two 8-wide AVX blocks of NaN guard band on each side of z
-	// n > minAVXElements (8) is what dispatches to AVX, and these sizes vary
-	// (n-1)%8 and (n-1)%4 so both the AVX and NEON reverse paths are stressed at
-	// their minimum reverse index and at every tail length.
-	for _, n := range []int{9, 10, 16, 17, 18, 31, 32, 33, 64, 65} {
+	// n > minAVXElements (8) is what dispatches to AVX. 9 to 16 sweeps (n-1)%8
+	// through all of 0..7, so the 8-wide AVX path is hit at every scalar-tail
+	// length and at its minimum reverse index; that range also covers (n-1)%4 for
+	// the 4-wide NEON path. The larger sizes add multi-iteration reverse walks.
+	for _, n := range []int{9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 31, 32, 33, 64, 65} {
 		t.Run(fmt.Sprintf("n=%d", n), func(t *testing.T) {
 			nan := float32(math.NaN())
 			zReBack := make([]float32, pad+n+pad)

--- a/f32/f32_test.go
+++ b/f32/f32_test.go
@@ -3452,16 +3452,17 @@ func TestRealFFTUnpack_KnownValues(t *testing.T) {
 // only in how their multiply-adds fuse, so they agree to within float32 rounding
 // rather than exactly.
 //
-// MEASURED by instrumenting this predicate and running the whole f32 suite: over
-// its 690 comparisons the worst absolute difference is 1.907e-06 on an AVX+FMA
-// amd64 core and 9.537e-07 on a NEON Cortex-A76, so realFFTUnpack32AbsTol carries
-// every row at about 52x the worst case.
+// MEASURED by instrumenting this predicate and running the whole f32 suite on a
+// default build: over its 690 comparisons the worst absolute difference is
+// 1.907e-06 on an AVX+FMA amd64 core and 9.537e-07 on a NEON Cortex-A76, so
+// realFFTUnpack32AbsTol carries every row at about 52x the worst case.
 //
-// Do not delete the absolute arm in favour of the relative one. It is the
-// deciding arm for 592 of those 690 comparisons, and the worst relative
-// difference, 1.425e-05, is above realFFTUnpack32RelTol. The relative band is a
-// safety valve for data larger than this fixture's; it only takes over above
-// |want| == 10.
+// Keep the absolute arm. On that build the worst relative difference, 1.425e-05,
+// is above realFFTUnpack32RelTol, so deleting the absolute arm fails
+// TestRealFFTUnpack_OverRead/n=64. Exactly one comparison depends on it, and at
+// GOAMD64=v3 the Go reference fuses differently and none does, so treat that
+// single comparison as the reason rather than any larger count. The relative band
+// only takes over above |want| == 10.
 const (
 	realFFTUnpack32AbsTol = 1e-4
 	realFFTUnpack32RelTol = 1e-5

--- a/f64/butterfly_complex_stage_test.go
+++ b/f64/butterfly_complex_stage_test.go
@@ -133,7 +133,9 @@ var stageBlockCounts = []int{1, 2, 3, 4, 5, 6, 7, 8, 16, 33}
 // MEASURED by flipping the sign in butterflyComplex64Go's complex multiply. Under
 // SIMD_DISABLE=all, which models the sub-AVX2 qemu legs added in #203/#213, this
 // test fails while MatchesPerBlockLoop and SIMDvsGo both stay green. Natively on
-// AVX2 all three fail.
+// AVX2 all three fail. It is not the only net on those legs, since
+// TestButterflyComplexStage_FullFFT also catches that mutation there; it is the
+// only one of the three parity tests that does.
 func TestButterflyComplexStage(t *testing.T) {
 	for _, span := range stageSpans {
 		for _, blocks := range stageBlockCounts {

--- a/f64/butterfly_complex_stage_test.go
+++ b/f64/butterfly_complex_stage_test.go
@@ -123,6 +123,17 @@ var stageSpans = []int{1, 2, 3, 4, 5, 6, 7, 8, 9, 15, 16, 17, 32, 64}
 // leftover case for both.
 var stageBlockCounts = []int{1, 2, 3, 4, 5, 6, 7, 8, 16, 33}
 
+// TestButterflyComplexStage is the one of this file's three parity tests that
+// still asserts something on a tier where the dispatcher declines SIMD, so do not
+// delete it as redundant with the two below. Its reference,
+// butterflyComplexStageRef, indexes re/im directly instead of delegating, while
+// the other two compare against code that reduces to the same Go fallback:
+// butterflyComplexStage64Go is only a loop over butterflyComplex64Go.
+//
+// MEASURED by flipping the sign in butterflyComplex64Go's complex multiply. Under
+// SIMD_DISABLE=all, which models the sub-AVX2 qemu legs added in #203/#213, this
+// test fails while MatchesPerBlockLoop and SIMDvsGo both stay green. Natively on
+// AVX2 all three fail.
 func TestButterflyComplexStage(t *testing.T) {
 	for _, span := range stageSpans {
 		for _, blocks := range stageBlockCounts {

--- a/f64/realfftunpack_test.go
+++ b/f64/realfftunpack_test.go
@@ -45,19 +45,24 @@ func realFFTUnpackRef(outRe, outIm, zRe, zIm, twRe, twIm []float64, n int) {
 
 // Tolerances for realFFTUnpackClose.
 //
-// MEASURED over sizes 2 to 1000: the worst absolute divergence between the
-// dispatched kernel and realFFTUnpackRef is 3.553e-15 on an AVX+FMA amd64 core
-// and 1.776e-15 on a NEON Cortex-A76, so realFFTUnpackAbsTol sits about 28x above
-// the worst case. The absolute floor has to exist because the unpack's sum and
-// difference can cancel to near zero while the rounding that produced them does
-// not shrink with them; the relative band only takes over above |want| == 0.01,
-// and the worst relative divergence measured is 3.757e-14 against it.
+// MEASURED by instrumenting this predicate and running the whole f64 suite: over
+// its 7106 comparisons the worst absolute divergence between the dispatched
+// kernel and realFFTUnpackRef is 2.842e-14 on an AVX2+FMA amd64 core (which is
+// the tier this kernel needs, see realFFTUnpack64) and 1.776e-15 on a NEON
+// Cortex-A76. realFFTUnpackAbsTol therefore sits about 35x above the worst case,
+// in line with the ~52x this repo uses elsewhere. The worst relative divergence
+// is 3.757e-14 against the 1e-11 band.
 //
-// The absolute floor was 1e-9 until #211, four orders of magnitude looser than
-// this, while the comment above it already named 1e-13 as the divergence it
-// needed to admit.
+// The two arms split at |want| == 0.1. Below that the absolute floor is the
+// deciding arm, which covers 40 of the 7106 comparisons, and the worst divergence
+// among those is 1.776e-15. The element producing the 2.842e-14 above is far
+// larger than 0.1, so the relative band is what carries it.
+//
+// The floor is there for outputs where the unpack cancels to near zero, and the
+// tightening is what gives it teeth: it was 1e-9 until #211, which admitted a
+// 1e-10 error at an exactly-cancelled element. This rejects that.
 const (
-	realFFTUnpackAbsTol = 1e-13
+	realFFTUnpackAbsTol = 1e-12
 	realFFTUnpackRelTol = 1e-11
 )
 
@@ -306,6 +311,11 @@ func TestRealFFTUnpack_OverRead(t *testing.T) {
 // TestRealFFTUnpack_ShortSlices exercises the length-validation guards: with n
 // taken from len(zRe), any operand shorter than required (zIm/outRe/outIm < n, or
 // twRe/twIm < n-1) must make the call return without writing output or panicking.
+//
+// Each case shortens exactly one operand, so every clause of the guard is pinned
+// on its own. Shortening twRe and twIm together, which this table used to do,
+// left either twiddle clause deletable with the package still green, since the
+// other clause caught the case on its own.
 func TestRealFFTUnpack_ShortSlices(t *testing.T) {
 	const n = 8
 	makeZ := func() ([]float64, []float64) {
@@ -316,10 +326,13 @@ func TestRealFFTUnpack_ShortSlices(t *testing.T) {
 		}
 		return zRe, zIm
 	}
-	makeTw := func(m int) ([]float64, []float64) {
-		a, b := make([]float64, m), make([]float64, m)
-		for i := range m {
-			a[i], b[i] = 0.5, -0.5
+	makeTw := func(reLen, imLen int) ([]float64, []float64) {
+		a, b := make([]float64, reLen), make([]float64, imLen)
+		for i := range a {
+			a[i] = 0.5
+		}
+		for i := range b {
+			b[i] = -0.5
 		}
 		return a, b
 	}
@@ -333,19 +346,20 @@ func TestRealFFTUnpack_ShortSlices(t *testing.T) {
 	}
 
 	cases := []struct {
-		name                              string
-		zImLen, outReLen, outImLen, twLen int
+		name                                         string
+		zImLen, outReLen, outImLen, twReLen, twImLen int
 	}{
-		{"shortZIm", n - 1, n, n, n - 1},
-		{"shortOutRe", n, n - 1, n, n - 1},
-		{"shortOutIm", n, n, n - 1, n - 1},
-		{"shortTwiddles", n, n, n, n - 2},
+		{"shortZIm", n - 1, n, n, n - 1, n - 1},
+		{"shortOutRe", n, n - 1, n, n - 1, n - 1},
+		{"shortOutIm", n, n, n - 1, n - 1, n - 1},
+		{"shortTwRe", n, n, n, n - 2, n - 1},
+		{"shortTwIm", n, n, n, n - 1, n - 2},
 	}
 	for _, c := range cases {
 		t.Run(c.name, func(t *testing.T) {
 			zRe, zImFull := makeZ()
 			zIm := zImFull[:c.zImLen]
-			twRe, twIm := makeTw(c.twLen)
+			twRe, twIm := makeTw(c.twReLen, c.twImLen)
 			outRe := make([]float64, c.outReLen)
 			outIm := make([]float64, c.outImLen)
 			RealFFTUnpack(outRe, outIm, zRe, zIm, twRe, twIm)

--- a/f64/realfftunpack_test.go
+++ b/f64/realfftunpack_test.go
@@ -43,12 +43,30 @@ func realFFTUnpackRef(outRe, outIm, zRe, zIm, twRe, twIm []float64, n int) {
 	}
 }
 
-// realFFTUnpackClose reports whether got is within the tight float64 tolerance
-// of want. Float64 FMA divergence is ~1e-13, so an absolute floor plus a
-// relative band comfortably covers it.
+// Tolerances for realFFTUnpackClose.
+//
+// MEASURED over sizes 2 to 1000: the worst absolute divergence between the
+// dispatched kernel and realFFTUnpackRef is 3.553e-15 on an AVX+FMA amd64 core
+// and 1.776e-15 on a NEON Cortex-A76, so realFFTUnpackAbsTol sits about 28x above
+// the worst case. The absolute floor has to exist because the unpack's sum and
+// difference can cancel to near zero while the rounding that produced them does
+// not shrink with them; the relative band only takes over above |want| == 0.01,
+// and the worst relative divergence measured is 3.757e-14 against it.
+//
+// The absolute floor was 1e-9 until #211, four orders of magnitude looser than
+// this, while the comment above it already named 1e-13 as the divergence it
+// needed to admit.
+const (
+	realFFTUnpackAbsTol = 1e-13
+	realFFTUnpackRelTol = 1e-11
+)
+
+// realFFTUnpackClose reports whether got is within the float64 tolerance of want.
+// The dispatched kernel and realFFTUnpackRef differ only in how their
+// multiply-adds fuse, so they agree to within rounding rather than exactly.
 func realFFTUnpackClose(got, want float64) bool {
 	diff := math.Abs(got - want)
-	return diff <= 1e-9 || diff <= math.Abs(want)*1e-11
+	return diff <= realFFTUnpackAbsTol || diff <= math.Abs(want)*realFFTUnpackRelTol
 }
 
 func TestRealFFTUnpack(t *testing.T) {

--- a/f64/realfftunpack_test.go
+++ b/f64/realfftunpack_test.go
@@ -45,22 +45,21 @@ func realFFTUnpackRef(outRe, outIm, zRe, zIm, twRe, twIm []float64, n int) {
 
 // Tolerances for realFFTUnpackClose.
 //
-// MEASURED by instrumenting this predicate and running the whole f64 suite: over
-// its 7106 comparisons the worst absolute divergence between the dispatched
-// kernel and realFFTUnpackRef is 2.842e-14 on an AVX2+FMA amd64 core (which is
-// the tier this kernel needs, see realFFTUnpack64) and 1.776e-15 on a NEON
-// Cortex-A76. realFFTUnpackAbsTol therefore sits about 35x above the worst case,
-// in line with the ~52x this repo uses elsewhere. The worst relative divergence
-// is 3.757e-14 against the 1e-11 band.
+// MEASURED by instrumenting this predicate and running the whole f64 suite on a
+// default build: over its 7106 comparisons the worst absolute divergence against
+// realFFTUnpackRef is 2.842e-14 on an AVX2+FMA amd64 core (the tier this kernel
+// needs, see realFFTUnpack64) and 1.776e-15 on a NEON Cortex-A76, so
+// realFFTUnpackAbsTol sits about 35x above the worst case. Those 7106 are not all
+// against realFFTUnpackRef: 2064 come from TestRealFFTUnpack_GoVsSIMD, which
+// compares against realFFTUnpack64Go. The worst relative divergence over all 7106
+// is 3.757e-14 against the 1e-11 band, and the two arms split at |want| == 0.1.
 //
-// The two arms split at |want| == 0.1. Below that the absolute floor is the
-// deciding arm, which covers 40 of the 7106 comparisons, and the worst divergence
-// among those is 1.776e-15. The element producing the 2.842e-14 above is far
-// larger than 0.1, so the relative band is what carries it.
-//
-// The floor is there for outputs where the unpack cancels to near zero, and the
-// tightening is what gives it teeth: it was 1e-9 until #211, which admitted a
-// 1e-10 error at an exactly-cancelled element. This rejects that.
+// Unlike its f32 counterpart the absolute floor here is unexercised: no
+// comparison in the suite depends on it, and deleting it leaves the package
+// green. It is for outputs where the unpack cancels to near zero, which these
+// fixtures never produce. So the tightening from the old 1e-9 changes no outcome
+// today. It narrows what the predicate would accept if such an output appears,
+// which is the whole of its value; do not read it as having fixed a live gap.
 const (
 	realFFTUnpackAbsTol = 1e-12
 	realFFTUnpackRelTol = 1e-11

--- a/f64/realfftunpack_test.go
+++ b/f64/realfftunpack_test.go
@@ -335,10 +335,22 @@ func TestRealFFTUnpack_ShortSlices(t *testing.T) {
 		}
 		return a, b
 	}
-	allZero := func(t *testing.T, name string, s []float64) {
+	// Outputs are prefilled with a sentinel rather than left zero. A zero-filled
+	// buffer cannot distinguish "the guard returned without writing" from "the
+	// kernel ran and wrote a zero", so the assertion would not catch the case it
+	// is named for.
+	const sentinel = -1.5
+	makeOut := func(n int) []float64 {
+		s := make([]float64, n)
+		for i := range s {
+			s[i] = sentinel
+		}
+		return s
+	}
+	untouched := func(t *testing.T, name string, s []float64) {
 		t.Helper()
 		for i, v := range s {
-			if v != 0 {
+			if v != sentinel {
 				t.Errorf("%s written at [%d]=%v, want untouched (guard should have returned)", name, i, v)
 			}
 		}
@@ -359,11 +371,11 @@ func TestRealFFTUnpack_ShortSlices(t *testing.T) {
 			zRe, zImFull := makeZ()
 			zIm := zImFull[:c.zImLen]
 			twRe, twIm := makeTw(c.twReLen, c.twImLen)
-			outRe := make([]float64, c.outReLen)
-			outIm := make([]float64, c.outImLen)
+			outRe := makeOut(c.outReLen)
+			outIm := makeOut(c.outImLen)
 			RealFFTUnpack(outRe, outIm, zRe, zIm, twRe, twIm)
-			allZero(t, "outRe", outRe)
-			allZero(t, "outIm", outIm)
+			untouched(t, "outRe", outRe)
+			untouched(t, "outIm", outIm)
 		})
 	}
 }


### PR DESCRIPTION
Closes #209. Closes #211.

Both issues were filed wholesale from gate runs without triage. This implements the items their triage notes kept and closes the rest as prose polish.

## f32 `RealFFTUnpack` gains the two tests its f64 twin already had

**`TestRealFFTUnpack_ShortSlices`** covers the length-validation guard at `f32/f32.go:1256-1258`, which had zero coverage and was the only reason the function sat at 83.3% statement coverage (100.0% with these tests).

Each case shortens exactly one operand, so each of the guard's five clauses is pinned individually. Measured by deleting each clause in turn, on both hosts:

| clause removed | result |
| --- | --- |
| `len(zIm) < n` | FAIL, only `ShortSlices/shortZIm` |
| `len(outRe) < n` | FAIL, only `ShortSlices/shortOutRe` |
| `len(outIm) < n` | FAIL, only `ShortSlices/shortOutIm` |
| `len(twRe) < n-1` | FAIL, only `ShortSlices/shortTwRe` |
| `len(twIm) < n-1` | FAIL, only `ShortSlices/shortTwIm` |

**f64's own version had the weakness this was written to avoid.** It shortened `twRe` and `twIm` together in one `shortTwiddles` row, which left either twiddle clause deletable with the whole package still green, since the other clause caught the case on its own. Split there too, and the table above now holds for both packages.

**`TestRealFFTUnpack_OverRead`** guards the reversed mirror load with a NaN guard band. Its doc comment states its limits rather than overselling it: sizing the reverse pointer to `&zRe[n-7]` is caught by this test **and** by `TestRealFFTUnpack`, `TestRealFFTUnpack_GoVsSIMD` and `TestRealFFTUnpack_SignedZero`. It is the only one that reports the over-read as such rather than as a value mismatch.

The sweep runs n = 9..16 plus larger sizes, so `(n-1)%8` covers all of 0..7 and the 8-wide AVX path is exercised at every scalar-tail length. The pad is two full blocks of the widest reachable kernel (8-wide AVX; f32 has no AVX-512 `realFFTUnpack`, and NEON is 4-wide).

## Tolerances are measured through the shipped predicates, not from a side fixture

Both tolerance comments were re-derived by instrumenting the actual `realFFTUnpackClose` / `realFFTUnpack32Close` and running the whole suite, rather than by measuring a synthetic fixture and attributing the number to the tests.

| | comparisons | worst absolute | worst relative | bound | headroom |
| --- | --- | --- | --- | --- | --- |
| f32, amd64 AVX+FMA | 690 | 1.907e-06 | 1.425e-05 | 1e-4 | 52x |
| f32, arm64 NEON | 690 | 9.537e-07 | 2.002e-07 | 1e-4 | 105x |
| f64, amd64 AVX2+FMA | 7106 | 2.842e-14 | 3.757e-14 | 1e-12 | 35x |
| f64, arm64 NEON | 7106 | 1.776e-15 | 1.892e-16 | 1e-12 | 563x |

The two arms are not equally load-bearing, and the comments say which is which by **dependency** rather than by magnitude partition, which is a distinction I got wrong twice before a reviewer measured it. Deleting the absolute arm fails exactly one comparison in f32 (`TestRealFFTUnpack_OverRead/n=64`) and none at all in f64, where the package stays green.

The f64 figures also decompose: of the 7106 comparisons, 2064 come from `TestRealFFTUnpack_GoVsSIMD`, which compares against `realFFTUnpack64Go` rather than `realFFTUnpackRef`, and the worst relative divergence lives in that population. All amd64 figures are from a default build; at `GOAMD64=v3` the Go reference fuses its multiply-adds and the f32 dependency count drops to zero. CI does not set `GOAMD64`.

## f64 `realFFTUnpackClose` tightens its absolute floor

1e-9 to 1e-12, three orders of magnitude. Its own doc comment already named ~1e-13 as the divergence it needed to admit, while the floor admitted a thousand times more.

Being honest about what this buys: no comparison in the current suite depends on the absolute arm, so the tightening changes no outcome today. What it changes is what the predicate would accept if an output that cancels to near zero ever appears:

| comparison | old (1e-9) | new (1e-12) |
| --- | --- | --- |
| 1e-10 vs 0 | admitted | **rejected** |
| 1e-11 vs 0 | admitted | **rejected** |
| 1e-13 vs 0 | admitted | admitted |

The relative band is unchanged at 1e-11 and still governs outputs above |want| == 0.1, which is every comparison the fixtures currently make.

## One #211 item turned out narrower than filed, and did not need code

#211 said all three implementation-versus-implementation comparisons in `f64/butterfly_complex_stage_test.go` prove nothing on the `SIMD_DISABLE` and qemu legs, and proposed adding an independently written oracle.

Measured by flipping the sign in `butterflyComplex64Go`'s complex multiply:

| test | `SIMD_DISABLE=all` | native AVX2 |
| --- | --- | --- |
| `TestButterflyComplexStage` | **FAIL** | FAIL |
| `..._MatchesPerBlockLoop` | ok (inert) | FAIL |
| `..._SIMDvsGo` | ok (inert) | FAIL |
| `..._FullFFT` | **FAIL** | ok |

Two of the three parity tests do go inert, because `butterflyComplexStage64Go` is only a loop over `butterflyComplex64Go`. But `butterflyComplexStageRef` is already the independent oracle #211 asked for, and `_FullFFT` is a second net on that tier, so the file was never unguarded there and no new oracle was written. What it lacked was a note saying which test carries those legs, so nobody deletes it as redundant. That note is now on `TestButterflyComplexStage`, with the measurement.

## Verification

`go vet` and the full 13-package suite green on amd64 (i7-1260P) and arm64 (Pi 5). `./f32 ./f64` green under `SIMD_DISABLE=avx2`, `avx` and `all` on amd64 and `neon`, `all` on arm64. Scoped to those two packages deliberately: `SIMD_DISABLE=all` fails two pre-existing `i16` dispatch tests that assert SSE2 is always present on amd64, which is unrelated to this change and untouched by it.

The two `gofmt` violations in `f64/` are pre-existing on `main` and untouched here.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Expanded FFT validation across SIMD-relevant sizes.
  * Added checks for numerical accuracy, memory safety, and short input/output handling.
  * Improved floating-point comparison tolerances for reliable precision checks.
  * Added independent coverage for incomplete twiddle-factor inputs.
  * Documented the rationale for continued butterfly-stage testing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->