### PR TITLE
f32: wire the STFT transform core onto ButterflyComplexStage

### DIFF
--- a/f32/stft.go
+++ b/f32/stft.go
@@ -28,9 +28,10 @@ import (
 //
 // The transform runs in float32 to match the rest of the f32 package; the
 // twiddle and unravel tables are computed in float64 and rounded once to float32
-// so the resident constants carry full precision. This first cut is a correct
-// scalar radix-2 transform (power-of-two nfft only); vectorizing the inner
-// butterfly is a separate, profile-gated change. See #108.
+// so the resident constants carry full precision. It is a radix-2 rfft
+// (power-of-two nfft only); its butterfly stages run through ButterflyComplexStage,
+// so they take the AVX+FMA / NEON vector paths where the span and block count
+// justify them and fall back to scalar Go otherwise. See #108 and #205.
 
 // ErrSTFT* describe invalid STFTPlan configurations.
 var (
@@ -76,9 +77,12 @@ type STFTPlan struct {
 
 	bitrev []int // bit-reversal permutation for the size-half FFT
 
-	// Twiddles for the size-half radix-2 FFT: twRe[t] = cos(2*pi*t/half),
-	// twIm[t] = -sin(2*pi*t/half) for t in [0, half/2).
-	twRe, twIm []float32
+	// Per-stage contiguous twiddles for the size-half radix-2 FFT, so each stage
+	// can be driven through ButterflyComplexStage (which reads its twiddles
+	// contiguous in j over [0, span)). Stage m in {2,4,...,half} uses span = m/2
+	// factors W_m^j = exp(-i*2*pi*j/m) for j in [0, span); the stage with span s
+	// occupies stageTwRe[s-1 : 2*s-1], and the tables total half-1 entries.
+	stageTwRe, stageTwIm []float32
 
 	// Unravel twiddles W_N^k = exp(-i*2*pi*k/nfft) for k in [0, half], used to
 	// recombine the even/odd half-spectra into the real-input spectrum.
@@ -104,15 +108,15 @@ func NewSTFTPlan(nfft int) (*STFTPlan, error) {
 	half := nfft >> 1
 
 	p := &STFTPlan{
-		nfft:   nfft,
-		half:   half,
-		bitrev: make([]int, half),
-		twRe:   make([]float32, max(half>>1, 1)),
-		twIm:   make([]float32, max(half>>1, 1)),
-		unRe:   make([]float32, half+1),
-		unIm:   make([]float32, half+1),
-		re:     make([]float32, half),
-		im:     make([]float32, half),
+		nfft:      nfft,
+		half:      half,
+		bitrev:    make([]int, half),
+		stageTwRe: make([]float32, max(half-1, 0)),
+		stageTwIm: make([]float32, max(half-1, 0)),
+		unRe:      make([]float32, half+1),
+		unIm:      make([]float32, half+1),
+		re:        make([]float32, half),
+		im:        make([]float32, half),
 	}
 
 	// Bit-reversal permutation for a size-half FFT.
@@ -128,12 +132,18 @@ func NewSTFTPlan(nfft int) (*STFTPlan, error) {
 		p.bitrev[i] = r
 	}
 
-	// Size-half FFT twiddles (computed in float64, stored as float32).
-	for t := range p.twRe {
-		ang := 2 * math.Pi * float64(t) / float64(half)
-		s, c := math.Sincos(ang)
-		p.twRe[t] = float32(c)
-		p.twIm[t] = float32(-s)
+	// Per-stage contiguous FFT twiddles (computed in float64, stored as float32):
+	// stage m in {2,4,...,half} writes its span = m/2 factors
+	// W_m^j = exp(-i*2*pi*j/m) starting at offset span-1.
+	for m := 2; m <= half; m <<= 1 {
+		span := m >> 1
+		off := span - 1
+		for j := range span {
+			ang := 2 * math.Pi * float64(j) / float64(m)
+			s, c := math.Sincos(ang)
+			p.stageTwRe[off+j] = float32(c)
+			p.stageTwIm[off+j] = float32(-s)
+		}
 	}
 
 	// Real-input unravel twiddles W_N^k.
@@ -148,7 +158,9 @@ func NewSTFTPlan(nfft int) (*STFTPlan, error) {
 }
 
 // fftHalf runs an in-place size-half radix-2 decimation-in-time complex FFT on
-// the plan's scratch (p.re, p.im), using the resident bit-reversal and twiddles.
+// the plan's scratch (p.re, p.im), using the resident bit-reversal and per-stage
+// twiddles. Each stage is one ButterflyComplexStage call, so the butterflies take
+// the AVX+FMA / NEON vector paths where the span and block count justify them.
 func (p *STFTPlan) fftHalf() {
 	re, im := p.re, p.im
 	// Bit-reversal reorder.
@@ -158,24 +170,12 @@ func (p *STFTPlan) fftHalf() {
 			im[i], im[j] = im[j], im[i]
 		}
 	}
-	// Butterfly stages.
+	// Butterfly stages. Stage m operates on span = m/2 with block stride m; its
+	// contiguous twiddles live at stageTwRe/stageTwIm[span-1 : 2*span-1].
 	for m := 2; m <= p.half; m <<= 1 {
-		halfM := m >> 1
-		step := p.half / m // twiddle stride into twRe/twIm
-		for k := 0; k < p.half; k += m {
-			for j := range halfM {
-				idx := j * step
-				wr, wi := p.twRe[idx], p.twIm[idx]
-				a := k + j
-				b := a + halfM
-				vr := wr*re[b] - wi*im[b]
-				vi := wr*im[b] + wi*re[b]
-				re[b] = re[a] - vr
-				im[b] = im[a] - vi
-				re[a] += vr
-				im[a] += vi
-			}
-		}
+		span := m >> 1
+		off := span - 1
+		ButterflyComplexStage(re, im, span, p.stageTwRe[off:off+span], p.stageTwIm[off:off+span])
 	}
 }
 

--- a/f32/stft_test.go
+++ b/f32/stft_test.go
@@ -124,6 +124,43 @@ func TestSTFTAgainstDFTF32(t *testing.T) {
 	}
 }
 
+// TestSTFTStageTwiddles pins the per-stage contiguous twiddle layout that
+// fftHalf and ButterflyComplexStage share: the table holds max(half-1, 0)
+// entries, and stage m in {2,4,...,half} keeps its span=m/2 factors
+// W_m^j = (cos(2*pi*j/m), -sin(2*pi*j/m)) at offset span-1. An off-by-one in the
+// offset or a wrong table length would put the wrong factor at [off+j] and fail
+// here, localized, rather than only surfacing as a spectrum mismatch downstream.
+// The f32 sibling of f64's TestSTFTStageTwiddles; the tolerance is float32-scale
+// (the factors are stored as float32 rounded once from a float64 sincos).
+func TestSTFTStageTwiddles(t *testing.T) {
+	for _, nfft := range []int{2, 4, 8, 16, 256, 1024} {
+		p, err := NewSTFTPlan(nfft)
+		if err != nil {
+			t.Fatalf("nfft=%d: NewSTFTPlan: %v", nfft, err)
+		}
+		half := nfft >> 1
+		wantLen := max(half-1, 0)
+		if len(p.stageTwRe) != wantLen || len(p.stageTwIm) != wantLen {
+			t.Fatalf("nfft=%d: twiddle table len = (%d,%d), want %d",
+				nfft, len(p.stageTwRe), len(p.stageTwIm), wantLen)
+		}
+		for m := 2; m <= half; m <<= 1 {
+			span := m >> 1
+			off := span - 1
+			for j := range span {
+				ang := 2 * math.Pi * float64(j) / float64(m)
+				s, c := math.Sincos(ang)
+				if d := math.Abs(float64(p.stageTwRe[off+j]) - c); d > 1e-6 {
+					t.Errorf("nfft=%d m=%d j=%d: stageTwRe=%g want %g", nfft, m, j, p.stageTwRe[off+j], c)
+				}
+				if d := math.Abs(float64(p.stageTwIm[off+j]) - (-s)); d > 1e-6 {
+					t.Errorf("nfft=%d m=%d j=%d: stageTwIm=%g want %g", nfft, m, j, p.stageTwIm[off+j], -s)
+				}
+			}
+		}
+	}
+}
+
 // TestSTFTPowerMatchesSTFTF32 verifies STFTPower equals |STFT|^2 bin-for-bin
 // (both derive from the same unravel, so the agreement is essentially exact).
 func TestSTFTPowerMatchesSTFTF32(t *testing.T) {

--- a/f32/stft_test.go
+++ b/f32/stft_test.go
@@ -150,11 +150,16 @@ func TestSTFTStageTwiddles(t *testing.T) {
 			for j := range span {
 				ang := 2 * math.Pi * float64(j) / float64(m)
 				s, c := math.Sincos(ang)
-				if d := math.Abs(float64(p.stageTwRe[off+j]) - c); d > 1e-6 {
-					t.Errorf("nfft=%d m=%d j=%d: stageTwRe=%g want %g", nfft, m, j, p.stageTwRe[off+j], c)
+				// NewSTFTPlan stores float32(c)/float32(-s) from this same float64
+				// sincos, so the stored bits must match exactly (same machine, same
+				// expression); an exact check catches any factor corruption a loose
+				// tolerance would let pass.
+				wantRe, wantIm := float32(c), float32(-s)
+				if math.Float32bits(p.stageTwRe[off+j]) != math.Float32bits(wantRe) {
+					t.Errorf("nfft=%d m=%d j=%d: stageTwRe=%g want %g", nfft, m, j, p.stageTwRe[off+j], wantRe)
 				}
-				if d := math.Abs(float64(p.stageTwIm[off+j]) - (-s)); d > 1e-6 {
-					t.Errorf("nfft=%d m=%d j=%d: stageTwIm=%g want %g", nfft, m, j, p.stageTwIm[off+j], -s)
+				if math.Float32bits(p.stageTwIm[off+j]) != math.Float32bits(wantIm) {
+					t.Errorf("nfft=%d m=%d j=%d: stageTwIm=%g want %g", nfft, m, j, p.stageTwIm[off+j], wantIm)
 				}
 			}
 		}


### PR DESCRIPTION
## Summary

`fftHalf` now drives each radix-2 stage through `f32.ButterflyComplexStage` (#229, merged in #230) instead of the inline scalar butterfly, and `NewSTFTPlan` precomputes per-stage contiguous twiddle tables (stage m holds span = m/2 factors `W_m^j = exp(-i*2*pi*j/m)` at offset span-1, half-1 entries total). This is the f32 half of #205; the f64 half shipped in #227.

The strided-to-contiguous twiddle mapping is exact: half/m is a power of two, so `cos(2*pi*(j*(half/m))/half)` and `cos(2*pi*j/m)` reduce to the same dyadic argument and store bit-identical float32 factors. The vector paths fuse where the old scalar loop did not, so output moves about 1e-7 relative; the Go fallback path stays bit-identical to the old code.

## Benchmarks

Whole-transform, nfft=1024 hop=768 (the librosa/BSG-BAT mel front-end shape), single core:

| bench | amd64 (i7-1260P) | arm64 (Pi 5) |
|---|---|---|
| STFT | -56.7% (2.31x) | -46.4% (1.87x) |
| STFTPower | -56.7% (2.31x) | -46.0% (1.85x) |

The whole-transform figures are diluted by the still-scalar frame packing and `unravelBin`, so the transform-core speedup is larger than these end-to-end numbers. Zero allocations preserved.

## Correctness

The naive-DFT parity, the librosa 0.11.0 golden (nfft=1024, hop=768), and the same-path `STFTPowerInto`-vs-`STFTPower` check all hold with the existing float32 tolerances; a 467k-execution differential fuzz against a direct DFT also passed. FMA rounds once instead of twice, so the vector result moves toward the float64 reference, not away. Verified on an AVX+FMA amd64 core and a Pi 5 Cortex-A76.

## Test Plan

- [x] `go test ./f32/` (amd64, native) including STFT parity, librosa golden, alloc-free
- [x] cross-compiled and ran the f32 test suite on real arm64 hardware (Pi 5)
- [x] benchmarked STFT/STFTPower against main on both arches

Closes #205

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Performance**
  * Improved real-time signal-processing performance on supported AVX/FMA and NEON hardware.
  * Added optimized vectorized FFT processing with automatic fallback on other systems.
  * Improved FFT processing consistency across different transform sizes.

* **Documentation**
  * Updated FFT documentation to describe the optimized processing implementation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->