### PR TITLE
f32: stage-level ButterflyComplexStage (radix-2 butterfly across a whole stage)

### DIFF
--- a/f32/butterfly_complex_stage_test.go
+++ b/f32/butterfly_complex_stage_test.go
@@ -1,0 +1,512 @@
+package f32
+
+import (
+	"fmt"
+	"math"
+	"testing"
+)
+
+// =============================================================================
+// BUTTERFLY COMPLEX STAGE TESTS (float32)
+// =============================================================================
+
+// butterflyComplexStageRef is an independent reference for one radix-2
+// decimation-in-time stage. It indexes re/im directly rather than delegating to
+// butterflyComplex32Go, so it does not share code with the implementation under
+// test.
+//
+// It is not an unfused baseline: whether these expressions fuse is the Go
+// compiler's choice, and it makes different choices per architecture (it
+// contracts them on ARM64, not on AMD64). Comparisons against it are therefore
+// tolerance-based, never bit-exact.
+func butterflyComplexStageRef(re, im []float32, span int, twRe, twIm []float32) {
+	if span <= 0 || len(twRe) < span || len(twIm) < span {
+		return
+	}
+	n := min(len(re), len(im))
+	for k := 0; k+2*span <= n; k += 2 * span {
+		for j := range span {
+			u, l := k+j, k+span+j
+
+			lr, li := re[l], im[l]
+			tr, ti := twRe[j], twIm[j]
+			tempRe := lr*tr - li*ti
+			tempIm := lr*ti + li*tr
+
+			ur, ui := re[u], im[u]
+			re[u] = ur + tempRe
+			im[u] = ui + tempIm
+			re[l] = ur - tempRe
+			im[l] = ui - tempIm
+		}
+	}
+}
+
+// stageTestData fills split-complex arrays and a twiddle pair with varied,
+// non-degenerate values. n is the element count, span the twiddle count.
+func stageTestData(n, span int) (re, im, twRe, twIm []float32) {
+	re = make([]float32, n)
+	im = make([]float32, n)
+	twRe = make([]float32, span)
+	twIm = make([]float32, span)
+	for i := range n {
+		re[i] = float32(math.Sin(float64(i)*0.317) * float64(i%7+1))
+		im[i] = float32(math.Cos(float64(i)*0.523) * float64(i%5+1))
+	}
+	for j := range span {
+		ang := -math.Pi * (float64(j) + stageTwiddlePhase) / float64(span)
+		sin, cos := math.Sincos(ang)
+		twRe[j] = float32(cos)
+		twIm[j] = float32(sin)
+	}
+	return re, im, twRe, twIm
+}
+
+// stageTwiddlePhase offsets the twiddle angle so that j == 0 is not the identity
+// twiddle (1, 0).
+//
+// This is load-bearing, not cosmetic. At span == 1 there is exactly one twiddle,
+// so an unoffset generator hands every span == 1 test tw = (1, 0), under which the
+// complex multiply collapses to a pass-through: temp_re = lr*1 - li*0 computes the
+// same bits as lr*1 + li*0. Any sign error in the span == 1 block-axis kernels is
+// then unobservable, and those kernels are the whole point of the primitive.
+// Verified: with this offset present, flipping VSUBPS to VADDPS in the AMD64
+// span == 1 path and FMLS to FMLA in the ARM64 one each make TestButterflyComplexStage
+// fail on real hardware (an AVX+FMA amd64 core and a Pi 5 Cortex-A76).
+// A real radix-2 stage-1 twiddle IS 1+0i, so TestButterflyComplexStage_FullFFT
+// cannot cover this either; only a synthetic twiddle can.
+//
+// The phase must be non-integral, or sin lands on zero at j == 0; and 2*(j+phase)
+// must never be an odd multiple of span, or cos lands on zero. 0.4 satisfies both
+// for every span in stageSpans, keeps |tw| == 1, and leaves both components above
+// 1e-3 in magnitude.
+const stageTwiddlePhase = 0.4
+
+// Tolerances for closeEnough.
+//
+// Three of this file's tests compare two implementations of the same butterfly
+// over the same data, differing only in how their multiply-adds fuse: SIMD vs
+// butterflyComplexStageRef, SIMD vs the per-block ButterflyComplex loop, and
+// SIMD vs the Go fallback. All three use this one bound rather than inventing
+// their own. Over the full stageSpans x stageBlockCounts sweep the largest
+// difference any of them produces is 9.54e-7, identical on an AVX+FMA amd64 core
+// and a NEON Cortex-A76 (both float32 tiers).
+//
+// The bound has to be absolute rather than relative, because the butterfly's
+// sum and difference can cancel to near zero while the rounding that produced
+// them does not shrink with them.
+//
+// So stageAbsTol carries every row, at ~10x the measured worst case. stageRelTol
+// is a safety valve for data larger than this fixture's; it only takes over
+// above |want| == 10 and no current row depends on it.
+const (
+	stageAbsTol = 1e-5
+	stageRelTol = 1e-6
+)
+
+// closeEnough is the tolerance used throughout: the vector and scalar paths fuse
+// their multiply-adds differently, so they agree to within rounding rather than
+// exactly.
+func closeEnough(got, want float32) bool {
+	diff := math.Abs(float64(got) - float64(want))
+	return diff <= stageAbsTol || diff <= math.Abs(float64(want))*stageRelTol
+}
+
+// stageSpans covers every dispatch path. On AVX (8-wide) span 1, 2 and 4 are the
+// block-axis paths; span 3, 5, 6 and 7 fill neither axis and run entirely in the
+// j-axis path's scalar tail; span 8 fills the j-axis exactly and 9..64 walk it
+// with and without a tail (span%8 != 0). On NEON (4-wide) span 1 and 2 are the
+// block-axis paths, span 3 is the scalar-tail-only span, and span 4+ walk the
+// j-axis.
+var stageSpans = []int{1, 2, 3, 4, 5, 6, 7, 8, 9, 15, 16, 17, 32, 64}
+
+// stageBlockCounts exercise the block-axis remainder tails. On AVX span 1
+// consumes 8 blocks per iteration, span 2 consumes 4 and span 4 consumes 2; on
+// NEON span 1 consumes 4 and span 2 consumes 2. Counts 1..9 plus 16, 17 and 33
+// cover every leftover case (and at least one full vector iteration) for all of
+// those widths.
+var stageBlockCounts = []int{1, 2, 3, 4, 5, 6, 7, 8, 9, 16, 17, 33}
+
+// TestButterflyComplexStage is the one of this file's three parity tests that
+// still asserts something on a tier where the dispatcher declines SIMD, so do not
+// delete it as redundant with the two below. Its reference,
+// butterflyComplexStageRef, indexes re/im directly instead of delegating, while
+// the other two compare against code that reduces to the same Go fallback:
+// butterflyComplexStage32Go is only a loop over butterflyComplex32Go.
+func TestButterflyComplexStage(t *testing.T) {
+	for _, span := range stageSpans {
+		for _, blocks := range stageBlockCounts {
+			t.Run(fmt.Sprintf("span=%d/blocks=%d", span, blocks), func(t *testing.T) {
+				n := 2 * span * blocks
+				re, im, twRe, twIm := stageTestData(n, span)
+
+				reRef := make([]float32, n)
+				imRef := make([]float32, n)
+				copy(reRef, re)
+				copy(imRef, im)
+
+				ButterflyComplexStage(re, im, span, twRe, twIm)
+				butterflyComplexStageRef(reRef, imRef, span, twRe, twIm)
+
+				for i := range n {
+					if !closeEnough(re[i], reRef[i]) {
+						t.Errorf("re[%d] = %v, want %v", i, re[i], reRef[i])
+					}
+					if !closeEnough(im[i], imRef[i]) {
+						t.Errorf("im[%d] = %v, want %v", i, im[i], imRef[i])
+					}
+				}
+			})
+		}
+	}
+}
+
+// TestButterflyComplexStage_MatchesPerBlockLoop pins the migration contract that
+// motivates the API: a consumer replacing its per-block ButterflyComplex loop
+// with one ButterflyComplexStage call must get the same spectrum back.
+//
+// Exact equality is not required. The stage and the per-block wrapper can reach
+// different code for the same span (below its SIMD threshold ButterflyComplex
+// runs the scalar fallback while the stage still vectorizes), and the two do not
+// round identically.
+func TestButterflyComplexStage_MatchesPerBlockLoop(t *testing.T) {
+	for _, span := range stageSpans {
+		for _, blocks := range []int{1, 3, 8} {
+			t.Run(fmt.Sprintf("span=%d/blocks=%d", span, blocks), func(t *testing.T) {
+				n := 2 * span * blocks
+				re, im, twRe, twIm := stageTestData(n, span)
+
+				reLoop := make([]float32, n)
+				imLoop := make([]float32, n)
+				copy(reLoop, re)
+				copy(imLoop, im)
+
+				ButterflyComplexStage(re, im, span, twRe, twIm)
+
+				for k := 0; k+2*span <= n; k += 2 * span {
+					ButterflyComplex(
+						reLoop[k:k+span], imLoop[k:k+span],
+						reLoop[k+span:k+2*span], imLoop[k+span:k+2*span],
+						twRe, twIm,
+					)
+				}
+
+				for i := range n {
+					if !closeEnough(re[i], reLoop[i]) {
+						t.Errorf("re[%d]: stage=%v, per-block loop=%v", i, re[i], reLoop[i])
+					}
+					if !closeEnough(im[i], imLoop[i]) {
+						t.Errorf("im[%d]: stage=%v, per-block loop=%v", i, im[i], imLoop[i])
+					}
+				}
+			})
+		}
+	}
+}
+
+// TestButterflyComplexStage_SIMDvsGo compares the dispatched kernel against the
+// Go fallback over an explicit (span, blocks) grid, rather than through the
+// public wrapper, which derives blocks from the slice lengths.
+//
+// This does NOT get below the SIMD-versus-Go threshold: that lives inside
+// butterflyComplexStage32, which is the function called here, so rows under it
+// compare the Go path against itself (blocks*span < 8 on amd64, < 4 on arm64).
+func TestButterflyComplexStage_SIMDvsGo(t *testing.T) {
+	for _, span := range stageSpans {
+		for _, blocks := range stageBlockCounts {
+			t.Run(fmt.Sprintf("span=%d/blocks=%d", span, blocks), func(t *testing.T) {
+				n := 2 * span * blocks
+				re, im, twRe, twIm := stageTestData(n, span)
+
+				reGo := make([]float32, n)
+				imGo := make([]float32, n)
+				copy(reGo, re)
+				copy(imGo, im)
+
+				butterflyComplexStage32(re, im, span, blocks, twRe, twIm)
+				butterflyComplexStage32Go(reGo, imGo, span, blocks, twRe, twIm)
+
+				for i := range n {
+					if !closeEnough(re[i], reGo[i]) {
+						t.Errorf("re[%d]: SIMD=%v, Go=%v", i, re[i], reGo[i])
+					}
+					if !closeEnough(im[i], imGo[i]) {
+						t.Errorf("im[%d]: SIMD=%v, Go=%v", i, im[i], imGo[i])
+					}
+				}
+			})
+		}
+	}
+}
+
+// stageFFTTolPerN2 bounds TestButterflyComplexStage_FullFFT's per-bin error.
+// The transform runs in float32 while the reference DFT accumulates in float64,
+// so the error is the transform's own; |X[k]| for this input grows like O(n) and
+// the per-bin rounding grows with it. Scaling the bound by n^2 keeps the headroom
+// from shrinking as larger sizes are added, the same choice the f64 sibling made.
+// Measured over n in [8, 512] on a NEON Cortex-A76 and an AVX+FMA amd64 core
+// (worst 1.79e-7 at n=8 rising to 2.34e-5 at n=512), this bound holds with at
+// least ~50x headroom at every size (the minimum is ~54x at n=8).
+const stageFFTTolPerN2 = 1.5e-7
+
+// TestButterflyComplexStage_FullFFT drives a complete iterative Cooley-Tukey
+// transform through ButterflyComplexStage and checks it against a naive DFT.
+// Every stage of an n-point transform uses a different span (1, 2, 4, ... n/2),
+// so one run walks every vectorization path in sequence and would catch a path
+// that is individually self-consistent but wrong relative to the others.
+func TestButterflyComplexStage_FullFFT(t *testing.T) {
+	for _, n := range []int{8, 16, 32, 64, 256, 512} {
+		t.Run(fmt.Sprintf("n=%d", n), func(t *testing.T) {
+			srcRe := make([]float32, n)
+			srcIm := make([]float32, n)
+			for i := range n {
+				srcRe[i] = float32(math.Sin(float64(i)*0.21) + 0.5*math.Cos(float64(i)*1.7))
+				srcIm[i] = float32(math.Cos(float64(i) * 0.13))
+			}
+
+			// Bit-reversal permutation into the working buffers.
+			re := make([]float32, n)
+			im := make([]float32, n)
+			bits := 0
+			for 1<<bits < n {
+				bits++
+			}
+			for i := range n {
+				r := 0
+				for b := range bits {
+					if i&(1<<b) != 0 {
+						r |= 1 << (bits - 1 - b)
+					}
+				}
+				re[r] = srcRe[i]
+				im[r] = srcIm[i]
+			}
+
+			twRe := make([]float32, n/2)
+			twIm := make([]float32, n/2)
+			for span := 1; span < n; span *= 2 {
+				for j := range span {
+					ang := -math.Pi * float64(j) / float64(span)
+					twRe[j] = float32(math.Cos(ang))
+					twIm[j] = float32(math.Sin(ang))
+				}
+				ButterflyComplexStage(re, im, span, twRe[:span], twIm[:span])
+			}
+
+			// Naive DFT reference, accumulated in float64 then compared in float32
+			// magnitude: the reference must be at least as accurate as the transform
+			// under test, so its accumulation is not itself the error source.
+			for k := range n {
+				var wantRe, wantIm float64
+				for i := range n {
+					ang := -2 * math.Pi * float64(k) * float64(i) / float64(n)
+					c, s := math.Cos(ang), math.Sin(ang)
+					wantRe += float64(srcRe[i])*c - float64(srcIm[i])*s
+					wantIm += float64(srcRe[i])*s + float64(srcIm[i])*c
+				}
+				// Accumulated rounding grows as n^2; see stageFFTTolPerN2.
+				tol := stageFFTTolPerN2 * float64(n) * float64(n)
+				if math.Abs(float64(re[k])-wantRe) > tol || math.Abs(float64(im[k])-wantIm) > tol {
+					t.Fatalf("bin %d = (%v, %v), want (%v, %v), tol %v",
+						k, re[k], im[k], wantRe, wantIm, tol)
+				}
+			}
+		})
+	}
+}
+
+// TestButterflyComplexStage_PartialBlockUntouched pins the documented boundary:
+// blocks are processed while k+2*span <= n, so a trailing run shorter than a
+// full block must be left exactly as it was.
+func TestButterflyComplexStage_PartialBlockUntouched(t *testing.T) {
+	const sentinel = -12345.5
+
+	for _, span := range stageSpans {
+		// Dedupe: for small spans the candidates collapse onto the same value, and
+		// Go silently disambiguates the duplicate subtest names as #01/#02, which
+		// reads as coverage that is not there.
+		seen := map[int]bool{}
+		extras := make([]int, 0, 4)
+		for _, extra := range []int{1, 2, span, 2*span - 1} {
+			if extra <= 0 || extra >= 2*span || seen[extra] {
+				continue
+			}
+			seen[extra] = true
+			extras = append(extras, extra)
+		}
+
+		// blocks up to 9 as well as 3: the AMD64 span == 1 path consumes eight
+		// blocks per vector iteration, so a partial block needs a block count that
+		// leaves the vector loop with both a full iteration and a live tail.
+		for _, blocks := range []int{3, 8, 9} {
+			for _, extra := range extras {
+				t.Run(fmt.Sprintf("span=%d/blocks=%d/extra=%d", span, blocks, extra), func(t *testing.T) {
+					checkPartialBlockUntouched(t, span, blocks, extra, sentinel)
+				})
+			}
+		}
+	}
+}
+
+// checkPartialBlockUntouched runs one shape of the partial-block boundary check:
+// the trailing `extra` elements must be untouched, and the complete blocks must
+// have been transformed.
+func checkPartialBlockUntouched(t *testing.T, span, blocks, extra int, sentinel float32) {
+	t.Helper()
+
+	used := 2 * span * blocks
+	n := used + extra
+	re, im, twRe, twIm := stageTestData(n, span)
+	beforeRe := append([]float32(nil), re...)
+	beforeIm := append([]float32(nil), im...)
+	for i := used; i < n; i++ {
+		re[i] = sentinel
+		im[i] = sentinel
+	}
+
+	ButterflyComplexStage(re, im, span, twRe, twIm)
+
+	for i := used; i < n; i++ {
+		if re[i] != sentinel {
+			t.Errorf("re[%d] = %v, want untouched sentinel %v", i, re[i], sentinel)
+		}
+		if im[i] != sentinel {
+			t.Errorf("im[%d] = %v, want untouched sentinel %v", i, im[i], sentinel)
+		}
+	}
+
+	// Assert the complete blocks WERE transformed. Without this the test passes
+	// against a stage that does nothing at all, which is exactly what its name
+	// promises to rule out.
+	for i := range used {
+		if re[i] != beforeRe[i] || im[i] != beforeIm[i] {
+			return
+		}
+	}
+	t.Errorf("no element in the %d complete-block elements changed; the stage did nothing", used)
+}
+
+// TestButterflyComplexStage_Degenerate covers every input the public wrapper is
+// documented to reject, and asserts it is a no-op rather than a panic.
+func TestButterflyComplexStage_Degenerate(t *testing.T) {
+	const span = 4
+	n := 2 * span * 2
+	_, _, twRe, twIm := stageTestData(n, span)
+
+	// nTwRe and nTwIm are separate on purpose. Driving both twiddle slices from a
+	// single field makes len(twRe) < span short-circuit first in every row, so the
+	// len(twIm) < span clause is never the one that fires and deleting it from the
+	// wrapper leaves the suite green. What it costs a caller passing a short twIm
+	// is worse than a lost no-op: the Go fallback would panic slicing twIm[:span],
+	// but the asm kernels derive every address from span and blocks, so they would
+	// read out of bounds silently. Each clause needs its own row.
+	cases := []struct {
+		name  string
+		span  int
+		nRe   int
+		nIm   int
+		nTwRe int
+		nTwIm int
+	}{
+		{"span=0", 0, n, n, span, span},
+		{"span=-1", -1, n, n, span, span},
+		{"nil slices", span, 0, 0, span, span},
+		{"nil twiddles", span, n, n, 0, 0},
+		{"twRe short", span, n, n, span - 1, span},
+		{"twIm short", span, n, n, span, span - 1},
+		{"twRe nil, twIm ok", span, n, n, 0, span},
+		{"twIm nil, twRe ok", span, n, n, span, 0},
+		{"re shorter than one block", span, 2*span - 1, n, span, span},
+		{"im shorter than one block", span, n, 2*span - 1, span, span},
+		{"exactly one element", span, 1, 1, span, span},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			// Build re and im at exactly the requested lengths, independently,
+			// so "re shorter" and "im shorter" really are distinct cases.
+			full, _, _, _ := stageTestData(n, span)
+			re := append([]float32(nil), full[:tc.nRe]...)
+			im := append([]float32(nil), full[:tc.nIm]...)
+
+			wantRe := append([]float32(nil), re...)
+			wantIm := append([]float32(nil), im...)
+
+			// Must not panic.
+			ButterflyComplexStage(re, im, tc.span, twRe[:tc.nTwRe], twIm[:tc.nTwIm])
+
+			// Every case here is a no-op: either the guard rejects it outright, or
+			// it clears the guard but contains no complete 2*span block.
+			for i := range im {
+				if im[i] != wantIm[i] {
+					t.Errorf("im[%d] = %v, want unchanged %v", i, im[i], wantIm[i])
+				}
+			}
+			for i := range re {
+				if re[i] != wantRe[i] {
+					t.Errorf("re[%d] = %v, want unchanged %v", i, re[i], wantRe[i])
+				}
+			}
+		})
+	}
+}
+
+func TestButterflyComplexStage_AllocFree(t *testing.T) {
+	// One case per vectorization path, so an allocation introduced in any of
+	// them fails here rather than only in the one shape a single case happens
+	// to take: span 1/2/4 are the block-axis paths, span 3 the scalar tail, span
+	// 8 the j-axis.
+	for _, span := range []int{1, 2, 3, 4, 8} {
+		t.Run(fmt.Sprintf("span=%d", span), func(t *testing.T) {
+			n := 2 * span * 16
+			re, im, twRe, twIm := stageTestData(n, span)
+			fn := func() { ButterflyComplexStage(re, im, span, twRe, twIm) }
+			if a := testing.AllocsPerRun(50, fn); a != 0 {
+				t.Errorf("ButterflyComplexStage allocated %v times per run, want 0", a)
+			}
+		})
+	}
+}
+
+func BenchmarkButterflyComplexStage(b *testing.B) {
+	// A fixed 1024-point transform's worth of butterflies per stage, swept over
+	// span. Work is identical in every row: blocks*span is constant at 512, so the
+	// only variable is how short the runs are. This is the shape issue #198 measured.
+	//
+	// Measure on an IDLE host, and interleave by running one full sweep per process
+	// invocation at -test.count=1 rather than using -test.count=N, so a dropped
+	// sustained-load P-state inflates the absolutes of every arm identically and
+	// leaves the Stage-vs-PerBlock ratio intact.
+	const n = 1024
+
+	for _, span := range []int{1, 2, 4, 6, 8, 10, 16, 32, 64, 128, 256, 512} {
+		blocks := n / (2 * span)
+
+		b.Run(fmt.Sprintf("Stage/span=%d", span), func(b *testing.B) {
+			re, im, twRe, twIm := stageTestData(n, span)
+			for b.Loop() {
+				ButterflyComplexStage(re, im, span, twRe, twIm)
+			}
+		})
+
+		b.Run(fmt.Sprintf("PerBlock/span=%d", span), func(b *testing.B) {
+			re, im, twRe, twIm := stageTestData(n, span)
+			for b.Loop() {
+				for k := 0; k < blocks*2*span; k += 2 * span {
+					ButterflyComplex(
+						re[k:k+span], im[k:k+span],
+						re[k+span:k+2*span], im[k+span:k+2*span],
+						twRe, twIm,
+					)
+				}
+			}
+		})
+
+		b.Run(fmt.Sprintf("Go/span=%d", span), func(b *testing.B) {
+			re, im, twRe, twIm := stageTestData(n, span)
+			for b.Loop() {
+				butterflyComplexStage32Go(re, im, span, blocks, twRe, twIm)
+			}
+		})
+	}
+}

