### PR TITLE
f32,f64,c64,crc: clear the batched low-severity findings (#204)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1039,15 +1039,15 @@ each package's `*_amd64.go` dispatch):
 
 | Package | amd64 minimum SIMD tier | Higher amd64 tiers used | Below the minimum |
 | ------- | ----------------------- | ----------------------- | ----------------- |
-| `f32`   | SSE2                    | AVX+FMA, AVX-512        | pure Go (baseline guarantees SSE2 on amd64) |
-| `f64`   | SSE2                    | AVX (no FMA), AVX+FMA, AVX-512 | pure Go (baseline guarantees SSE2) |
+| `f32`   | SSE2                    | AVX+FMA, AVX2, AVX-512  | pure Go (baseline guarantees SSE2 on amd64) |
+| `f64`   | SSE2                    | AVX (no FMA), AVX+FMA, AVX2, AVX-512 | pure Go (baseline guarantees SSE2) |
 | `c128`  | SSE2                    | AVX (no FMA), AVX+FMA, AVX-512 | pure Go (baseline guarantees SSE2) |
 | `c64`   | SSE4.1 (BLENDPS)        | AVX+FMA, AVX-512        | pure Go |
 | `i16`   | SSE2 (interleave, dot, xcorr); AVX2 (Abs, MulQ15, MaxAbs) | AVX2; AVX-VNNI (xcorr) | pure Go (baseline guarantees SSE2 for the SSE2-tier ops) |
 | `i32`   | AVX (interleave), AVX2 (arithmetic) | -           | pure Go |
 | `i8`    | AVX2                    | -                       | pure Go |
 | `f16`   | F16C (slice conversions only) | -                 | pure Go (all f16 compute is pure Go on amd64) |
-| `crc`   | PCLMULQDQ               | -                       | scalar slice-by-16 |
+| `crc`   | PCLMULQDQ + SSE4.1      | -                       | scalar slice-by-16 |
 
 SSE2 is part of the amd64 baseline, so `f32`/`f64`/`c128` always run SIMD on amd64
 (their pure-Go path is effectively a non-amd64 safety net), and so do `i16`'s
@@ -1056,6 +1056,17 @@ reduction are AVX2-or-Go, like `i8` and the `i32` arithmetic. AVX-512 uses the
 `AVX512F && AVX512VL` gate. `cpu.Info()` reports the host-wide tier (AVX-512 /
 AVX+FMA / AVX / SSE2 / scalar); a package whose minimum is above that tier (e.g.
 `i32` on an SSE-only host) runs pure Go even though `Info()` shows SSE2.
+
+AVX2 sits between AVX+FMA and AVX-512 for `f32` and `f64` and is easy to miss,
+because the kernels behind it keep the `...AVX` name and only their dispatch
+guard names AVX2. Both packages gate `Sigmoid`, `Tanh`, `Exp`, `Log`, `Pow`,
+`InterleaveN` and `DeinterleaveN` on it; `f32` adds `MinIdxOfSumRows` (unit
+slides), `Int16ToFloat32Scale` and `Float32ToInt16Scale`, and `f64` adds
+`Autocorrelate` and `RealFFTUnpack`. `cpu.Info()` cannot show this: it collapses
+AVX2 into `AMD64 AVX+FMA`, so an AVX+FMA host without AVX2 (AMD Piledriver and
+Steamroller) reports the same string while taking the Go path for those
+operations. `TestAmd64KernelISALevel` and `TestAmd64KernelDispatchRequiresAVX2`
+are what keep the names and the guards consistent.
 
 ARM64 runs NEON kernels throughout, with an FP16 (FEAT_FP16) fast path in `f16`
 and FP16-widened variants elsewhere, plus an SDOT (FEAT_DotProd) fast path for

--- a/asmcheck_test.go
+++ b/asmcheck_test.go
@@ -183,10 +183,15 @@ func crossCheckObjdump(t *testing.T, file, tool string, deferred []objdumpDirect
 	}
 }
 
