### PR TITLE
f32: fused Float32ToInt32ScaleClampSigned (single-pass quantize + sign)

### DIFF
--- a/asmcheck_test.go
+++ b/asmcheck_test.go
@@ -312,6 +312,8 @@ type singleRoundingKernel struct {
 var singleRoundingKernels = []singleRoundingKernel{
 	{"f32/f32_amd64.s", "float32ToInt32ScaleClampAVX", "VMULPS", "VADDPS"},
 	{"f32/f32_arm64.s", "float32ToInt32ScaleClampNEON", "FMUL", "FADD"},
+	{"f32/f32_amd64.s", "float32ToInt32ScaleClampSignedAVX", "VMULPS", "VADDPS"},
+	{"f32/f32_arm64.s", "float32ToInt32ScaleClampSignedNEON", "FMUL", "FADD"},
 }
 
 // asmFuncBody returns the lines of the TEXT ·fn(...) block, from its TEXT line to

--- a/f32/f32.go
+++ b/f32/f32.go
@@ -10,7 +10,8 @@
 // Rounding and fusion: each floating-point operation is a single IEEE-754
 // rounded instruction. The elementwise scale, offset, clamp and float-to-fixed
 // conversion primitives (for example [Scale], [AddScalar], [ClampScale],
-// [Float32ToInt32ScaleClamp] and the Int*ToFloat32Scale family) never contract a
+// [Float32ToInt32ScaleClamp], [Float32ToInt32ScaleClampSigned] and the
+// Int*ToFloat32Scale family) never contract a
 // multiply and a following add into a fused multiply-add: a consumer that
 // reproduces a scalar reference bit-for-bit depends on the product rounding to
 // float32 before the add. Where fusion is wanted, use [FMA] or the AXPY
@@ -1126,6 +1127,68 @@ func Float32ToInt32ScaleClamp(dst []int32, src []float32, scale, offset, minV, m
 func Float32ToInt32ScaleClampUnsafe(dst []int32, src []float32, scale, offset, minV, maxV float32) {
 	// Slice dst to len(src) to ensure SIMD implementations don't write past dst
 	float32ToInt32ScaleClamp(dst[:len(src)], src, scale, offset, minV, maxV)
+}
+
+// Float32ToInt32ScaleClampSigned converts float32 magnitudes to int32 in one pass
+// and reattaches a sign, fusing the affine fixed-point quantize and the sign
+// transfer so both happen in a single pass over memory:
+//
+//	dst[i] = copysign(int32(clamp(mag[i]*scale + offset, minV, maxV)), sign[i])
+//
+// It is the signed sibling of Float32ToInt32ScaleClamp, exactly as CopySign is
+// the sign-transfer sibling of the magnitude ops. The magnitude path is identical
+// to Float32ToInt32ScaleClamp: the product rounds before offset is added and is
+// never contracted into an FMA; truncation is toward zero; out-of-range values
+// clamp to [minV, maxV] rather than wrapping; +Inf -> maxV, -Inf -> minV, and a
+// NaN magnitude -> 0 (its sign is not applied). The sign then follows IEEE-754
+// copysign semantics on bit 31 of sign[i]: the clamped magnitude is made
+// non-negative and given sign[i]'s sign bit. In the common case the magnitude is
+// computed from a rectified value and this reattaches the original sign; there
+// sign(0) is a no-op on a zero result, so a zero-magnitude lane is unaffected by
+// its sign source. Only bit 31 of sign[i] is read, so its NaN payload is
+// irrelevant.
+//
+// Fusing this into one kernel avoids the store-to-load stall of the two-pass
+// composition, where Float32ToInt32ScaleClamp writes dst with wide vector stores
+// and a following scalar pass reloads dst with narrow int32 loads to negate: the
+// int32 result never leaves registers between the magnitude and the sign step.
+//
+// The result is bit-identical across the AVX, NEON, and portable-Go paths (no
+// relaxed tier) when max(|minV|, |maxV|) <= 2147483520.0. That is tighter than
+// Float32ToInt32ScaleClamp's minV >= -2147483648.0 lower bound, because the sign
+// step re-expands a floor-clamped magnitude before the truncating conversion: a
+// value clamped to a minV below -2147483520.0 and then given a positive sign
+// reaches +2^31, which converts in an architecture-dependent way (x86 yields the
+// integer indefinite 0x80000000, ARM64 saturates), exactly as the sibling
+// documents for an out-of-range value. Keep minV >= -2147483520.0 (and, as for
+// the sibling, maxV <= 2147483520.0) for a portable result. Processes
+// min(len(dst), len(mag), len(sign)) elements.
+//
+// Uses AVX on AMD64 (8x float32; the sign is applied with VANDPS/VORPS in the
+// float domain, so AVX2 is not required), NEON on ARM64 (4x float32, one BIT).
+func Float32ToInt32ScaleClampSigned(dst []int32, mag, sign []float32, scale, offset, minV, maxV float32) {
+	n := min(len(dst), len(mag), len(sign))
+	if n == 0 {
+		return
+	}
+	float32ToInt32ScaleClampSigned(dst[:n], mag[:n], sign[:n], scale, offset, minV, maxV)
+}
+
+// Float32ToInt32ScaleClampSignedUnsafe converts float32 magnitudes to int32 with
+// a reattached sign without length validation. This is a low-overhead variant for
+// performance-critical code paths.
+//
+// PRECONDITIONS (caller must ensure):
+//   - len(dst) >= len(mag)
+//   - len(sign) >= len(mag)
+//   - len(mag) > 0
+//
+// Violating these preconditions results in undefined behavior.
+// Use Float32ToInt32ScaleClampSigned for safe operation with automatic length handling.
+func Float32ToInt32ScaleClampSignedUnsafe(dst []int32, mag, sign []float32, scale, offset, minV, maxV float32) {
+	// Slice dst and sign to len(mag) so SIMD implementations neither write past dst
+	// nor read past sign.
+	float32ToInt32ScaleClampSigned(dst[:len(mag)], mag, sign[:len(mag)], scale, offset, minV, maxV)
 }
 
 // ============================================================================

--- a/f32/f32_amd64.go
+++ b/f32/f32_amd64.go
@@ -1256,6 +1256,20 @@ func float32ToInt32ScaleClamp(dst []int32, src []float32, scale, offset, minV, m
 	float32ToInt32ScaleClampGo(dst, src, scale, offset, minV, maxV)
 }
 
+func float32ToInt32ScaleClampSigned(dst []int32, mag, sign []float32, scale, offset, minV, maxV float32) {
+	// Pure AVX: the magnitude path matches float32ToInt32ScaleClampAVX and the
+	// sign is applied in the float domain (VANDPS/VORPS) before VCVTTPS2DQ, so the
+	// int32 output needs no saturating pack and AVX2 is not required.
+	if cpu.X86.AVX && len(dst) >= minAVXElements {
+		float32ToInt32ScaleClampSignedAVX(dst, mag, sign, scale, offset, minV, maxV)
+		return
+	}
+	float32ToInt32ScaleClampSignedGo(dst, mag, sign, scale, offset, minV, maxV)
+}
+
+//go:noescape
+func float32ToInt32ScaleClampSignedAVX(dst []int32, mag, sign []float32, scale, offset, minV, maxV float32)
+
 //go:noescape
 func float32ToInt32ScaleClampAVX(dst []int32, src []float32, scale, offset, minV, maxV float32)
 

--- a/f32/f32_amd64.s
+++ b/f32/f32_amd64.s
@@ -4851,6 +4851,83 @@ f32toi32_done:
     VZEROUPPER
     RET
 
+// func float32ToInt32ScaleClampSignedAVX(dst []int32, mag, sign []float32, scale, offset, minV, maxV float32)
+// dst[i] = copysign(int32(clamp(mag[i]*scale + offset, minV, maxV)), sign[i]).
+// The magnitude path is identical to float32ToInt32ScaleClampAVX (VMULPS then
+// VADDPS, two roundings, never an FMA). The sign is applied in the FLOAT domain
+// (VANDPS abs mask, VANDPS sign mask, VORPS) before VCVTTPS2DQ; truncation toward
+// zero commutes with the sign, and the int32 output needs no saturating pack, so
+// no AVX2 op is used. NaN magnitudes are zeroed by ANDing the int32 result with
+// the pre-clamp (v == v) mask, exactly as in the unsigned kernel.
+// Frame: dst(24) + mag(24) + sign(24) + scale(4)+offset(4)+minV(4)+maxV(4) = 88.
+TEXT ·float32ToInt32ScaleClampSignedAVX(SB), NOSPLIT, $0-88
+    MOVQ dst_base+0(FP), DX        // DX = dst pointer (int32 out)
+    MOVQ dst_len+8(FP), CX         // CX = length (== len(mag) == len(sign))
+    MOVQ mag_base+24(FP), SI       // SI = mag pointer (float32 in)
+    MOVQ sign_base+48(FP), DI      // DI = sign pointer (float32 in)
+
+    VBROADCASTSS scale+72(FP), Y3  // Y3 = scale  x8
+    VBROADCASTSS offset+76(FP), Y4 // Y4 = offset x8
+    VBROADCASTSS minV+80(FP), Y5   // Y5 = minV   x8
+    VBROADCASTSS maxV+84(FP), Y6   // Y6 = maxV   x8
+    VMOVUPS absf32mask<>(SB), Y7        // Y7 = 0x7fffffff x8 (|v| mask)
+    VMOVUPS roundf32_signmask<>(SB), Y8 // Y8 = 0x80000000 x8 (sign-bit mask)
+
+    MOVQ CX, AX
+    SHRQ $3, AX                    // len / 8
+    JZ   f32toi32s_tail
+
+f32toi32s_loop8:
+    VMOVUPS (SI), Y0               // 8 x float32 magnitude source
+    VMULPS Y3, Y0, Y0              // v = mag * scale (rounds to float32)
+    VADDPS Y4, Y0, Y0             // v += offset (separate rounding; NOT an FMA)
+    VCMPPS $0, Y0, Y0, Y1        // Y1 = (v == v) ? ones : 0  (0 for NaN), pre-clamp
+    VMAXPS Y5, Y0, Y0           // clamp low  (>= minV; -Inf -> minV)
+    VMINPS Y6, Y0, Y0          // clamp high (<= maxV; +Inf -> maxV)
+    VMOVUPS (DI), Y2          // 8 x float32 sign source
+    VANDPS Y7, Y0, Y0        // |v|
+    VANDPS Y8, Y2, Y2       // sign[i] & sign bit
+    VORPS Y2, Y0, Y0       // |v| carrying sign[i]'s sign bit
+    VCVTTPS2DQ Y0, Y0     // 8 x int32, truncate toward zero
+    VANDPS Y1, Y0, Y0    // NaN magnitude lanes -> 0
+    VMOVDQU Y0, (DX)     // store 8 x int32 (32 bytes)
+    ADDQ $32, SI
+    ADDQ $32, DI
+    ADDQ $32, DX
+    DECQ AX
+    JNZ  f32toi32s_loop8
+
+f32toi32s_tail:
+    ANDQ $7, CX                    // remainder = len % 8
+    JZ   f32toi32s_done
+
+    // Back up to the final aligned block of 8 and reprocess it (overlap). All
+    // three streams are 4-byte elements, so each backs up by (8 - rem) * 4 bytes.
+    MOVQ $8, BX
+    SUBQ CX, BX                    // BX = 8 - (len % 8)  (1..7)
+    SHLQ $2, BX                    // (8 - rem) * 4 bytes
+    SUBQ BX, SI
+    SUBQ BX, DI
+    SUBQ BX, DX
+
+    VMOVUPS (SI), Y0               // final 8 x float32 magnitude
+    VMULPS Y3, Y0, Y0
+    VADDPS Y4, Y0, Y0
+    VCMPPS $0, Y0, Y0, Y1
+    VMAXPS Y5, Y0, Y0
+    VMINPS Y6, Y0, Y0
+    VMOVUPS (DI), Y2               // final 8 x float32 sign
+    VANDPS Y7, Y0, Y0
+    VANDPS Y8, Y2, Y2
+    VORPS Y2, Y0, Y0
+    VCVTTPS2DQ Y0, Y0
+    VANDPS Y1, Y0, Y0
+    VMOVDQU Y0, (DX)               // store final 8 x int32
+
+f32toi32s_done:
+    VZEROUPPER
+    RET
+
 // ============================================================================
 // SPLIT-FORMAT COMPLEX OPERATIONS
 // ============================================================================

--- a/f32/f32_arm64.go
+++ b/f32/f32_arm64.go
@@ -834,6 +834,17 @@ func float32ToInt32ScaleClamp(dst []int32, src []float32, scale, offset, minV, m
 	float32ToInt32ScaleClampGo(dst, src, scale, offset, minV, maxV)
 }
 
+func float32ToInt32ScaleClampSigned(dst []int32, mag, sign []float32, scale, offset, minV, maxV float32) {
+	if hasNEON && len(dst) >= 4 {
+		float32ToInt32ScaleClampSignedNEON(dst, mag, sign, scale, offset, minV, maxV)
+		return
+	}
+	float32ToInt32ScaleClampSignedGo(dst, mag, sign, scale, offset, minV, maxV)
+}
+
+//go:noescape
+func float32ToInt32ScaleClampSignedNEON(dst []int32, mag, sign []float32, scale, offset, minV, maxV float32)
+
 //go:noescape
 func float32ToInt32ScaleClampNEON(dst []int32, src []float32, scale, offset, minV, maxV float32)
 

--- a/f32/f32_arm64.s
+++ b/f32/f32_arm64.s
@@ -2291,6 +2291,76 @@ f32toi32_neon_tail:
 f32toi32_neon_done:
     RET
 
+// func float32ToInt32ScaleClampSignedNEON(dst []int32, mag, sign []float32, scale, offset, minV, maxV float32)
+// dst[i] = copysign(int32(clamp(mag[i]*scale + offset, minV, maxV)), sign[i]).
+// The magnitude path is identical to float32ToInt32ScaleClampNEON (FMUL then
+// FADD, two roundings, never an FMLA). The sign is applied with a single BIT
+// (bitwise insert-if-true) using a 0x80000000 lane mask, before FCVTZS:
+// truncation toward zero commutes with the sign. A NaN magnitude stays NaN
+// through BIT (only its sign bit changes) and FCVTZS(NaN) yields 0.
+// Frame: dst(24) + mag(24) + sign(24) + scale(4)+offset(4)+minV(4)+maxV(4) = 88.
+TEXT ·float32ToInt32ScaleClampSignedNEON(SB), NOSPLIT, $0-88
+    MOVD dst_base+0(FP), R0        // R0 = dst pointer (int32 out)
+    MOVD dst_len+8(FP), R3         // R3 = length (== len(mag) == len(sign))
+    MOVD mag_base+24(FP), R1       // R1 = mag pointer (float32 in)
+    MOVD sign_base+48(FP), R2      // R2 = sign pointer (float32 in)
+    FMOVS scale+72(FP), F2         // F2 = scale
+    FMOVS offset+76(FP), F3        // F3 = offset
+    FMOVS minV+80(FP), F4          // F4 = minV
+    FMOVS maxV+84(FP), F5          // F5 = maxV
+
+    // Broadcast each scalar to all 4 lanes (DUP element form, native VDUP).
+    VDUP V2.S[0], V2.S4            // scale  x4
+    VDUP V3.S[0], V3.S4            // offset x4
+    VDUP V4.S[0], V4.S4            // minV   x4
+    VDUP V5.S[0], V5.S4            // maxV   x4
+
+    // Sign-bit mask 0x80000000 broadcast to V6 for the BIT copysign.
+    MOVD $0x80000000, R8
+    FMOVS R8, F6
+    VDUP V6.S[0], V6.S4            // 0x80000000 x4
+
+    LSR $2, R3, R4                 // R4 = len / 4
+    CBZ R4, f32toi32s_neon_tail
+
+f32toi32s_neon_loop4:
+    VLD1.P 16(R1), [V0.S4]         // V0 = 4 x float32 magnitude source
+    WORD $0x6E22DC00              // FMUL V0.4S, V0.4S, V2.4S   (v = mag * scale)
+    WORD $0x4E23D400             // FADD V0.4S, V0.4S, V3.4S   (v += offset; separate, not FMLA)
+    WORD $0x4E24F400            // FMAX V0.4S, V0.4S, V4.4S   (>= minV; -Inf -> minV, NaN propagates)
+    WORD $0x4EA5F400           // FMIN V0.4S, V0.4S, V5.4S   (<= maxV; +Inf -> maxV, NaN propagates)
+    VLD1.P 16(R2), [V1.S4]    // V1 = 4 x float32 sign source
+    WORD $0x6EA61C20         // BIT V0.16B, V1.16B, V6.16B (insert sign[i]'s sign bit into |v|)
+    WORD $0x4EA1B800        // FCVTZS V0.4S, V0.4S        (truncate toward zero; NaN -> 0)
+    VST1.P [V0.S4], 16(R0)  // store 4 x int32 (16 bytes)
+    SUB $1, R4
+    CBNZ R4, f32toi32s_neon_loop4
+
+f32toi32s_neon_tail:
+    AND $3, R3, R5                 // R5 = len % 4
+    CBZ R5, f32toi32s_neon_done
+
+    // Back up to the final aligned block of 4 and reprocess it (overlap). All
+    // three streams are 4-byte elements, so each backs up by (4 - rem) * 4 bytes.
+    MOVD $4, R6
+    SUB R5, R6, R6                 // R6 = 4 - (len % 4)  (1..3)
+    LSL $2, R6, R7                 // R7 = (4 - rem) * 4 bytes
+    SUB R7, R1, R1
+    SUB R7, R2, R2
+    SUB R7, R0, R0
+    VLD1 (R1), [V0.S4]             // final 4 x float32 magnitude
+    WORD $0x6E22DC00               // FMUL V0.4S, V0.4S, V2.4S
+    WORD $0x4E23D400               // FADD V0.4S, V0.4S, V3.4S
+    WORD $0x4E24F400               // FMAX V0.4S, V0.4S, V4.4S
+    WORD $0x4EA5F400               // FMIN V0.4S, V0.4S, V5.4S
+    VLD1 (R2), [V1.S4]             // final 4 x float32 sign
+    WORD $0x6EA61C20               // BIT V0.16B, V1.16B, V6.16B
+    WORD $0x4EA1B800               // FCVTZS V0.4S, V0.4S
+    VST1 [V0.S4], (R0)             // store final 4 x int32
+
+f32toi32s_neon_done:
+    RET
+
 // ============================================================================
 // SPLIT-FORMAT COMPLEX OPERATIONS
 // ============================================================================

--- a/f32/f32_go.go
+++ b/f32/f32_go.go
@@ -830,6 +830,36 @@ func float32ToInt32ScaleClampGo(dst []int32, src []float32, scale, offset, minV,
 	}
 }
 
+// float32ToInt32ScaleClampSignedGo is the pure-Go reference for
+// Float32ToInt32ScaleClampSigned. The magnitude path is exactly
+// float32ToInt32ScaleClampGo; the sign of sign[i] (IEEE-754 copysign, bit 31) is
+// applied to the clamped value in the float domain before the truncating
+// conversion. Truncation toward zero commutes with the sign, so the result
+// equals copysign(int32(clamp(mag[i]*scale+offset, minV, maxV)), sign[i]).
+func float32ToInt32ScaleClampSignedGo(dst []int32, mag, sign []float32, scale, offset, minV, maxV float32) {
+	for i := range mag {
+		v := float32(mag[i]*scale) + offset // two roundings; the conversion blocks FMA fusion
+		if v != v {                         // NaN magnitude -> 0 (sign not applied), as on both kernels
+			dst[i] = 0
+			continue
+		}
+		// Clamp order mirrors the kernels' FMAX(minV) then FMIN(maxV).
+		if v < minV {
+			v = minV
+		}
+		if v > maxV {
+			v = maxV
+		}
+		// Copysign in the float domain: |v| carrying sign[i]'s sign bit. This is
+		// the same bit operation the AVX (VANDPS/VORPS) and NEON (BIT) kernels run
+		// before their truncating conversion.
+		v = math.Float32frombits(
+			(math.Float32bits(v) &^ (1 << float32SignBitPos)) |
+				(math.Float32bits(sign[i]) & (1 << float32SignBitPos)))
+		dst[i] = int32(v) // truncate toward zero
+	}
+}
+
 // ============================================================================
 // SPLIT-FORMAT COMPLEX OPERATIONS (Pure Go)
 // ============================================================================

--- a/f32/f32_other.go
+++ b/f32/f32_other.go
@@ -77,6 +77,10 @@ func float32ToInt32ScaleClamp(dst []int32, src []float32, scale, offset, minV, m
 	float32ToInt32ScaleClampGo(dst, src, scale, offset, minV, maxV)
 }
 
+func float32ToInt32ScaleClampSigned(dst []int32, mag, sign []float32, scale, offset, minV, maxV float32) {
+	float32ToInt32ScaleClampSignedGo(dst, mag, sign, scale, offset, minV, maxV)
+}
+
 // Split-format complex operations
 func mulComplex32(dstRe, dstIm, aRe, aIm, bRe, bIm []float32) {
 	mulComplex32Go(dstRe, dstIm, aRe, aIm, bRe, bIm)

--- a/f32/float32_to_int32_scale_clamp_signed_test.go
+++ b/f32/float32_to_int32_scale_clamp_signed_test.go
@@ -320,11 +320,15 @@ func TestFloat32ToInt32ScaleClampSignedUnsafe(t *testing.T) {
 func FuzzFloat32ToInt32ScaleClampSigned(f *testing.F) {
 	f.Add(uint64(0x1234567), 17, float32(3.0), float32(0.4054), float32(-5000), float32(5000))
 	f.Add(uint64(0xdeadbeef), 40, float32(1.0), float32(0.0), float32(-100), float32(100))
+	f.Add(uint64(1), math.MinInt, float32(1.0), float32(0.0), float32(-100), float32(100)) // regression: n=MinInt must not panic in normalization
 	f.Fuzz(func(t *testing.T, seed uint64, n int, scale, offset, minV, maxV float32) {
+		// Bound n FIRST, then take the absolute value: negating before bounding
+		// would overflow on n == math.MinInt (-math.MinInt is still math.MinInt),
+		// leaving a negative length that panics make. After %300, |n| < 300.
+		n %= 300
 		if n < 0 {
 			n = -n
 		}
-		n %= 300
 		// The signed kernel abs's the clamped magnitude before the truncating
 		// conversion, so cross-tier bit-identity needs max(|minV|,|maxV|) <=
 		// 2147483520 (tighter than the unsigned kernel; see the doc). NaN bounds are

--- a/f32/float32_to_int32_scale_clamp_signed_test.go
+++ b/f32/float32_to_int32_scale_clamp_signed_test.go
@@ -1,0 +1,393 @@
+package f32
+
+import (
+	"math"
+	"testing"
+)
+
+// float32ToInt32ScaleClampSignedRef is an independent oracle for
+// Float32ToInt32ScaleClampSigned. The magnitude path uses float64 intermediates
+// (each float32(...) cast rounds exactly once, reproducing the two-rounding
+// no-FMA contract by a route the compiler cannot fuse), and the sign is applied
+// with math.Copysign rather than the production bit manipulation, so a bug in
+// either half is caught by a genuinely different computation.
+func float32ToInt32ScaleClampSignedRef(dst []int32, mag, sign []float32, scale, offset, minV, maxV float32) {
+	n := min(len(dst), len(mag), len(sign))
+	for i := range n {
+		p := float32(float64(mag[i]) * float64(scale)) // product, rounded to float32
+		v := float32(float64(p) + float64(offset))     // + offset, rounded to float32
+		if v != v {                                    // NaN magnitude -> 0 (sign not applied)
+			dst[i] = 0
+			continue
+		}
+		if v < minV { // max(v, minV)
+			v = minV
+		}
+		if v > maxV { // min(v, maxV); inverted bounds (minV>maxV) yield maxV
+			v = maxV
+		}
+		// copysign in the float domain, before the truncating conversion.
+		v = float32(math.Copysign(float64(v), float64(sign[i])))
+		dst[i] = int32(v) // truncate toward zero
+	}
+}
+
+// signRamp32 returns a deterministic sign source: alternating and drifting signs,
+// including exact zeros, so lanes exercise both sign bits at every residue.
+func signRamp32(n int) []float32 {
+	s := make([]float32, n)
+	for i := range s {
+		s[i] = float32((i%7)-3) * 0.5 // -1.5..1.5, hits 0 at i%7==3
+	}
+	return s
+}
+
+func TestFloat32ToInt32ScaleClampSigned(t *testing.T) {
+	inf := float32(math.Inf(1))
+	nan := float32(math.NaN())
+	negZero := float32(math.Copysign(0, -1))
+	negNaN := math.Float32frombits(math.Float32bits(nan) | (1 << 31)) // NaN with bit 31 set
+	cases := []struct {
+		name                      string
+		mag, sign                 []float32
+		scale, offset, minV, maxV float32
+	}{
+		{"empty", nil, nil, 2.0, 0.5, -100, 100},
+		{"single_pos", []float32{1.5}, []float32{3.0}, 2.0, 0.4, -100, 100},
+		{"single_neg", []float32{1.5}, []float32{-3.0}, 2.0, 0.4, -100, 100},
+		{"four", []float32{1, 0.5, 2, 3}, []float32{-1, 1, -1, 1}, 3.0, 0.25, -100, 100},
+		{"eight", []float32{2, 1, 0.25, 0, 0.25, 1, 2, 3.5}, []float32{-5, 5, -5, 5, -5, 5, -5, 5}, 4.0, 0.4054, -1000, 1000},
+		{"nine", float32Ramp32(9), signRamp32(9), 7.0, 0.5, -5000, 5000},
+		{"block16", float32Ramp32(16), signRamp32(16), 7.0, 0.5, -5000, 5000},
+		{"block17", float32Ramp32(17), signRamp32(17), 7.0, 0.5, -5000, 5000},
+		{"residue_31", float32Ramp32(31), signRamp32(31), 3.0, 0.1, -2000, 2000},
+		// A negative magnitude source with a positive sign: copysign abs's the
+		// magnitude first, so the result is positive (this is what distinguishes
+		// copysign from a plain conditional negate).
+		{"neg_mag_pos_sign", []float32{-4, -4, -4, -4}, []float32{1, 1, 1, 1}, 1.0, 0.0, -100, 100},
+		{"neg_mag_neg_sign", []float32{-4, -4, -4, -4}, []float32{-1, -1, -1, -1}, 1.0, 0.0, -100, 100},
+		// Negative-zero sign bit must produce a negative result (bit 31, not < 0).
+		{"neg_zero_sign", []float32{5, 5, 5, 5}, []float32{negZero, negZero, negZero, negZero}, 1.0, 0.0, -100, 100},
+		// Zero magnitude with a negative sign: copysign(0) stays 0 as int32.
+		{"zero_mag_neg_sign", []float32{0, 0, 0, 0}, []float32{-1, -1, -1, -1}, 1.0, 0.0, -100, 100},
+		// +Inf -> maxV, -Inf -> minV in the magnitude, then signed; NaN magnitude -> 0.
+		{"inf_nan_mag", []float32{inf, -inf, nan, 5, -5, nan, inf, -inf}, []float32{-1, -1, -1, -1, 1, 1, 1, 1}, 1.0, 0.0, -100, 100},
+		// NaN magnitude -> 0 regardless of sign, even when the clamp range excludes 0.
+		{"nan_mag_excl_zero", []float32{nan, 50, nan, 20}, []float32{-1, -1, -1, -1}, 1.0, 0.0, 10, 100},
+		// NaN sign source: only its sign bit is read (positive NaN -> positive).
+		{"nan_sign", []float32{5, 5, 5, 5}, []float32{nan, nan, nan, nan}, 1.0, 0.0, -100, 100},
+		// Negative NaN sign source: bit 31 is set, so the result is negative.
+		{"neg_nan_sign", []float32{5, 5, 5, 5}, []float32{negNaN, negNaN, negNaN, negNaN}, 1.0, 0.0, -100, 100},
+		// Inverted bounds (minV > maxV): every clamped value is maxV, then signed.
+		{"inverted", []float32{-100, 0, 100, 5}, []float32{-1, 1, -1, 1}, 1.0, 0.0, 50, 10},
+		// Truncation toward zero on both signs.
+		{"trunc", []float32{0.7, 1.5, 2.999, 2.999, 0.999, 0.001}, []float32{-1, -1, 1, -1, 1, -1}, 1.0, 0.0, -1000, 1000},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			dst := make([]int32, len(tc.mag))
+			Float32ToInt32ScaleClampSigned(dst, tc.mag, tc.sign, tc.scale, tc.offset, tc.minV, tc.maxV)
+			want := make([]int32, len(tc.mag))
+			float32ToInt32ScaleClampSignedRef(want, tc.mag, tc.sign, tc.scale, tc.offset, tc.minV, tc.maxV)
+			for i := range dst {
+				if dst[i] != want[i] {
+					t.Errorf("[%d] = %d, want %d (mag=%g sign=%g scale=%g offset=%g minV=%g maxV=%g)",
+						i, dst[i], want[i], tc.mag[i], tc.sign[i], tc.scale, tc.offset, tc.minV, tc.maxV)
+				}
+			}
+		})
+	}
+}
+
+// TestFloat32ToInt32ScaleClampSignedGo exercises the pure-Go fallback directly
+// against the oracle, catching a compiler that fuses the reference's magnitude
+// multiply-add into a single-rounding FMA.
+func TestFloat32ToInt32ScaleClampSignedGo(t *testing.T) {
+	mag := float32Ramp32(200)
+	sign := signRamp32(200)
+	for i := range 7 { // a few offset-boundary values with alternating signs
+		mag = append(mag, float32(i)+0.4054)
+		sign = append(sign, float32(1-2*(i&1)))
+	}
+	dst := make([]int32, len(mag))
+	want := make([]int32, len(mag))
+	float32ToInt32ScaleClampSignedGo(dst, mag, sign, 4097.0, 0.4054, -1e9, 1e9)
+	float32ToInt32ScaleClampSignedRef(want, mag, sign, 4097.0, 0.4054, -1e9, 1e9)
+	for i := range dst {
+		if dst[i] != want[i] {
+			t.Fatalf("Go[%d] = %d, want %d (mag=%g sign=%g)", i, dst[i], want[i], mag[i], sign[i])
+		}
+	}
+}
+
+// TestFloat32ToInt32ScaleClampSigned_NoFMA is an FMA detector on the magnitude
+// path, identical in construction to the unsigned kernel's detector: with
+// mag=scale=4097 and offset=-(2^24+2^13) the correct two-rounding magnitude is 0,
+// so every lane must be 0; a fused multiply-add would yield a non-zero magnitude.
+func TestFloat32ToInt32ScaleClampSigned_NoFMA(t *testing.T) {
+	const offset = -16785408.0 // -(2^24 + 2^13)
+	mag := make([]float32, 12) // > 8 so the AVX body runs, includes a residue
+	sign := make([]float32, 12)
+	for i := range mag {
+		mag[i] = 4097.0
+		sign[i] = -1.0 // negative sign; copysign(0) is still 0, so lanes stay 0
+	}
+	dst := make([]int32, len(mag))
+	Float32ToInt32ScaleClampSigned(dst, mag, sign, 4097.0, offset, -1000, 1000)
+	for i := range dst {
+		if dst[i] != 0 {
+			t.Fatalf("[%d] = %d, want 0 (non-zero means the magnitude multiply and add fused into an FMA)", i, dst[i])
+		}
+	}
+}
+
+// TestFloat32ToInt32ScaleClampSigned_TierParity asserts the dispatched SIMD path
+// is bit-identical to the pure-Go reference across every 8-wide AVX and 4-wide
+// NEON residue. The "no relaxed tier" contract: AVX == NEON == Go, exactly.
+func TestFloat32ToInt32ScaleClampSigned_TierParity(t *testing.T) {
+	for n := 1; n <= 40; n++ {
+		mag := make([]float32, n)
+		sign := make([]float32, n)
+		for i := range mag {
+			mag[i] = float32(i%97-48) * 0.37
+			sign[i] = float32((i*13)%11 - 5) // spans both sign bits and zero
+		}
+		got := make([]int32, n)
+		want := make([]int32, n)
+		Float32ToInt32ScaleClampSigned(got, mag, sign, 3.0, 0.4054, -5000, 5000)
+		float32ToInt32ScaleClampSignedGo(want, mag, sign, 3.0, 0.4054, -5000, 5000)
+		for i := range got {
+			if got[i] != want[i] {
+				t.Fatalf("n=%d [%d]: SIMD=%d Go=%d (mag=%g sign=%g)", n, i, got[i], want[i], mag[i], sign[i])
+			}
+		}
+	}
+}
+
+// TestFloat32ToInt32ScaleClampSigned_ContractEdgeSIMD drives the extreme
+// clean-conversion int32 bounds through the vector body (len >= 8) with signs.
+// The signed kernel is a SEPARATE assembly function from the unsigned one, so the
+// sibling's edge test does not cover its abs-then-convert path. minV/maxV are the
+// largest magnitudes that stay bit-identical across tiers (|bound| <= 2147483520,
+// per the doc): a floor-clamp with a positive sign abs's to +2147483520, which
+// must convert to exactly that rather than overflowing to 0x80000000 / saturating.
+func TestFloat32ToInt32ScaleClampSigned_ContractEdgeSIMD(t *testing.T) {
+	const minV, maxV = -2147483520.0, 2147483520.0
+	// Values that clamp to the floor, the ceiling, and land mid-range, spanning
+	// past the 8-wide AVX block so the vector path and its overlap tail both run.
+	mag := []float32{-5e9, 5e9, -5e9, 5e9, 1000, -1000, 0, 2147483520, -2147483520, 3}
+	sign := []float32{1, 1, -1, -1, 1, -1, -1, 1, 1, -1}
+	dst := make([]int32, len(mag))
+	Float32ToInt32ScaleClampSigned(dst, mag, sign, 1.0, 0.0, minV, maxV)
+	want := make([]int32, len(mag))
+	float32ToInt32ScaleClampSignedRef(want, mag, sign, 1.0, 0.0, minV, maxV)
+	for i := range dst {
+		if dst[i] != want[i] {
+			t.Fatalf("[%d] = %d, want %d (mag=%g sign=%g)", i, dst[i], want[i], mag[i], sign[i])
+		}
+	}
+	// The exact edge case from the contract note: floor-clamp (mag=-5e9 -> minV)
+	// with a positive sign abs's to +2147483520 and must NOT overflow.
+	if dst[0] != 2147483520 {
+		t.Fatalf("floor-clamp with positive sign = %d, want 2147483520 (overflow to 0x80000000?)", dst[0])
+	}
+	if dst[2] != -2147483520 { // same floor, negative sign, stays at the clean floor
+		t.Fatalf("floor-clamp with negative sign = %d, want -2147483520", dst[2])
+	}
+}
+
+// TestFloat32ToInt32ScaleClampSigned_MatchesUnsignedPlusSign ties the primitive
+// to its documented role as the signed sibling of Float32ToInt32ScaleClamp: the
+// result must equal the unsigned magnitude quantization with a copysign applied.
+// Because truncation toward zero commutes with the sign, copysign(int32(clamp),
+// sign) equals the abs of the unsigned int32 carrying sign[i]'s sign bit.
+func TestFloat32ToInt32ScaleClampSigned_MatchesUnsignedPlusSign(t *testing.T) {
+	n := 33
+	mag := make([]float32, n)
+	sign := make([]float32, n)
+	for i := range mag {
+		mag[i] = float32(i%50) * 0.5 // non-negative magnitudes (the rectified common case)
+		sign[i] = float32((i%5)-2) * 3
+	}
+	const scale, offset, minV, maxV = 2.0, 0.4054, 0.0, 1000.0
+
+	got := make([]int32, n)
+	Float32ToInt32ScaleClampSigned(got, mag, sign, scale, offset, minV, maxV)
+
+	unsigned := make([]int32, n)
+	Float32ToInt32ScaleClamp(unsigned, mag, scale, offset, minV, maxV)
+	for i := range got {
+		a := unsigned[i]
+		if a < 0 {
+			a = -a
+		}
+		want := a
+		if math.Signbit(float64(sign[i])) {
+			want = -a
+		}
+		if got[i] != want {
+			t.Fatalf("[%d] signed=%d, unsigned=%d sign=%g -> want %d", i, got[i], unsigned[i], sign[i], want)
+		}
+	}
+}
+
+// TestFloat32ToInt32ScaleClampSigned_Consumer covers the motivating pattern
+// (go-aac quantize_bands): a magnitude computed from a rectified value, with the
+// original sample's sign reattached. dst[i] == copysign(quantize(|x[i]|), x[i]).
+func TestFloat32ToInt32ScaleClampSigned_Consumer(t *testing.T) {
+	negZero := float32(math.Copysign(0, -1)) // a real -0.0 (the literal -0.0 is +0.0 in Go)
+	x := []float32{-3.2, 3.2, -0.4, 0.4, -100, 100, 0, negZero, 7.7, -7.7, 1e6, -1e6}
+	mag := make([]float32, len(x))
+	for i, v := range x {
+		mag[i] = float32(math.Abs(float64(v))) // rectified magnitude source
+	}
+	const scale, offset, minV, maxV = 0.5, 0.4054, 0.0, 5000.0
+
+	dst := make([]int32, len(x))
+	Float32ToInt32ScaleClampSigned(dst, mag, x, scale, offset, minV, maxV)
+	for i, v := range x {
+		q := float32(float64(mag[i])*scale) + offset
+		if q > maxV {
+			q = maxV
+		}
+		mI := int32(q) // magnitude is non-negative here
+		want := mI
+		if math.Signbit(float64(v)) {
+			want = -mI
+		}
+		if dst[i] != want {
+			t.Fatalf("[%d] x=%g: got %d want %d", i, v, dst[i], want)
+		}
+	}
+}
+
+func TestFloat32ToInt32ScaleClampSigned_AllocFree(t *testing.T) {
+	mag := float32Ramp32(512)
+	sign := signRamp32(512)
+	dst := make([]int32, len(mag))
+	if a := testing.AllocsPerRun(10, func() {
+		Float32ToInt32ScaleClampSigned(dst, mag, sign, 3.0, 0.4054, -5000, 5000)
+	}); a != 0 {
+		t.Fatalf("safe: allocations = %v, want 0", a)
+	}
+	if a := testing.AllocsPerRun(10, func() {
+		Float32ToInt32ScaleClampSignedUnsafe(dst, mag, sign, 3.0, 0.4054, -5000, 5000)
+	}); a != 0 {
+		t.Fatalf("unsafe: allocations = %v, want 0", a)
+	}
+}
+
+// TestFloat32ToInt32ScaleClampSigned_LengthMismatch processes exactly
+// min(len(dst), len(mag), len(sign)) elements and leaves the dst tail untouched.
+func TestFloat32ToInt32ScaleClampSigned_LengthMismatch(t *testing.T) {
+	mag := []float32{1, 2, 3, 4, 5}
+	sign := []float32{-1, 1, -1, 1} // shorter than mag
+	dst := make([]int32, 6)         // longer than mag
+	for i := range dst {
+		dst[i] = -999 // sentinel
+	}
+	Float32ToInt32ScaleClampSigned(dst, mag, sign, 2.0, 0.5, -1000, 1000)
+	// n = min(6, 5, 4) = 4 elements written.
+	want := make([]int32, 4)
+	float32ToInt32ScaleClampSignedRef(want, mag[:4], sign[:4], 2.0, 0.5, -1000, 1000)
+	for i := range 4 {
+		if dst[i] != want[i] {
+			t.Fatalf("[%d] = %d, want %d", i, dst[i], want[i])
+		}
+	}
+	if dst[4] != -999 || dst[5] != -999 {
+		t.Fatalf("tail overwritten: dst[4]=%d dst[5]=%d, want sentinel -999", dst[4], dst[5])
+	}
+}
+
+func TestFloat32ToInt32ScaleClampSignedUnsafe(t *testing.T) {
+	mag := float32Ramp32(37)
+	sign := signRamp32(37)
+	dst := make([]int32, len(mag))
+	safe := make([]int32, len(mag))
+	Float32ToInt32ScaleClampSignedUnsafe(dst, mag, sign, 3.0, 0.4, -1500, 1500)
+	Float32ToInt32ScaleClampSigned(safe, mag, sign, 3.0, 0.4, -1500, 1500)
+	for i := range dst {
+		if dst[i] != safe[i] {
+			t.Fatalf("[%d] unsafe=%d safe=%d", i, dst[i], safe[i])
+		}
+	}
+}
+
+// FuzzFloat32ToInt32ScaleClampSigned differentially fuzzes the dispatched SIMD
+// path against the pure-Go reference: any divergence (magnitude path, clamp, sign
+// bit, residue handling) fails.
+func FuzzFloat32ToInt32ScaleClampSigned(f *testing.F) {
+	f.Add(uint64(0x1234567), 17, float32(3.0), float32(0.4054), float32(-5000), float32(5000))
+	f.Add(uint64(0xdeadbeef), 40, float32(1.0), float32(0.0), float32(-100), float32(100))
+	f.Fuzz(func(t *testing.T, seed uint64, n int, scale, offset, minV, maxV float32) {
+		if n < 0 {
+			n = -n
+		}
+		n %= 300
+		// The signed kernel abs's the clamped magnitude before the truncating
+		// conversion, so cross-tier bit-identity needs max(|minV|,|maxV|) <=
+		// 2147483520 (tighter than the unsigned kernel; see the doc). NaN bounds are
+		// out of contract too. Outside this window the tiers legitimately diverge
+		// (x86 integer-indefinite vs ARM64 saturation), so do not compare there.
+		const cleanMax = 2147483520.0
+		if minV != minV || maxV != maxV ||
+			math.Abs(float64(minV)) > cleanMax || math.Abs(float64(maxV)) > cleanMax {
+			t.Skip("minV/maxV out of the signed clean-conversion range")
+		}
+		mag := make([]float32, n)
+		sign := make([]float32, n)
+		r := seed | 1
+		next := func() float32 {
+			r ^= r << 13
+			r ^= r >> 7
+			r ^= r << 17
+			return math.Float32frombits(uint32(r))
+		}
+		for i := range mag {
+			mag[i] = next()
+			sign[i] = next()
+		}
+		got := make([]int32, n)
+		want := make([]int32, n)
+		Float32ToInt32ScaleClampSigned(got, mag, sign, scale, offset, minV, maxV)
+		float32ToInt32ScaleClampSignedGo(want, mag, sign, scale, offset, minV, maxV)
+		for i := range got {
+			if got[i] != want[i] {
+				t.Fatalf("n=%d [%d]: SIMD=%d Go=%d (mag=%g sign=%g scale=%g offset=%g minV=%g maxV=%g)",
+					n, i, got[i], want[i], mag[i], sign[i], scale, offset, minV, maxV)
+			}
+		}
+	})
+}
+
+func BenchmarkFloat32ToInt32ScaleClampSigned(b *testing.B) {
+	mag := float32Ramp32(4096)
+	sign := signRamp32(4096)
+	dst := make([]int32, len(mag))
+	b.ReportAllocs()
+	b.SetBytes(int64(len(mag) * 4))
+	for b.Loop() {
+		Float32ToInt32ScaleClampSigned(dst, mag, sign, 3.0, 0.4054, -5000, 5000)
+	}
+}
+
+// BenchmarkFloat32ToInt32ScaleClampSigned_TwoPass is the composition the fused
+// kernel replaces: quantize with wide vector stores, then a scalar pass reloading
+// dst with narrow int32 loads to negate. It exists to substantiate that the fused
+// single-pass form avoids the store-to-load stall.
+func BenchmarkFloat32ToInt32ScaleClampSigned_TwoPass(b *testing.B) {
+	mag := float32Ramp32(4096)
+	sign := signRamp32(4096)
+	dst := make([]int32, len(mag))
+	b.ReportAllocs()
+	b.SetBytes(int64(len(mag) * 4))
+	for b.Loop() {
+		Float32ToInt32ScaleClamp(dst, mag, 3.0, 0.4054, -5000, 5000)
+		for i := range dst {
+			if math.Signbit(float64(sign[i])) {
+				dst[i] = -dst[i]
+			}
+		}
+	}
+}


### PR DESCRIPTION
## Summary

Adds `f32.Float32ToInt32ScaleClampSigned` (and its `...Unsafe` variant): a fused, single-pass affine fixed-point quantize that also reattaches a sign.

The two-pass idiom this replaces, `Float32ToInt32ScaleClamp` writing `dst` with wide vector stores, then a scalar pass reloading `dst` with narrow int32 loads to negate, loses to a store-to-load forwarding stall: a narrow int32 load overlapping a still-in-flight wide store forwards slowly (often 10+ cycles). That made vectorizing the kernel a net full-encode regression in a real consumer (go-aac's `quantize_bands`, which left the kernel scalar as a result). Fusing keeps the int32 result in registers between the magnitude and sign steps, so the stall never happens.

```
dst[i] = copysign(int32(clamp(mag[i]*scale + offset, minV, maxV)), sign[i])
```

## Design

The magnitude path is identical to `Float32ToInt32ScaleClamp`: the product rounds before the offset add and is never contracted into an FMA; clamp not wrap; `+Inf -> maxV`, `-Inf -> minV`; NaN magnitude -> 0; truncate toward zero. It is the signed sibling of that primitive exactly as `CopySign` is the sign-transfer sibling of the magnitude ops.

The sign is applied in the **float domain before the truncating conversion**, because truncation toward zero commutes with the sign, so `int32(copysign_float(clamp, sign)) == copysign(int32(clamp), sign)`. AVX does this with `VANDPS`/`VORPS` (abs then OR in the sign bit); NEON does it in a single `BIT`. Keeping the sign in the float domain means no 256-bit integer op is needed, so the kernel stays **AVX1, not AVX2**, matching the sibling's tier (AVX + Go on amd64, NEON + Go on arm64).

The result is bit-identical across the AVX, NEON, and portable-Go paths (no relaxed tier). One subtlety worth calling out: because the abs step re-expands a floor-clamped magnitude before the conversion, cross-tier identity holds when `max(|minV|, |maxV|) <= 2147483520.0`, which is **tighter** than the sibling's `minV >= -2147483648.0` floor. A value clamped below `-2147483520.0` and then given a positive sign reaches `+2^31`, which converts architecture-dependently (x86 integer-indefinite vs ARM64 saturation), exactly as the sibling documents for an out-of-range value. The doc states this tighter bound and the clean-conversion edge is exercised through the vector body.

## Related Issues

Fixes #199.

## Performance

Fused kernel vs the naive scalar two-pass composition it replaces (`BenchmarkFloat32ToInt32ScaleClampSigned` vs `..._TwoPass`), single core pinned, 4096 elements:

| Arch | Speedup |
|------|---------|
| amd64 AVX+FMA (i7-1260P) | ~4x |
| arm64 NEON (Raspberry Pi 5) | 3.7x |

Zero allocations. Framed against a naive scalar sign pass; against a hand-vectorized two-pass the margin would be smaller, but the win, one fewer full pass over memory plus no store-to-load dependency, is baseline-independent.

## Test Plan

- [x] Table parity against an independent float64 + `math.Copysign` oracle (NaN/Inf magnitude, negative-zero and negative-NaN sign, inverted bounds, negative-magnitude-with-positive-sign, truncation)
- [x] Cross-tier bit-identity (SIMD == Go) across every 8-wide AVX and 4-wide NEON residue
- [x] Contract-edge test driving the clean int32 boundary through the vector body
- [x] no-FMA magnitude detector; both kernels registered in `singleRoundingKernels` (`TestNoFMAContract`)
- [x] Differential fuzz (1M+ execs) SIMD vs Go
- [x] Zero-allocation assertions (safe and Unsafe); length-mismatch min-of-3 with untouched tail
- [x] Full `f32` suite green on amd64 (AVX) and Raspberry Pi 5 (NEON); `asmcheck` validates the new `BIT` WORD against `arm64asm`; whole repo `go test ./...` green

## Follow-ups (deferred, out of scope)

- A behavioral saturation-clamp (one extra `min` op) could honor the full `-2147483648.0` lower bound instead of documenting the tighter one; left as a maintainer call.
- Minor: hoisting the portable-Go reference's per-iteration bounds checks (kept consistent with the unsigned sibling, which has the same shape); benchmarking a non-multiple length to guard the overlap tail.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added signed float32-to-int32 conversion with scaling, offsetting, clamping, and per-value sign handling.
  * Added safe length-checked and unsafe high-performance variants.
  * Added optimized AVX and NEON implementations with a portable fallback.
  * NaN values convert to zero, while infinities are clamped to configured bounds.

* **Tests**
  * Added comprehensive correctness, edge-case, parity, allocation, fuzz, and benchmark coverage.
  * Enforced separate multiplication and addition rounding behavior across implementations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->