--- a/f32/f32.go
+++ b/f32/f32.go
@@ -1276,6 +1276,54 @@ func ButterflyComplex(upperRe, upperIm, lowerRe, lowerIm, twRe, twIm []float32) 
 	butterflyComplex32(upperRe[:n], upperIm[:n], lowerRe[:n], lowerIm[:n], twRe[:n], twIm[:n])
 }
 
+// butterflyStageRadix is the radix of a decimation-in-time stage: every block
+// holds exactly one upper half and one lower half, each span elements long, so
+// a block is butterflyStageRadix*span elements wide.
+const butterflyStageRadix = 2
+
+// ButterflyComplexStage applies one complete radix-2 decimation-in-time stage
+// in place over split-complex data. For every block k in steps of 2*span, and
+// every j in [0, span), it performs the ButterflyComplex operation on the pair
+// (k+j, k+span+j) with twiddle (twRe[j], twIm[j]):
+//
+//	temp_re = re[k+span+j]*twRe[j] - im[k+span+j]*twIm[j]
+//	temp_im = re[k+span+j]*twIm[j] + im[k+span+j]*twRe[j]
+//	re[k+j], re[k+span+j] = re[k+j]+temp_re, re[k+j]-temp_re
+//	im[k+j], im[k+span+j] = im[k+j]+temp_im, im[k+j]-temp_im
+//
+// It is the stage-level form of [ButterflyComplex]. Driving a stage through
+// ButterflyComplex costs one call per block, so the call count grows as the
+// runs get short and per-call overhead dominates the small-span stages. Taking
+// the whole stage lets the implementation pick its own vectorization axis,
+// which is not expressible through the per-block API: across j when span is
+// large enough to fill a vector, and across blocks when span is short enough
+// that a whole vector of them fits. The float32 vector is 8 lanes on AVX and 4
+// on NEON, so span 1, 2 and 4 vectorize across blocks on AVX (1 and 2 on NEON);
+// a span that fills neither axis runs the scalar tail.
+//
+// The stage is a no-op unless span > 0, len(twRe) >= span and len(twIm) >= span,
+// and it is also a no-op when no complete block fits. Blocks are processed while
+// k+2*span <= n, where n = min(len(re), len(im)); a trailing partial block is
+// left untouched.
+//
+// Uses AVX+FMA on AMD64, NEON on ARM64, with a pure Go fallback. As with
+// [ButterflyComplex], results are not guaranteed bit-identical between the
+// vector and fallback paths, so do not depend on exact equality across build
+// targets or across spans.
+func ButterflyComplexStage(re, im []float32, span int, twRe, twIm []float32) {
+	if span <= 0 || len(twRe) < span || len(twIm) < span {
+		return
+	}
+	n := min(len(re), len(im))
+	blockLen := butterflyStageRadix * span
+	blocks := n / blockLen
+	if blocks == 0 {
+		return
+	}
+	used := blocks * blockLen
+	butterflyComplexStage32(re[:used], im[:used], span, blocks, twRe[:span], twIm[:span])
+}
+
 // RealFFTUnpack performs the unpacking step of a real-valued FFT.
 //
 // Given Z = FFT(packed real data of size 2n), this computes the real FFT output X

