### PR TITLE
asmcheck: extend the amd64 ISA check to the FMA3 axis (#201)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -56,6 +56,34 @@ suite cross-checks every `WORD` against `golang.org/x/arch/arm64asm` (see
 `asmcheck_test.go` / the public `asmcheck` package). When you add or change a `WORD`,
 verify the encoding with `aarch64-linux-gnu-as` + objdump or `arm64asm`.
 
+### AMD64: the dispatch guard is machine-checked, on two axes
+
+An amd64 kernel's body is checked against the CPU features its dispatch actually
+requires. A guard that is merely documented is not enough; both of these fail the
+suite rather than SIGILLing on hardware CI does not own.
+
+- **AVX2** (`asmcheck_amd64_isa_test.go`, `asmcheck_amd64_gate_test.go`, #200). The
+  name suffix is a claim: a kernel called `...AVX` may not contain an AVX2-only
+  encoding. The traps are register-source `VBROADCASTSS`/`VBROADCASTSD` and any
+  256-bit integer op, since AVX1's YMM support is float-only. A kernel that must
+  outrun its name goes in `avx2GatedAVXKernels` together with the gate that
+  protects it; renaming it to `...AVX2` is the better fix.
+- **FMA3** (`asmcheck_amd64_fma_test.go`, #201). `cpu.X86.FMA` is a CPUID bit
+  separate from AVX, so a `VFMADD`-family instruction needs its own conjunct in
+  the guard. A kernel using one may not be assigned by `initAVXNoFMA`, `initSSE`,
+  `initSSE2` or `initGo`, and may not be dispatched from a branch testing only
+  `cpu.X86.AVX`. f64 and c128 keep an `initAVXNoFMA` tier precisely for the parts
+  that have AVX and no FMA3.
+
+Both checks are pure source analysis, so they run on any host. Both resolve a
+guard spelled through a cached package var, a function parameter or a local, so
+write the dispatch in whatever shape reads best. Neither can see across a package
+boundary: only `<pkg>/*_amd64.go` is parsed.
+
+Separately, `TestNoFMAContract` forbids fusing in the kernels listed in
+`singleRoundingKernels`. That is the #156 numerical contract about where rounding
+happens, not about CPU features, and it applies to both architectures.
+
 ## Testing across architectures
 
 - AMD64 tests run natively here.

--- a/asmcheck/x86isa.go
+++ b/asmcheck/x86isa.go
@@ -20,6 +20,7 @@ package asmcheck
 
 import (
 	"regexp"
+	"slices"
 	"strings"
 )
 
@@ -49,21 +50,56 @@ func (l X86Level) String() string {
 	}
 }
 
-// X86Use is one instruction that requires a feature level above AVX1.
+// X86Feature names a CPUID feature bit that is ORTHOGONAL to the AVX level
+// ladder, so it cannot be expressed as an X86Level. A CPU can have AVX1 with or
+// without it, which is why it needs its own axis rather than a rung.
+type X86Feature string
+
+// X86FeatureFMA is FMA3, CPUID.01H:ECX.FMA[bit 12], reported by Go as
+// cpu.X86.HasFMA. It is a separate bit from AVX: Sandy Bridge and Ivy Bridge
+// have AVX and no FMA3, and this repo keeps an initAVXNoFMA dispatch tier for
+// exactly those parts. A VFMADD-family instruction reaching such a CPU faults
+// with #UD (SIGILL), the same failure #196 and #197 were about on the AVX2 axis.
+const X86FeatureFMA X86Feature = "FMA"
+
+// X86Use is one instruction that requires a feature level above AVX1, or a
+// feature off the level ladder, or both.
 type X86Use struct {
-	Line   int      // 1-based line number in the scanned source
-	Text   string   // the instruction as written, with any comment stripped
-	Level  X86Level // the level the instruction needs
-	Reason string   // why it needs that level
+	Line    int        // 1-based line number in the scanned source
+	Text    string     // the instruction as written, with any comment stripped
+	Level   X86Level   // the level the instruction needs
+	Feature X86Feature // an off-ladder feature it needs, or "" for none
+	Reason  string     // why it needs that level or feature
 }
 
 // X86Kernel is one TEXT symbol together with the instructions in it that need
-// more than AVX1.
+// more than plain AVX1.
+//
+// Off-ladder features are derived from Uses rather than stored alongside Level,
+// so there is one place a feature can be recorded and no second field to keep in
+// step with it.
 type X86Kernel struct {
 	Name  string   // symbol name, without the leading interpunct
 	Line  int      // 1-based line of the TEXT directive
 	Level X86Level // the highest level any instruction in the body needs
-	Uses  []X86Use // instructions above AVX1, in source order; nil when clean
+	Uses  []X86Use // qualifying instructions, in source order; nil when clean
+}
+
+// Needs reports whether the kernel's body uses an instruction requiring f.
+func (k X86Kernel) Needs(f X86Feature) bool {
+	return slices.ContainsFunc(k.Uses, func(u X86Use) bool { return u.Feature == f })
+}
+
+// FeatureUses returns the instructions in the kernel that require f, in source
+// order.
+func (k X86Kernel) FeatureUses(f X86Feature) []X86Use {
+	out := make([]X86Use, 0, len(k.Uses))
+	for _, u := range k.Uses {
+		if u.Feature == f {
+			out = append(out, u)
+		}
+	}
+	return out
 }
 
 // avx2Mnemonics are AVX2-only in every VEX form, whatever their operands.
@@ -134,6 +170,13 @@ var (
 	maskOperandRe = regexp.MustCompile(`^K[0-7]$`)
 	// xmmOperandRe matches an operand that is exactly an XMM register.
 	xmmOperandRe = regexp.MustCompile(`^X\d+$`)
+	// fmaRe matches the FMA3 multiply-add family. The set is closed and regular:
+	// an optional N for the negated forms, ADD or SUB, an optional second ADD or
+	// SUB for the alternating VFMADDSUB/VFMSUBADD pair, one of the three operand
+	// orders, then packed or scalar and single or double. Every member is FMA3,
+	// in both its 128-bit and 256-bit form, so no operand inspection is needed:
+	// unlike VBROADCASTSS, there is no FMA mnemonic with an AVX1-legal form.
+	fmaRe = regexp.MustCompile(`^VF(N)?M(ADD|SUB)(ADD|SUB)?(132|213|231)[PS][SD]$`)
 )
 
 // noFeatureMnemonics are directives and instructions that carry no SIMD feature
@@ -202,6 +245,23 @@ func x86InstrLevel(instr string) (level X86Level, reason string) {
 	return X86LevelAVX, ""
 }
 
+// x86InstrFeature reports the off-ladder CPUID feature one AMD64 instruction
+// needs, or "" if it needs none. It is deliberately independent of
+// x86InstrLevel: an FMA3 instruction is AVX1-legal as far as the level ladder is
+// concerned, and an AVX-512 kernel's EVEX-encoded FMA needs no separate claim
+// because every AVX-512 part implements FMA3. What this catches is the middle
+// case the ladder cannot express, an AVX1 CPU without FMA3.
+func x86InstrFeature(instr string) (feature X86Feature, reason string) {
+	m := instrRe.FindStringSubmatch(instr)
+	if m == nil {
+		return "", ""
+	}
+	if fmaRe.MatchString(m[1]) {
+		return X86FeatureFMA, "FMA3 multiply-add (a CPUID bit separate from AVX)"
+	}
+	return "", ""
+}
+
 // ScanX86Source parses every TEXT symbol in an AMD64 assembly source and reports
 // each one's required feature level together with the instructions that set it.
 // Kernels are returned in source order. Content before the first TEXT directive
@@ -231,11 +291,17 @@ func ScanX86Source(src string) []X86Kernel {
 				continue
 			}
 			level, reason := x86InstrLevel(stmt)
-			if level == X86LevelAVX {
+			feature, freason := x86InstrFeature(stmt)
+			if level == X86LevelAVX && feature == "" {
 				continue
 			}
+			if reason == "" {
+				reason = freason
+			}
 			k := &out[cur]
-			k.Uses = append(k.Uses, X86Use{Line: i + 1, Text: stmt, Level: level, Reason: reason})
+			k.Uses = append(k.Uses, X86Use{
+				Line: i + 1, Text: stmt, Level: level, Feature: feature, Reason: reason,
+			})
 			if level > k.Level {
 				k.Level = level
 			}

--- a/asmcheck_amd64_fma_test.go
+++ b/asmcheck_amd64_fma_test.go
@@ -1,0 +1,523 @@
+package simd
+
+// FMA3 is the sibling of the AVX2 axis that #200 modelled, and until #201 it was
+// unguarded. cpu.X86.FMA is a CPUID bit separate from AVX: Sandy Bridge and Ivy
+// Bridge have AVX and no FMA3, which is why f64 and c128 keep an initAVXNoFMA
+// dispatch tier. Every FMA-using kernel in this repo is correct today only
+// because a hand-written guard says so, and nothing checked those guards.
+//
+// Three edits used to pass the whole suite and SIGILL on Sandy Bridge, all three
+// verified against the tree before these tests existed:
+//
+//  1. adding VFMADD231PD to f64 clampAVX, a kernel initAVXNoFMA assigns
+//  2. adding VFMADD231PS to f32 copySignAVX, dispatched on plain cpu.X86.AVX
+//  3. deleting `&& cpu.X86.FMA` from f32 realFFTUnpack32's guard
+//
+// The two tests here split the dispatch surface between them. Kernels reached
+// through an init-time tier assignment are covered by TestAmd64InitTierFMA,
+// which reads the tier switch; kernels reached through a per-call branch are
+// covered by TestAmd64KernelDispatchRequiresFMA, which reuses the #200 dominance
+// walker on the FMA identifier set. Case 1 is the first, cases 2 and 3 the second.
+
+import (
+	"go/ast"
+	"maps"
+	"os"
+	"path/filepath"
+	"slices"
+	"strings"
+	"testing"
+
+	"github.com/tphakala/simd/asmcheck"
+)
+
+// initTierFMA classifies every init-time tier assigner by whether the CPU that
+// reaches it is guaranteed to have FMA3. A tier mapped false must assign only
+// FMA-free kernels.
+//
+// initAVX512 is true by architecture: FMA3 predates AVX-512 and every part
+// implementing an AVX-512 extension implements it. initAVX is true by dispatch
+// rather than by architecture, so it is not taken on trust; assertAVXTierNamesFMA
+// reads each package's tier switch and fails if the condition selecting initAVX
+// stops naming FMA.
+var initTierFMA = map[string]bool{
+	"initAVX512":   true,
+	"initAVX":      true,
+	"initAVXNoFMA": false,
+	"initSSE":      false,
+	"initSSE2":     false,
+	"initGo":       false,
+}
+
+// noFMATierPackages are the packages that keep an explicit AVX-without-FMA tier.
+// f32 and c64 do not: their init() falls from AVX+FMA straight to SSE, so an
+// AVX1-only part gets SSE kernels rather than a separate AVX tier. The list is
+// asserted rather than derived so that renaming initAVXNoFMA, or adding one to a
+// third package, has to be a deliberate edit here.
+var noFMATierPackages = []string{"c128", "f64"}
+
+// TestAmd64InitTierFMA asserts that no kernel needing FMA3 is assigned by a tier
+// that runs on CPUs which may lack it.
+func TestAmd64InitTierFMA(t *testing.T) {
+	var gotNoFMATier []string
+
+	for _, pkgDir := range amd64PackageDirs(t) {
+		needsFMA := fmaKernels(t, pkgDir)
+		pf := parseAmd64Package(t, pkgDir)
+
+		sawTier := false
+		for _, name := range sortedFuncNames(pf.funcs) {
+			if !isInitTier(name) {
+				continue
+			}
+			// "init" itself is the entry point that picks a tier, not a tier.
+			if name == "init" {
+				continue
+			}
+			guaranteed, known := initTierFMA[name]
+			if !known {
+				t.Errorf("%s: %s looks like an init-time tier assigner but is not "+
+					"classified in initTierFMA. Add it with true if the CCPU reaching it "+
+					"always has FMA3, false otherwise. Leaving it out would let the tier "+
+					"assign FMA kernels unchecked.", pkgDir, name)
+				continue
+			}
+			sawTier = true
+			if guaranteed {
+				continue
+			}
+			for _, kernel := range referencedIdents(pf.funcs[name], needsFMA) {
+				t.Errorf("%s: %s assigns %s, whose body uses FMA3.\n"+
+					"\tfirst FMA use: %s\n"+
+					"This tier runs on CPUs without FMA3 (Intel Sandy/Ivy Bridge, and the "+
+					"AVX-without-FMA parts initAVXNoFMA exists for), so that kernel faults "+
+					"with SIGILL there. Assign the SSE2 sibling in this tier instead.",
+					pkgDir, name, kernel, fmaUseText(needsFMA[kernel]))
+			}
+		}
+		// Packages without a tiered init dispatch per call instead, and
+		// TestAmd64KernelDispatchRequiresFMA covers those; only the presence of
+		// an unclassified tier is an error here.
+		_ = sawTier
+		if pf.funcs["initAVXNoFMA"] != nil {
+			gotNoFMATier = append(gotNoFMATier, pkgDir)
+		}
+		assertAVXTierNamesFMA(t, pkgDir, pf)
+	}
+
+	slices.Sort(gotNoFMATier)
+	if !slices.Equal(gotNoFMATier, noFMATierPackages) {
+		t.Errorf("packages defining initAVXNoFMA are %v, expected %v.\n"+
+			"That tier is the one place an FMA-free AVX path is spelled out, so this "+
+			"list is what tells the check where to look. A package that gained one "+
+			"needs adding; a package that lost one either dropped the tier (fine, drop "+
+			"it here too) or renamed it, in which case its FMA kernels are now "+
+			"unchecked.", gotNoFMATier, noFMATierPackages)
+	}
+}
+
+// assertAVXTierNamesFMA verifies the one entry initTierFMA takes on dispatch
+// rather than architecture: that the condition selecting initAVX requires FMA.
+// Without this the classification would be a prose claim, and deleting
+// `&& cpu.X86.FMA` from a tier switch would silently promote every FMA kernel in
+// that tier onto AVX1-only CPUs.
+func assertAVXTierNamesFMA(t *testing.T, pkgDir string, pf *pkgFuncs) {
+	t.Helper()
+	if pf.funcs["initAVX"] == nil {
+		return // package has no AVX tier; nothing to verify
+	}
+	cond, bound, where := tierSelector(pf, "initAVX")
+	if cond == nil {
+		t.Errorf("%s: could not find the switch case that calls initAVX, so the claim "+
+			"that its tier implies FMA3 is unverified. initTierFMA marks initAVX as "+
+			"FMA-guaranteed only because the dispatch says so.", pkgDir)
+		return
+	}
+	if !positiveGate(cond, bound, fmaGateIdents) {
+		t.Errorf("%s: the case selecting initAVX (in %s) does not require FMA3, but "+
+			"initTierFMA classifies that tier as FMA-guaranteed and every FMA kernel it "+
+			"assigns relies on it. Restore the cpu.X86.FMA conjunct, or move the "+
+			"FMA-using kernels into a tier that has one.", pkgDir, where)
+	}
+}
+
+// tierSelector finds the switch case that calls tier and returns its condition,
+// together with the name of the function holding the switch.
+//
+// Two shapes occur. f32, f64 and c64 switch on the feature expressions directly
+// inside init(). c128 passes them as booleans into selectImpl, so the case reads
+// `case avxFMA:` and the real condition is the matching argument at the single
+// call site; bindParams resolves that, which is why the returned condition can
+// be evaluated the same way in both shapes.
+func tierSelector(pf *pkgFuncs, tier string) (ast.Expr, *pkgFuncs, string) {
+	for _, name := range sortedFuncNames(pf.funcs) {
+		fn := pf.funcs[name]
+		if fn.Body == nil {
+			continue
+		}
+		var found ast.Expr
+		ast.Inspect(fn.Body, func(n ast.Node) bool {
+			cc, ok := n.(*ast.CaseClause)
+			if !ok || found != nil || len(cc.List) == 0 {
+				return true
+			}
+			if !callsFunc(cc.Body, tier) {
+				return true
+			}
+			found = cc.List[0]
+			return false
+		})
+		if found != nil {
+			return found, bindParams(pf, name), name
+		}
+	}
+	return nil, pf, ""
+}
+
+// bindParams returns a view of pf in which identifiers local to the named
+// function resolve to the CPU expressions behind them. Two kinds are bound, and
+// both are real dispatch idioms here:
+//
+//   - Parameters, from the arguments at the function's single call site. This is
+//     what makes c128's `case avxFMA:` resolve to the expression init() passed
+//     into selectImpl.
+//   - Local declarations, `useAVX := !useAVX512 && cpu.X86.AVX && cpu.X86.FMA`,
+//     which f32's indexed batch dot uses before an early-out guard. Without this
+//     the guard reads as a test of an opaque bool and the kernel looks ungated.
+//
+// Locals are collected function-wide rather than only up to the reference. That
+// cannot manufacture a gate: an assignment only matters when the identifier also
+// appears in a condition that dominates the reference, and dominance is decided
+// separately. It does mean a reassigned or shadowed name resolves to whichever
+// binding is seen last, which no dispatch function in this repo does.
+//
+// A parameter list with anything other than exactly one call site is left
+// unbound: the condition then fails to resolve and the caller reports that
+// rather than guessing.
+func bindParams(pf *pkgFuncs, name string) *pkgFuncs {
+	fn := pf.funcs[name]
+	if fn == nil || fn.Body == nil {
+		return pf
+	}
+
+	locals := map[string]ast.Expr{}
+	ast.Inspect(fn.Body, func(n ast.Node) bool {
+		as, ok := n.(*ast.AssignStmt)
+		if !ok || len(as.Lhs) != len(as.Rhs) {
+			return true
+		}
+		for i, lhs := range as.Lhs {
+			if id, ok := lhs.(*ast.Ident); ok {
+				locals[id.Name] = as.Rhs[i]
+			}
+		}
+		return true
+	})
+
+	var params []string
+	if fn.Type.Params != nil {
+		for _, field := range fn.Type.Params.List {
+			for _, id := range field.Names {
+				params = append(params, id.Name)
+			}
+		}
+	}
+	if len(params) > 0 {
+		var args []ast.Expr
+		calls := 0
+		for _, caller := range sortedFuncNames(pf.funcs) {
+			cf := pf.funcs[caller]
+			if cf.Body == nil || caller == name {
+				continue
+			}
+			ast.Inspect(cf.Body, func(n ast.Node) bool {
+				call, ok := n.(*ast.CallExpr)
+				if !ok {
+					return true
+				}
+				if id, ok := call.Fun.(*ast.Ident); ok && id.Name == name {
+					calls++
+					args = call.Args
+				}
+				return true
+			})
+		}
+		if calls == 1 && len(args) == len(params) {
+			for i, p := range params {
+				locals[p] = args[i]
+			}
+		}
+	}
+
+	if len(locals) == 0 {
+		return pf
+	}
+	bound := &pkgFuncs{funcs: pf.funcs, varInits: map[string]ast.Expr{}}
+	maps.Copy(bound.varInits, pf.varInits)
+	maps.Copy(bound.varInits, locals)
+	return bound
+}
+
+// isInitTier reports whether a dispatch function is one of the init-time tier
+// assigners rather than a per-call dispatcher.
+func isInitTier(name string) bool {
+	return strings.HasPrefix(name, "init")
+}
+
+// callsFunc reports whether any statement in body calls the named function.
+func callsFunc(body []ast.Stmt, name string) bool {
+	found := false
+	for _, s := range body {
+		ast.Inspect(s, func(n ast.Node) bool {
+			if found {
+				return false
+			}
+			call, ok := n.(*ast.CallExpr)
+			if !ok {
+				return true
+			}
+			if id, ok := call.Fun.(*ast.Ident); ok && id.Name == name {
+				found = true
+			}
+			return !found
+		})
+	}
+	return found
+}
+
+// referencedIdents returns the keys of want that appear as identifiers in fn,
+// sorted, so a failure reports identically on every run.
+func referencedIdents(fn *ast.FuncDecl, want map[string]asmcheck.X86Kernel) []string {
+	if fn == nil || fn.Body == nil {
+		return nil
+	}
+	out := make([]string, 0, len(want))
+	ast.Inspect(fn.Body, func(n ast.Node) bool {
+		id, ok := n.(*ast.Ident)
+		if !ok {
+			return true
+		}
+		if _, wanted := want[id.Name]; wanted && !slices.Contains(out, id.Name) {
+			out = append(out, id.Name)
+		}
+		return true
+	})
+	slices.Sort(out)
+	return out
+}
+
+// fmaKernels returns the FMA-using kernels defined by pkgDir's amd64 assembly,
+// keyed by symbol name.
+func fmaKernels(t *testing.T, pkgDir string) map[string]asmcheck.X86Kernel {
+	t.Helper()
+	out := map[string]asmcheck.X86Kernel{}
+	paths, err := filepath.Glob(filepath.Join(pkgDir, "*_amd64.s"))
+	if err != nil {
+		t.Fatalf("glob %s: %v", pkgDir, err)
+	}
+	for _, p := range paths {
+		src, rerr := os.ReadFile(p)
+		if rerr != nil {
+			t.Fatalf("read %s: %v", p, rerr)
+		}
+		for _, k := range asmcheck.ScanX86Source(string(src)) {
+			if k.Needs(asmcheck.X86FeatureFMA) {
+				out[k.Name] = k
+			}
+		}
+	}
+	return out
+}
+
+// fmaUseText renders a kernel's first FMA instruction for an error message.
+func fmaUseText(k asmcheck.X86Kernel) string {
+	uses := k.FeatureUses(asmcheck.X86FeatureFMA)
+	if len(uses) == 0 {
+		return "(none)"
+	}
+	return uses[0].Text
+}
+
+// amd64PackageDirs returns every directory holding amd64 assembly, sorted.
+func amd64PackageDirs(t *testing.T) []string {
+	t.Helper()
+	var dirs []string
+	for _, f := range findAmd64Asm(t) {
+		d := filepath.Dir(f)
+		if !slices.Contains(dirs, d) {
+			dirs = append(dirs, d)
+		}
+	}
+	slices.Sort(dirs)
+	return dirs
+}
+
+// fmaAxis is the FMA3 dispatch axis. Unlike the AVX2 axis it also reaches the
+// initXxx tier assigners, because their guard is at the call site in init() and
+// checkKernelGated walks up to it. TestAmd64InitTierFMA covers the same ground
+// from the other direction, naming the tier rather than the kernel, so a tier
+// that stops being FMA-guaranteed is reported once per tier and not once per
+// kernel it assigns.
+var fmaAxis = gateAxis{
+	name:   "FMA3",
+	idents: fmaGateIdents,
+	remedy: "An AVX1-only CPU without FMA3 (Intel Sandy/Ivy Bridge, and the parts " +
+		"initAVXNoFMA exists for) reaching this kernel faults with SIGILL, the same " +
+		"way #196/#197 did on the AVX2 axis. Add the cpu.X86.FMA conjunct to this " +
+		"branch, or move the kernel behind one.",
+	firstLine: firstFMAUseLine,
+	firstText: firstFMAUseText,
+}
+
+func firstFMAUseLine(k asmcheck.X86Kernel) int {
+	uses := k.FeatureUses(asmcheck.X86FeatureFMA)
+	if len(uses) == 0 {
+		return k.Line
+	}
+	return uses[0].Line
+}
+
+func firstFMAUseText(k asmcheck.X86Kernel) string {
+	uses := k.FeatureUses(asmcheck.X86FeatureFMA)
+	if len(uses) == 0 {
+		return ""
+	}
+	return uses[0].Text + "  (" + uses[0].Reason + ")"
+}
+
+// TestAmd64KernelDispatchRequiresFMA asserts that every AMD64 kernel whose body
+// uses FMA3 and which is dispatched from a per-call branch sits behind a
+// condition requiring FMA3.
+func TestAmd64KernelDispatchRequiresFMA(t *testing.T) {
+	parsed := map[string]*pkgFuncs{}
+	checked := 0
+
+	for _, file := range findAmd64Asm(t) {
+		src, err := os.ReadFile(file)
+		if err != nil {
+			t.Fatalf("read %s: %v", file, err)
+		}
+		pkgDir := filepath.Dir(file)
+
+		for _, k := range asmcheck.ScanX86Source(string(src)) {
+			if !k.Needs(asmcheck.X86FeatureFMA) {
+				continue
+			}
+			pf := parsed[pkgDir]
+			if pf == nil {
+				pf = parseAmd64Package(t, pkgDir)
+				parsed[pkgDir] = pf
+			}
+			checked++
+			checkKernelGated(t, file, pkgDir, k, pf, fmaAxis)
+		}
+	}
+
+	// A scanner that stopped recognising the FMA mnemonics would leave every
+	// assertion above vacuous while the test still reported success.
+	if checked == 0 {
+		t.Error("no FMA-using kernels found in any amd64 assembly, but this repo has " +
+			"many. The FMA classifier has stopped matching and this test is checking " +
+			"nothing.")
+	}
+}
+
+// fmaMnemonics is every FMA3 instruction Go's assembler accepts on amd64: the
+// four multiply-add bases in packed and scalar, single and double, across the
+// three operand orders, plus the two alternating forms which are packed-only.
+//
+// The list is not a sample. It was checked against the toolchain's own opcode
+// table, where it is exactly the set whose name begins VFM or VFNM:
+//
+//	grep -ohE '\bVF[A-Z0-9]*\b' "$(go env GOROOT)"/src/cmd/internal/obj/x86/anames.go |
+//	  sort -u | grep -E '^VF(N)?M'
+//
+// On go1.26 that yields 60 names, all 60 of which the classifier's pattern
+// matches, and it matches none of the other 1544 amd64 mnemonics in the table.
+// Regenerate and recompare if a future Go adds an encoding.
+func fmaMnemonics() []string {
+	out := make([]string, 0, 60)
+	for _, base := range []string{"VFMADD", "VFMSUB", "VFNMADD", "VFNMSUB"} {
+		for _, order := range []string{"132", "213", "231"} {
+			for _, size := range []string{"PD", "PS", "SD", "SS"} {
+				out = append(out, base+order+size)
+			}
+		}
+	}
+	// VFMADDSUB and VFMSUBADD alternate add and subtract across lanes, which has
+	// no meaning for a single scalar, so they exist only in packed form.
+	for _, base := range []string{"VFMADDSUB", "VFMSUBADD"} {
+		for _, order := range []string{"132", "213", "231"} {
+			for _, size := range []string{"PD", "PS"} {
+				out = append(out, base+order+size)
+			}
+		}
+	}
+	return out
+}
+
+// TestFMAMnemonicCoverage pins the classifier against every FMA3 mnemonic Go's
+// assembler accepts, so a narrowing of the pattern is caught here rather than by
+// a SIGILL on hardware nobody in CI owns.
+func TestFMAMnemonicCoverage(t *testing.T) {
+	names := fmaMnemonics()
+	if len(names) != 60 {
+		t.Fatalf("built %d FMA mnemonics, expected the 60 in Go's amd64 opcode table; "+
+			"the generator above no longer matches the ISA it documents", len(names))
+	}
+	fma := make([]string, 0, len(names))
+	for _, n := range names {
+		fma = append(fma, n+" Y1, Y2, Y0")
+	}
+
+	notFMA := []string{
+		"VMULPD Y1, Y2, Y0", "VADDPS Y1, Y2, Y0", "VMOVUPS (DI), Y0",
+		"VFMADD X1, X2, X0", // no operand-order digits: not an FMA3 spelling
+		"MULPD X1, X0", "RET", "VPERMPD $0x1B, Y2, Y2",
+	}
+
+	for _, instr := range fma {
+		src := "TEXT ·k(SB), NOSPLIT, $0-0\n    " + instr + "\n    RET\n"
+		k := asmcheck.ScanX86Source(src)
+		if len(k) != 1 {
+			t.Fatalf("%s: expected 1 kernel, got %d", instr, len(k))
+		}
+		if !k[0].Needs(asmcheck.X86FeatureFMA) {
+			t.Errorf("%s: not classified as needing FMA3", instr)
+		}
+		// An FMA instruction must not inflate the AVX level ladder: these
+		// kernels are named ...AVX on purpose and the ISA test would reject them.
+		if k[0].Level != asmcheck.X86LevelAVX {
+			t.Errorf("%s: inflated the level to %s; FMA is an orthogonal axis",
+				instr, k[0].Level)
+		}
+	}
+
+	for _, instr := range notFMA {
+		src := "TEXT ·k(SB), NOSPLIT, $0-0\n    " + instr + "\n    RET\n"
+		k := asmcheck.ScanX86Source(src)
+		if len(k) != 1 {
+			t.Fatalf("%s: expected 1 kernel, got %d", instr, len(k))
+		}
+		if k[0].Needs(asmcheck.X86FeatureFMA) {
+			t.Errorf("%s: wrongly classified as needing FMA3", instr)
+		}
+	}
+}
+
+// TestFMAGateIdentsExcludeAVX2 pins the deliberate omission. AVX2 and FMA3 are
+// separate CPUID bits; treating AVX2 as evidence of FMA3 would make an
+// AVX2-gated branch look like a valid home for an FMA kernel.
+func TestFMAGateIdentsExcludeAVX2(t *testing.T) {
+	for _, ident := range []string{avx2Feature, "AVX", "AVXVNNI", "SSE2"} {
+		if fmaGateIdents[ident] {
+			t.Errorf("fmaGateIdents accepts %q as establishing FMA3, but it does not. "+
+				"Only cpu.X86.FMA does directly, and AVX512F/AVX512VL by implication.",
+				strings.ToUpper(ident))
+		}
+	}
+	if !fmaGateIdents["FMA"] {
+		t.Error("fmaGateIdents does not accept FMA, so no branch can ever satisfy the " +
+			"FMA dispatch check and TestAmd64KernelDispatchRequiresFMA would fail wholesale")
+	}
+}

--- a/asmcheck_amd64_fma_test.go
+++ b/asmcheck_amd64_fma_test.go
@@ -65,7 +65,6 @@ func TestAmd64InitTierFMA(t *testing.T) {
 		needsFMA := fmaKernels(t, pkgDir)
 		pf := parseAmd64Package(t, pkgDir)
 
-		sawTier := false
 		for _, name := range sortedFuncNames(pf.funcs) {
 			if !isInitTier(name) {
 				continue
@@ -77,12 +76,11 @@ func TestAmd64InitTierFMA(t *testing.T) {
 			guaranteed, known := initTierFMA[name]
 			if !known {
 				t.Errorf("%s: %s looks like an init-time tier assigner but is not "+
-					"classified in initTierFMA. Add it with true if the CCPU reaching it "+
+					"classified in initTierFMA. Add it with true if the CPU reaching it "+
 					"always has FMA3, false otherwise. Leaving it out would let the tier "+
 					"assign FMA kernels unchecked.", pkgDir, name)
 				continue
 			}
-			sawTier = true
 			if guaranteed {
 				continue
 			}
@@ -95,10 +93,10 @@ func TestAmd64InitTierFMA(t *testing.T) {
 					pkgDir, name, kernel, fmaUseText(needsFMA[kernel]))
 			}
 		}
-		// Packages without a tiered init dispatch per call instead, and
-		// TestAmd64KernelDispatchRequiresFMA covers those; only the presence of
-		// an unclassified tier is an error here.
-		_ = sawTier
+		// A package with no tiered init dispatches per call instead, which
+		// TestAmd64KernelDispatchRequiresFMA covers, so finding no tier here is
+		// not itself an error. What must not go unnoticed is an initAVXNoFMA
+		// that moved or appeared, hence the set comparison after the loop.
 		if pf.funcs["initAVXNoFMA"] != nil {
 			gotNoFMATier = append(gotNoFMATier, pkgDir)
 		}

--- a/asmcheck_amd64_gate_test.go
+++ b/asmcheck_amd64_gate_test.go
@@ -39,18 +39,45 @@ import (
 // cpu.clearAVX2 clears it alongside AVX2, so it implies AVX2 in this repo by
 // construction. Package-level caches such as `var hasAVX2 = cpu.X86.AVX2` are
 // resolved to their initializer rather than trusted by name; see gateVars.
+// avx2Feature is the cpu.X86 field name and the label used in failure messages.
+const avx2Feature = "AVX2"
+
 var avx2GateIdents = map[string]bool{
-	"AVX2": true, "AVX512F": true, "AVX512VL": true, "AVXVNNI": true,
+	avx2Feature: true, "AVX512F": true, "AVX512VL": true, "AVXVNNI": true,
+}
+
+// fmaGateIdents are the identifiers that establish FMA3. Only cpu.X86.FMA does
+// directly. AVX512F/AVX512VL are included because every part implementing an
+// AVX-512 extension also implements FMA3, which is what lets an AVX-512 tier
+// carry FMA kernels without naming FMA. AVX2 is deliberately NOT here: it is a
+// separate CPUID bit, and although no shipping part has AVX2 without FMA3, the
+// architecture does not require the pairing and this repo's whole reason for an
+// initAVXNoFMA tier is that the two axes are independent.
+var fmaGateIdents = map[string]bool{
+	"FMA": true, "AVX512F": true, "AVX512VL": true,
 }
 
 // pkgFuncs is one package's amd64 dispatch source, parsed once.
 type pkgFuncs struct {
 	funcs map[string]*ast.FuncDecl
-	// gateVars holds package-level bools whose initializer establishes AVX2,
-	// for example `var hasAVX2 = cpu.X86.AVX2`. Resolving the initializer is
-	// what stops the check trusting a name: redefining hasAVX2 as cpu.X86.AVX
+	// varInits holds package-level bool vars and their initializer expressions,
+	// for example `var hasAVX2 = cpu.X86.AVX2`. The expression is kept rather
+	// than a precomputed verdict so the same parse serves every feature axis,
+	// and so the check never trusts a name: redefining hasAVX2 as cpu.X86.AVX
 	// must fail, and by name alone it would not.
-	gateVars map[string]bool
+	varInits map[string]ast.Expr
+}
+
+// avx2Axis is the AVX2 dispatch axis added by #200.
+var avx2Axis = gateAxis{
+	name:   avx2Feature,
+	idents: avx2GateIdents,
+	remedy: "An AVX1-only CPU (Intel Sandy/Ivy Bridge, AMD Bulldozer) or an " +
+		"AVX+FMA3-without-AVX2 CPU (AMD Piledriver, Steamroller) reaching this " +
+		"kernel faults with SIGILL. That is #196/#197. Restore the AVX2 guard on " +
+		"this branch, or move the kernel behind one.",
+	firstLine: firstUseLine,
+	firstText: firstUseText,
 }
 
 // TestAmd64KernelDispatchRequiresAVX2 asserts that every AMD64 kernel whose body
@@ -77,14 +104,14 @@ func TestAmd64KernelDispatchRequiresAVX2(t *testing.T) {
 				pf = parseAmd64Package(t, pkgDir)
 				parsed[pkgDir] = pf
 			}
-			checkKernelGated(t, file, pkgDir, k, pf)
+			checkKernelGated(t, file, pkgDir, k, pf, avx2Axis)
 		}
 	}
 }
 
-// checkKernelGated reports every dispatch of one AVX2-requiring kernel that is
-// not dominated by an AVX2 condition.
-func checkKernelGated(t *testing.T, file, pkgDir string, k asmcheck.X86Kernel, pf *pkgFuncs) {
+// checkKernelGated reports every dispatch of one feature-requiring kernel that
+// is not dominated by a condition establishing that feature.
+func checkKernelGated(t *testing.T, file, pkgDir string, k asmcheck.X86Kernel, pf *pkgFuncs, ax gateAxis) {
 	t.Helper()
 	refs := 0
 	for _, name := range sortedFuncNames(pf.funcs) {
@@ -94,24 +121,71 @@ func checkKernelGated(t *testing.T, file, pkgDir string, k asmcheck.X86Kernel, p
 		}
 		for _, path := range referencePaths(fn, k.Name) {
 			refs++
-			if dominatedByAVX2(path, fn, pf) {
+			if dominatedByGate(path, bindParams(pf, name), ax.idents) {
 				continue
 			}
-			t.Errorf("%s: kernel %s needs AVX2, but %s.%s dispatches it from a branch "+
-				"that does not require AVX2.\n"+
-				"\tfirst AVX2 use: %s:%d %s\n"+
-				"An AVX1-only CPU (Intel Sandy/Ivy Bridge, AMD Bulldozer) or an "+
-				"AVX+FMA3-without-AVX2 CPU (AMD Piledriver, Steamroller) reaching this "+
-				"kernel faults with SIGILL. That is #196/#197. Restore the AVX2 guard on "+
-				"this branch, or move the kernel behind one.",
-				file, k.Name, pkgDir, name, file, firstUseLine(k), firstUseText(k))
+			// The guard may sit one frame up. Two shapes in this repo put it
+			// there: the initXxx tier assigners, whose selecting case lives in
+			// init(), and helpers such as dotProductBatchKernel that take the
+			// tier decision as a bool parameter and are only ever called from an
+			// already-gated branch.
+			if callSitesGated(name, pf, ax.idents, 0) {
+				continue
+			}
+			t.Errorf("%s: kernel %s needs %s, but %s.%s dispatches it from a branch "+
+				"that does not require %s, and not every call site of %s requires it "+
+				"either.\n\tfirst %s use: %s:%d %s\n%s",
+				file, k.Name, ax.name, pkgDir, name, ax.name, name,
+				ax.name, file, ax.firstLine(k), ax.firstText(k), ax.remedy)
 		}
 	}
 	if refs == 0 {
-		t.Errorf("%s: kernel %s needs AVX2 but nothing in %s references it. "+
+		t.Errorf("%s: kernel %s needs %s but nothing in %s references it. "+
 			"Either it is dead code, or its dispatch lives somewhere this test does not "+
-			"parse (only %s/*_amd64.go is read).", file, k.Name, pkgDir, pkgDir)
+			"parse (only %s/*_amd64.go is read).", file, k.Name, ax.name, pkgDir, pkgDir)
 	}
+}
+
+// callSiteDepth bounds the walk up the call graph. This repo's deepest gated
+// chain is two hops (init -> selectImpl -> initAVX in c128), so three leaves
+// slack; the bound is what stops a recursive pair from spinning.
+const callSiteDepth = 3
+
+// callSitesGated reports whether EVERY call site of the named function is itself
+// reached only when the gate held. A function nothing calls returns false: an
+// unreferenced dispatcher proves nothing, and treating "no call sites" as safe
+// would silently excuse a helper whose caller had been deleted.
+func callSitesGated(name string, pf *pkgFuncs, idents map[string]bool, depth int) bool {
+	if depth > callSiteDepth {
+		return false
+	}
+	sites := 0
+	for _, caller := range sortedFuncNames(pf.funcs) {
+		cf := pf.funcs[caller]
+		if cf.Body == nil || caller == name {
+			continue
+		}
+		for _, path := range referencePaths(cf, name) {
+			sites++
+			if dominatedByGate(path, bindParams(pf, caller), idents) {
+				continue
+			}
+			if callSitesGated(caller, pf, idents, depth+1) {
+				continue
+			}
+			return false
+		}
+	}
+	return sites > 0
+}
+
+// gateAxis describes one CPU feature axis the dispatch check can be run over.
+type gateAxis struct {
+	name      string          // the feature as it appears in messages
+	idents    map[string]bool // identifiers whose truth establishes it
+	remedy    string          // what the author should do about a failure
+	firstLine func(asmcheck.X86Kernel) int
+	firstText func(asmcheck.X86Kernel) string
 }
 
 func firstUseLine(k asmcheck.X86Kernel) int {
@@ -138,7 +212,7 @@ func parseAmd64Package(t *testing.T, dir string) *pkgFuncs {
 	if len(paths) == 0 {
 		t.Fatalf("no *_amd64.go in %s, so no dispatch could be checked", dir)
 	}
-	pf := &pkgFuncs{funcs: map[string]*ast.FuncDecl{}, gateVars: map[string]bool{}}
+	pf := &pkgFuncs{funcs: map[string]*ast.FuncDecl{}, varInits: map[string]ast.Expr{}}
 	fset := token.NewFileSet()
 	for _, p := range paths {
 		f, perr := parser.ParseFile(fset, p, nil, parser.SkipObjectResolution)
@@ -152,15 +226,17 @@ func parseAmd64Package(t *testing.T, dir string) *pkgFuncs {
 					pf.funcs[decl.Name.Name] = decl
 				}
 			case *ast.GenDecl:
-				collectGateVars(decl, pf.gateVars)
+				collectVarInits(decl, pf.varInits)
 			}
 		}
 	}
 	return pf
 }
 
-// collectGateVars records package-level vars whose initializer establishes AVX2.
-func collectGateVars(decl *ast.GenDecl, out map[string]bool) {
+// collectVarInits records package-level vars together with their initializer
+// expressions, so a gate spelled through a cached bool can be resolved to the
+// CPU feature it actually reads.
+func collectVarInits(decl *ast.GenDecl, out map[string]ast.Expr) {
 	if decl.Tok != token.VAR {
 		return
 	}
@@ -170,8 +246,8 @@ func collectGateVars(decl *ast.GenDecl, out map[string]bool) {
 			continue
 		}
 		for i, name := range vs.Names {
-			if i < len(vs.Values) && mentionsGateIdent(vs.Values[i]) {
-				out[name.Name] = true
+			if i < len(vs.Values) {
+				out[name.Name] = vs.Values[i]
 			}
 		}
 	}
@@ -198,48 +274,47 @@ func referencePaths(fn *ast.FuncDecl, name string) [][]ast.Node {
 	return out
 }
 
-// dominatedByAVX2 reports whether the reference at the end of path is reached
-// only when an AVX2 condition held.
+// dominatedByGate reports whether the reference at the end of path is reached
+// only when a condition in idents held.
 //
 // Two shapes count, and they are the two this repo uses. First, the reference
 // sits inside the taken branch of an `if` (or a `case`) whose condition requires
-// AVX2 positively. Second, an earlier statement in an enclosing block is an
-// early-out guard, `if !hasAVX2 { return }`, which is a negated gate whose body
-// leaves the function.
-func dominatedByAVX2(path []ast.Node, fn *ast.FuncDecl, pf *pkgFuncs) bool {
+// the feature positively. Second, an earlier statement in an enclosing block is
+// an early-out guard, `if !hasAVX2 { return }`, which is a negated gate whose
+// body leaves the function.
+func dominatedByGate(path []ast.Node, pf *pkgFuncs, idents map[string]bool) bool {
 	for i, n := range path {
 		switch node := n.(type) {
 		case *ast.IfStmt:
 			// Only the then-branch is guarded by the condition. A reference in
 			// the else-branch is reached precisely when the condition was false.
-			if i+1 < len(path) && path[i+1] == ast.Node(node.Body) && positiveGate(node.Cond, pf) {
+			if i+1 < len(path) && path[i+1] == ast.Node(node.Body) && positiveGate(node.Cond, pf, idents) {
 				return true
 			}
 		case *ast.CaseClause:
 			for _, expr := range node.List {
-				if positiveGate(expr, pf) {
+				if positiveGate(expr, pf, idents) {
 					return true
 				}
 			}
 		case *ast.BlockStmt:
-			if i+1 < len(path) && earlyOutGuardBefore(node, path[i+1], pf) {
+			if i+1 < len(path) && earlyOutGuardBefore(node, path[i+1], pf, idents) {
 				return true
 			}
 		}
 	}
-	_ = fn
 	return false
 }
 
 // earlyOutGuardBefore reports whether block contains, before stmt, an
-// `if !<avx2 gate> { ... return ... }` guard.
-func earlyOutGuardBefore(block *ast.BlockStmt, stmt ast.Node, pf *pkgFuncs) bool {
+// `if !<gate> { ... return ... }` guard.
+func earlyOutGuardBefore(block *ast.BlockStmt, stmt ast.Node, pf *pkgFuncs, idents map[string]bool) bool {
 	for _, s := range block.List {
 		if ast.Node(s) == stmt {
 			return false
 		}
 		ifStmt, ok := s.(*ast.IfStmt)
-		if !ok || !negativeGate(ifStmt.Cond, pf) {
+		if !ok || !negativeGate(ifStmt.Cond, pf, idents) {
 			continue
 		}
 		if blockExits(ifStmt.Body) {
@@ -270,63 +345,77 @@ func blockExits(b *ast.BlockStmt) bool {
 	}
 }
 
-// positiveGate reports whether cond requires AVX2 when true. A gate identifier
-// under a `!` does not count: that is the inverted guard, which runs the kernel
-// on exactly the CPUs that lack the feature.
-func positiveGate(cond ast.Expr, pf *pkgFuncs) bool {
-	return gatePolarity(cond, pf, false)
+// positiveGate reports whether cond requires the feature named by idents when
+// true. A gate identifier under a `!` does not count: that is the inverted
+// guard, which runs the kernel on exactly the CPUs that lack the feature.
+func positiveGate(cond ast.Expr, pf *pkgFuncs, idents map[string]bool) bool {
+	return gatePolarity(cond, pf, idents, false)
 }
 
-// negativeGate reports whether cond is true when AVX2 is ABSENT.
-func negativeGate(cond ast.Expr, pf *pkgFuncs) bool {
-	return gatePolarity(cond, pf, true)
+// negativeGate reports whether cond is true when the feature is ABSENT.
+func negativeGate(cond ast.Expr, pf *pkgFuncs, idents map[string]bool) bool {
+	return gatePolarity(cond, pf, idents, true)
 }
 
-// gatePolarity walks cond looking for an AVX2 gate whose sense matches want
+// gateWalkDepth bounds the recursion through cached vars and predicate
+// functions. Two hops covers every shape in this repo (`hasAVX2` resolving to
+// cpu.X86.AVX2, and logSIMDOK32 returning a conjunction of them); the bound
+// exists so a var or predicate that refers to itself cannot spin.
+const gateWalkDepth = 4
+
+// gatePolarity walks cond looking for a gate in idents whose sense matches want
 // (want=false: the gate as written; want=true: the gate under a `!`).
-func gatePolarity(cond ast.Expr, pf *pkgFuncs, want bool) bool {
+func gatePolarity(cond ast.Expr, pf *pkgFuncs, idents map[string]bool, want bool) bool {
 	found := false
-	var walk func(e ast.Expr, negated bool)
-	walk = func(e ast.Expr, negated bool) {
-		if e == nil || found {
+	var walk func(e ast.Expr, negated bool, depth int)
+	walk = func(e ast.Expr, negated bool, depth int) {
+		if e == nil || found || depth > gateWalkDepth {
 			return
 		}
 		switch x := e.(type) {
 		case *ast.UnaryExpr:
 			if x.Op == token.NOT {
-				walk(x.X, !negated)
+				walk(x.X, !negated, depth)
 				return
 			}
-			walk(x.X, negated)
+			walk(x.X, negated, depth)
 		case *ast.BinaryExpr:
-			walk(x.X, negated)
-			walk(x.Y, negated)
+			walk(x.X, negated, depth)
+			walk(x.Y, negated, depth)
 		case *ast.ParenExpr:
-			walk(x.X, negated)
+			walk(x.X, negated, depth)
 		case *ast.SelectorExpr:
-			if avx2GateIdents[x.Sel.Name] && negated == want {
+			if idents[x.Sel.Name] && negated == want {
 				found = true
 			}
 		case *ast.Ident:
-			if (avx2GateIdents[x.Name] || pf.gateVars[x.Name]) && negated == want {
+			if idents[x.Name] && negated == want {
 				found = true
+				return
+			}
+			// A cached gate such as `var hasAVX2 = cpu.X86.AVX2`. Resolving the
+			// initializer rather than trusting the name is what makes redefining
+			// it as cpu.X86.AVX fail the check.
+			if init, ok := pf.varInits[x.Name]; ok {
+				walk(init, negated, depth+1)
 			}
 		case *ast.CallExpr:
 			// A predicate such as logSIMDOK32(n) whose body returns the gate.
-			if id, ok := x.Fun.(*ast.Ident); ok && negated == want && predicateGates(id.Name, pf) {
+			id, ok := x.Fun.(*ast.Ident)
+			if ok && negated == want && predicateGates(id.Name, pf, idents, depth+1) {
 				found = true
 			}
 		}
 	}
-	walk(cond, false)
+	walk(cond, false, 0)
 	return found
 }
 
 // predicateGates reports whether a same-package function returns an expression
-// that requires AVX2, which is how the log and pow family keeps its guard.
-func predicateGates(name string, pf *pkgFuncs) bool {
+// that requires the feature, which is how the log and pow family keeps its guard.
+func predicateGates(name string, pf *pkgFuncs, idents map[string]bool, depth int) bool {
 	fn := pf.funcs[name]
-	if fn == nil || fn.Body == nil {
+	if fn == nil || fn.Body == nil || depth > gateWalkDepth {
 		return false
 	}
 	found := false
@@ -339,33 +428,11 @@ func predicateGates(name string, pf *pkgFuncs) bool {
 			return true
 		}
 		for _, r := range ret.Results {
-			if gatePolarity(r, pf, false) {
+			if gatePolarity(r, pf, idents, false) {
 				found = true
 			}
 		}
 		return true
-	})
-	return found
-}
-
-// mentionsGateIdent reports whether e contains an AVX2 feature identifier.
-func mentionsGateIdent(e ast.Expr) bool {
-	found := false
-	ast.Inspect(e, func(n ast.Node) bool {
-		if found {
-			return false
-		}
-		switch x := n.(type) {
-		case *ast.SelectorExpr:
-			if avx2GateIdents[x.Sel.Name] {
-				found = true
-			}
-		case *ast.Ident:
-			if avx2GateIdents[x.Name] {
-				found = true
-			}
-		}
-		return !found
 	})
 	return found
 }

--- a/asmcheck_amd64_gate_test.go
+++ b/asmcheck_amd64_gate_test.go
@@ -38,7 +38,7 @@ import (
 // AVXVNNI is defined in cpu/cpu_amd64.go as AVX2 AND the VNNI bit, and
 // cpu.clearAVX2 clears it alongside AVX2, so it implies AVX2 in this repo by
 // construction. Package-level caches such as `var hasAVX2 = cpu.X86.AVX2` are
-// resolved to their initializer rather than trusted by name; see gateVars.
+// resolved to their initializer rather than trusted by name; see varInits.
 // avx2Feature is the cpu.X86 field name and the label used in failure messages.
 const avx2Feature = "AVX2"
 


### PR DESCRIPTION
Closes #201.

## The gap

`cpu.X86.FMA` is a CPUID bit separate from AVX. Sandy Bridge and Ivy Bridge have AVX and no FMA3, which is exactly why `f64` and `c128` keep an `initAVXNoFMA` dispatch tier. Sixty kernels in this repo use `VFMADD`-family instructions, and every one of them was correct only because a hand-written guard said so. Nothing checked those guards.

Six edits used to pass the whole suite and SIGILL on Sandy Bridge. I ran all six against the tree **before** writing anything, so the gap is measured rather than assumed, and all six now fail:

| | sabotage | caught by |
|---|---|---|
| A | `VFMADD231PD` added to `f64 clampAVX`, a kernel `initAVXNoFMA` assigns | `TestAmd64InitTierFMA` |
| B | `VFMADD231PS` added to `f32 copySignAVX`, dispatched on plain `cpu.X86.AVX` | `TestAmd64KernelDispatchRequiresFMA` |
| C | `&& cpu.X86.FMA` deleted from `f32 realFFTUnpack32`'s guard | `TestAmd64KernelDispatchRequiresFMA` |
| D | `&& cpu.X86.FMA` deleted from `f64`'s `init()` tier switch | both |
| E | `&& cpu.X86.FMA` deleted from `c128`'s `selectImpl` argument | both |
| F | an AVX2 guard weakened to AVX | `TestAmd64KernelDispatchRequiresAVX2` |

A is the reproducer named in the issue. F is a regression check on the refactor below, verified in isolation so the AVX2 axis is not merely passing because the FMA one flagged the same file.

## The scanner

`X86Feature` is a new axis **orthogonal** to `X86Level`, because FMA cannot be a rung on a ladder that AVX2 also sits on: a CPU can have AVX1 with or without FMA3, and AVX2 without FMA3 is architecturally permitted even though nothing ships it. An FMA instruction classifies as `X86LevelAVX`, so kernel names, `avx2GatedAVXKernels` and the existing ISA test output are all unchanged.

`TestFMAMnemonicCoverage` pins **all 60** FMA mnemonics Go's assembler accepts, not a sample. That set was taken from the toolchain's own opcode table:

```
grep -ohE '\bVF[A-Z0-9]*\b' "$(go env GOROOT)"/src/cmd/internal/obj/x86/anames.go | sort -u | grep -E '^VF(N)?M'
```

which yields 60 names on go1.26. The classifier's pattern matches all 60 and none of the other 1544 amd64 mnemonics in that table.

## The two checks

The dispatch surface splits in two, so each check reports the right thing once rather than the wrong thing many times.

`TestAmd64InitTierFMA` classifies the init tiers and asserts no FMA-using kernel is assigned by one that runs on CPUs without FMA. `initAVX512` is FMA-guaranteed by architecture. `initAVX` is FMA-guaranteed by *dispatch*, so that one is not taken on trust: the test reads each package's tier switch and fails if the case selecting `initAVX` stops naming FMA. The expected set of packages defining `initAVXNoFMA` is asserted too, so renaming the tier or adding one to a third package has to be a deliberate edit rather than a silent loss of coverage.

`TestAmd64KernelDispatchRequiresFMA` reuses the #200 dominance walker on the FMA identifier set.

## Refactor, and why it also strengthens the AVX2 check

Making the walker serve a second axis needed three changes:

1. The gate-identifier set is a parameter rather than hardcoded to AVX2.
2. **A guard may live one frame up.** When a reference is not dominated inside its own function, every call site of that function is checked instead, recursively with a depth bound. This is what covers the `initXxx` tiers, whose case is in `init()`, and helpers like `dotProductBatchKernel` that take the tier decision as a `bool` parameter.
3. **Identifiers resolve through more shapes**: package-level vars, function parameters bound from a single call site, and local declarations.

Point 3 is worth calling out because it started as a false positive and turned out to be a real blind spot. `f32`'s indexed batch dot guards with

```go
useAVX512 := cpu.X86.AVX512F && cpu.X86.AVX512VL
useAVX := !useAVX512 && cpu.X86.AVX && cpu.X86.FMA
if !useAVX512 && !useAVX { ...fallback...; return false }
```

The guard is correct, but the walker could only resolve package-level vars, so it read `!useAVX` as a test of an opaque bool. I could have added an exemption entry; that would have left the check permanently unable to see a *real* bug written in that shape, which several dispatchers here use. Resolving locals fixes the blind spot instead.

Local declarations are collected function-wide rather than only up to the reference. That cannot manufacture a gate, because an assignment only matters when the identifier also appears in a condition that dominates, and dominance is decided separately.

## Deliberate omission

AVX2 is **not** accepted as evidence of FMA3. They are separate CPUID bits, and the independence of the two axes is the entire reason `initAVXNoFMA` exists. `TestFMAGateIdentsExcludeAVX2` pins that, since it is the kind of shortcut that looks harmless. `AVX512F`/`AVX512VL` are accepted, because every part implementing an AVX-512 extension implements FMA3, and that is what lets an AVX-512 tier carry FMA kernels without naming FMA.

## Not this

`TestNoFMAContract` already existed and is unrelated: it forbids fusing in the kernels listed in `singleRoundingKernels`, which is the #156 contract about where rounding happens, not about CPU features. Different question, different kernel set, both architectures.

## Docs

CLAUDE.md gains a section on the amd64 checks. They have been undocumented since #200 and now constrain any contributor adding a kernel, so shipping a third machine-checked constraint without saying so seemed worse than the small scope overlap. This covers one bullet of #204's doc list; the rest of that issue stands.

## Verification

Full suite passes on darwin/arm64. `golangci-lint` output is identical to `main` on both GOARCHs (131 pre-existing issues, 0 added). The checks are pure source analysis, so they need no x86 hardware and run wherever the suite does.