### PR TITLE
f32,f64: replace the realFFTUnpackAVX scalar tail with an overlapping block (#215)

### DIFF
--- a/f32/f32.go
+++ b/f32/f32.go
@@ -1248,15 +1248,17 @@ func ButterflyComplex(upperRe, upperIm, lowerRe, lowerIm, twRe, twIm []float32) 
 //
 // # Aliasing
 //
-// outRe and outIm must not overlap zRe or zIm in any way, not even as an exact
-// element-for-element overlay. Every bin reads the mirror z[n-k] as well as
-// z[k], so a write to out[k] destroys an input that the bin at n-k has not
-// consumed yet. Measured on the pure Go path, the first corrupted bin is
-// floor(n/2)+1 and every bin above it is wrong. The vector kernels currently
-// survive a few more sizes, because a SIMD block loads its whole input block
-// before storing any output lane, but that is block scheduling rather than a
-// guarantee and it varies with kernel width and n. Pass output slices distinct
-// from the input.
+// outRe and outIm must not overlap each other, nor any of zRe, zIm, twRe or
+// twIm, in any way, not even as an exact element-for-element overlay. Bin k
+// reads z at both k and the mirror n-k, plus the twiddles at k-1, before it
+// writes out[k], so any overlay lets a store land on an input that a later bin
+// has not read yet. Measured on the pure Go path, an output overlaid on z first
+// corrupts bin floor(n/2)+1 and every bin above it. The vector kernels survive a
+// few more sizes, because a SIMD block loads its whole input block before
+// storing any output lane, but that is block scheduling rather than a guarantee
+// and it varies with kernel width and n. Passing the same slice as outRe and
+// outIm makes every bin wrong on every path. Pass outputs distinct from the
+// inputs and from each other.
 //
 // Uses AVX+FMA on AMD64, NEON on ARM64, with pure Go fallback.
 func RealFFTUnpack(outRe, outIm, zRe, zIm, twRe, twIm []float32) {

--- a/f32/f32.go
+++ b/f32/f32.go
@@ -1246,6 +1246,18 @@ func ButterflyComplex(upperRe, upperIm, lowerRe, lowerIm, twRe, twIm []float32) 
 //	X[0] = Z[0].real + Z[0].imag  (DC component)
 //	X[n] = Z[0].real - Z[0].imag  (Nyquist component)
 //
+// # Aliasing
+//
+// outRe and outIm must not overlap zRe or zIm in any way, not even as an exact
+// element-for-element overlay. Every bin reads the mirror z[n-k] as well as
+// z[k], so a write to out[k] destroys an input that the bin at n-k has not
+// consumed yet. Measured on the pure Go path, the first corrupted bin is
+// floor(n/2)+1 and every bin above it is wrong. The vector kernels currently
+// survive a few more sizes, because a SIMD block loads its whole input block
+// before storing any output lane, but that is block scheduling rather than a
+// guarantee and it varies with kernel width and n. Pass output slices distinct
+// from the input.
+//
 // Uses AVX+FMA on AMD64, NEON on ARM64, with pure Go fallback.
 func RealFFTUnpack(outRe, outIm, zRe, zIm, twRe, twIm []float32) {
 	n := len(zRe)

--- a/f32/f32_amd64.s
+++ b/f32/f32_amd64.s
@@ -5234,7 +5234,12 @@ TEXT ·realFFTUnpackAVX(SB), NOSPLIT, $0-152
     DECQ AX                          // AX = n - 1
     MOVQ AX, R13                     // R13 = n - 1 (save for remainder)
     SHRQ $3, AX                      // AX = (n-1) / 8 = number of SIMD iterations
-    JZ   realfft_remainder           // Skip SIMD loop if < 8 elements
+    // Zero full blocks means n <= 8, which realFFTUnpack32 never dispatches: its
+    // guard is n > minAVXElements and minAVXElements is 8. The overlapping
+    // remainder block below anchors at k = n-8 and mirror-reads zRe[1..8], so it
+    // needs n >= 9; writing nothing is the memory-safe answer to a caller that
+    // ignores the threshold, where falling through would over-read the input.
+    JZ   realfft_done
 
     // Set up reverse pointers: R9 = &zRe[n-8], R10 = &zIm[n-8].
     // BX (not R14) holds byte offsets: R14 is the goroutine g pointer on Go amd64.
@@ -5335,11 +5340,26 @@ realfft_loop8:
     JNZ  realfft_loop8
 
 realfft_remainder:
-    // Handle remaining elements (n-1) % 8
+    // Handle the remaining (n-1) % 8 elements with one more FULL 8-wide block
+    // anchored at k = n-8, overlapping the block just written, rather than
+    // walking the leftovers one at a time. Bin k reads zRe/zIm at k and at the
+    // mirror n-k plus the twiddles at k-1, and nothing a previous bin produced,
+    // so recomputing the last 8 stores the identical values. The idiom is the
+    // same one the i8 reductions (#149) and MinIdxOfSumRows (#170) use.
+    //
+    // Idempotence needs the inputs to still be the inputs, which is why
+    // RealFFTUnpack documents that the output must not overlap zRe/zIm. See #215.
     ANDQ $7, R13                     // R13 = remainder count
     JZ   realfft_done
 
-    // Reload base pointers for remainder (need to recalculate positions)
+    // Zero the remainder before re-entering the loop: the block below ends on the
+    // loop's own DECQ/JNZ, falls through to this label a second time, and must
+    // find nothing left to do.
+    XORL R13, R13
+
+    // Reload the six slice bases, every one of which the loop advanced. CX still
+    // holds n (the loop never writes it) and is reloaded only to keep this block
+    // independent of that invariant.
     MOVQ outRe_base+0(FP), DX
     MOVQ outIm_base+24(FP), SI
     MOVQ zRe_base+48(FP), DI
@@ -5348,114 +5368,34 @@ realfft_remainder:
     MOVQ twIm_base+120(FP), R12
     MOVQ n+144(FP), CX
 
-    // Calculate starting k for remainder: 1 + 8 * num_full_iterations
-    MOVQ CX, AX
-    DECQ AX                          // AX = n - 1
-    SHRQ $3, AX                      // AX = num_full_iterations
-    SHLQ $3, AX                      // AX = 8 * num_full_iterations
-    INCQ AX                          // AX = 1 + 8 * num_full_iterations = starting k
+    // Mirror pointers first, while DI and R8 still hold the bases. At k = n-8 the
+    // block reads z[n-k-7 .. n-k] = z[1 .. 8], one element in from the start.
+    // Index 8 is why the block needs n >= 9, which the caller's threshold gives.
+    MOVQ DI, R9
+    ADDQ $4, R9                      // R9 = &zRe[1]
+    MOVQ R8, R10
+    ADDQ $4, R10                     // R10 = &zIm[1]
 
-    // Offset pointers to starting k
-    MOVQ AX, BX
-    SHLQ $2, BX                      // BX = k * 4 bytes
-    ADDQ BX, DX                      // DX = &outRe[k]
-    ADDQ BX, SI                      // SI = &outIm[k]
+    // Forward and output pointers to k = n-8.
+    MOVQ CX, BX
+    SUBQ $8, BX                      // BX = n - 8 = k
+    SHLQ $2, BX                      // BX = k * 4 = byte offset
     ADDQ BX, DI                      // DI = &zRe[k]
     ADDQ BX, R8                      // R8 = &zIm[k]
+    ADDQ BX, DX                      // DX = &outRe[k]
+    ADDQ BX, SI                      // SI = &outIm[k]
 
-    // Twiddle offset is (k-1)
-    DECQ AX
-    MOVQ AX, BX
-    SHLQ $2, BX
+    // Twiddles are indexed k-1, so they top out at n-2 against a length n-1 slice.
+    SUBQ $4, BX                      // BX = (k-1) * 4
     ADDQ BX, R11                     // R11 = &twRe[k-1]
     ADDQ BX, R12                     // R12 = &twIm[k-1]
-    INCQ AX                          // Restore AX = k
 
-    // Mirror pointers for the tail. nk = n-k falls by one as k rises, so R9 and
-    // R10 walk backwards through zRe/zIm instead of being recomputed from the
-    // frame on every iteration. Both are dead here: the 8-wide loop above has
-    // finished with them, and this block sets both unconditionally, so the
-    // AX == 0 entry that skips the vector preamble is covered too.
-    MOVQ CX, BX
-    SUBQ AX, BX                      // BX = n - k = nk of the first tail element
-    SHLQ $2, BX                      // BX = nk * 4 = byte offset
-    MOVQ zRe_base+48(FP), R9
-    ADDQ BX, R9                      // R9 = &zRe[nk]
-    MOVQ zIm_base+72(FP), R10
-    ADDQ BX, R10                     // R10 = &zIm[nk]
-
-    // Tail constants, hoisted out of the loop and loaded from RODATA with VEX.
-    // Whenever the 8-wide loop ran, the upper YMM halves are dirty here (the
-    // only VZEROUPPER is at realfft_done), so a legacy-SSE MOVD in the loop
-    // body pays an AVX-SSE transition: MEASURED at 2 assists.sse_avx_mix per
-    // iteration on an i7-1260P, about 213 cycles each, which is essentially the
-    // whole per-element tail cost. Dropping them took n=64 from 662 ns to
-    // 27 ns. See #208.
-    VMOVSS roundf32_half<>(SB), X13     // X13 = 0.5f
-    VMOVSS roundf32_signmask<>(SB), X14 // X14 = 0x80000000 (sign bit only)
-
-realfft_scalar:
-    // Load Z[k]
-    VMOVSS (DI), X0                  // X0 = zRe[k]
-    VMOVSS (R8), X1                  // X1 = zIm[k]
-
-    // Load conj(Z[n-k])
-    VMOVSS (R9), X2                  // X2 = zRe[nk]
-    VMOVSS (R10), X3                 // X3 = zIm[nk]
-
-    // Negate X3 for conjugate: znkIm = -zIm[nk]. The sign-bit flip matches the
-    // 8-wide body above and realFFTUnpack32Go, both of which negate; a 0 - x
-    // subtract returns +0 for zIm[nk] == +0 where -x returns -0.
-    VXORPS X14, X3, X3               // X3 = -zIm[nk] = znkIm
-
-    // evenRe = 0.5 * (zkRe + znkRe)
-    VADDSS X0, X2, X4
-    VMULSS X4, X13, X4               // X4 = evenRe
-
-    // evenIm = 0.5 * (zkIm + znkIm)
-    VADDSS X1, X3, X5
-    VMULSS X5, X13, X5               // X5 = evenIm
-
-    // diffRe = zkRe - znkRe
-    VSUBSS X2, X0, X6                // X6 = diffRe
-
-    // diffIm = zkIm - znkIm
-    VSUBSS X3, X1, X7                // X7 = diffIm
-
-    // Load twiddles
-    VMOVSS (R11), X8                 // X8 = wr
-    VMOVSS (R12), X9                 // X9 = wi
-
-    // oddRe = 0.5 * (wr*diffIm + wi*diffRe)
-    VMULSS X8, X7, X10               // X10 = wr * diffIm
-    VFMADD231SS X9, X6, X10          // X10 = wr*diffIm + wi*diffRe
-    VMULSS X10, X13, X10             // X10 = oddRe
-
-    // oddIm = 0.5 * (wi*diffIm - wr*diffRe)
-    VMULSS X9, X7, X11               // X11 = wi * diffIm
-    VFNMADD231SS X8, X6, X11         // X11 = wi*diffIm - wr*diffRe
-    VMULSS X11, X13, X11             // X11 = oddIm
-
-    // output = even + odd
-    VADDSS X4, X10, X0               // X0 = outRe
-    VADDSS X5, X11, X1               // X1 = outIm
-
-    // Store
-    VMOVSS X0, (DX)
-    VMOVSS X1, (SI)
-
-    // Advance pointers
-    ADDQ $4, DI
-    ADDQ $4, R8
-    SUBQ $4, R9                      // mirror zRe: nk--
-    SUBQ $4, R10                     // mirror zIm: nk--
-    ADDQ $4, R11
-    ADDQ $4, R12
-    ADDQ $4, DX
-    ADDQ $4, SI
-
-    DECQ R13
-    JNZ  realfft_scalar
+    // Y13/Y14 still hold 0.5f and the sign mask, so the re-entered loop needs no
+    // fresh constant load: the loop body reads both but writes neither, and the
+    // only path into this label that skips the preamble is the zero-full-blocks
+    // test at the top of the function, which now branches to realfft_done.
+    MOVQ $1, AX                      // exactly one more iteration
+    JMP  realfft_loop8
 
 realfft_done:
     VZEROUPPER

--- a/f32/f32_test.go
+++ b/f32/f32_test.go
@@ -3331,7 +3331,13 @@ func TestRealFFTUnpack_GoVsSIMD(t *testing.T) {
 	// bit-identical in general: the two paths can make different FMA contraction
 	// choices, and which of them fuses depends on GOARCH and on the dispatched
 	// CPU tier.
-	sizes := []int{9, 16, 17, 32, 64, 128, 256, 512}
+	//
+	// 9 through 16 is one full (n-1)%8 cycle, so every AVX remainder length is
+	// compared against the reference and not just the empty and maximal ones.
+	// This arm goes inert wherever the dispatcher declines SIMD, because it then
+	// calls realFFTUnpack32Go on both sides; TestRealFFTUnpack_SignedZero carries
+	// the independent oracle that holds on every tier.
+	sizes := []int{9, 10, 11, 12, 13, 14, 15, 16, 17, 32, 64, 128, 256, 512}
 
 	for _, n := range sizes {
 		t.Run(fmt.Sprintf("n=%d", n), func(t *testing.T) {
@@ -3384,9 +3390,9 @@ func TestRealFFTUnpack_GoVsSIMD(t *testing.T) {
 
 // TestRealFFTUnpack_AllocFree pins the package convention that every operation
 // writes into caller-provided slices and allocates nothing. n = 67 gives
-// (n-1)%8 == 2, so the run covers eight full AVX blocks and a two-iteration
-// scalar remainder; a tail that allocated would go unnoticed at a size where
-// (n-1)%8 is zero.
+// (n-1)%8 == 2, so the run covers eight full AVX blocks plus the overlapping
+// remainder block; remainder handling that allocated would go unnoticed at a
+// size where (n-1)%8 is zero and the remainder path is skipped.
 func TestRealFFTUnpack_AllocFree(t *testing.T) {
 	const n = 67
 	zRe := make([]float32, n)
@@ -3498,9 +3504,14 @@ func realFFTUnpack32Close(got, want float32) bool {
 func TestRealFFTUnpack_OverRead(t *testing.T) {
 	const pad = 16 // two 8-wide AVX blocks of NaN guard band on each side of z
 	// n > minAVXElements (8) is what dispatches to AVX. 9 to 16 sweeps (n-1)%8
-	// through all of 0..7, so the 8-wide AVX path is hit at every scalar-tail
+	// through all of 0..7, so the 8-wide AVX path is hit at every remainder
 	// length and at its minimum reverse index; that range also covers (n-1)%4 for
 	// the 4-wide NEON path. The larger sizes add multi-iteration reverse walks.
+	//
+	// This is the test that bounds the overlapping remainder block (#215). That
+	// block re-anchors at k = n-8 and mirror-reads zRe[1..8] whatever n is, so at
+	// n = 9 its forward and mirror windows are the same 8 elements and both sit
+	// hard against the ends of z; a guard band violation would show up here first.
 	for _, n := range []int{9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 31, 32, 33, 64, 65} {
 		t.Run(fmt.Sprintf("n=%d", n), func(t *testing.T) {
 			nan := float32(math.NaN())
@@ -3623,7 +3634,9 @@ func TestRealFFTUnpack_ShortSlices(t *testing.T) {
 // zero and nothing rounds: the comparison can be bit-for-bit. The AVX scalar
 // tail used to negate for the conjugate with 0 - x, which returns +0 where -x
 // returns -0, so it disagreed with both its own 8-wide body and the Go
-// reference on these inputs (#208).
+// reference on these inputs (#208). #215 then replaced that tail with an
+// overlapping 8-wide block, so on AMD64 there is no longer a separate negation
+// to drift; the NEON kernel still has a scalar tail and this still guards it.
 //
 // Both comparisons are needed and neither covers the other. Dispatched-vs-Go
 // pins the kernel, but wherever the dispatcher declines SIMD it CALLS
@@ -3633,10 +3646,10 @@ func TestRealFFTUnpack_ShortSlices(t *testing.T) {
 // of adding the second would just move the blind spot onto the AVX path, where
 // realFFTUnpack32Go stops being reachable from RealFFTUnpack.
 func TestRealFFTUnpack_SignedZero(t *testing.T) {
-	// (n-1)%8 runs 0..7 over 9..16, so the AVX scalar tail is exercised at every
-	// length it can have; the NEON tail is (n-1)%4 and this list sweeps that too.
-	// 64 and 65 add a size with several full 8-wide blocks ahead of a full tail
-	// and one with no tail at all.
+	// (n-1)%8 runs 0..7 over 9..16, so the AVX remainder path is exercised at
+	// every length it can have; the NEON scalar tail is (n-1)%4 and this list
+	// sweeps that too. 64 and 65 add a size with several full 8-wide blocks ahead
+	// of a full remainder and one with no remainder at all.
 	sizes := []int{9, 10, 11, 12, 13, 14, 15, 16, 64, 65}
 
 	for _, n := range sizes {
@@ -3711,48 +3724,76 @@ func TestRealFFTUnpack_SignedZero(t *testing.T) {
 	}
 }
 
+// benchRealFFTUnpack32 runs fn at size n over freshly built inputs. Shared by
+// BenchmarkRealFFTUnpack and BenchmarkRealFFTUnpackTail so the two measure the
+// same thing at different size ranges.
+func benchRealFFTUnpack32(b *testing.B, n int, fn func(outRe, outIm, zRe, zIm, twRe, twIm []float32, n int)) {
+	b.Helper()
+	zRe := make([]float32, n)
+	zIm := make([]float32, n)
+	twRe := make([]float32, n-1)
+	twIm := make([]float32, n-1)
+	outRe := make([]float32, n)
+	outIm := make([]float32, n)
+
+	for i := range n {
+		zRe[i] = float32(i) * 0.1
+		zIm[i] = float32(i) * 0.2
+	}
+	for k := 1; k < n; k++ {
+		angle := -2 * math.Pi * float64(k) / float64(2*n)
+		twRe[k-1] = float32(math.Cos(angle))
+		twIm[k-1] = float32(math.Sin(angle))
+	}
+
+	b.ResetTimer()
+	b.SetBytes(int64(n * 4 * 4)) // 4 slices of float32 (in/out re/im)
+
+	for i := 0; i < b.N; i++ {
+		fn(outRe, outIm, zRe, zIm, twRe, twIm, n)
+	}
+}
+
+// benchRealFFTUnpack32Dispatched adapts the public entry point, which takes no
+// explicit n, to the shared helper's signature.
+func benchRealFFTUnpack32Dispatched(outRe, outIm, zRe, zIm, twRe, twIm []float32, _ int) {
+	RealFFTUnpack(outRe, outIm, zRe, zIm, twRe, twIm)
+}
+
 func BenchmarkRealFFTUnpack(b *testing.B) {
 	// 513 sits next to 512 because every power of two in this list has
-	// (n-1)%8 == 7, the longest AVX scalar tail (and (n-1)%4 == 3, the longest
-	// NEON one). Without a size where the tail is empty its cost is charged to
-	// every row and reads as the kernel's baseline.
+	// (n-1)%8 == 7, the longest AVX remainder (and (n-1)%4 == 3, the longest NEON
+	// scalar tail). Without a size where the remainder is empty its cost is
+	// charged to every row and reads as the kernel's baseline.
 	sizes := []int{64, 128, 256, 512, 513, 1024, 4096}
-
-	benchFn := func(b *testing.B, n int, fn func(outRe, outIm, zRe, zIm, twRe, twIm []float32, n int)) {
-		b.Helper()
-		zRe := make([]float32, n)
-		zIm := make([]float32, n)
-		twRe := make([]float32, n-1)
-		twIm := make([]float32, n-1)
-		outRe := make([]float32, n)
-		outIm := make([]float32, n)
-
-		for i := range n {
-			zRe[i] = float32(i) * 0.1
-			zIm[i] = float32(i) * 0.2
-		}
-		for k := 1; k < n; k++ {
-			angle := -2 * math.Pi * float64(k) / float64(2*n)
-			twRe[k-1] = float32(math.Cos(angle))
-			twIm[k-1] = float32(math.Sin(angle))
-		}
-
-		b.ResetTimer()
-		b.SetBytes(int64(n * 4 * 4)) // 4 slices of float32 (in/out re/im)
-
-		for i := 0; i < b.N; i++ {
-			fn(outRe, outIm, zRe, zIm, twRe, twIm, n)
-		}
-	}
 
 	for _, n := range sizes {
 		b.Run(fmt.Sprintf("SIMD_%d", n), func(b *testing.B) {
-			benchFn(b, n, func(outRe, outIm, zRe, zIm, twRe, twIm []float32, _ int) {
-				RealFFTUnpack(outRe, outIm, zRe, zIm, twRe, twIm)
-			})
+			benchRealFFTUnpack32(b, n, benchRealFFTUnpack32Dispatched)
 		})
 		b.Run(fmt.Sprintf("Go_%d", n), func(b *testing.B) {
-			benchFn(b, n, realFFTUnpack32Go)
+			benchRealFFTUnpack32(b, n, realFFTUnpack32Go)
+		})
+	}
+}
+
+// BenchmarkRealFFTUnpackTail sweeps one full remainder cycle at the smallest
+// dispatched sizes, so the per-tail-length cost is visible as a slope across
+// adjacent rows. n = 9 is the first size the AVX kernel takes (the guard is
+// n > minAVXElements with minAVXElements == 8) and has an empty remainder,
+// (n-1)%8 == 0; n = 16 has the longest one, (n-1)%8 == 7. The shipped size list
+// in BenchmarkRealFFTUnpack holds only those two extremes and nothing between,
+// which is what makes a change in remainder handling hard to read there.
+//
+// The NEON kernel is 4 wide, so this range covers two of its cycles rather than
+// one; the same slope reading applies per group of four.
+func BenchmarkRealFFTUnpackTail(b *testing.B) {
+	for n := 9; n <= 16; n++ {
+		b.Run(fmt.Sprintf("SIMD_%d", n), func(b *testing.B) {
+			benchRealFFTUnpack32(b, n, benchRealFFTUnpack32Dispatched)
+		})
+		b.Run(fmt.Sprintf("Go_%d", n), func(b *testing.B) {
+			benchRealFFTUnpack32(b, n, realFFTUnpack32Go)
 		})
 	}
 }

--- a/f32/f32_test.go
+++ b/f32/f32_test.go
@@ -3747,7 +3747,11 @@ func benchRealFFTUnpack32(b *testing.B, n int, fn func(outRe, outIm, zRe, zIm, t
 	}
 
 	b.ResetTimer()
-	b.SetBytes(int64(n * 4 * 4)) // 4 slices of float32 (in/out re/im)
+	// 6 float32 slices touched (in/out re/im + twiddles), matching the f64
+	// helper. This counted 4 before, omitting twRe/twIm, which understated the
+	// traffic and made the two packages' MB/s columns incomparable. ns/op is
+	// unaffected; only the derived MB/s figures move.
+	b.SetBytes(int64(n * 4 * 6))
 
 	for i := 0; i < b.N; i++ {
 		fn(outRe, outIm, zRe, zIm, twRe, twIm, n)

--- a/f32/f32_test.go
+++ b/f32/f32_test.go
@@ -3753,7 +3753,7 @@ func benchRealFFTUnpack32(b *testing.B, n int, fn func(outRe, outIm, zRe, zIm, t
 	// unaffected; only the derived MB/s figures move.
 	b.SetBytes(int64(n * 4 * 6))
 
-	for i := 0; i < b.N; i++ {
+	for range b.N {
 		fn(outRe, outIm, zRe, zIm, twRe, twIm, n)
 	}
 }

--- a/f64/f64.go
+++ b/f64/f64.go
@@ -987,15 +987,17 @@ const realFFTUnpackMinN = 2
 //
 // # Aliasing
 //
-// outRe and outIm must not overlap zRe or zIm in any way, not even as an exact
-// element-for-element overlay. Every bin reads the mirror z[n-k] as well as
-// z[k], so a write to out[k] destroys an input that the bin at n-k has not
-// consumed yet. Measured on the pure Go path, the first corrupted bin is
-// floor(n/2)+1 and every bin above it is wrong. The vector kernels currently
-// survive a few more sizes, because a SIMD block loads its whole input block
-// before storing any output lane, but that is block scheduling rather than a
-// guarantee and it varies with kernel width and n. Pass output slices distinct
-// from the input.
+// outRe and outIm must not overlap each other, nor any of zRe, zIm, twRe or
+// twIm, in any way, not even as an exact element-for-element overlay. Bin k
+// reads z at both k and the mirror n-k, plus the twiddles at k-1, before it
+// writes out[k], so any overlay lets a store land on an input that a later bin
+// has not read yet. Measured on the pure Go path, an output overlaid on z first
+// corrupts bin floor(n/2)+1 and every bin above it. The vector kernels survive a
+// few more sizes, because a SIMD block loads its whole input block before
+// storing any output lane, but that is block scheduling rather than a guarantee
+// and it varies with kernel width and n. Passing the same slice as outRe and
+// outIm makes every bin wrong on every path. Pass outputs distinct from the
+// inputs and from each other.
 //
 // It is the float64 counterpart of f32.RealFFTUnpack.
 //

--- a/f64/f64.go
+++ b/f64/f64.go
@@ -985,6 +985,18 @@ const realFFTUnpackMinN = 2
 //	X[0] = Z[0].real + Z[0].imag  (DC component)
 //	X[n] = Z[0].real - Z[0].imag  (Nyquist component)
 //
+// # Aliasing
+//
+// outRe and outIm must not overlap zRe or zIm in any way, not even as an exact
+// element-for-element overlay. Every bin reads the mirror z[n-k] as well as
+// z[k], so a write to out[k] destroys an input that the bin at n-k has not
+// consumed yet. Measured on the pure Go path, the first corrupted bin is
+// floor(n/2)+1 and every bin above it is wrong. The vector kernels currently
+// survive a few more sizes, because a SIMD block loads its whole input block
+// before storing any output lane, but that is block scheduling rather than a
+// guarantee and it varies with kernel width and n. Pass output slices distinct
+// from the input.
+//
 // It is the float64 counterpart of f32.RealFFTUnpack.
 //
 // Uses AVX2+FMA on AMD64, NEON on ARM64, with a pure Go fallback.

--- a/f64/f64_amd64.s
+++ b/f64/f64_amd64.s
@@ -6456,7 +6456,12 @@ TEXT ·realFFTUnpackAVX(SB), NOSPLIT, $0-152
     DECQ AX                          // AX = n - 1
     MOVQ AX, R13                     // R13 = n - 1 (save for remainder)
     SHRQ $2, AX                      // AX = (n-1) / 4 = number of SIMD iterations
-    JZ   realfft64_remainder         // Skip SIMD loop if < 4 elements
+    // Zero full blocks means n <= 4, which realFFTUnpack64 never dispatches: its
+    // guard is n > minAVXElements and minAVXElements is 4. The overlapping
+    // remainder block below anchors at k = n-4 and mirror-reads zRe[1..4], so it
+    // needs n >= 5; writing nothing is the memory-safe answer to a caller that
+    // ignores the threshold, where falling through would over-read the input.
+    JZ   realfft64_done
 
     // Set up reverse pointers: R9 = &zRe[n-4], R10 = &zIm[n-4].
     // BX (not R14) holds byte offsets: R14 is the goroutine g pointer on Go amd64.
@@ -6554,11 +6559,26 @@ realfft64_loop4:
     JNZ  realfft64_loop4
 
 realfft64_remainder:
-    // Handle remaining elements (n-1) % 4
+    // Handle the remaining (n-1) % 4 elements with one more FULL 4-wide block
+    // anchored at k = n-4, overlapping the block just written, rather than
+    // walking the leftovers one at a time. Bin k reads zRe/zIm at k and at the
+    // mirror n-k plus the twiddles at k-1, and nothing a previous bin produced,
+    // so recomputing the last 4 stores the identical values. The idiom is the
+    // same one the i8 reductions (#149) and MinIdxOfSumRows (#170) use.
+    //
+    // Idempotence needs the inputs to still be the inputs, which is why
+    // RealFFTUnpack documents that the output must not overlap zRe/zIm. See #215.
     ANDQ $3, R13                     // R13 = remainder count
     JZ   realfft64_done
 
-    // Reload base pointers for remainder (need to recalculate positions)
+    // Zero the remainder before re-entering the loop: the block below ends on the
+    // loop's own DECQ/JNZ, falls through to this label a second time, and must
+    // find nothing left to do.
+    XORL R13, R13
+
+    // Reload the six slice bases, every one of which the loop advanced. CX still
+    // holds n (the loop never writes it) and is reloaded only to keep this block
+    // independent of that invariant.
     MOVQ outRe_base+0(FP), DX
     MOVQ outIm_base+24(FP), SI
     MOVQ zRe_base+48(FP), DI
@@ -6567,114 +6587,35 @@ realfft64_remainder:
     MOVQ twIm_base+120(FP), R12
     MOVQ n+144(FP), CX
 
-    // Calculate starting k for remainder: 1 + 4 * num_full_iterations
-    MOVQ CX, AX
-    DECQ AX                          // AX = n - 1
-    SHRQ $2, AX                      // AX = num_full_iterations
-    SHLQ $2, AX                      // AX = 4 * num_full_iterations
-    INCQ AX                          // AX = 1 + 4 * num_full_iterations = starting k
+    // Mirror pointers first, while DI and R8 still hold the bases. At k = n-4 the
+    // block reads z[n-k-3 .. n-k] = z[1 .. 4], one element in from the start.
+    // Index 4 is why the block needs n >= 5, which the caller's threshold gives.
+    MOVQ DI, R9
+    ADDQ $8, R9                      // R9 = &zRe[1]
+    MOVQ R8, R10
+    ADDQ $8, R10                     // R10 = &zIm[1]
 
-    // Offset pointers to starting k
-    MOVQ AX, BX
-    SHLQ $3, BX                      // BX = k * 8 bytes
-    ADDQ BX, DX                      // DX = &outRe[k]
-    ADDQ BX, SI                      // SI = &outIm[k]
+    // Forward and output pointers to k = n-4.
+    MOVQ CX, BX
+    SUBQ $4, BX                      // BX = n - 4 = k
+    SHLQ $3, BX                      // BX = k * 8 = byte offset
     ADDQ BX, DI                      // DI = &zRe[k]
     ADDQ BX, R8                      // R8 = &zIm[k]
+    ADDQ BX, DX                      // DX = &outRe[k]
+    ADDQ BX, SI                      // SI = &outIm[k]
 
-    // Twiddle offset is (k-1)
-    DECQ AX
-    MOVQ AX, BX
-    SHLQ $3, BX
+    // Twiddles are indexed k-1, so they top out at n-2 against a length n-1 slice.
+    SUBQ $8, BX                      // BX = (k-1) * 8
     ADDQ BX, R11                     // R11 = &twRe[k-1]
     ADDQ BX, R12                     // R12 = &twIm[k-1]
-    INCQ AX                          // Restore AX = k
 
-    // Mirror pointers for the tail. nk = n-k falls by one as k rises, so R9 and
-    // R10 walk backwards through zRe/zIm instead of being recomputed from the
-    // frame on every iteration. Both are dead here: the 4-wide loop above has
-    // finished with them, and this block sets both unconditionally, so the
-    // AX == 0 entry that skips the vector preamble is covered too.
-    MOVQ CX, BX
-    SUBQ AX, BX                      // BX = n - k = nk of the first tail element
-    SHLQ $3, BX                      // BX = nk * 8 = byte offset
-    MOVQ zRe_base+48(FP), R9
-    ADDQ BX, R9                      // R9 = &zRe[nk]
-    MOVQ zIm_base+72(FP), R10
-    ADDQ BX, R10                     // R10 = &zIm[nk]
-
-    // Tail constants, hoisted out of the loop and loaded from RODATA with VEX.
-    // Whenever the 4-wide loop ran, the upper YMM halves are dirty here (the
-    // only VZEROUPPER is at realfft64_done), so a legacy-SSE MOVQ in the loop
-    // body pays an AVX-SSE transition: MEASURED at 2 assists.sse_avx_mix per
-    // iteration on an i7-1260P, about 213 cycles each, which is essentially the
-    // whole per-element tail cost. Dropping them took n=64 from 314 ns to
-    // 32 ns. See #208.
-    VMOVSD roundf64_half<>(SB), X13     // X13 = 0.5
-    VMOVSD roundf64_signmask<>(SB), X14 // X14 = 0x8000000000000000 (sign bit)
-
-realfft64_scalar:
-    // Load Z[k]
-    VMOVSD (DI), X0                  // X0 = zRe[k]
-    VMOVSD (R8), X1                  // X1 = zIm[k]
-
-    // Load conj(Z[n-k])
-    VMOVSD (R9), X2                  // X2 = zRe[nk]
-    VMOVSD (R10), X3                 // X3 = zIm[nk]
-
-    // Negate X3 for conjugate: znkIm = -zIm[nk]. The sign-bit flip matches the
-    // 4-wide body above and realFFTUnpack64Go, both of which negate; a 0 - x
-    // subtract returns +0 for zIm[nk] == +0 where -x returns -0.
-    VXORPD X14, X3, X3               // X3 = -zIm[nk] = znkIm
-
-    // evenRe = 0.5 * (zkRe + znkRe)
-    VADDSD X0, X2, X4
-    VMULSD X4, X13, X4               // X4 = evenRe
-
-    // evenIm = 0.5 * (zkIm + znkIm)
-    VADDSD X1, X3, X5
-    VMULSD X5, X13, X5               // X5 = evenIm
-
-    // diffRe = zkRe - znkRe
-    VSUBSD X2, X0, X6                // X6 = diffRe
-
-    // diffIm = zkIm - znkIm
-    VSUBSD X3, X1, X7                // X7 = diffIm
-
-    // Load twiddles
-    VMOVSD (R11), X8                 // X8 = wr
-    VMOVSD (R12), X9                 // X9 = wi
-
-    // oddRe = 0.5 * (wr*diffIm + wi*diffRe)
-    VMULSD X8, X7, X10               // X10 = wr * diffIm
-    VFMADD231SD X9, X6, X10          // X10 = wr*diffIm + wi*diffRe
-    VMULSD X10, X13, X10             // X10 = oddRe
-
-    // oddIm = 0.5 * (wi*diffIm - wr*diffRe)
-    VMULSD X9, X7, X11               // X11 = wi * diffIm
-    VFNMADD231SD X8, X6, X11         // X11 = wi*diffIm - wr*diffRe
-    VMULSD X11, X13, X11             // X11 = oddIm
-
-    // output = even + odd
-    VADDSD X4, X10, X0               // X0 = outRe
-    VADDSD X5, X11, X1               // X1 = outIm
-
-    // Store
-    VMOVSD X0, (DX)
-    VMOVSD X1, (SI)
-
-    // Advance pointers
-    ADDQ $8, DI
-    ADDQ $8, R8
-    SUBQ $8, R9                      // mirror zRe: nk--
-    SUBQ $8, R10                     // mirror zIm: nk--
-    ADDQ $8, R11
-    ADDQ $8, R12
-    ADDQ $8, DX
-    ADDQ $8, SI
-
-    DECQ R13
-    JNZ  realfft64_scalar
+    // Y13/Y14 still hold 0.5 and the sign bit, so the re-entered loop needs no
+    // fresh constant materialisation: the loop body reads both but writes neither,
+    // and the only path into this label that skips the preamble is the
+    // zero-full-blocks test at the top of the function, which now branches to
+    // realfft64_done.
+    MOVQ $1, AX                      // exactly one more iteration
+    JMP  realfft64_loop4
 
 realfft64_done:
     VZEROUPPER

--- a/f64/realfftunpack_test.go
+++ b/f64/realfftunpack_test.go
@@ -74,7 +74,7 @@ func realFFTUnpackClose(got, want float64) bool {
 }
 
 func TestRealFFTUnpack(t *testing.T) {
-	// 6 and 10 give (n-1) % 4 == 1, the only AVX scalar-tail length not otherwise hit.
+	// 6 and 10 give (n-1) % 4 == 1, the only AVX remainder length not otherwise hit.
 	sizes := []int{2, 3, 4, 5, 6, 8, 9, 10, 16, 17, 31, 32, 33, 63, 64, 65, 128, 256, 512, 1000}
 
 	for _, n := range sizes {
@@ -145,7 +145,13 @@ func TestRealFFTUnpack_GoVsSIMD(t *testing.T) {
 	// Test that Go and SIMD implementations produce identical results.
 	// n=3 exercises the arm64 NEON path (n>2); the larger sizes exercise the
 	// amd64 AVX path (n>4).
-	sizes := []int{3, 5, 9, 16, 17, 32, 64, 128, 256, 512}
+	//
+	// 5 through 8 is one full (n-1)%4 cycle, so every AVX remainder length is
+	// compared against the reference and not just the empty and maximal ones.
+	// This arm goes inert wherever the dispatcher declines SIMD, because it then
+	// calls realFFTUnpack64Go on both sides; TestRealFFTUnpack_SignedZero carries
+	// the independent oracle that holds on every tier.
+	sizes := []int{3, 5, 6, 7, 8, 9, 16, 17, 32, 64, 128, 256, 512}
 
 	for _, n := range sizes {
 		t.Run(fmt.Sprintf("n=%d", n), func(t *testing.T) {
@@ -385,7 +391,9 @@ func TestRealFFTUnpack_ShortSlices(t *testing.T) {
 // zero and nothing rounds: the comparison can be bit-for-bit. The AVX scalar
 // tail used to negate for the conjugate with 0 - x, which returns +0 where -x
 // returns -0, so it disagreed with both its own 4-wide body and the Go
-// reference on these inputs (#208).
+// reference on these inputs (#208). #215 then replaced that tail with an
+// overlapping 4-wide block, so on AMD64 there is no longer a separate negation
+// to drift; the NEON kernel still has a scalar tail and this still guards it.
 //
 // Both comparisons are needed and neither covers the other. Dispatched-vs-Go
 // pins the kernel, but wherever the dispatcher declines SIMD it CALLS
@@ -395,10 +403,10 @@ func TestRealFFTUnpack_ShortSlices(t *testing.T) {
 // of adding the second would just move the blind spot onto the AVX path, where
 // realFFTUnpack64Go stops being reachable from RealFFTUnpack.
 func TestRealFFTUnpack_SignedZero(t *testing.T) {
-	// (n-1)%4 runs 0..3 over 5..8, so the AVX scalar tail is exercised at every
-	// length it can have; the NEON tail is (n-1)%2 and this list sweeps that too.
-	// 16, 64 and 65 add sizes with several full 4-wide blocks ahead of the tail,
-	// including one with no tail at all.
+	// (n-1)%4 runs 0..3 over 5..8, so the AVX remainder path is exercised at every
+	// length it can have; the NEON scalar tail is (n-1)%2 and this list sweeps
+	// that too. 16, 64 and 65 add sizes with several full 4-wide blocks ahead of
+	// the remainder, including one with no remainder at all.
 	sizes := []int{5, 6, 7, 8, 16, 64, 65}
 
 	for _, n := range sizes {
@@ -473,48 +481,74 @@ func TestRealFFTUnpack_SignedZero(t *testing.T) {
 	}
 }
 
+// benchRealFFTUnpack64 runs fn at size n over freshly built inputs. Shared by
+// BenchmarkRealFFTUnpack and BenchmarkRealFFTUnpackTail so the two measure the
+// same thing at different size ranges.
+func benchRealFFTUnpack64(b *testing.B, n int, fn func(outRe, outIm, zRe, zIm, twRe, twIm []float64, n int)) {
+	b.Helper()
+	zRe := make([]float64, n)
+	zIm := make([]float64, n)
+	twRe := make([]float64, n-1)
+	twIm := make([]float64, n-1)
+	outRe := make([]float64, n)
+	outIm := make([]float64, n)
+
+	for i := range n {
+		zRe[i] = float64(i) * 0.1
+		zIm[i] = float64(i) * 0.2
+	}
+	for k := 1; k < n; k++ {
+		angle := -2 * math.Pi * float64(k) / float64(2*n)
+		twRe[k-1] = math.Cos(angle)
+		twIm[k-1] = math.Sin(angle)
+	}
+
+	b.ResetTimer()
+	b.SetBytes(int64(n * 8 * 6)) // 6 float64 slices touched (in/out re/im + twiddles)
+
+	for range b.N {
+		fn(outRe, outIm, zRe, zIm, twRe, twIm, n)
+	}
+}
+
+// benchRealFFTUnpack64Dispatched adapts the public entry point, which takes no
+// explicit n, to the shared helper's signature.
+func benchRealFFTUnpack64Dispatched(outRe, outIm, zRe, zIm, twRe, twIm []float64, _ int) {
+	RealFFTUnpack(outRe, outIm, zRe, zIm, twRe, twIm)
+}
+
 func BenchmarkRealFFTUnpack(b *testing.B) {
 	// 513 sits next to 512 because every power of two in this list has
-	// (n-1)%4 == 3, the longest AVX scalar tail (and (n-1)%2 == 1, the longest
-	// NEON one). Without a size where the tail is empty its cost is charged to
-	// every row and reads as the kernel's baseline.
+	// (n-1)%4 == 3, the longest AVX remainder (and (n-1)%2 == 1, the longest NEON
+	// scalar tail). Without a size where the remainder is empty its cost is
+	// charged to every row and reads as the kernel's baseline.
 	sizes := []int{64, 128, 256, 512, 513, 1024, 4096}
-
-	benchFn := func(b *testing.B, n int, fn func(outRe, outIm, zRe, zIm, twRe, twIm []float64, n int)) {
-		b.Helper()
-		zRe := make([]float64, n)
-		zIm := make([]float64, n)
-		twRe := make([]float64, n-1)
-		twIm := make([]float64, n-1)
-		outRe := make([]float64, n)
-		outIm := make([]float64, n)
-
-		for i := range n {
-			zRe[i] = float64(i) * 0.1
-			zIm[i] = float64(i) * 0.2
-		}
-		for k := 1; k < n; k++ {
-			angle := -2 * math.Pi * float64(k) / float64(2*n)
-			twRe[k-1] = math.Cos(angle)
-			twIm[k-1] = math.Sin(angle)
-		}
-
-		b.ResetTimer()
-		b.SetBytes(int64(n * 8 * 6)) // 6 float64 slices touched (in/out re/im + twiddles)
-
-		for range b.N {
-			fn(outRe, outIm, zRe, zIm, twRe, twIm, n)
-		}
-	}
 
 	for _, n := range sizes {
 		b.Run(fmt.Sprintf("SIMD_%d", n), func(b *testing.B) {
-			benchFn(b, n, func(outRe, outIm, zRe, zIm, twRe, twIm []float64, _ int) {
-				RealFFTUnpack(outRe, outIm, zRe, zIm, twRe, twIm)
-			})
+			benchRealFFTUnpack64(b, n, benchRealFFTUnpack64Dispatched)
 		})
 		b.Run(fmt.Sprintf("Go_%d", n), func(b *testing.B) {
-			benchFn(b, n, realFFTUnpack64Go)
+			benchRealFFTUnpack64(b, n, realFFTUnpack64Go)
+		})
+	}
+}
+
+// BenchmarkRealFFTUnpackTail sweeps two full remainder cycles at the smallest
+// dispatched sizes, so the per-tail-length cost is visible as a slope across
+// adjacent rows. n = 5 is the first size the AVX kernel takes (the guard is
+// n > minAVXElements with minAVXElements == 4) and has an empty remainder,
+// (n-1)%4 == 0; n = 8 has the longest one, (n-1)%4 == 3, and 9..12 repeat the
+// cycle one block higher. The shipped size list in BenchmarkRealFFTUnpack holds
+// only the two extremes and nothing between, which is what makes a change in
+// remainder handling hard to read there.
+func BenchmarkRealFFTUnpackTail(b *testing.B) {
+	for n := 5; n <= 12; n++ {
+		b.Run(fmt.Sprintf("SIMD_%d", n), func(b *testing.B) {
+			benchRealFFTUnpack64(b, n, benchRealFFTUnpack64Dispatched)
+		})
+		b.Run(fmt.Sprintf("Go_%d", n), func(b *testing.B) {
+			benchRealFFTUnpack64(b, n, realFFTUnpack64Go)
 		})
 	}
 }


### PR DESCRIPTION
Closes #215.

## What changed

The AVX `realFFTUnpack` kernels walked the trailing `(n-1)%width` bins one at a time. Each scalar iteration cost about as much as an entire vector block, so the remainder dominated the small sizes: an f32 tail of 7 ran about 10 ns against about 2 ns for one more 8-wide pass.

The scalar loop is replaced by one more **full** vector block anchored at `k = n-width`, overlapping the block just written. Bin `k` reads `zRe`/`zIm` at `k` and at the mirror `n-k`, plus the twiddles at `k-1`, and nothing a previous bin produced, so recomputing the last few bins stores identical values. This is the idiom the i8 reductions (#149) and `MinIdxOfSumRows` (#170) already use.

Bounds hold at every dispatched size. The block anchors at `k = n-8` (f32) or `k = n-4` (f64) and mirror-reads `z[1..width]`, so it needs `n >= 9` / `n >= 5`, which is exactly what the dispatch guard `n > minAVXElements` gives. Twiddles top out at `n-2` against a length `n-1` slice.

## Measured

i7-1260P, `taskset` pinned, six interleaved A/B rounds so P-state drift cannot land on one side.

| benchmark | before | after | delta |
|---|---|---|---|
| f32 `SIMD_64` | 28.44n | 20.59n | -27.6% |
| f32 `SIMD_128` | 41.54n | 33.96n | -18.2% |
| f32 `SIMD_256` | 69.18n | 61.52n | -11.1% |
| f32 `SIMD_512` | 123.5n | 116.1n | -6.0% |
| f64 `SIMD_64` | 34.20n | 31.34n | -8.4% |
| f64 `SIMD_128` | 59.96n | 55.05n | -8.2% |

The tail sweep is the real evidence, because it shows the shape of the change rather than a single number. f32:

| n | remainder | before | after |
|---|---|---|---|
| 9 | 0 | 9.671n | 9.713n |
| 10 | 1 | 11.96n | 11.71n |
| 11 | 2 | 13.17n | 11.71n |
| 12 | 3 | 14.71n | 11.73n |
| 13 | 4 | 15.88n | 11.64n |
| 14 | 5 | 17.01n | 11.64n |
| 15 | 6 | 18.41n | 11.64n |
| 16 | 7 | 19.53n | 11.63n |

Remainder cost was linear in the remainder length and is now constant. `n=9` has no remainder and is unchanged, as are `SIMD_513` ((513-1)%8 == 0) and `SIMD_4096`; those are untouched controls rather than rows I had to explain away. Remainder 1 comes out a wash rather than a regression, so unlike #170 this needs no `leftover >= 2` gate.

Two f64 rows (`SIMD_256`, `SIMD_1024`) show very high variance in this run and report no significant change; the host was not perfectly quiet. The tail rows, which are what the change touches, are +/-1-4% at p=0.002.

## The aliasing precondition

An overlapping block re-reads `z` at indices whose `out` positions the preceding iteration already wrote, which is only sound if `out` and `z` do not overlap. `RealFFTUnpack` documented no aliasing rule, so this adds one.

Worth being clear that this documents an existing restriction rather than introducing one. Exact aliasing was already broken. Measured with `RealFFTUnpack(out, out, ...)` against a separate-buffer run, on the pure Go path the first corrupted bin is `floor(n/2)+1` at every size tested, in both f32 and f64, contiguous to the end: the mirrored read means writing `out[k]` destroys an input that bin `n-k` has not consumed. The vector kernels survive a few more sizes (f32 NEON at n=5 is entirely clean) only because a SIMD block loads its whole input block before storing any output lane. That is block scheduling, not a guarantee, and it varies with kernel width and n. This change alters which sizes happen to survive, not whether the contract is violated.

The remaining package-wide aliasing gap is filed separately rather than bundled here, because stating a blanket rule would require auditing every kernel's load-before-store behaviour and that is a bigger claim than this PR can back.

## Tests

- `BenchmarkRealFFTUnpackTail` added, sweeping a full remainder cycle at the smallest dispatched sizes. The shipped size list held only the empty and the maximal remainder with nothing between, which is what made remainder cost unreadable there.
- Go-vs-SIMD parity sizes extended to cover every remainder length, not just 0 and max.
- Test comments describing a scalar tail the AMD64 path no longer has are corrected. The NEON kernels still have theirs, so those halves are kept.

Verified: full f32 and f64 suites pass on amd64 at the AVX2, AVX1+FMA and pure Go tiers, and on arm64 hardware. `golangci-lint` output is identical to `main` (101 pre-existing issues, 0 added) on both GOARCHs.

Three sabotages of the new block each turn the suite red, so the coverage is not vacuous: mirror anchored at `zRe[2]` instead of `zRe[1]`; the overlap block skipped entirely; and the f64 twiddle index using `k` instead of `k-1`.

## Not in scope

The NEON kernels keep their scalar tails. The same transform applies there, but I have no tail-cost measurement on arm64 and did not want an unmeasured change riding along with a contract change.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved real FFT unpacking for short and non-aligned input sizes on supported SIMD systems.
  * Prevented unsafe processing and corrected remainder handling for AVX implementations.
  * Expanded coverage for edge cases, signed zero values, and guarded memory regions.

* **Documentation**
  * Clarified that input and output slices must not overlap during unpacking.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->