-// TestNoUncheckedAmd64Encodings is a warn-only tripwire: amd64 currently has no
-// hand-encoded instructions. If any appear (for example from AVX-512 work that
-// the Go assembler cannot express as mnemonics), this logs them so they can be
-// brought under a decoder-based check too. It does not fail the build.
+// TestNoUncheckedAmd64Encodings is a warn-only tripwire over hand-encoded amd64
+// instructions, which are not covered by a decoder-based check the way the ARM64
+// WORDs are. It logs what it finds and does not fail the build.
+//
+// It is not looking at an empty set: i16's AVX-VNNI kernel carries four BYTE
+// directives, because go1.26 assembles VPDPWSSD to the EVEX form, which faults
+// on Alder Lake, so the VEX bytes are spelled out instead (#169). Those four are
+// what this test prints on every run. AVX-512 work that the assembler cannot
+// express as mnemonics would land here too.
 func TestNoUncheckedAmd64Encodings(t *testing.T) {
 	var hits []string
 	err := filepath.WalkDir(".", func(p string, d os.DirEntry, err error) error {

--- a/c64/c64_amd64.s
+++ b/c64/c64_amd64.s
@@ -182,9 +182,13 @@ scale_avx_remainder:
     JZ   scale_avx_done
 
 scale_avx_tail:
+    // X1 and X4 are the low halves of Y1 and Y4, which the prologue set before
+    // the branch that skips the 4-wide loop, and which that loop reads but never
+    // writes. So the scalar broadcast and swap are already in place on every path
+    // here; reloading s and re-shuffling it once per tail element was pure
+    // repetition. Lanes 2 and 3 differ from the old zero-extended form and do not
+    // matter: only the low complex is stored (#204).
     VMOVSD (SI), X0
-    VMOVSD s+48(FP), X1
-    VSHUFPS $0xB1, X1, X1, X4
 
     VMOVSLDUP X0, X2
     VMOVSHDUP X0, X3
@@ -441,9 +445,9 @@ scale_avx512_remainder:
     JZ   scale_avx512_done
 
 scale_avx512_tail:
+    // Same reasoning as scale_avx_tail: X1/X4 alias the low halves of Z1/Z4,
+    // which the prologue set and the 16-wide loop only reads (#204).
     VMOVSD (SI), X0
-    VMOVSD s+48(FP), X1
-    VSHUFPS $0xB1, X1, X1, X4
 
     VMOVSLDUP X0, X2
     VMOVSHDUP X0, X3

--- a/c64/c64_test.go
+++ b/c64/c64_test.go
@@ -437,8 +437,20 @@ func BenchmarkAdd(b *testing.B) {
 	benchmarkBinaryOp(b, 1024, Add, addGo)
 }
 
+// BenchmarkScale sweeps sizes rather than pinning one. The old single row was
+// size = 1024, which is 0 mod 4 and 0 mod 16, so it never executed either
+// kernel's scalar tail and a per-call cost could not be separated from a
+// per-element one (#204). 1025 is the ragged partner.
 func BenchmarkScale(b *testing.B) {
-	size := 1024
+	for _, size := range []int{64, 1024, 1025, 4096} {
+		b.Run(fmt.Sprintf("n%d", size), func(b *testing.B) {
+			benchScaleAt(b, size)
+		})
+	}
+}
+
+func benchScaleAt(b *testing.B, size int) {
+	b.Helper()
 	a := make([]complex64, size)
 	dst := make([]complex64, size)
 	s := complex64(1.5 + 2.5i)

--- a/crc/crc_amd64.go
+++ b/crc/crc_amd64.go
@@ -10,15 +10,26 @@ import "github.com/tphakala/simd/cpu"
 // the benchmarks; FLAC frames are kilobytes, so the hot path always folds.
 const minFoldBytes = 64
 
-var hasPCLMULQDQ = cpu.X86.PCLMULQDQ
+// hasFoldISA reports whether every instruction crc16FoldBlocks uses is present,
+// which is more than its name suggests. The kernel folds with PCLMULQDQ, but it
+// also byte-swaps with PSHUFB (SSSE3) and moves the accumulator halves with
+// PINSRQ/PEXTRQ (SSE4.1), and PCLMULQDQ implies neither: they are separate CPUID
+// bits, exactly as FMA3 is separate from AVX (#201).
+//
+// No shipping part has PCLMULQDQ without SSE4.1 (Westmere onward, Bulldozer
+// onward and Jaguar onward all carry both), so this is a latent mismatch rather
+// than an observed fault. Stating the real requirement costs one CPUID read at
+// init and removes the need to know that history to audit the guard. SSE4.1
+// implies SSSE3, so testing it covers PSHUFB too.
+var hasFoldISA = cpu.X86.PCLMULQDQ && cpu.X86.SSE41
 
 // foldSupported reports whether the carry-less-multiply kernel is active.
-func foldSupported() bool { return hasPCLMULQDQ }
+func foldSupported() bool { return hasFoldISA }
 
 // checksum16 folds the bulk of p with PCLMULQDQ when available, then reduces the
 // folded accumulator plus the trailing tail with the scalar path.
 func checksum16(p []byte) uint16 {
-	if hasPCLMULQDQ && len(p) >= minFoldBytes {
+	if hasFoldISA && len(p) >= minFoldBytes {
 		full := len(p) &^ (blockBytes - 1)
 		var acc [2]uint64
 		crc16FoldBlocks(&acc, p[:full])

--- a/f32/f32_amd64.s
+++ b/f32/f32_amd64.s
@@ -4050,17 +4050,6 @@ DATA exp_magic<>+0x18(SB)/4, $0x4b400000
 DATA exp_magic<>+0x1c(SB)/4, $0x4b400000
 GLOBL exp_magic<>(SB), RODATA|NOPTR, $32
 
-// 127 << 23 = 1065353216 (exponent bias)
-DATA exp_bias<>+0x00(SB)/4, $0x3f800000  // This is 1.0 as integer = 127<<23
-DATA exp_bias<>+0x04(SB)/4, $0x3f800000
-DATA exp_bias<>+0x08(SB)/4, $0x3f800000
-DATA exp_bias<>+0x0c(SB)/4, $0x3f800000
-DATA exp_bias<>+0x10(SB)/4, $0x3f800000
-DATA exp_bias<>+0x14(SB)/4, $0x3f800000
-DATA exp_bias<>+0x18(SB)/4, $0x3f800000
-DATA exp_bias<>+0x1c(SB)/4, $0x3f800000
-GLOBL exp_bias<>(SB), RODATA|NOPTR, $32
-
 // Exp clamp thresholds: ±88.0 keeps the 2^k reconstruction inside the
 // representable float32 range (exp(88) ~= 1.65e38 < MaxFloat32). Matches the
 // pure-Go fallback's overflow/underflow clamp.

--- a/f32/f32_go.go
+++ b/f32/f32_go.go
@@ -899,6 +899,18 @@ const realFFTUnpackHalf = 0.5
 //
 //	X[k] = 0.5*(Z[k] + conj(Z[n-k])) + W[k]*(-0.5i)*(Z[k] - conj(Z[n-k]))
 func realFFTUnpack32Go(outRe, outIm, zRe, zIm, twRe, twIm []float32, n int) {
+	if n < realFFTUnpackMinN {
+		return
+	}
+	// Reslice to exactly the range the loop touches, so the prover can discharge
+	// the bounds checks from the loop condition alone. Without this the mirrored
+	// index n-k defeats it and every iteration pays eight IsInBounds; the caller
+	// has already validated these lengths, so the reslices cannot panic. This is
+	// the only realFFTUnpack path on an AVX+FMA3 part without AVX2 (#204).
+	zRe, zIm = zRe[:n], zIm[:n]
+	outRe, outIm = outRe[:n], outIm[:n]
+	twRe, twIm = twRe[:n-1], twIm[:n-1]
+
 	// Process k from 1 to n-1
 	// For each k, we need Z[k] and Z[n-k] (mirrored)
 	for k := 1; k < n; k++ {

--- a/f32/f32_test.go
+++ b/f32/f32_test.go
@@ -1232,18 +1232,26 @@ func BenchmarkMinIdx_1000(b *testing.B) {
 	_ = idx
 }
 
-func BenchmarkAddScaled_1000(b *testing.B) {
-	dst := make([]float32, 1000)
-	s := make([]float32, 1000)
-	for i := range dst {
-		dst[i] = float32(i)
-		s[i] = 1.0
-	}
+// BenchmarkAddScaled sweeps sizes rather than pinning one. The old single row
+// was n = 1000, which is 0 mod 8 and 0 mod 16, so it never executed the kernel's
+// scalar tail and a per-call cost could not be separated from a per-element one
+// (#204). 1001 is the ragged partner; 64 and 4096 bracket the cache behaviour.
+func BenchmarkAddScaled(b *testing.B) {
+	for _, n := range []int{64, 1000, 1001, 4096} {
+		b.Run(fmt.Sprintf("%d", n), func(b *testing.B) {
+			dst := make([]float32, n)
+			s := make([]float32, n)
+			for i := range dst {
+				dst[i] = float32(i)
+				s[i] = 1.0
+			}
 
-	b.SetBytes(1000 * 4 * 3) // read dst, read s, write dst
+			b.SetBytes(int64(n * 4 * 3)) // read dst, read s, write dst
 
-	for b.Loop() {
-		AddScaled(dst, 2.0, s)
+			for b.Loop() {
+				AddScaled(dst, 2.0, s)
+			}
+		})
 	}
 }
 

--- a/f32/go_impl_amd64_test.go
+++ b/f32/go_impl_amd64_test.go
@@ -11,75 +11,78 @@ import (
 // Tests for init functions to ensure they properly configure function pointers
 // These tests are AMD64-specific because they test x86 SIMD initialization paths.
 
-func TestInitGo(t *testing.T) {
-	savedDotProduct := dotProductImpl
-	// init* also reassigns convolveValidMaxAbsImpl; restore it so the fused kernel
-	// stays consistent with dotProductImpl for the exact-equality convolution tests.
-	savedConvolveValidMaxAbs := convolveValidMaxAbsImpl
-
-	initGo()
-
-	a := []float32{1, 2, 3, 4}
-	b := []float32{4, 3, 2, 1}
-
-	got := dotProductImpl(a, b)
-	want := float32(20)
-	if got != want {
-		t.Errorf("After initGo, dotProduct = %v, want %v", got, want)
-	}
-
-	dotProductImpl = savedDotProduct
-	convolveValidMaxAbsImpl = savedConvolveValidMaxAbs
+// tierInits enumerates every init-time tier assigner in this package together
+// with the CPU support it needs. initAVX was missing from this file entirely
+// (#204): the AVX kernels were reachable only through the package's own init(),
+// so nothing here ever bound them, and they were never checked against a
+// sibling tier.
+var tierInits = []struct {
+	name      string
+	init      func()
+	supported func() bool
+	// minSIMD is the value the tier must leave in minSIMDElements, or 0 when the
+	// tier does not set it.
+	minSIMD int
+}{
+	{"Go", initGo, func() bool { return true }, 0},
+	{"SSE", initSSE, func() bool { return cpu.X86.SSE2 }, 0},
+	{"AVX", initAVX, func() bool { return cpu.X86.AVX && cpu.X86.FMA }, 0},
+	{"AVX512", initAVX512, func() bool { return cpu.X86.AVX512F && cpu.X86.AVX512VL }, minAVX512Elements},
 }
 
-func TestInitSSE(t *testing.T) {
-	savedDotProduct := dotProductImpl
-	// init* also reassigns convolveValidMaxAbsImpl; restore it so the fused kernel
+// TestInitTiers binds each tier in turn and checks its dotProduct against the
+// pure-Go reference over lengths that reach the vector body, not just its scalar
+// tail. The previous form used one length-4 input, which is below both
+// minAVXElements and minAVX512Elements, so it exercised the tail of whichever
+// kernel it bound and could not have told two tiers apart.
+func TestInitTiers(t *testing.T) {
+	// Lengths straddling the block widths: 4 stays under every vector threshold,
+	// 8 and 16 are whole AVX blocks, 17 and 33 leave a remainder, 64 covers
+	// several AVX-512 blocks.
+	lengths := []int{4, 8, 16, 17, 33, 64}
+
+	// init* reassigns convolveValidMaxAbsImpl too; restore it so the fused kernel
 	// stays consistent with dotProductImpl for the exact-equality convolution tests.
-	savedConvolveValidMaxAbs := convolveValidMaxAbsImpl
-
-	initSSE()
-
-	a := []float32{1, 2, 3, 4}
-	b := []float32{4, 3, 2, 1}
-
-	got := dotProductImpl(a, b)
-	want := float32(20)
-	if got != want {
-		t.Errorf("After initSSE, dotProduct = %v, want %v", got, want)
-	}
-
-	dotProductImpl = savedDotProduct
-	convolveValidMaxAbsImpl = savedConvolveValidMaxAbs
-}
-
-func TestInitAVX512(t *testing.T) {
-	if !cpu.X86.AVX512F || !cpu.X86.AVX512VL {
-		t.Skip("AVX-512 not supported on this CPU")
-	}
-
 	savedDotProduct := dotProductImpl
-	// init* also reassigns convolveValidMaxAbsImpl; restore it so the fused kernel
-	// stays consistent with dotProductImpl for the exact-equality convolution tests.
 	savedConvolveValidMaxAbs := convolveValidMaxAbsImpl
 	savedMinSIMD := minSIMDElements
+	t.Cleanup(func() {
+		dotProductImpl = savedDotProduct
+		convolveValidMaxAbsImpl = savedConvolveValidMaxAbs
+		minSIMDElements = savedMinSIMD
+	})
 
-	initAVX512()
+	for _, tier := range tierInits {
+		t.Run(tier.name, func(t *testing.T) {
+			if !tier.supported() {
+				t.Skipf("%s not supported on this CPU", tier.name)
+			}
+			tier.init()
 
-	a := []float32{1, 2, 3, 4}
-	b := []float32{4, 3, 2, 1}
+			if tier.minSIMD != 0 && minSIMDElements != tier.minSIMD {
+				t.Errorf("init%s left minSIMDElements = %d, want %d",
+					tier.name, minSIMDElements, tier.minSIMD)
+			}
 
-	got := dotProductImpl(a, b)
-	want := float32(20)
-	if got != want {
-		t.Errorf("After initAVX512, dotProduct = %v, want %v", got, want)
+			for _, n := range lengths {
+				a := make([]float32, n)
+				b := make([]float32, n)
+				for i := range n {
+					// Asymmetric values on purpose: a ramp against its own
+					// reverse yields the same total when lanes are dropped or
+					// reordered, so it cannot detect a missing block.
+					a[i] = float32(i)*0.5 + 1
+					b[i] = float32(n-i) * 0.25
+				}
+				got := dotProductImpl(a, b)
+				want := dotProductGo(a, b)
+				// Vector and scalar summation orders differ, so this is a
+				// tolerance check rather than bit equality.
+				if diff := float64(got - want); diff > 1e-3 || diff < -1e-3 {
+					t.Errorf("n=%d: init%s dotProduct = %v, Go reference = %v (diff %v)",
+						n, tier.name, got, want, diff)
+				}
+			}
+		})
 	}
-
-	if minSIMDElements != minAVX512Elements {
-		t.Errorf("initAVX512 didn't set minSIMDElements correctly")
-	}
-
-	dotProductImpl = savedDotProduct
-	convolveValidMaxAbsImpl = savedConvolveValidMaxAbs
-	minSIMDElements = savedMinSIMD
 }

--- a/f32/go_impl_amd64_test.go
+++ b/f32/go_impl_amd64_test.go
@@ -76,11 +76,15 @@ func TestInitTiers(t *testing.T) {
 				}
 				got := dotProductImpl(a, b)
 				want := dotProductGo(a, b)
-				// Vector and scalar summation orders differ, so this is a
-				// tolerance check rather than bit equality.
-				if diff := float64(got - want); diff > 1e-3 || diff < -1e-3 {
+				// closeFloat32 scales with the magnitude, which matters because
+				// a dot product grows with n. Measured on this input family, the
+				// tiers agree exactly up to n = 256 and diverge by 2688 in
+				// absolute terms at n = 4096, all of it summation order: a fixed
+				// absolute tolerance would read that as a kernel bug the moment
+				// anyone extended the length list.
+				if !closeFloat32(got, want) {
 					t.Errorf("n=%d: init%s dotProduct = %v, Go reference = %v (diff %v)",
-						n, tier.name, got, want, diff)
+						n, tier.name, got, want, float64(got-want))
 				}
 			}
 		})

--- a/f64/f64_amd64.go
+++ b/f64/f64_amd64.go
@@ -696,7 +696,7 @@ func realFFTUnpack64(outRe, outIm, zRe, zIm, twRe, twIm []float64, n int) {
 	// and the constants use register-source VBROADCASTSD plus VPCMPEQD/VPSLLQ on
 	// YMM, all AVX2-only. Gating on plain AVX would let an AVX1+FMA part (e.g. AMD
 	// Piledriver) reach it and SIGILL. hasAVX2 is the same guard the other VPERMPD
-	// users in this package use (autocorrelate, interleaveN).
+	// users in this package use (autocorrelate64, interleaveN64).
 	// n > minAVXElements means n >= 5, so (n-1) >= 4 = one full 4-wide AVX pass.
 	if hasAVX2 && cpu.X86.FMA && n > minAVXElements {
 		realFFTUnpackAVX(outRe, outIm, zRe, zIm, twRe, twIm, n)

--- a/f64/f64_go.go
+++ b/f64/f64_go.go
@@ -736,6 +736,18 @@ const realFFTUnpackHalf = 0.5
 //
 //	X[k] = 0.5*(Z[k] + conj(Z[n-k])) + W[k]*(-0.5i)*(Z[k] - conj(Z[n-k]))
 func realFFTUnpack64Go(outRe, outIm, zRe, zIm, twRe, twIm []float64, n int) {
+	if n < realFFTUnpackMinN {
+		return
+	}
+	// Reslice to exactly the range the loop touches, so the prover can discharge
+	// the bounds checks from the loop condition alone. Without this the mirrored
+	// index n-k defeats it and every iteration pays eight IsInBounds; the caller
+	// has already validated these lengths, so the reslices cannot panic. Same
+	// change as realFFTUnpack32Go (#204).
+	zRe, zIm = zRe[:n], zIm[:n]
+	outRe, outIm = outRe[:n], outIm[:n]
+	twRe, twIm = twRe[:n-1], twIm[:n-1]
+
 	// Process k from 1 to n-1
 	// For each k, we need Z[k] and Z[n-k] (mirrored)
 	for k := 1; k < n; k++ {

--- a/f64/f64_test.go
+++ b/f64/f64_test.go
@@ -1,6 +1,7 @@
 package f64
 
 import (
+	"fmt"
 	"math"
 	"testing"
 
@@ -684,18 +685,26 @@ func BenchmarkMaxIdx_1000(b *testing.B) {
 	_ = result
 }
 
-func BenchmarkAddScaled_1000(b *testing.B) {
-	dst := make([]float64, 1000)
-	s := make([]float64, 1000)
-	for i := range dst {
-		dst[i] = float64(i)
-		s[i] = float64(i)
-	}
+// BenchmarkAddScaled sweeps sizes rather than pinning one. The old single row
+// was n = 1000, which is 0 mod 4 and 0 mod 8, so it never executed the kernel's
+// scalar tail and a per-call cost could not be separated from a per-element one
+// (#204). 1001 is the ragged partner; 64 and 4096 bracket the cache behaviour.
+func BenchmarkAddScaled(b *testing.B) {
+	for _, n := range []int{64, 1000, 1001, 4096} {
+		b.Run(fmt.Sprintf("%d", n), func(b *testing.B) {
+			dst := make([]float64, n)
+			s := make([]float64, n)
+			for i := range dst {
+				dst[i] = float64(i)
+				s[i] = 1.0
+			}
 
-	b.SetBytes(1000 * 8 * 2) // read s, read+write dst
+			b.SetBytes(int64(n * 8 * 3)) // read dst, read s, write dst
 
-	for b.Loop() {
-		AddScaled(dst, 0.5, s)
+			for b.Loop() {
+				AddScaled(dst, 2.0, s)
+			}
+		})
 	}
 }
 


### PR DESCRIPTION
Closes #204.

Every claim in the issue was re-checked against the tree before being acted on. All ten held. One turned out to be worth considerably more than "low severity" implied.

## The one that was mislabelled

`realFFTUnpack32Go` paid **eight** `IsInBounds` per iteration, because the mirrored index `n-k` defeats the prover. Reslicing to exactly the range the loop touches drops that to two, with six one-time `IsSliceInBounds` hoisted out of the loop.

Measured on an i7-1260P, `taskset` pinned, six interleaved A/B rounds:

| | before | after | delta |
|---|---|---|---|
| f32 `Go_64` | 128.9n | 96.2n | -25.3% |
| f32 `Go_512` | 1038.5n | 756.6n | -27.1% |
| f32 `Go_4096` | 8.298µ | 6.061µ | -27.0% |
| f64 `Go_64` | 130.8n | 97.7n | -25.3% |
| f64 `Go_512` | 1044.0n | 724.9n | -30.6% |

All at p=0.002, consistent across every size. Bounds checks were a quarter of the fallback's runtime. That matters more than the issue implied, because as it noted this is now the **only** `realFFTUnpack` path on an AVX+FMA3 part without AVX2.

The f64 twin had the same eight checks and got the same treatment. The issue named only the f32 symbol, but fixing one and leaving its sibling slower would have been arbitrary.

I stopped at two checks rather than zero. Removing the last two needs the loop reindexed off `k`, which is the variable the documented formula is written in; that trades readability for very little.

## The guard bug

`crc16FoldBlocks` was gated on `cpu.X86.PCLMULQDQ` alone, but its body also uses `PSHUFB` (SSSE3) and `PINSRQ`/`PEXTRQ` (SSE4.1), and PCLMULQDQ architecturally implies neither. No shipping part has one without the others (Westmere onward, Bulldozer onward, Jaguar onward all carry both), so this was a latent mismatch rather than an observed fault. The guard now states its real requirement, which costs one CPUID read at init and removes the need to know that CPU history to audit it.

## Test quality

f32's tier test bound `initGo`, `initSSE` and `initAVX512` but **never `initAVX`**, so the AVX kernels were never checked against a sibling tier. It also used a single length-4 input, below both `minAVXElements` and `minAVX512Elements`, so it exercised the tail of whichever kernel it bound and could not have told two tiers apart.

Replaced with a table over all four tiers across lengths that reach the vector body. Verified by mutation rather than assumed:

- negating the FMA in `dotProductAVX` fails the **AVX** arm, at n=33 and n=64, which the old length-4 input could never have reached
- negating it in `dotProductAVX512` fails the **AVX-512** arm, and only under SDE, where #96 made that tier executable at all

My first attempt at that mutation was a no-op (`VXORPS Y0, Y0, Y0` at function entry, which the kernel itself repeats three lines later as accumulator init) and the test passed. Worth recording, because a sabotage that does nothing looks exactly like a vacuous test.

## Dead and redundant code

`exp_bias<>` in `f32_amd64.s` had zero code references and was byte-identical to `exp_one<>`: 32 bytes of RODATA plus a misleading comment. Deleted.

c64's `scaleAVX` and `scaleAVX512` reloaded `s` and recomputed the swapped vector once per tail element, when the low halves of `Y1`/`Y4` and `Z1`/`Z4` already held both. Safe to drop on every path: the prologue sets them before the branch that skips the wide loop, and the loop only reads them. The differing upper lanes are discarded, since the tail stores one complex.

## Docs

The README listed neither f32's nor f64's AVX2 tier, though both have had AVX2-only paths for a while. The tier table and a new paragraph now name them, verified by mapping every `cpu.X86.AVX2` guard in both packages to its enclosing function rather than by recalling which ones they are. That check caught me out once: my first draft listed `Int16ToFloat32Scale` and missed `Float32ToInt16Scale`, which is gated too. crc's row gains SSE4.1.

Also: `f64_amd64.go` named `autocorrelate`/`interleaveN`, whose real symbols are `autocorrelate64`/`interleaveN64`; and `TestNoUncheckedAmd64Encodings` claimed amd64 has no hand-encoded instructions, when i16's AVX-VNNI kernel has four and they are exactly what it prints on every run.

## Benchmarks

`BenchmarkAddScaled` (f32 and f64) and c64's `BenchmarkScale` were single-size and width-aligned, so neither ever ran its kernel's scalar tail and neither could separate a per-call cost from a per-element one. Both now sweep sizes with a ragged partner.

## Not done, deliberately

f32's `float32ToInt16ScaleAVX` is gated on AVX2 though its body is AVX1-clean. It is over-strict and safe, costing AVX1-only parts a Go path they need not take. The issue calls it not worth changing without a benchmark, I did not produce one, so the gate stands rather than being changed on a hunch.

## Verification

Full suite green on amd64 natively, under `SIMD_DISABLE=all`, and under SDE at the AVX-512 tier; f32/f64/c64 green on arm64 hardware. `golangci-lint` output identical to `main` on both GOARCHs (131 pre-existing issues, 0 added).