--- a/f32/f32_amd64.go
+++ b/f32/f32_amd64.go
@@ -1313,6 +1313,31 @@ func butterflyComplex32(upperRe, upperIm, lowerRe, lowerIm, twRe, twIm []float32
 	butterflyComplex32Go(upperRe, upperIm, lowerRe, lowerIm, twRe, twIm)
 }
 
+func butterflyComplexStage32(re, im []float32, span, blocks int, twRe, twIm []float32) {
+	// butterflyComplexStageAVX is correct for every span: across j when span fills
+	// an 8-wide YMM, across blocks for span 1, 2 and 4 (all below the float32 lane
+	// count). span 3, 5, 6 and 7 fill neither axis and run through the kernel's
+	// scalar tail, which still beats the Go fallback because the kernel absorbs the
+	// whole block loop into one call while the Go path pays a call per block that is
+	// over the inliner's budget.
+	//
+	// The guard below is about total work, not about span: a stage carrying fewer
+	// than minAVXElements butterflies goes to Go regardless of its span. So "every
+	// span" describes what the kernel handles, not what always reaches it.
+	//
+	// AVX+FMA is the whole requirement, with no AVX2 anywhere: the block-axis paths
+	// shuffle with VSHUFPS/VUNPCKLPS/VUNPCKHPS (span 1), VUNPCKLPD/VUNPCKHPD (span 2)
+	// and VPERM2F128 (span 4), and splat their twiddles with the memory-source forms
+	// of VBROADCASTSS, VBROADCASTSD and VBROADCASTF128. The register-source
+	// VBROADCASTSS/VBROADCASTSD would be AVX2, the trap TestAmd64KernelISALevel
+	// sweeps for.
+	if cpu.X86.AVX && cpu.X86.FMA && blocks*span >= minAVXElements {
+		butterflyComplexStageAVX(re, im, span, blocks, twRe, twIm)
+		return
+	}
+	butterflyComplexStage32Go(re, im, span, blocks, twRe, twIm)
+}
+
 func realFFTUnpack32(outRe, outIm, zRe, zIm, twRe, twIm []float32, n int) {
 	// Use AVX+FMA if available and have enough elements. realFFTUnpackAVX needs
 	// nothing above AVX1+FMA3; TestAmd64KernelISALevel enforces the AVX2 half of
@@ -1339,6 +1364,15 @@ func absSqComplexAVX(dst, aRe, aIm []float32)
 
 //go:noescape
 func butterflyComplexAVX(upperRe, upperIm, lowerRe, lowerIm, twRe, twIm []float32)
+
+// Callers MUST satisfy len(re) == len(im) == 2*span*blocks and
+// len(twRe) == len(twIm) >= span, with span >= 1 and blocks >= 1. Every address
+// the kernel forms is derived from span and blocks, never from the slice headers,
+// so a violated precondition reads and writes out of bounds silently rather than
+// panicking the way the Go fallback would. ButterflyComplexStage establishes it.
+//
+//go:noescape
+func butterflyComplexStageAVX(re, im []float32, span, blocks int, twRe, twIm []float32)
 
 //go:noescape
 func realFFTUnpackAVX(outRe, outIm, zRe, zIm, twRe, twIm []float32, n int)

--- a/f32/f32_amd64.s
+++ b/f32/f32_amd64.s
@@ -5272,6 +5272,381 @@ butterfly_done:
     VZEROUPPER
     RET
 
+// func butterflyComplexStageAVX(re, im []float32, span, blocks int, twRe, twIm []float32)
+// One complete radix-2 decimation-in-time stage, in place over split-complex
+// float32. For every block k in steps of 2*span and every j in [0, span), the
+// butterfly at (k+j, k+span+j) with twiddle tw[j]. Same arithmetic sequence as
+// butterflyComplexAVX above (VMULPS/VMULPS/VSUBPS then VMULPS/VFMADD231PS), so a
+// stage produces the same bits as driving THAT KERNEL per block, for every span
+// and block count tested. That is a kernel-to-kernel statement, not a claim about
+// the exported ButterflyComplex, whose dispatch withholds short slices from this
+// kernel.
+//
+// The stage form exists to pick its own vectorization axis. Long spans vectorize
+// across j, where the twiddles and both halves of the block are contiguous. The
+// float32 vector is 8 wide, so spans of 1, 2 and 4 cannot fill a YMM along j and
+// vectorize across blocks instead, gathering 8 (span 1), 4 (span 2) or 2 (span 4)
+// blocks per iteration with in-register shuffles.
+//
+// span 3, 5, 6 and 7 have neither axis: they enter the j-axis path, whose 8-wide
+// bound (span &^ 7) is 0 there, so every butterfly runs in that path's scalar
+// tail. They are still dispatched here, because absorbing the block loop into one
+// call beats the Go fallback's call per block. Real radix-2 stages use only
+// power-of-two spans, so those are synthetic-test spans, not hot paths.
+//
+// AVX+FMA only, no AVX2: the block-axis shuffles are VSHUFPS/VUNPCKLPS/VUNPCKHPS
+// (span 1), VUNPCKLPD/VUNPCKHPD (span 2) and VPERM2F128 (span 4), the twiddle
+// splats are the memory-source forms of VBROADCASTSS, VBROADCASTSD and
+// VBROADCASTF128, and all vector arithmetic is floating point. Frame:
+// re(24)+im(24)+span(8)+blocks(8)+twRe(24)+twIm(24) = 112 bytes.
+TEXT ·butterflyComplexStageAVX(SB), NOSPLIT, $0-112
+    MOVQ re_base+0(FP), DX           // DX = re block base
+    MOVQ im_base+24(FP), R8          // R8 = im block base
+    MOVQ span+48(FP), CX             // CX = span
+    MOVQ blocks+56(FP), AX           // AX = block count
+    MOVQ twRe_base+64(FP), R9        // R9 = twRe base
+    MOVQ twIm_base+88(FP), R10       // R10 = twIm base
+
+    TESTQ AX, AX
+    JZ    bfstage_done
+    CMPQ  CX, $1
+    JEQ   bfstage_span1
+    CMPQ  CX, $2
+    JEQ   bfstage_span2
+    CMPQ  CX, $4
+    JEQ   bfstage_span4
+
+// ---------------------------------------------------------------------------
+// Long span: vectorize across j. Per block, span/8 full YMM iterations over the
+// contiguous run, then a scalar tail for span%8. Twiddles restart at j=0 for
+// every block, so they are addressed by the same j index as the data.
+// ---------------------------------------------------------------------------
+    MOVQ CX, R11
+    SHLQ $2, R11                     // R11 = span*4 = upper->lower byte offset
+    MOVQ CX, R12
+    SHLQ $3, R12                     // R12 = span*8 = block stride in bytes
+    MOVQ CX, R13
+    ANDQ $-8, R13                    // R13 = span &^ 7 = 8-wide loop bound
+
+bfstage_block:
+    LEAQ (DX)(R11*1), SI             // SI = lower re for this block
+    LEAQ (R8)(R11*1), DI             // DI = lower im for this block
+    XORQ BX, BX                      // BX = j
+    CMPQ BX, R13
+    JGE  bfstage_tail_pre
+
+bfstage_vec:
+    VMOVUPS (SI)(BX*4), Y0           // Y0 = lower_re[j:j+8]
+    VMOVUPS (DI)(BX*4), Y1           // Y1 = lower_im[j:j+8]
+    VMOVUPS (R9)(BX*4), Y2           // Y2 = tw_re[j:j+8]
+    VMOVUPS (R10)(BX*4), Y3          // Y3 = tw_im[j:j+8]
+
+    VMULPS Y0, Y2, Y4                // Y4 = lr*tr
+    VMULPS Y1, Y3, Y5                // Y5 = li*ti
+    VSUBPS Y5, Y4, Y4                // Y4 = temp_re = lr*tr - li*ti
+    VMULPS Y0, Y3, Y5                // Y5 = lr*ti
+    VFMADD231PS Y1, Y2, Y5           // Y5 = temp_im = lr*ti + li*tr
+
+    VMOVUPS (DX)(BX*4), Y0           // Y0 = upper_re[j:j+8]
+    VMOVUPS (R8)(BX*4), Y1           // Y1 = upper_im[j:j+8]
+
+    VADDPS Y0, Y4, Y2                // upper_re + temp_re
+    VSUBPS Y4, Y0, Y3                // upper_re - temp_re
+    VMOVUPS Y2, (DX)(BX*4)
+    VMOVUPS Y3, (SI)(BX*4)
+    VADDPS Y1, Y5, Y2                // upper_im + temp_im
+    VSUBPS Y5, Y1, Y3                // upper_im - temp_im
+    VMOVUPS Y2, (R8)(BX*4)
+    VMOVUPS Y3, (DI)(BX*4)
+
+    ADDQ $8, BX
+    CMPQ BX, R13
+    JLT  bfstage_vec
+
+bfstage_tail_pre:
+    CMPQ BX, CX
+    JGE  bfstage_next
+
+bfstage_tail:
+    VMOVSS (SI)(BX*4), X0            // X0 = lower_re[j]
+    VMOVSS (DI)(BX*4), X1            // X1 = lower_im[j]
+    VMOVSS (R9)(BX*4), X2            // X2 = tw_re[j]
+    VMOVSS (R10)(BX*4), X3           // X3 = tw_im[j]
+
+    VMULSS X0, X2, X4
+    VMULSS X1, X3, X5
+    VSUBSS X5, X4, X4                // X4 = temp_re
+    VMULSS X0, X3, X5
+    VFMADD231SS X1, X2, X5           // X5 = temp_im
+
+    VMOVSS (DX)(BX*4), X0            // X0 = upper_re[j]
+    VMOVSS (R8)(BX*4), X1            // X1 = upper_im[j]
+
+    VADDSS X0, X4, X2
+    VSUBSS X4, X0, X3
+    VMOVSS X2, (DX)(BX*4)
+    VMOVSS X3, (SI)(BX*4)
+    VADDSS X1, X5, X2
+    VSUBSS X5, X1, X3
+    VMOVSS X2, (R8)(BX*4)
+    VMOVSS X3, (DI)(BX*4)
+
+    INCQ BX
+    CMPQ BX, CX
+    JLT  bfstage_tail
+
+bfstage_next:
+    ADDQ R12, DX
+    ADDQ R12, R8
+    DECQ AX
+    JNZ  bfstage_block
+    JMP  bfstage_done
+
+// ---------------------------------------------------------------------------
+// span == 1: each block is one pair [u, l], so re/im are fully interleaved.
+// Take 8 blocks (16 float32) at a time in two YMM loads. VSHUFPS $0x88/$0xDD
+// separate the uppers from the lowers; both land in the same cross-lane order
+// [0,1,4,5,2,3,6,7], which is harmless because the twiddle is one broadcast
+// scalar. VUNPCKLPS/VUNPCKHPS re-interleave on the way out, putting every lane
+// back at its original memory position. All three shuffles are AVX1 float ops,
+// so this stays below AVX2.
+// ---------------------------------------------------------------------------
+bfstage_span1:
+    VBROADCASTSS (R9), Y6            // Y6 = tw_re[0] in all lanes
+    VBROADCASTSS (R10), Y7          // Y7 = tw_im[0] in all lanes
+
+    MOVQ AX, BX
+    SHRQ $3, BX                      // BX = blocks/8 = 8-block iterations
+    JZ   bfstage_span1_tail_pre
+
+bfstage_span1_vec:
+    VMOVUPS (DX), Y0                 // [u0,l0,u1,l1,u2,l2,u3,l3] re
+    VMOVUPS 32(DX), Y1               // [u4,l4,u5,l5,u6,l6,u7,l7] re
+    VSHUFPS $0x88, Y1, Y0, Y4        // upper_re = [u0,u1,u4,u5,u2,u3,u6,u7]
+    VSHUFPS $0xDD, Y1, Y0, Y5        // lower_re, same lane order
+    VMOVUPS (R8), Y2                 // im, blocks 0-3
+    VMOVUPS 32(R8), Y3               // im, blocks 4-7
+    VSHUFPS $0x88, Y3, Y2, Y8        // upper_im, same lane order
+    VSHUFPS $0xDD, Y3, Y2, Y9        // lower_im, same lane order
+
+    VMULPS Y5, Y6, Y10               // lr*tr
+    VMULPS Y9, Y7, Y11               // li*ti
+    VSUBPS Y11, Y10, Y10             // Y10 = temp_re
+    VMULPS Y5, Y7, Y11               // lr*ti
+    VFMADD231PS Y9, Y6, Y11          // Y11 = temp_im
+
+    VADDPS Y4, Y10, Y0               // new upper_re
+    VSUBPS Y10, Y4, Y1               // new lower_re
+    VADDPS Y8, Y11, Y2               // new upper_im
+    VSUBPS Y11, Y8, Y3               // new lower_im
+
+    VUNPCKLPS Y1, Y0, Y12            // [U0,L0,U1,L1,U2,L2,U3,L3] re
+    VUNPCKHPS Y1, Y0, Y13            // [U4,L4,U5,L5,U6,L6,U7,L7] re
+    VMOVUPS Y12, (DX)
+    VMOVUPS Y13, 32(DX)
+    VUNPCKLPS Y3, Y2, Y12            // im, blocks 0-3
+    VUNPCKHPS Y3, Y2, Y13            // im, blocks 4-7
+    VMOVUPS Y12, (R8)
+    VMOVUPS Y13, 32(R8)
+
+    ADDQ $64, DX
+    ADDQ $64, R8
+    DECQ BX
+    JNZ  bfstage_span1_vec
+
+bfstage_span1_tail_pre:
+    ANDQ $7, AX                      // AX = leftover blocks (0..7)
+    JZ   bfstage_done
+
+bfstage_span1_tail:
+    VMOVSS 4(DX), X0                 // lower_re
+    VMOVSS 4(R8), X1                 // lower_im
+    VMULSS X0, X6, X4
+    VMULSS X1, X7, X5
+    VSUBSS X5, X4, X4                // temp_re
+    VMULSS X0, X7, X5
+    VFMADD231SS X1, X6, X5           // temp_im
+
+    VMOVSS (DX), X0                  // upper_re
+    VMOVSS (R8), X1                  // upper_im
+    VADDSS X0, X4, X2
+    VSUBSS X4, X0, X3
+    VMOVSS X2, (DX)
+    VMOVSS X3, 4(DX)
+    VADDSS X1, X5, X2
+    VSUBSS X5, X1, X3
+    VMOVSS X2, (R8)
+    VMOVSS X3, 4(R8)
+
+    ADDQ $8, DX
+    ADDQ $8, R8
+    DECQ AX
+    JNZ  bfstage_span1_tail
+    JMP  bfstage_done
+
+// ---------------------------------------------------------------------------
+// span == 2: each block is [u0,u1,l0,l1], and a float32 pair is exactly one
+// 64-bit lane, so this is the float32 sibling of the f64 span == 1 path. Take 4
+// blocks (16 float32) at a time; VUNPCKLPD/VUNPCKHPD gather the four upper pairs
+// into one YMM and the four lower pairs into another (in the harmless permuted
+// order [0,2,1,3]), and the same unpacks put them back on the way out. The
+// twiddle pair repeats per block, which is one memory-source VBROADCASTSD.
+// ---------------------------------------------------------------------------
+bfstage_span2:
+    VBROADCASTSD (R9), Y6            // Y6 = [tr0,tr1] pair in every 64-bit lane
+    VBROADCASTSD (R10), Y7          // Y7 = [ti0,ti1] pair in every 64-bit lane
+
+    MOVQ AX, BX
+    SHRQ $2, BX                      // BX = blocks/4 = 4-block iterations
+    JZ   bfstage_span2_tail_pre
+
+bfstage_span2_vec:
+    VMOVUPS (DX), Y0                 // blocks 0,1 re = [U0,L0,U1,L1] (64-bit lanes)
+    VMOVUPS 32(DX), Y1               // blocks 2,3 re
+    VUNPCKLPD Y1, Y0, Y4             // upper_re = [U0,U2,U1,U3]
+    VUNPCKHPD Y1, Y0, Y5             // lower_re = [L0,L2,L1,L3]
+    VMOVUPS (R8), Y2                 // blocks 0,1 im
+    VMOVUPS 32(R8), Y3               // blocks 2,3 im
+    VUNPCKLPD Y3, Y2, Y8             // upper_im
+    VUNPCKHPD Y3, Y2, Y9             // lower_im
+
+    VMULPS Y5, Y6, Y10               // lr*tr
+    VMULPS Y9, Y7, Y11               // li*ti
+    VSUBPS Y11, Y10, Y10             // temp_re
+    VMULPS Y5, Y7, Y11               // lr*ti
+    VFMADD231PS Y9, Y6, Y11          // temp_im
+
+    VADDPS Y4, Y10, Y0               // new upper_re
+    VSUBPS Y10, Y4, Y1               // new lower_re
+    VADDPS Y8, Y11, Y2               // new upper_im
+    VSUBPS Y11, Y8, Y3               // new lower_im
+
+    VUNPCKLPD Y1, Y0, Y12            // blocks 0,1 re = [U0,L0,U1,L1]
+    VUNPCKHPD Y1, Y0, Y13            // blocks 2,3 re
+    VMOVUPS Y12, (DX)
+    VMOVUPS Y13, 32(DX)
+    VUNPCKLPD Y3, Y2, Y12            // blocks 0,1 im
+    VUNPCKHPD Y3, Y2, Y13            // blocks 2,3 im
+    VMOVUPS Y12, (R8)
+    VMOVUPS Y13, 32(R8)
+
+    ADDQ $64, DX
+    ADDQ $64, R8
+    DECQ BX
+    JNZ  bfstage_span2_vec
+
+bfstage_span2_tail_pre:
+    ANDQ $3, AX                      // leftover blocks (0..3)
+    JZ   bfstage_done
+
+bfstage_span2_tail:
+    // One block, two j lanes: load each pair into the low 64 bits of an XMM
+    // (VMOVSD zeros the upper lanes, so the wide multiply's spare lanes are 0).
+    VMOVSD (DX), X4                  // [u0,u1]
+    VMOVSD 8(DX), X5                 // [l0,l1]
+    VMOVSD (R8), X8                  // [ui0,ui1]
+    VMOVSD 8(R8), X9                 // [li0,li1]
+
+    VMULPS X5, X6, X10               // lr*tr
+    VMULPS X9, X7, X11               // li*ti
+    VSUBPS X11, X10, X10             // temp_re
+    VMULPS X5, X7, X11               // lr*ti
+    VFMADD231PS X9, X6, X11          // temp_im
+
+    VADDPS X4, X10, X0
+    VSUBPS X10, X4, X1
+    VMOVSD X0, (DX)
+    VMOVSD X1, 8(DX)
+    VADDPS X8, X11, X2
+    VSUBPS X11, X8, X3
+    VMOVSD X2, (R8)
+    VMOVSD X3, 8(R8)
+
+    ADDQ $16, DX
+    ADDQ $16, R8
+    DECQ AX
+    JNZ  bfstage_span2_tail
+    JMP  bfstage_done
+
+// ---------------------------------------------------------------------------
+// span == 4: each block is [u0..u3,l0..l3], exactly one 128-bit half per side,
+// the float32 sibling of the f64 span == 2 path. Take 2 blocks (16 float32) at a
+// time; VPERM2F128 collects the two upper halves into one YMM and the two lower
+// halves into another. The twiddle quad repeats per block, which is one
+// memory-source VBROADCASTF128.
+// ---------------------------------------------------------------------------
+bfstage_span4:
+    VBROADCASTF128 (R9), Y6          // Y6 = [tr0,tr1,tr2,tr3] in both 128-bit halves
+    VBROADCASTF128 (R10), Y7         // Y7 = [ti0,ti1,ti2,ti3] in both halves
+
+    MOVQ AX, BX
+    SHRQ $1, BX                      // BX = blocks/2 = 2-block iterations
+    JZ   bfstage_span4_tail_pre
+
+bfstage_span4_vec:
+    VMOVUPS (DX), Y0                 // block0 re = [u0..u3,l0..l3]
+    VMOVUPS 32(DX), Y1               // block1 re
+    VPERM2F128 $0x20, Y1, Y0, Y4     // upper_re = [u0..u3,u0'..u3']
+    VPERM2F128 $0x31, Y1, Y0, Y5     // lower_re = [l0..l3,l0'..l3']
+    VMOVUPS (R8), Y2                 // block0 im
+    VMOVUPS 32(R8), Y3               // block1 im
+    VPERM2F128 $0x20, Y3, Y2, Y8     // upper_im
+    VPERM2F128 $0x31, Y3, Y2, Y9     // lower_im
+
+    VMULPS Y5, Y6, Y10
+    VMULPS Y9, Y7, Y11
+    VSUBPS Y11, Y10, Y10             // temp_re
+    VMULPS Y5, Y7, Y11
+    VFMADD231PS Y9, Y6, Y11          // temp_im
+
+    VADDPS Y4, Y10, Y0               // new upper_re
+    VSUBPS Y10, Y4, Y1               // new lower_re
+    VADDPS Y8, Y11, Y2               // new upper_im
+    VSUBPS Y11, Y8, Y3               // new lower_im
+
+    VPERM2F128 $0x20, Y1, Y0, Y12    // block0 re = [U0..U3,L0..L3]
+    VPERM2F128 $0x31, Y1, Y0, Y13    // block1 re
+    VMOVUPS Y12, (DX)
+    VMOVUPS Y13, 32(DX)
+    VPERM2F128 $0x20, Y3, Y2, Y12    // block0 im
+    VPERM2F128 $0x31, Y3, Y2, Y13    // block1 im
+    VMOVUPS Y12, (R8)
+    VMOVUPS Y13, 32(R8)
+
+    ADDQ $64, DX
+    ADDQ $64, R8
+    DECQ BX
+    JNZ  bfstage_span4_vec
+
+bfstage_span4_tail_pre:
+    ANDQ $1, AX                      // one leftover block at most
+    JZ   bfstage_done
+
+    // Single block, 4 lanes wide: XMM halves of the same broadcast twiddles.
+    VMOVUPS (DX), X4                 // [u0..u3]
+    VMOVUPS 16(DX), X5               // [l0..l3]
+    VMOVUPS (R8), X8                 // [ui0..ui3]
+    VMOVUPS 16(R8), X9               // [li0..li3]
+
+    VMULPS X5, X6, X10
+    VMULPS X9, X7, X11
+    VSUBPS X11, X10, X10             // temp_re
+    VMULPS X5, X7, X11
+    VFMADD231PS X9, X6, X11          // temp_im
+
+    VADDPS X4, X10, X0
+    VSUBPS X10, X4, X1
+    VMOVUPS X0, (DX)
+    VMOVUPS X1, 16(DX)
+    VADDPS X8, X11, X2
+    VSUBPS X11, X8, X3
+    VMOVUPS X2, (R8)
+    VMOVUPS X3, 16(R8)
+
+bfstage_done:
+    VZEROUPPER
+    RET
+
 // ============================================================================
 // REAL FFT UNPACK - UNPACKING STEP FOR REAL-VALUED FFT
 // ============================================================================

--- a/f32/f32_arm64.go
+++ b/f32/f32_arm64.go
@@ -884,6 +884,20 @@ func butterflyComplex32(upperRe, upperIm, lowerRe, lowerIm, twRe, twIm []float32
 	butterflyComplex32Go(upperRe, upperIm, lowerRe, lowerIm, twRe, twIm)
 }
 
+func butterflyComplexStage32(re, im []float32, span, blocks int, twRe, twIm []float32) {
+	// butterflyComplexStageNEON is correct for every span: across j when span
+	// fills a 4-wide vector, across blocks for span 1 and 2 (both below the
+	// float32 lane count). span 3 fills neither axis and runs entirely in the
+	// kernel's scalar tail, which still beats the Go fallback's call per block.
+	// One 4-wide iteration needs 4 lanes, so anything below 4 total butterflies
+	// falls to Go.
+	if hasNEON && blocks*span >= 4 {
+		butterflyComplexStageNEON(re, im, span, blocks, twRe, twIm)
+		return
+	}
+	butterflyComplexStage32Go(re, im, span, blocks, twRe, twIm)
+}
+
 func realFFTUnpack32(outRe, outIm, zRe, zIm, twRe, twIm []float32, n int) {
 	// Use NEON if available and have enough elements
 	// Need at least 5 elements: process k=1..n-1 where n>=5 gives 4+ iterations
@@ -905,6 +919,15 @@ func absSqComplexNEON(dst, aRe, aIm []float32)
 
 //go:noescape
 func butterflyComplexNEON(upperRe, upperIm, lowerRe, lowerIm, twRe, twIm []float32)
+
+// Callers MUST satisfy len(re) == len(im) == 2*span*blocks and
+// len(twRe) == len(twIm) >= span, with span >= 1 and blocks >= 1. Every address
+// the kernel forms is derived from span and blocks, never from the slice headers,
+// so a violated precondition reads and writes out of bounds silently rather than
+// panicking the way the Go fallback would. ButterflyComplexStage establishes it.
+//
+//go:noescape
+func butterflyComplexStageNEON(re, im []float32, span, blocks int, twRe, twIm []float32)
 
 //go:noescape
 func realFFTUnpackNEON(outRe, outIm, zRe, zIm, twRe, twIm []float32, n int)

--- a/f32/f32_arm64.s
+++ b/f32/f32_arm64.s
@@ -2697,6 +2697,304 @@ butterfly_neon_scalar_loop:
 butterfly_neon_done:
     RET
 
+// func butterflyComplexStageNEON(re, im []float32, span, blocks int, twRe, twIm []float32)
+// One complete radix-2 decimation-in-time stage, in place over split-complex
+// float32, NEON (4 float32 lanes per .4S register). The float32 sibling of
+// f64.butterflyComplexStageNEON: the vector is 4 wide instead of 2, so span 1 and
+// 2 vectorize across blocks (both below the lane count) while span >= 4 vectorizes
+// across j. span 3 fills neither axis and runs the j-axis scalar tail; real
+// radix-2 stages use only power-of-two spans, so that is a synthetic-test span.
+//
+// Every hand-encoded WORD carries its decoded mnemonic; asmcheck cross-checks each
+// against golang.org/x/arch/arm64asm. Frame:
+// re(24)+im(24)+span(8)+blocks(8)+twRe(24)+twIm(24) = 112 bytes.
+TEXT ·butterflyComplexStageNEON(SB), NOSPLIT, $0-112
+    MOVD re_base+0(FP), R0           // R0 = re block base
+    MOVD im_base+24(FP), R1          // R1 = im block base
+    MOVD span+48(FP), R4             // R4 = span
+    MOVD blocks+56(FP), R5           // R5 = block count
+    MOVD twRe_base+64(FP), R2        // R2 = twRe base
+    MOVD twIm_base+88(FP), R3        // R3 = twIm base
+
+    CBZ  R5, bfstage_neon_done
+    CMP  $1, R4
+    BEQ  bfstage_neon_span1
+    CMP  $2, R4
+    BEQ  bfstage_neon_span2
+
+    // ----------------------------------------------------------------------
+    // span >= 3: vectorize across j, four lanes per iteration, scalar tail for
+    // span%4. Pointers are reset from the block bases on every block. span 3
+    // has span/4 == 0, so it runs entirely in the scalar tail.
+    // ----------------------------------------------------------------------
+    LSL  $2, R4, R24                 // R24 = span*4 = upper->lower byte offset
+    LSL  $3, R4, R25                 // R25 = span*8 = block stride in bytes
+    LSR  $2, R4, R8                  // R8 = span/4 = vector iterations per block
+    AND  $3, R4, R9                  // R9 = span&3 = scalar butterflies per block
+
+bfstage_neon_block:
+    MOVD R0, R6                      // R6 = upper re
+    MOVD R1, R7                      // R7 = upper im
+    ADD  R24, R0, R19               // R19 = lower re
+    ADD  R24, R1, R20               // R20 = lower im
+    MOVD R2, R21                     // R21 = twRe
+    MOVD R3, R22                     // R22 = twIm
+    MOVD R8, R23                     // R23 = working copy of the vector count
+    CBZ  R23, bfstage_neon_tail_pre
+
+bfstage_neon_vec:
+    VLD1   (R19), [V2.S4]            // V2 = lowerRe[j:j+4]
+    VLD1   (R20), [V3.S4]            // V3 = lowerIm[j:j+4]
+    VLD1.P 16(R21), [V4.S4]          // V4 = twRe[j:j+4]
+    VLD1.P 16(R22), [V5.S4]          // V5 = twIm[j:j+4]
+    VLD1   (R6), [V0.S4]             // V0 = upperRe[j:j+4]
+    VLD1   (R7), [V1.S4]             // V1 = upperIm[j:j+4]
+
+    // tempRe = lowerRe*twRe - lowerIm*twIm
+    WORD $0x6E24DC46                 // FMUL V6.4S, V2.4S, V4.4S
+    WORD $0x4EA5CC66                 // FMLS V6.4S, V3.4S, V5.4S
+    // tempIm = lowerRe*twIm + lowerIm*twRe
+    WORD $0x6E25DC47                 // FMUL V7.4S, V2.4S, V5.4S
+    WORD $0x4E24CC67                 // FMLA V7.4S, V3.4S, V4.4S
+
+    WORD $0x4E26D408                 // FADD V8.4S, V0.4S, V6.4S  (new upperRe)
+    WORD $0x4EA6D40A                 // FSUB V10.4S, V0.4S, V6.4S (new lowerRe)
+    WORD $0x4E27D429                 // FADD V9.4S, V1.4S, V7.4S  (new upperIm)
+    WORD $0x4EA7D42B                 // FSUB V11.4S, V1.4S, V7.4S (new lowerIm)
+
+    VST1.P [V8.S4], 16(R6)
+    VST1.P [V9.S4], 16(R7)
+    VST1.P [V10.S4], 16(R19)
+    VST1.P [V11.S4], 16(R20)
+
+    SUB  $1, R23
+    CBNZ R23, bfstage_neon_vec
+
+bfstage_neon_tail_pre:
+    MOVD R9, R23                     // R23 = scalar butterflies remaining
+    CBZ  R23, bfstage_neon_next
+
+bfstage_neon_tail:
+    FMOVS (R19), F2                  // lowerRe
+    FMOVS (R20), F3                  // lowerIm
+    FMOVS (R21), F4                  // twRe
+    FMOVS (R22), F5                  // twIm
+    FMULS F2, F4, F6
+    FMULS F3, F5, F7
+    FSUBS F7, F6, F6                 // F6 = tempRe
+    FMULS F2, F5, F7
+    FMULS F3, F4, F8
+    FADDS F7, F8, F7                 // F7 = tempIm
+    FMOVS (R6), F0                   // upperRe
+    FMOVS (R7), F1                   // upperIm
+    FADDS F0, F6, F8
+    FSUBS F6, F0, F9
+    FADDS F1, F7, F10
+    FSUBS F7, F1, F11
+    FMOVS F8, (R6)
+    FMOVS F10, (R7)
+    FMOVS F9, (R19)
+    FMOVS F11, (R20)
+    ADD  $4, R6
+    ADD  $4, R7
+    ADD  $4, R19
+    ADD  $4, R20
+    ADD  $4, R21
+    ADD  $4, R22
+    SUB  $1, R23
+    CBNZ R23, bfstage_neon_tail
+
+bfstage_neon_next:
+    ADD  R25, R0, R0
+    ADD  R25, R1, R1
+    SUB  $1, R5
+    CBNZ R5, bfstage_neon_block
+    RET
+
+    // ----------------------------------------------------------------------
+    // span == 1: every block is one [u, l] pair, so re/im are fully
+    // interleaved. Take 4 blocks (8 float32) per iteration, UZP1/UZP2 (.4S) to
+    // separate the uppers from the lowers, ZIP1/ZIP2 (.4S) to re-interleave on
+    // the way out. The twiddle is the single tw[0], splatted once.
+    // ----------------------------------------------------------------------
+bfstage_neon_span1:
+    FMOVS (R2), F12
+    VDUP  V12.S[0], V12.S4           // V12 = twRe[0] in all four lanes
+    FMOVS (R3), F13
+    VDUP  V13.S[0], V13.S4           // V13 = twIm[0] in all four lanes
+
+    LSR  $2, R5, R23                 // R23 = blocks/4 = 4-block iterations
+    CBZ  R23, bfstage_neon_span1_tail_pre
+
+bfstage_neon_span1_vec:
+    VLD1 (R0), [V0.S4]               // V0 = [u0,l0,u1,l1] re
+    ADD  $16, R0, R6
+    VLD1 (R6), [V1.S4]               // V1 = [u2,l2,u3,l3] re
+    VLD1 (R1), [V4.S4]               // V4 = [u0,l0,u1,l1] im
+    ADD  $16, R1, R7
+    VLD1 (R7), [V5.S4]               // V5 = [u2,l2,u3,l3] im
+
+    WORD $0x4E811802                 // UZP1 V2.4S, V0.4S, V1.4S -> upperRe [u0,u1,u2,u3]
+    WORD $0x4E815803                 // UZP2 V3.4S, V0.4S, V1.4S -> lowerRe [l0,l1,l2,l3]
+    WORD $0x4E851886                 // UZP1 V6.4S, V4.4S, V5.4S -> upperIm
+    WORD $0x4E855887                 // UZP2 V7.4S, V4.4S, V5.4S -> lowerIm
+
+    // tempRe = lowerRe*twRe - lowerIm*twIm
+    WORD $0x6E2CDC68                 // FMUL V8.4S, V3.4S, V12.4S
+    WORD $0x4EADCCE8                 // FMLS V8.4S, V7.4S, V13.4S
+    // tempIm = lowerRe*twIm + lowerIm*twRe
+    WORD $0x6E2DDC69                 // FMUL V9.4S, V3.4S, V13.4S
+    WORD $0x4E2CCCE9                 // FMLA V9.4S, V7.4S, V12.4S
+
+    WORD $0x4E28D44A                 // FADD V10.4S, V2.4S, V8.4S  (new upperRe)
+    WORD $0x4EA8D44B                 // FSUB V11.4S, V2.4S, V8.4S  (new lowerRe)
+    WORD $0x4E29D4CE                 // FADD V14.4S, V6.4S, V9.4S  (new upperIm)
+    WORD $0x4EA9D4CF                 // FSUB V15.4S, V6.4S, V9.4S  (new lowerIm)
+
+    WORD $0x4E8B3940                 // ZIP1 V0.4S, V10.4S, V11.4S -> [U0,L0,U1,L1] re
+    WORD $0x4E8B7941                 // ZIP2 V1.4S, V10.4S, V11.4S -> [U2,L2,U3,L3] re
+    WORD $0x4E8F39C4                 // ZIP1 V4.4S, V14.4S, V15.4S -> im
+    WORD $0x4E8F79C5                 // ZIP2 V5.4S, V14.4S, V15.4S -> im
+
+    VST1.P [V0.S4], 16(R0)
+    VST1.P [V1.S4], 16(R0)
+    VST1.P [V4.S4], 16(R1)
+    VST1.P [V5.S4], 16(R1)
+
+    SUB  $1, R23
+    CBNZ R23, bfstage_neon_span1_vec
+
+bfstage_neon_span1_tail_pre:
+    AND  $3, R5, R23                 // leftover blocks (0..3)
+    CBZ  R23, bfstage_neon_done
+
+bfstage_neon_span1_tail:
+    FMOVS 4(R0), F2                  // lowerRe
+    FMOVS 4(R1), F3                  // lowerIm
+    // F12/F13 lane 0 still hold twRe[0]/twIm[0]: the vector loop only reads
+    // V12/V13, never writes them, so no reload is needed.
+    FMULS F2, F12, F6
+    FMULS F3, F13, F7
+    FSUBS F7, F6, F6                 // tempRe
+    FMULS F2, F13, F7
+    FMULS F3, F12, F8
+    FADDS F7, F8, F7                 // tempIm
+    FMOVS (R0), F0                   // upperRe
+    FMOVS (R1), F1                   // upperIm
+    FADDS F0, F6, F8
+    FSUBS F6, F0, F9
+    FADDS F1, F7, F10
+    FSUBS F7, F1, F11
+    FMOVS F8, (R0)
+    FMOVS F10, (R1)
+    FMOVS F9, 4(R0)
+    FMOVS F11, 4(R1)
+    ADD  $8, R0
+    ADD  $8, R1
+    SUB  $1, R23
+    CBNZ R23, bfstage_neon_span1_tail
+    RET
+
+    // ----------------------------------------------------------------------
+    // span == 2: each block is [u0,u1,l0,l1], and a float32 pair is exactly one
+    // 64-bit lane, so UZP1/UZP2 (.2D) gather two blocks' upper pairs into one
+    // register and their lower pairs into another, ZIP1/ZIP2 (.2D) put them
+    // back. Arithmetic is .4S (2 blocks x 2 j). The twiddle pair [tr0,tr1]
+    // repeats per block, splatted once with FMOVD + VDUP (.D).
+    // ----------------------------------------------------------------------
+bfstage_neon_span2:
+    FMOVD (R2), F12
+    VDUP  V12.D[0], V12.D2           // V12 = [tr0,tr1,tr0,tr1]
+    FMOVD (R3), F13
+    VDUP  V13.D[0], V13.D2           // V13 = [ti0,ti1,ti0,ti1]
+
+    LSR  $1, R5, R23                 // R23 = blocks/2 = 2-block iterations
+    CBZ  R23, bfstage_neon_span2_tail_pre
+
+bfstage_neon_span2_vec:
+    VLD1 (R0), [V0.S4]               // block0 re = [u0,u1,l0,l1]
+    ADD  $16, R0, R6
+    VLD1 (R6), [V1.S4]               // block1 re
+    VLD1 (R1), [V4.S4]               // block0 im
+    ADD  $16, R1, R7
+    VLD1 (R7), [V5.S4]               // block1 im
+
+    WORD $0x4EC11802                 // UZP1 V2.2D, V0.2D, V1.2D -> upperRe [u0,u1,u0',u1']
+    WORD $0x4EC15803                 // UZP2 V3.2D, V0.2D, V1.2D -> lowerRe [l0,l1,l0',l1']
+    WORD $0x4EC51886                 // UZP1 V6.2D, V4.2D, V5.2D -> upperIm
+    WORD $0x4EC55887                 // UZP2 V7.2D, V4.2D, V5.2D -> lowerIm
+
+    // tempRe = lowerRe*twRe - lowerIm*twIm
+    WORD $0x6E2CDC68                 // FMUL V8.4S, V3.4S, V12.4S
+    WORD $0x4EADCCE8                 // FMLS V8.4S, V7.4S, V13.4S
+    // tempIm = lowerRe*twIm + lowerIm*twRe
+    WORD $0x6E2DDC69                 // FMUL V9.4S, V3.4S, V13.4S
+    WORD $0x4E2CCCE9                 // FMLA V9.4S, V7.4S, V12.4S
+
+    WORD $0x4E28D44A                 // FADD V10.4S, V2.4S, V8.4S  (new upperRe)
+    WORD $0x4EA8D44B                 // FSUB V11.4S, V2.4S, V8.4S  (new lowerRe)
+    WORD $0x4E29D4CE                 // FADD V14.4S, V6.4S, V9.4S  (new upperIm)
+    WORD $0x4EA9D4CF                 // FSUB V15.4S, V6.4S, V9.4S  (new lowerIm)
+
+    WORD $0x4ECB3940                 // ZIP1 V0.2D, V10.2D, V11.2D -> [u0,u1,l0,l1] block0 re
+    WORD $0x4ECB7941                 // ZIP2 V1.2D, V10.2D, V11.2D -> block1 re
+    WORD $0x4ECF39C4                 // ZIP1 V4.2D, V14.2D, V15.2D -> block0 im
+    WORD $0x4ECF79C5                 // ZIP2 V5.2D, V14.2D, V15.2D -> block1 im
+
+    VST1.P [V0.S4], 16(R0)
+    VST1.P [V1.S4], 16(R0)
+    VST1.P [V4.S4], 16(R1)
+    VST1.P [V5.S4], 16(R1)
+
+    SUB  $1, R23
+    CBNZ R23, bfstage_neon_span2_vec
+
+bfstage_neon_span2_tail_pre:
+    AND  $1, R5, R23                 // one leftover block at most
+    CBZ  R23, bfstage_neon_done
+
+    // Single block: two scalar butterflies at j = 0 and j = 1. R4 == span == 2.
+    MOVD R0, R6                      // upper re
+    MOVD R1, R7                      // upper im
+    ADD  $8, R0, R19                 // lower re = upper + span*4
+    ADD  $8, R1, R20                 // lower im
+    MOVD R2, R21                     // twRe
+    MOVD R3, R22                     // twIm
+    MOVD R4, R23                     // span = 2 butterflies
+
+bfstage_neon_span2_tail_loop:
+    FMOVS (R19), F2                  // lowerRe
+    FMOVS (R20), F3                  // lowerIm
+    FMOVS (R21), F4                  // twRe
+    FMOVS (R22), F5                  // twIm
+    FMULS F2, F4, F6
+    FMULS F3, F5, F7
+    FSUBS F7, F6, F6                 // tempRe
+    FMULS F2, F5, F7
+    FMULS F3, F4, F8
+    FADDS F7, F8, F7                 // tempIm
+    FMOVS (R6), F0                   // upperRe
+    FMOVS (R7), F1                   // upperIm
+    FADDS F0, F6, F8
+    FSUBS F6, F0, F9
+    FADDS F1, F7, F10
+    FSUBS F7, F1, F11
+    FMOVS F8, (R6)
+    FMOVS F10, (R7)
+    FMOVS F9, (R19)
+    FMOVS F11, (R20)
+    ADD  $4, R6
+    ADD  $4, R7
+    ADD  $4, R19
+    ADD  $4, R20
+    ADD  $4, R21
+    ADD  $4, R22
+    SUB  $1, R23
+    CBNZ R23, bfstage_neon_span2_tail_loop
+
+bfstage_neon_done:
+    RET
+
 // ============================================================================
 // REAL FFT UNPACK - UNPACKING STEP FOR REAL-VALUED FFT
 // ============================================================================

--- a/f32/f32_go.go
+++ b/f32/f32_go.go
@@ -921,6 +921,20 @@ func butterflyComplex32Go(upperRe, upperIm, lowerRe, lowerIm, twRe, twIm []float
 	}
 }
 
+// butterflyComplexStage32Go applies one radix-2 decimation-in-time stage in
+// place over split-complex data. blocks is the number of complete 2*span
+// blocks; the caller has already reconciled it against len(re)/len(im).
+func butterflyComplexStage32Go(re, im []float32, span, blocks int, twRe, twIm []float32) {
+	tr, ti := twRe[:span], twIm[:span]
+	for b := range blocks {
+		k := b * butterflyStageRadix * span
+		mid, end := k+span, k+butterflyStageRadix*span
+		upRe, upIm := re[k:mid:mid], im[k:mid:mid]
+		loRe, loIm := re[mid:end:end], im[mid:end:end]
+		butterflyComplex32Go(upRe, upIm, loRe, loIm, tr, ti)
+	}
+}
+
 // realFFTUnpackHalf is the constant 0.5 used in real FFT unpack computation.
 const realFFTUnpackHalf = 0.5
 

--- a/f32/f32_other.go
+++ b/f32/f32_other.go
@@ -92,6 +92,9 @@ func absSqComplex32(dst, aRe, aIm []float32) { absSqComplex32Go(dst, aRe, aIm) }
 func butterflyComplex32(upperRe, upperIm, lowerRe, lowerIm, twRe, twIm []float32) {
 	butterflyComplex32Go(upperRe, upperIm, lowerRe, lowerIm, twRe, twIm)
 }
+func butterflyComplexStage32(re, im []float32, span, blocks int, twRe, twIm []float32) {
+	butterflyComplexStage32Go(re, im, span, blocks, twRe, twIm)
+}
 func realFFTUnpack32(outRe, outIm, zRe, zIm, twRe, twIm []float32, n int) {
 	realFFTUnpack32Go(outRe, outIm, zRe, zIm, twRe, twIm, n)
 }


### PR DESCRIPTION
## Summary

The float32 sibling of `f64.ButterflyComplexStage` (#207). It applies one complete radix-2 decimation-in-time FFT stage in place over split-complex data, so the kernel picks its own vectorization axis rather than paying one call per block through the per-block `ButterflyComplex`.

The float32 vector is 8 lanes on AVX (vs 4 for f64) and 4 on NEON (vs 2), so the span thresholds shift. The AVX kernel vectorizes across blocks for span 1 (VSHUFPS deinterleave), span 2 (VUNPCKLPD, treating float32 pairs as 64-bit lanes) and span 4 (VPERM2F128), and across j for span >= 8; the NEON kernel across blocks for span 1 and 2 (UZP/ZIP), across j for span >= 4. Spans that fill neither axis run the scalar tail. The kernel is AVX+FMA only with no AVX2 (checked by `TestAmd64KernelISALevel`), and the new NEON `WORD` encodings are cross-checked against `arm64asm` by asmcheck.

## Benchmarks

Stage vs the per-block `ButterflyComplex` loop, over a 1024-point stage's worth of butterflies (blocks*span constant), interleaved on an idle host:

| span | amd64 (i7-1260P) | arm64 (Pi 5 Cortex-A76) |
|---|---|---|
| 1 | 33.7x | 14.3x |
| 2 | 24.4x | 8.3x |
| 4 | 13.9x | 5.4x |
| 8 | 7.2x | 3.4x |
| 16 | 4.1x | 2.6x |

The small-span block-axis paths are the biggest wins, and those are the early FFT stages with the most blocks, i.e. the hot part of the STFT transform core.

## Correctness

The Go reference is the source of truth; the AVX and NEON kernels have a scalar tail. Parity against the reference is within 9.54e-7 on both arches (the vector and Go paths fuse differently and are not bit-identical, matching the f64 primitive). Coverage: zero-allocation assertion, differential parity vs the reference and vs the per-block loop, degenerate-input no-ops, partial-block-untouched, and a full iterative Cooley-Tukey FFT test that walks every vectorization path in sequence against a naive DFT. Verified on an AVX+FMA amd64 core and a Pi 5 Cortex-A76.

## Test Plan

- [x] `go test ./f32/` (amd64, native)
- [x] cross-compiled and ran the f32 test binary on real arm64 hardware (Pi 5)
- [x] asmcheck WORD cross-check, AVX ISA-level and FMA-gate checks, register-clobber check
- [x] mutation-tested: a sign flip in the AVX and NEON span-1 paths is caught on both arches

This unblocks the f32 half of #205 (wiring the STFT transform core onto the stage kernel).

Closes #229

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added float32 FFT butterfly-stage processing across complete data blocks.
  * Added architecture-optimized acceleration for supported platforms, with a portable fallback.
  * Preserves incomplete trailing data and handles empty or degenerate inputs safely.

* **Bug Fixes**
  * Improved validation for data spans and twiddle-factor lengths.

* **Tests**
  * Added comprehensive correctness, boundary, parity, allocation, and performance coverage.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->