### PR TITLE
f64: wire the STFT transform core onto ButterflyComplexStage

### DIFF
--- a/f64/stft.go
+++ b/f64/stft.go
@@ -25,8 +25,10 @@ import (
 //     frame is packed into the FFT input, and STFTPower emits |X|^2 directly
 //     without materializing the complex bins.
 //
-// This first cut is a correct scalar radix-2 transform (power-of-two nfft only);
-// vectorizing the inner butterfly is a separate, profile-gated change. See #108.
+// The transform is a radix-2 rfft (power-of-two nfft only); its butterfly stages
+// run through ButterflyComplexStage, so they take the AVX+FMA / NEON vector paths
+// where the span and block count justify them and fall back to scalar Go
+// otherwise. See #108 and #205.
 
 // ErrSTFT* describe invalid STFTPlan configurations.
 var (
@@ -72,9 +74,12 @@ type STFTPlan struct {
 
 	bitrev []int // bit-reversal permutation for the size-half FFT
 
-	// Twiddles for the size-half radix-2 FFT: twRe[t] = cos(2*pi*t/half),
-	// twIm[t] = -sin(2*pi*t/half) for t in [0, half/2).
-	twRe, twIm []float64
+	// Per-stage contiguous twiddles for the size-half radix-2 FFT, so each stage
+	// can be driven through ButterflyComplexStage (which reads its twiddles
+	// contiguous in j over [0, span)). Stage m in {2,4,...,half} uses span = m/2
+	// factors W_m^j = exp(-i*2*pi*j/m) for j in [0, span); the stage with span s
+	// occupies stageTwRe[s-1 : 2*s-1], and the tables total half-1 entries.
+	stageTwRe, stageTwIm []float64
 
 	// Unravel twiddles W_N^k = exp(-i*2*pi*k/nfft) for k in [0, half], used to
 	// recombine the even/odd half-spectra into the real-input spectrum.
@@ -100,15 +105,15 @@ func NewSTFTPlan(nfft int) (*STFTPlan, error) {
 	half := nfft >> 1
 
 	p := &STFTPlan{
-		nfft:   nfft,
-		half:   half,
-		bitrev: make([]int, half),
-		twRe:   make([]float64, max(half>>1, 1)),
-		twIm:   make([]float64, max(half>>1, 1)),
-		unRe:   make([]float64, half+1),
-		unIm:   make([]float64, half+1),
-		re:     make([]float64, half),
-		im:     make([]float64, half),
+		nfft:      nfft,
+		half:      half,
+		bitrev:    make([]int, half),
+		stageTwRe: make([]float64, max(half-1, 0)),
+		stageTwIm: make([]float64, max(half-1, 0)),
+		unRe:      make([]float64, half+1),
+		unIm:      make([]float64, half+1),
+		re:        make([]float64, half),
+		im:        make([]float64, half),
 	}
 
 	// Bit-reversal permutation for a size-half FFT.
@@ -124,12 +129,17 @@ func NewSTFTPlan(nfft int) (*STFTPlan, error) {
 		p.bitrev[i] = r
 	}
 
-	// Size-half FFT twiddles.
-	for t := range p.twRe {
-		ang := 2 * math.Pi * float64(t) / float64(half)
-		s, c := math.Sincos(ang)
-		p.twRe[t] = c
-		p.twIm[t] = -s
+	// Per-stage contiguous FFT twiddles: stage m in {2,4,...,half} writes its
+	// span = m/2 factors W_m^j = exp(-i*2*pi*j/m) starting at offset span-1.
+	for m := 2; m <= half; m <<= 1 {
+		span := m >> 1
+		off := span - 1
+		for j := range span {
+			ang := 2 * math.Pi * float64(j) / float64(m)
+			s, c := math.Sincos(ang)
+			p.stageTwRe[off+j] = c
+			p.stageTwIm[off+j] = -s
+		}
 	}
 
 	// Real-input unravel twiddles W_N^k.
@@ -144,7 +154,9 @@ func NewSTFTPlan(nfft int) (*STFTPlan, error) {
 }
 
 // fftHalf runs an in-place size-half radix-2 decimation-in-time complex FFT on
-// the plan's scratch (p.re, p.im), using the resident bit-reversal and twiddles.
+// the plan's scratch (p.re, p.im), using the resident bit-reversal and per-stage
+// twiddles. Each stage is one ButterflyComplexStage call, so the butterflies take
+// the AVX+FMA / NEON vector paths where the span and block count justify them.
 func (p *STFTPlan) fftHalf() {
 	re, im := p.re, p.im
 	// Bit-reversal reorder.
@@ -154,24 +166,12 @@ func (p *STFTPlan) fftHalf() {
 			im[i], im[j] = im[j], im[i]
 		}
 	}
-	// Butterfly stages.
+	// Butterfly stages. Stage m operates on span = m/2 with block stride m; its
+	// contiguous twiddles live at stageTwRe/stageTwIm[span-1 : 2*span-1].
 	for m := 2; m <= p.half; m <<= 1 {
-		halfM := m >> 1
-		step := p.half / m // twiddle stride into twRe/twIm
-		for k := 0; k < p.half; k += m {
-			for j := range halfM {
-				idx := j * step
-				wr, wi := p.twRe[idx], p.twIm[idx]
-				a := k + j
-				b := a + halfM
-				vr := wr*re[b] - wi*im[b]
-				vi := wr*im[b] + wi*re[b]
-				re[b] = re[a] - vr
-				im[b] = im[a] - vi
-				re[a] += vr
-				im[a] += vi
-			}
-		}
+		span := m >> 1
+		off := span - 1
+		ButterflyComplexStage(re, im, span, p.stageTwRe[off:off+span], p.stageTwIm[off:off+span])
 	}
 }
 

--- a/f64/stft_test.go
+++ b/f64/stft_test.go
@@ -701,3 +701,36 @@ func TestSTFTGuards(t *testing.T) {
 		}
 	}
 }
+
+// TestSTFTStageTwiddles pins the per-stage contiguous twiddle layout that lets
+// fftHalf drive each radix-2 stage through ButterflyComplexStage (issue #205).
+// Stage m in {2,4,...,half} must hold span = m/2 factors W_m^j = exp(-i*2*pi*j/m)
+// at offset span-1, and the tables must total exactly half-1 entries.
+func TestSTFTStageTwiddles(t *testing.T) {
+	for _, nfft := range []int{2, 4, 8, 16, 256, 1024} {
+		p, err := NewSTFTPlan(nfft)
+		if err != nil {
+			t.Fatalf("nfft=%d: NewSTFTPlan: %v", nfft, err)
+		}
+		half := nfft >> 1
+		wantLen := max(half-1, 0)
+		if len(p.stageTwRe) != wantLen || len(p.stageTwIm) != wantLen {
+			t.Fatalf("nfft=%d: twiddle table len = (%d,%d), want %d",
+				nfft, len(p.stageTwRe), len(p.stageTwIm), wantLen)
+		}
+		for m := 2; m <= half; m <<= 1 {
+			span := m >> 1
+			off := span - 1
+			for j := range span {
+				ang := 2 * math.Pi * float64(j) / float64(m)
+				s, c := math.Sincos(ang)
+				if d := math.Abs(p.stageTwRe[off+j] - c); d > 1e-15 {
+					t.Errorf("nfft=%d m=%d j=%d: stageTwRe=%g want %g", nfft, m, j, p.stageTwRe[off+j], c)
+				}
+				if d := math.Abs(p.stageTwIm[off+j] - (-s)); d > 1e-15 {
+					t.Errorf("nfft=%d m=%d j=%d: stageTwIm=%g want %g", nfft, m, j, p.stageTwIm[off+j], -s)
+				}
+			}
+		}
+	}
+}


### PR DESCRIPTION
## Summary

`STFTPlan.fftHalf` ran a hand-rolled scalar radix-2 butterfly loop. This routes each stage through the existing `ButterflyComplexStage` primitive instead, so the f64 STFT transform core now takes the AVX+FMA (amd64) / NEON (arm64) vector paths that primitive already ships, with a scalar Go fallback below the vectorization threshold.

The only real work was the twiddle layout. `ButterflyComplexStage` reads its twiddles contiguous in `j` over `[0, span)`, while `fftHalf` read one shared `half/2` table with a stride (`twRe[j*step]`, `step = half/m`). `NewSTFTPlan` now precomputes per-stage contiguous tables: stage `m` in `{2,4,...,half}` holds `span = m/2` factors `W_m^j = exp(-i*2*pi*j/m)` at offset `span-1`, `half-1` entries total (about 2x the twiddle memory, roughly 8KB more at nfft=2048). The mapping is exact rather than approximate: `half/m` is a power of two, so `cos(2*pi*(j*(half/m))/half)` and `cos(2*pi*j/m)` reduce to the same dyadic argument and produce bit-identical twiddle factors.

The vector path fuses (FMA) where the old inline loop did not, so output moves by about 1e-14 relative. This breaks no contract: `ButterflyComplexStage` already disclaims cross-target bit-exactness, and the STFT API documents output conventions (Hermitian half-spectrum, librosa framing), not exact bits. Every existing STFT test compares against an independent naive DFT (tol `1e-9*nfft`), the real-librosa golden vector (tol `1e-6` relative), or the same code path (tol `1e-12`), all of which retain large margin; the `STFTPowerInto`-vs-`STFTPower` `1e-12` check stays exact because both share `fftHalf`. Zero allocations are preserved (the per-stage tables are resident in the plan and sliced, not allocated).

`f32/stft.go` intentionally keeps its scalar loop for now: `f32` has no stage-level butterfly primitive yet (the vector is 8 lanes on AVX and 4 on NEON, so the span thresholds and shuffles differ), so wiring it requires first adding `f32.ButterflyComplexStage`. That is a separate follow-up under the same issue.

## Related Issues

Relates to #205 (the f64 half; f32 remains, pending an `f32.ButterflyComplexStage` primitive). Builds on `f64.ButterflyComplexStage` from #207 / #198.

## Performance

Whole-transform benchmarks (`BenchmarkSTFT`, `BenchmarkSTFTPower`), interleaved `-count=6`, single core pinned, compared with benchstat. The whole-transform figures are diluted by the still-scalar frame packing and `unravelBin`, consistent with the transform being roughly 40-60% of a full render.

| Arch | STFT | STFTPower |
|------|------|-----------|
| amd64 AVX+FMA (i7-1260P) | -71.8% | -53.3% |
| arm64 NEON (Raspberry Pi 5) | -33.9% | -34.2% |

Zero allocations on both arches, before and after.

## Test Plan

- [x] Full `f64` suite green on amd64 (AVX+FMA), including naive-DFT parity, `FuzzSTFT`, and the librosa golden
- [x] Full `f64` suite green on arm64 (Raspberry Pi 5, NEON), same tests
- [x] Whole repo `go test ./...` green on amd64 (including root `asmcheck`)
- [x] New `TestSTFTStageTwiddles` pins the per-stage twiddle layout and the `nfft=2` empty-table edge
- [x] Zero-allocation assertions (`AllocsPerRun == 0`) still hold
- [x] `go vet` and `golangci-lint` clean on the changed files