### PR TITLE
docs: document the amd64 asmcheck ISA and dispatch checks

### DIFF
--- a/docs/assembly-encoding.md
+++ b/docs/assembly-encoding.md
@@ -88,6 +88,40 @@ way in.
 - `PADDD`/`PADDL` and `PSRLDQ`/`PSRLO` are accepted as aliases.
 - `PSHUFD`, `MOVWLSX`, `CMOVQLT` all assemble under their familiar names.
 
+## AMD64: ISA-level and dispatch checks on kernels
+
+Beyond spelling, an amd64 kernel is machine-checked against the CPU features its
+name claims and its dispatch actually guards. All three checks below are pure
+source analysis, so they run on any host and fail the suite with an actionable
+message rather than letting a mis-gated kernel SIGILL on hardware CI does not own.
+The authoritative write-up is the `CLAUDE.md` section "AMD64: the dispatch guard is
+machine-checked, on two axes", and the enforcing tests named below are the source
+of truth for the exact encodings and tiers each one covers. This is the short
+pointer version, so a contributor adding a kernel meets the constraints here in the
+assembly guide and follows the reference for the full rationale:
+
+- **Name versus body** (`TestAmd64KernelISALevel`, `asmcheck_amd64_isa_test.go`,
+  #200). A kernel named `...AVX` may not contain an AVX2-only encoding. The traps
+  are register-source `VBROADCASTSS`/`VBROADCASTSD` and any 256-bit integer op,
+  since AVX1's YMM support is float-only. A kernel that genuinely needs AVX2 under
+  an `...AVX` name goes in `avx2GatedAVXKernels` alongside the gate that protects
+  it; renaming it to `...AVX2` is the better fix.
+- **Dispatch versus body, AVX2** (`TestAmd64KernelDispatchRequiresAVX2`,
+  `asmcheck_amd64_gate_test.go`, #200). The Go guard selecting an AVX2 kernel must
+  actually require AVX2, checked by dominance over the dispatch rather than by the
+  word appearing somewhere in the function.
+- **Dispatch versus body, FMA3** (`TestAmd64InitTierFMA` and
+  `TestAmd64KernelDispatchRequiresFMA`, `asmcheck_amd64_fma_test.go`, #201).
+  `cpu.X86.FMA` is a CPUID bit separate from AVX, so a `VFMADD`-family instruction
+  needs its own conjunct in the guard. A kernel using one may not be assigned by
+  `initAVXNoFMA`, `initSSE`, `initSSE2` or `initGo`, nor dispatched from a branch
+  testing only `cpu.X86.AVX`.
+
+`TestNoFMAContract` is unrelated despite the name. It forbids fusing in the kernels
+listed in `singleRoundingKernels`, which is the #156 contract about where rounding
+happens, not a CPU-feature check, and it applies to both architectures (it is the
+same test flagged in the ARM64 FMA caveat above).
+
 ## Verifying a new WORD encoding without aarch64 binutils
 
 `aarch64-linux-gnu-as` / `objdump` are not installed on every dev box. The working


### PR DESCRIPTION
Fixes #226.

`docs/assembly-encoding.md` presented `asmcheck` as the ARM64 `WORD`-encoding checker only and said nothing about the three machine-checked constraints an amd64 kernel now has to satisfy, so a contributor adding one would hit them without any warning from the assembly guide. This adds a short "AMD64: ISA-level and dispatch checks on kernels" section that states the three constraints, names the test enforcing each and its file, and points at `CLAUDE.md` for the full rationale rather than duplicating it.

The three constraints, briefly: name versus body (`TestAmd64KernelISALevel`, a `...AVX` kernel may not contain an AVX2-only encoding), dispatch versus body for AVX2 (`TestAmd64KernelDispatchRequiresAVX2`, the guard must require AVX2 by dominance), and dispatch versus body for FMA3 (`TestAmd64InitTierFMA` and `TestAmd64KernelDispatchRequiresFMA`, an FMA-using kernel needs its own `cpu.X86.FMA` conjunct and may not be assigned by an FMA-free init tier). The section also notes that `TestNoFMAContract` is unrelated despite the name: it is the #156 single-rounding contract over `singleRoundingKernels` and applies to both architectures.

The content already exists in `CLAUDE.md` (added in a prior change) and is current, so I deliberately kept this a short pointer rather than a second full copy that could drift. The intro designates `CLAUDE.md` and the enforcing tests as the source of truth for the exact encodings and tiers, so this section is unambiguously the discoverability echo, not a competing authority.

Docs-only change. `go build ./...` and `go vet ./...` pass; I verified every referenced symbol, test name, file attribution, and issue number against the actual test sources.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added guidance on validating AMD64 kernel instruction-set levels and dispatch behavior.
  * Documented AVX/AVX2 naming checks, AVX2 dispatch guards, and separate FMA3 feature gating.
  * Clarified the distinction between feature validation and the single-rounding FMA contract.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->