### PR TITLE
f64: fused RealFFTPower (single-pass power-spectrum unpack)

### DIFF
--- a/README.md
+++ b/README.md
@@ -157,7 +157,7 @@ sum := crc.Checksum16(p) // bit-identical to the scalar reference, zero-alloc
 **Scope:** `f64` carries the FLAC/LPC and scientific double-precision surface,
 including `Autocorrelate` (lag-vectorized LPC autocorrelation) and the split-format
 FFT butterfly building blocks (`ButterflyComplex`, `ButterflyComplexStage`,
-`RealFFTUnpack`) that a double-precision FFT/STFT path needs. The broader
+`RealFFTUnpack`, `RealFFTPower`) that a double-precision FFT/STFT path needs. The broader
 audio/ML helpers (PCM conversions, the general split-format complex ops such as
 `MulComplex` / `AbsSqComplex`, indexed/strided dot products) live in `f32`
 instead, so the two float surfaces remain intentionally asymmetric.
@@ -221,6 +221,7 @@ roughly 30x to under 2x, so the small-span stages stop dominating the transform.
 | **Complex/FFT** | `ButterflyComplex(uRe,uIm,lRe,lIm,twRe,twIm)` | FFT butterfly with twiddle multiply | 4x (AVX+FMA) / 2x (NEON)   |
 |                 | `ButterflyComplexStage(re,im,span,twRe,twIm)` | One whole radix-2 DIT stage (any span) | 4x (AVX+FMA) / 2x (NEON)   |
 |                 | `RealFFTUnpack(outRe,outIm,zRe,zIm,twRe,twIm)` | Real-FFT even/odd unpack step | 4x (AVX2) / 2x (NEON)       |
+|                 | `RealFFTPower(dst,zRe,zIm,twRe,twIm)`         | Fused real-FFT power spectrum \|X_k\|^2 (single pass) | 4x (AVX2) / 2x (NEON)       |
 | **Audio**       | `Interleave2(dst, a, b)`            | Pack stereo: [L,R,L,R,...]    | 4x / 2x                             |
 |                 | `Deinterleave2(a, b, src)`          | Unpack stereo to channels     | 4x / 2x                             |
 |                 | `InterleaveN(dst, srcs)`            | Pack N planar streams (any N; N-stream Interleave2) | N=2,4,8 AVX, N=3,6 AVX2 / N=2,3,4 NEON; else Go |

--- a/asmcheck_amd64_isa_test.go
+++ b/asmcheck_amd64_isa_test.go
@@ -79,6 +79,7 @@ var avx2GatedAVXKernels = map[string]string{
 	"f64/f64_amd64.s:powElemAVX":       f64LogGate,
 	"f64/f64_amd64.s:autocorrStep4AVX": "f64_amd64.go autocorrelate64: hasAVX2 early-out",
 	"f64/f64_amd64.s:realFFTUnpackAVX": "f64_amd64.go realFFTUnpack64: hasAVX2 && cpu.X86.FMA",
+	"f64/f64_amd64.s:realFFTPowerAVX":  "f64_amd64.go realFFTPower64: hasAVX2 && cpu.X86.FMA",
 }
 
 // TestAmd64KernelISALevel asserts that no AMD64 kernel uses an instruction above

--- a/doc.go
+++ b/doc.go
@@ -94,7 +94,7 @@
 //
 // Spectral (f64, f32): STFTPlan (NewSTFTPlan, STFT, STFTPower, STFTPowerInto, NumFrames) - fused real-input short-time Fourier transform with optional librosa-style center=true framing (PadMode: NoPad/PadZero/PadReflect)
 //
-// FFT primitives (f64, f32): ButterflyComplex (radix-2 butterfly with twiddle multiply, split-complex), RealFFTUnpack (real-FFT even/odd unpack step); f64 additionally has ButterflyComplexStage, one whole radix-2 decimation-in-time stage at any span, which picks its vectorization axis from the span
+// FFT primitives (f64, f32): ButterflyComplex (radix-2 butterfly with twiddle multiply, split-complex), RealFFTUnpack (real-FFT even/odd unpack step); f64 additionally has ButterflyComplexStage, one whole radix-2 decimation-in-time stage at any span, which picks its vectorization axis from the span, and RealFFTPower, the fused power-writing counterpart of RealFFTUnpack that emits the |X_k|^2 power spectrum in one pass
 //
 // Integer DSP (i16): Interleave2, Deinterleave2, DotProduct, DotProductUnsafe, XCorr (widening int16 x int16 -> wrapping int32; ARM64 SMLAL/SMLAL2, amd64 PMADDWD/VPMADDWD; XCorr evaluates 4 correlation lags per kernel call), Abs, MaxAbs, MulQ15 (wrapping 16-bit absolute value, widened abs-max, rounding Q15 multiply)
 //

--- a/f64/f64.go
+++ b/f64/f64.go
@@ -1047,11 +1047,12 @@ func RealFFTUnpack(outRe, outIm, zRe, zIm, twRe, twIm []float64) {
 //	|X[0]|^2 = (Z[0].real + Z[0].imag)^2  (DC)
 //	|X[n]|^2 = (Z[0].real - Z[0].imag)^2  (Nyquist)
 //
-// The SIMD kernels fuse the magnitude-squared with an FMA on their vector lanes
-// (single rounding), while the pure-Go path uses a separate multiply and add, so
-// the two agree only to within rounding, exactly as the RealFFTUnpack odd-term FMA
-// already does. (The arm64 NEON scalar-remainder element uses separate ops, like
-// the Go path.)
+// The SIMD kernels fuse the magnitude-squared with a hardware FMA on their vector
+// lanes (single rounding). The pure-Go path writes a separate multiply and add,
+// but the Go compiler contracts that into an FMA on some architectures (arm64) and
+// not others (amd64). So the results agree only to within rounding, not
+// bit-for-bit, and the exact bits can differ across architectures, exactly as the
+// RealFFTUnpack odd-term FMA already does.
 //
 // # Aliasing
 //

--- a/f64/f64.go
+++ b/f64/f64.go
@@ -1013,3 +1013,63 @@ func RealFFTUnpack(outRe, outIm, zRe, zIm, twRe, twIm []float64) {
 	}
 	realFFTUnpack64(outRe, outIm, zRe, zIm, twRe, twIm, n)
 }
+
+// RealFFTPower writes the power spectrum dst[k] = |X[k]|^2 for k in [1, n-1] of a
+// packed real-input FFT, given the half-size complex spectrum Z (length n) and the
+// unpack twiddles, without materialising the complex bins X.
+//
+// It is the fused, power-writing counterpart of RealFFTUnpack: identical inputs
+// and identical bin range, but it emits |X_k|^2 directly. Each bin unpacks exactly
+// as RealFFTUnpack does and is then squared and summed in registers:
+//
+//	evenRe = 0.5*(zRe[k] + zRe[n-k]); evenIm = 0.5*(zIm[k] - zIm[n-k])
+//	diffRe = zRe[k] - zRe[n-k];       diffIm = zIm[k] + zIm[n-k]
+//	oddRe  = 0.5*(twRe[k]*diffIm + twIm[k]*diffRe)
+//	oddIm  = 0.5*(twIm[k]*diffIm - twRe[k]*diffRe)
+//	X[k].re = evenRe + oddRe; X[k].im = evenIm + oddIm
+//	dst[k]  = X[k].re^2 + X[k].im^2
+//
+// so it makes a single pass over the spectrum with no intermediate complex bins. A
+// spectrogram, mel front end, or PSD consumer wants |X_k|^2, and computing it as
+// RealFFTUnpack + Mul + FMA is three passes over the bins that write and re-read
+// the complex half-spectrum; folding the magnitude-squared into the unpack drops
+// the two extra passes. See issue #198.
+//
+// Parameters:
+//   - dst: output power, dst[k] = |X[k]|^2 written for k in [1, n-1] (length >= n)
+//   - zRe, zIm: half-size complex spectrum Z, length n
+//   - twRe, twIm: twiddle factors W[k] at index k-1 (length n-1), where
+//     W[k] = exp(-i*pi*k/n) = cos(pi*k/n) - i*sin(pi*k/n)
+//
+// The DC bin (k=0) and Nyquist bin (k=n) are the caller's responsibility, exactly
+// as for RealFFTUnpack. Both are real, so their powers are:
+//
+//	|X[0]|^2 = (Z[0].real + Z[0].imag)^2  (DC)
+//	|X[n]|^2 = (Z[0].real - Z[0].imag)^2  (Nyquist)
+//
+// The SIMD kernels fuse the magnitude-squared with an FMA on their vector lanes
+// (single rounding), while the pure-Go path uses a separate multiply and add, so
+// the two agree only to within rounding, exactly as the RealFFTUnpack odd-term FMA
+// already does. (The arm64 NEON scalar-remainder element uses separate ops, like
+// the Go path.)
+//
+// # Aliasing
+//
+// dst must not overlap zRe, zIm, twRe or twIm in any way, not even as an exact
+// element-for-element overlay. Bin k reads Z at both k and the mirror n-k plus the
+// twiddle at k-1 before it writes dst at k, and the SIMD kernels re-read the tail
+// input with an overlapping block, so any overlay lets a store land on an input a
+// later bin has not read yet. Same precondition as RealFFTUnpack.
+//
+// Uses AVX2+FMA on AMD64, NEON on ARM64, with a pure Go fallback.
+func RealFFTPower(dst, zRe, zIm, twRe, twIm []float64) {
+	n := len(zRe)
+	if n < realFFTUnpackMinN {
+		return
+	}
+	// Validate slice lengths.
+	if len(zIm) < n || len(dst) < n || len(twRe) < n-1 || len(twIm) < n-1 {
+		return
+	}
+	realFFTPower64(dst, zRe, zIm, twRe, twIm, n)
+}

--- a/f64/f64_amd64.go
+++ b/f64/f64_amd64.go
@@ -705,6 +705,19 @@ func realFFTUnpack64(outRe, outIm, zRe, zIm, twRe, twIm []float64, n int) {
 	realFFTUnpack64Go(outRe, outIm, zRe, zIm, twRe, twIm, n)
 }
 
+func realFFTPower64(dst, zRe, zIm, twRe, twIm []float64, n int) {
+	// realFFTPowerAVX shares realFFTUnpackAVX's reversed mirror load (VPERMPD plus
+	// register-source constants), so it needs AVX2, not just AVX+FMA, for the same
+	// reason; see the realFFTUnpack64 comment above. It also uses VFMADD for both
+	// the odd term and the fused magnitude-squared, so cpu.X86.FMA is required.
+	// n > minAVXElements means n >= 5, so (n-1) >= 4 = one full 4-wide AVX pass.
+	if hasAVX2 && cpu.X86.FMA && n > minAVXElements {
+		realFFTPowerAVX(dst, zRe, zIm, twRe, twIm, n)
+		return
+	}
+	realFFTPower64Go(dst, zRe, zIm, twRe, twIm, n)
+}
+
 func sigmoid64(dst, src []float64) {
 	// Requires AVX2: sigmoidAVX reconstructs 2^k with 256-bit YMM integer ops
 	// (VCVTTPD2DQ/VPMOVSXDQ/VPSLLQ/VPADDQ) that do not exist on AVX1-only CPUs.
@@ -1115,3 +1128,8 @@ func butterflyComplexStageAVX(re, im []float64, span, blocks int, twRe, twIm []f
 //
 //go:noescape
 func realFFTUnpackAVX(outRe, outIm, zRe, zIm, twRe, twIm []float64, n int)
+
+// RealFFTPower assembly function declaration
+//
+//go:noescape
+func realFFTPowerAVX(dst, zRe, zIm, twRe, twIm []float64, n int)

--- a/f64/f64_amd64.s
+++ b/f64/f64_amd64.s
@@ -6620,3 +6620,170 @@ realfft64_remainder:
 realfft64_done:
     VZEROUPPER
     RET
+
+// func realFFTPowerAVX(dst, zRe, zIm, twRe, twIm []float64, n int)
+// Real-FFT power step, 4 float64 lanes per YMM (AVX+FMA). It unpacks bin X[k]
+// exactly as realFFTUnpackAVX does, then writes dst[k] = X[k].re^2 + X[k].im^2
+// with a fused multiply-add, so the complex bins are never stored. For k in
+// [1, n-1] with nk = n-k:
+//   znk    = conj(Z[nk]) = (zRe[nk], -zIm[nk])
+//   even   = 0.5*(Z[k] + znk) ; diff = Z[k] - znk
+//   oddRe  = 0.5*(wr*diffIm + wi*diffRe) ; oddIm = 0.5*(wi*diffIm - wr*diffRe)
+//   X[k]   = even + odd ; dst[k] = X[k].re^2 + X[k].im^2
+// The mirror slice is read in reverse and permuted, identically to the unpack.
+// Frame: dst(24)+zRe(24)+zIm(24)+twRe(24)+twIm(24)+n(8) = 128 bytes.
+TEXT ·realFFTPowerAVX(SB), NOSPLIT, $0-128
+    // Load parameters
+    MOVQ dst_base+0(FP), DX          // DX = dst pointer
+    MOVQ zRe_base+24(FP), DI         // DI = zRe pointer (forward)
+    MOVQ zIm_base+48(FP), R8         // R8 = zIm pointer (forward)
+    MOVQ twRe_base+72(FP), R11       // R11 = twRe pointer
+    MOVQ twIm_base+96(FP), R12       // R12 = twIm pointer
+    MOVQ n+120(FP), CX               // CX = n
+
+    // Calculate number of iterations: (n-1) / 4
+    MOVQ CX, AX
+    DECQ AX                          // AX = n - 1
+    MOVQ AX, R13                     // R13 = n - 1 (save for remainder)
+    SHRQ $2, AX                      // AX = (n-1) / 4 = number of SIMD iterations
+    // Zero full blocks means n <= 4, which realFFTPower64 never dispatches: its
+    // guard is n > minAVXElements and minAVXElements is 4. The overlapping
+    // remainder block below anchors at k = n-4 and mirror-reads zRe[1..4], so it
+    // needs n >= 5; writing nothing is the memory-safe answer to a caller that
+    // ignores the threshold.
+    JZ   realfftpow64_done
+
+    // Set up reverse pointers: R9 = &zRe[n-4], R10 = &zIm[n-4].
+    // BX (not R14) holds byte offsets: R14 is the goroutine g pointer on Go amd64.
+    MOVQ CX, BX                      // BX = n
+    SUBQ $4, BX                      // BX = n - 4
+    SHLQ $3, BX                      // BX = (n-4) * 8 = byte offset
+    MOVQ DI, R9
+    ADDQ BX, R9                      // R9 = &zRe[n-4]
+    MOVQ R8, R10
+    ADDQ BX, R10                     // R10 = &zIm[n-4]
+
+    // Offset forward and output pointers to start at index 1
+    ADDQ $8, DI                      // DI = &zRe[1]
+    ADDQ $8, R8                      // R8 = &zIm[1]
+    ADDQ $8, DX                      // DX = &dst[1]
+
+    // Broadcast 0.5 (0x3FE0000000000000 = 0.5)
+    MOVQ $0x3FE0000000000000, BX
+    MOVQ BX, X13
+    VBROADCASTSD X13, Y13            // Y13 = 0.5 broadcast
+
+    // Sign mask for negation (0x8000000000000000 = the float64 sign bit).
+    VPCMPEQD Y14, Y14, Y14           // Y14 = all 1s
+    VPSLLQ $63, Y14, Y14             // Y14 = 0x8000000000000000
+
+realfftpow64_loop4:
+    // Load forward Z[k:k+4]
+    VMOVUPD (DI), Y0                 // Y0 = zRe[k:k+4] (forward)
+    VMOVUPD (R8), Y1                 // Y1 = zIm[k:k+4] (forward)
+
+    // Load reverse Z[n-k-3:n-k+1] and reverse the order so a forward vector
+    // Z[k:k+4] pairs with Z[nk:nk-3]. 0x1B = [3,2,1,0] over 4 qwords.
+    VMOVUPD (R9), Y2                 // Y2 = zRe[n-k-3:n-k+1] (to be reversed)
+    VMOVUPD (R10), Y3                // Y3 = zIm[n-k-3:n-k+1] (to be reversed)
+    VPERMPD $0x1B, Y2, Y2
+    VPERMPD $0x1B, Y3, Y3
+
+    // For conjugate: znkIm = -zIm[n-k]
+    VXORPD Y14, Y3, Y3               // Y3 = znkIm
+
+    // even = 0.5 * (Z[k] + conj(Z[n-k]))
+    VADDPD Y0, Y2, Y4                // Y4 = zkRe + znkRe
+    VMULPD Y4, Y13, Y4               // Y4 = evenRe
+    VADDPD Y1, Y3, Y5                // Y5 = zkIm + znkIm
+    VMULPD Y5, Y13, Y5               // Y5 = evenIm
+
+    // diff = Z[k] - conj(Z[n-k])
+    VSUBPD Y2, Y0, Y6                // Y6 = diffRe
+    VSUBPD Y3, Y1, Y7                // Y7 = diffIm
+
+    // Load twiddles W[k]
+    VMOVUPD (R11), Y8                // Y8 = wr
+    VMOVUPD (R12), Y9                // Y9 = wi
+
+    // oddRe = 0.5 * (wr*diffIm + wi*diffRe)
+    VMULPD Y8, Y7, Y10               // Y10 = wr * diffIm
+    VFMADD231PD Y9, Y6, Y10          // Y10 = wr*diffIm + wi*diffRe
+    VMULPD Y10, Y13, Y10             // Y10 = oddRe
+
+    // oddIm = 0.5 * (wi*diffIm - wr*diffRe)
+    VMULPD Y9, Y7, Y11               // Y11 = wi * diffIm
+    VFNMADD231PD Y8, Y6, Y11         // Y11 = wi*diffIm - wr*diffRe
+    VMULPD Y11, Y13, Y11             // Y11 = oddIm
+
+    // X[k] = even + odd
+    VADDPD Y4, Y10, Y0               // Y0 = outRe = evenRe + oddRe
+    VADDPD Y5, Y11, Y1               // Y1 = outIm = evenIm + oddIm
+
+    // dst[k] = outRe^2 + outIm^2 (fused magnitude-squared)
+    VMULPD Y0, Y0, Y2                // Y2 = outRe^2
+    VFMADD231PD Y1, Y1, Y2           // Y2 = outRe^2 + outIm^2
+    VMOVUPD Y2, (DX)                 // store power[k:k+4]
+
+    // Advance pointers
+    ADDQ $32, DI                     // forward zRe += 4
+    ADDQ $32, R8                     // forward zIm += 4
+    SUBQ $32, R9                     // reverse zRe -= 4
+    SUBQ $32, R10                    // reverse zIm -= 4
+    ADDQ $32, R11                    // twRe += 4
+    ADDQ $32, R12                    // twIm += 4
+    ADDQ $32, DX                     // dst += 4
+
+    DECQ AX
+    JNZ  realfftpow64_loop4
+
+realfftpow64_remainder:
+    // Handle the remaining (n-1) % 4 elements with one more FULL 4-wide block
+    // anchored at k = n-4, overlapping the block just written. Bin k reads inputs
+    // only (z at k and the mirror n-k, twiddles at k-1) and nothing a previous bin
+    // produced, so recomputing the last 4 stores the identical values. Same idiom
+    // as realFFTUnpackAVX; it relies on dst not overlapping the inputs.
+    ANDQ $3, R13                     // R13 = remainder count
+    JZ   realfftpow64_done
+
+    // Zero the remainder before re-entering: the block below ends on the loop's own
+    // DECQ/JNZ, falls through to this label a second time, and must find nothing
+    // left to do.
+    XORL R13, R13
+
+    // Reload the five slice bases the loop advanced. CX still holds n.
+    MOVQ dst_base+0(FP), DX
+    MOVQ zRe_base+24(FP), DI
+    MOVQ zIm_base+48(FP), R8
+    MOVQ twRe_base+72(FP), R11
+    MOVQ twIm_base+96(FP), R12
+    MOVQ n+120(FP), CX
+
+    // Mirror pointers first, while DI and R8 still hold the bases. At k = n-4 the
+    // block reads z[n-k-3 .. n-k] = z[1 .. 4], one element in from the start.
+    MOVQ DI, R9
+    ADDQ $8, R9                      // R9 = &zRe[1]
+    MOVQ R8, R10
+    ADDQ $8, R10                     // R10 = &zIm[1]
+
+    // Forward and output pointers to k = n-4.
+    MOVQ CX, BX
+    SUBQ $4, BX                      // BX = n - 4 = k
+    SHLQ $3, BX                      // BX = k * 8 = byte offset
+    ADDQ BX, DI                      // DI = &zRe[k]
+    ADDQ BX, R8                      // R8 = &zIm[k]
+    ADDQ BX, DX                      // DX = &dst[k]
+
+    // Twiddles are indexed k-1, so they top out at n-2 against a length n-1 slice.
+    SUBQ $8, BX                      // BX = (k-1) * 8
+    ADDQ BX, R11                     // R11 = &twRe[k-1]
+    ADDQ BX, R12                     // R12 = &twIm[k-1]
+
+    // Y13/Y14 still hold 0.5 and the sign bit, so the re-entered loop needs no
+    // fresh constant materialisation.
+    MOVQ $1, AX                      // exactly one more iteration
+    JMP  realfftpow64_loop4
+
+realfftpow64_done:
+    VZEROUPPER
+    RET

--- a/f64/f64_arm64.go
+++ b/f64/f64_arm64.go
@@ -541,8 +541,20 @@ func realFFTUnpack64(outRe, outIm, zRe, zIm, twRe, twIm []float64, n int) {
 	realFFTUnpack64Go(outRe, outIm, zRe, zIm, twRe, twIm, n)
 }
 
+func realFFTPower64(dst, zRe, zIm, twRe, twIm []float64, n int) {
+	// One NEON iteration needs 2 float64 lanes; n > 2 means (n-1) >= 2.
+	if hasNEON && n > 2 {
+		realFFTPowerNEON(dst, zRe, zIm, twRe, twIm, n)
+		return
+	}
+	realFFTPower64Go(dst, zRe, zIm, twRe, twIm, n)
+}
+
 //go:noescape
 func realFFTUnpackNEON(outRe, outIm, zRe, zIm, twRe, twIm []float64, n int)
+
+//go:noescape
+func realFFTPowerNEON(dst, zRe, zIm, twRe, twIm []float64, n int)
 
 func sigmoid64(dst, src []float64) {
 	// Assumes len(src) >= len(dst); caller ensures this via public API

--- a/f64/f64_arm64.s
+++ b/f64/f64_arm64.s
@@ -3265,3 +3265,214 @@ realfft64_neon_scalar:
 
 realfft64_neon_done:
     RET
+
+// func realFFTPowerNEON(dst, zRe, zIm, twRe, twIm []float64, n int)
+// Real-FFT power step, 2 float64 lanes (.2D). It unpacks bin X[k] exactly as
+// realFFTUnpackNEON does, then writes dst[k] = X[k].re^2 + X[k].im^2 with a fused
+// multiply-add, so the complex bins are never stored. For k in [1, n-1] with
+// nk = n-k:
+//   znk    = conj(Z[nk]) = (zRe[nk], -zIm[nk])
+//   even   = 0.5*(Z[k] + znk) ; diff = Z[k] - znk
+//   oddRe  = 0.5*(wr*diffIm + wi*diffRe) ; oddIm = 0.5*(wi*diffIm - wr*diffRe)
+//   X[k]   = even + odd ; dst[k] = X[k].re^2 + X[k].im^2
+// The mirror slice is read in reverse; EXT #8 swaps the two f64 lanes.
+// Frame: dst(24)+zRe(24)+zIm(24)+twRe(24)+twIm(24)+n(8) = 128 bytes.
+TEXT ·realFFTPowerNEON(SB), NOSPLIT, $0-128
+    // Load parameters
+    MOVD dst_base+0(FP), R0          // R0 = dst pointer
+    MOVD zRe_base+24(FP), R2         // R2 = zRe pointer (forward)
+    MOVD zIm_base+48(FP), R3         // R3 = zIm pointer (forward)
+    MOVD twRe_base+72(FP), R4        // R4 = twRe pointer
+    MOVD twIm_base+96(FP), R5        // R5 = twIm pointer
+    MOVD n+120(FP), R6               // R6 = n
+
+    // Calculate number of iterations: (n-1) / 2
+    SUB $1, R6, R7                   // R7 = n - 1
+    MOVD R7, R14                     // R14 = n - 1 (save for remainder; R14 is a temp on arm64, g is R28)
+    LSR $1, R7                       // R7 = (n-1) / 2 = number of SIMD iterations
+    CBZ R7, realfftpow64_neon_remainder // Skip SIMD loop if < 2 elements
+
+    // Set up reverse pointers: zRe[n-2], zIm[n-2]
+    SUB $2, R6, R8                   // R8 = n - 2
+    LSL $3, R8                       // R8 = (n-2) * 8 = byte offset
+    MOVD zRe_base+24(FP), R9
+    ADD R8, R9                       // R9 = &zRe[n-2]
+    MOVD zIm_base+48(FP), R10
+    ADD R8, R10                      // R10 = &zIm[n-2]
+
+    // Offset forward and output pointers to start at index 1
+    ADD $8, R2                       // R2 = &zRe[1]
+    ADD $8, R3                       // R3 = &zIm[1]
+    ADD $8, R0                       // R0 = &dst[1]
+
+    // Load 0.5 constant into V30
+    MOVD $0x3FE0000000000000, R11    // 0.5 in IEEE 754 double
+    FMOVD R11, F30
+    WORD $0x4E0807DE                 // DUP V30.2D, V30.D[0]
+
+realfftpow64_neon_loop2:
+    // Load forward Z[k:k+2]
+    VLD1.P 16(R2), [V0.D2]           // V0 = zRe[k:k+2] (forward)
+    VLD1.P 16(R3), [V1.D2]           // V1 = zIm[k:k+2] (forward)
+
+    // Load reverse Z[n-k-1:n-k+1] and reverse the order
+    VLD1 (R9), [V2.D2]               // V2 = zRe[n-k-1:n-k+1] (to be reversed)
+    VLD1 (R10), [V3.D2]              // V3 = zIm[n-k-1:n-k+1] (to be reversed)
+
+    // Reverse V2 and V3: swap the two f64 lanes ([0,1] -> [1,0]) via EXT #8
+    WORD $0x6E024042                 // EXT V2.16B, V2.16B, V2.16B, #8
+    WORD $0x6E034063                 // EXT V3.16B, V3.16B, V3.16B, #8
+
+    // For conjugate: znkIm = -zIm[n-k]
+    WORD $0x6EE0F863                 // FNEG V3.2D, V3.2D  (negate for conjugate)
+
+    // Compute even = 0.5 * (Z[k] + conj(Z[n-k]))
+    WORD $0x4E62D404                 // FADD V4.2D, V0.2D, V2.2D  (zkRe + znkRe)
+    WORD $0x6E7EDC84                 // FMUL V4.2D, V4.2D, V30.2D  (evenRe)
+    WORD $0x4E63D425                 // FADD V5.2D, V1.2D, V3.2D  (zkIm + znkIm)
+    WORD $0x6E7EDCA5                 // FMUL V5.2D, V5.2D, V30.2D  (evenIm)
+
+    // Compute diff = Z[k] - conj(Z[n-k])
+    WORD $0x4EE2D406                 // FSUB V6.2D, V0.2D, V2.2D  (diffRe)
+    WORD $0x4EE3D427                 // FSUB V7.2D, V1.2D, V3.2D  (diffIm)
+
+    // Load twiddles W[k]
+    VLD1.P 16(R4), [V8.D2]           // V8 = twRe (wr)
+    VLD1.P 16(R5), [V9.D2]           // V9 = twIm (wi)
+
+    // oddRe = 0.5 * (wr*diffIm + wi*diffRe)
+    WORD $0x6E67DD0A                 // FMUL V10.2D, V8.2D, V7.2D   (wr * diffIm)
+    WORD $0x4E66CD2A                 // FMLA V10.2D, V9.2D, V6.2D   (V10 += wi * diffRe)
+    WORD $0x6E7EDD4A                 // FMUL V10.2D, V10.2D, V30.2D (oddRe)
+
+    // oddIm = 0.5 * (wi*diffIm - wr*diffRe)
+    WORD $0x6E67DD2B                 // FMUL V11.2D, V9.2D, V7.2D   (wi * diffIm)
+    WORD $0x4EE6CD0B                 // FMLS V11.2D, V8.2D, V6.2D   (V11 -= wr * diffRe)
+    WORD $0x6E7EDD6B                 // FMUL V11.2D, V11.2D, V30.2D (oddIm)
+
+    // Compute output X[k] = even + odd
+    WORD $0x4E6AD480                 // FADD V0.2D, V4.2D, V10.2D  (outRe)
+    WORD $0x4E6BD4A1                 // FADD V1.2D, V5.2D, V11.2D  (outIm)
+
+    // dst[k] = outRe^2 + outIm^2 (fused magnitude-squared)
+    WORD $0x6E60DC0C                 // FMUL V12.2D, V0.2D, V0.2D  (outRe^2)
+    WORD $0x4E61CC2C                 // FMLA V12.2D, V1.2D, V1.2D  (V12 += outIm^2)
+    VST1.P [V12.D2], 16(R0)          // Store power[k:k+2]
+
+    // Move reverse pointers backward
+    SUB $16, R9                      // reverse zRe -= 2
+    SUB $16, R10                     // reverse zIm -= 2
+
+    SUB $1, R7
+    CBNZ R7, realfftpow64_neon_loop2
+
+realfftpow64_neon_remainder:
+    // Handle remaining element (n-1) % 2
+    AND $1, R14
+    CBZ R14, realfftpow64_neon_done
+
+    // Reload base pointers for remainder
+    MOVD dst_base+0(FP), R0
+    MOVD zRe_base+24(FP), R2
+    MOVD zIm_base+48(FP), R3
+    MOVD twRe_base+72(FP), R4
+    MOVD twIm_base+96(FP), R5
+    MOVD n+120(FP), R6
+
+    // Calculate starting k for remainder: 1 + 2 * num_full_iterations
+    SUB $1, R6, R7                   // R7 = n - 1
+    LSR $1, R7                       // R7 = num_full_iterations
+    LSL $1, R7                       // R7 = 2 * num_full_iterations
+    ADD $1, R7                       // R7 = starting k
+
+    // Offset pointers to starting k
+    LSL $3, R7, R8                   // R8 = k * 8 bytes
+    ADD R8, R0                       // R0 = &dst[k]
+    ADD R8, R2                       // R2 = &zRe[k]
+    ADD R8, R3                       // R3 = &zIm[k]
+
+    // Twiddle offset is (k-1)
+    SUB $1, R7
+    LSL $3, R7, R8
+    ADD R8, R4                       // R4 = &twRe[k-1]
+    ADD R8, R5                       // R5 = &twIm[k-1]
+    ADD $1, R7                       // Restore R7 = k
+
+realfftpow64_neon_scalar:
+    // Calculate mirror index: nk = n - k
+    SUB R7, R6, R8                   // R8 = n - k = nk
+
+    // Load Z[k]
+    FMOVD (R2), F0                   // F0 = zRe[k]
+    FMOVD (R3), F1                   // F1 = zIm[k]
+
+    // Load conj(Z[n-k])
+    MOVD zRe_base+24(FP), R9
+    LSL $3, R8, R10
+    ADD R10, R9
+    FMOVD (R9), F2                   // F2 = zRe[nk]
+
+    MOVD zIm_base+48(FP), R9
+    ADD R10, R9
+    FMOVD (R9), F3                   // F3 = zIm[nk]
+
+    // Negate F3 for conjugate: znkIm = -zIm[nk]
+    FNEGD F3, F3                     // F3 = -zIm[nk] = znkIm
+
+    // Load 0.5 constant
+    MOVD $0x3FE0000000000000, R11
+    FMOVD R11, F13                   // F13 = 0.5
+
+    // evenRe = 0.5 * (zkRe + znkRe)
+    FADDD F0, F2, F4                 // F4 = zkRe + znkRe
+    FMULD F4, F13, F4                // F4 = evenRe
+
+    // evenIm = 0.5 * (zkIm + znkIm)
+    FADDD F1, F3, F5                 // F5 = zkIm + znkIm
+    FMULD F5, F13, F5                // F5 = evenIm
+
+    // diffRe = zkRe - znkRe
+    FSUBD F2, F0, F6                 // F6 = diffRe
+
+    // diffIm = zkIm - znkIm
+    FSUBD F3, F1, F7                 // F7 = diffIm
+
+    // Load twiddles
+    FMOVD (R4), F8                   // F8 = wr
+    FMOVD (R5), F9                   // F9 = wi
+
+    // oddRe = 0.5 * (wr*diffIm + wi*diffRe)
+    FMULD F8, F7, F10                // F10 = wr * diffIm
+    FMULD F9, F6, F11                // F11 = wi * diffRe
+    FADDD F10, F11, F10              // F10 = wr*diffIm + wi*diffRe
+    FMULD F10, F13, F10              // F10 = oddRe
+
+    // oddIm = 0.5 * (wi*diffIm - wr*diffRe)
+    FMULD F9, F7, F11                // F11 = wi * diffIm
+    FMULD F8, F6, F12                // F12 = wr * diffRe
+    FSUBD F12, F11, F11              // F11 = wi*diffIm - wr*diffRe
+    FMULD F11, F13, F11              // F11 = oddIm
+
+    // output = even + odd
+    FADDD F4, F10, F0                // F0 = outRe
+    FADDD F5, F11, F1                // F1 = outIm
+
+    // dst[k] = outRe^2 + outIm^2 (separate multiply and add on the scalar tail)
+    FMULD F0, F0, F12                // F12 = outRe^2
+    FMULD F1, F1, F14                // F14 = outIm^2
+    FADDD F12, F14, F12              // F12 = power
+    FMOVD F12, (R0)
+
+    // Advance pointers
+    ADD $8, R2
+    ADD $8, R3
+    ADD $8, R4
+    ADD $8, R5
+    ADD $8, R0
+    ADD $1, R7                       // k++
+
+    SUB $1, R14
+    CBNZ R14, realfftpow64_neon_scalar
+
+realfftpow64_neon_done:
+    RET

--- a/f64/f64_go.go
+++ b/f64/f64_go.go
@@ -783,11 +783,14 @@ func realFFTUnpack64Go(outRe, outIm, zRe, zIm, twRe, twIm []float64, n int) {
 // realFFTPower64Go writes dst[k] = |X[k]|^2 for k in [1, n-1] from the half-size
 // complex spectrum Z: it unpacks bin X[k] exactly as realFFTUnpack64Go does, then
 // squares and sums in place so the complex bins are never materialised. It is the
-// source of truth for RealFFTPower; the SIMD kernels compute the same values, with
-// the magnitude-squared fused (FMA) so they agree only to within rounding.
+// source of truth for RealFFTPower.
 //
-// The squaring uses separate multiply and add (no FMA), so dst[k] is bit-for-bit
-// equal to squaring realFFTUnpack64Go's X[k] on the pure-Go path.
+// The magnitude-squared and odd-term multiply-adds are written as separate
+// multiply and add, but the Go compiler may contract them into hardware FMAs on
+// architectures that have one (it does on arm64, not on amd64), so the exact
+// rounding of the pure-Go path is architecture-dependent. RealFFTPower therefore
+// agrees with an independent unpack-then-square only to within rounding, not
+// bit-for-bit, on every path.
 func realFFTPower64Go(dst, zRe, zIm, twRe, twIm []float64, n int) {
 	if n < realFFTUnpackMinN {
 		return

--- a/f64/f64_go.go
+++ b/f64/f64_go.go
@@ -779,3 +779,44 @@ func realFFTUnpack64Go(outRe, outIm, zRe, zIm, twRe, twIm []float64, n int) {
 		outIm[k] = evenIm + oddIm
 	}
 }
+
+// realFFTPower64Go writes dst[k] = |X[k]|^2 for k in [1, n-1] from the half-size
+// complex spectrum Z: it unpacks bin X[k] exactly as realFFTUnpack64Go does, then
+// squares and sums in place so the complex bins are never materialised. It is the
+// source of truth for RealFFTPower; the SIMD kernels compute the same values, with
+// the magnitude-squared fused (FMA) so they agree only to within rounding.
+//
+// The squaring uses separate multiply and add (no FMA), so dst[k] is bit-for-bit
+// equal to squaring realFFTUnpack64Go's X[k] on the pure-Go path.
+func realFFTPower64Go(dst, zRe, zIm, twRe, twIm []float64, n int) {
+	if n < realFFTUnpackMinN {
+		return
+	}
+	// Reslice to the exact ranges the loop touches so the prover can discharge the
+	// bounds checks from the loop condition alone; the mirror index n-k otherwise
+	// defeats it, the same way realFFTUnpack64Go handles it. The caller has already
+	// validated these lengths, so the reslices cannot panic.
+	zRe, zIm = zRe[:n], zIm[:n]
+	dst = dst[:n]
+	twRe, twIm = twRe[:n-1], twIm[:n-1]
+
+	for k := 1; k < n; k++ {
+		nk := n - k // Mirror index
+
+		zkRe, zkIm := zRe[k], zIm[k]
+		znkRe, znkIm := zRe[nk], -zIm[nk] // conj(Z[n-k])
+
+		evenRe := realFFTUnpackHalf * (zkRe + znkRe)
+		evenIm := realFFTUnpackHalf * (zkIm + znkIm)
+		diffRe := zkRe - znkRe
+		diffIm := zkIm - znkIm
+
+		wr, wi := twRe[k-1], twIm[k-1]
+		oddRe := realFFTUnpackHalf * (wr*diffIm + wi*diffRe)
+		oddIm := realFFTUnpackHalf * (wi*diffIm - wr*diffRe)
+
+		xRe := evenRe + oddRe
+		xIm := evenIm + oddIm
+		dst[k] = xRe*xRe + xIm*xIm
+	}
+}

--- a/f64/f64_other.go
+++ b/f64/f64_other.go
@@ -80,3 +80,7 @@ func butterflyComplexStage64(re, im []float64, span, blocks int, twRe, twIm []fl
 func realFFTUnpack64(outRe, outIm, zRe, zIm, twRe, twIm []float64, n int) {
 	realFFTUnpack64Go(outRe, outIm, zRe, zIm, twRe, twIm, n)
 }
+
+func realFFTPower64(dst, zRe, zIm, twRe, twIm []float64, n int) {
+	realFFTPower64Go(dst, zRe, zIm, twRe, twIm, n)
+}

--- a/f64/fuzz_test.go
+++ b/f64/fuzz_test.go
@@ -455,58 +455,47 @@ func FuzzF64Pow(f *testing.F) {
 	})
 }
 
-// FuzzF64RealFFTPower differentially tests the fused power kernel at every length.
-// Two checks run per input. First, the pure-Go reference realFFTPower64Go must
-// equal squaring realFFTUnpack64Go's X[k] bit-for-bit on every bin, since both use
-// separate multiply and add; this runs on arbitrary finite inputs (f64sFinite
-// strips NaN/Inf, so the two routes always see identical finite operands). Second,
-// the dispatched kernel (AVX/NEON with a fused magnitude-squared) must agree with
-// the Go reference to within a fixed absolute tolerance on bounded [-1,1] inputs,
-// where the power and its FMA rounding error are both O(1); this is the arm that
-// stresses the SIMD tail/remainder at random n.
+// FuzzF64RealFFTPower differentially tests the fused power kernel at every length,
+// on bounded [-1,1) inputs so the power stays O(1) and the tolerance is robust
+// against cancellation. Two checks run per input: (1) the pure-Go reference
+// realFFTPower64Go matches an independent unpack-then-square (realFFTUnpack64Go
+// squared) to within rounding, pinning the reference's bin math; (2) the dispatched
+// kernel (AVX/NEON, fused magnitude-squared) matches the Go reference to within
+// rounding, stressing the SIMD tail/remainder at random n. The comparisons are
+// tolerance-based, not bit-for-bit, because the Go compiler contracts the
+// reference's multiply-adds into hardware FMAs on some architectures (arm64) and
+// not others (amd64), so the last bit of the pure-Go path is not portable.
 func FuzzF64RealFFTPower(f *testing.F) {
 	addByteLenSeeds(f)
 	f.Fuzz(func(t *testing.T, raw []byte) {
-		v := f64sFinite(raw)
-		n := len(v) / 2
+		u := f64sUnit(raw) // bounded to [-1, 1)
+		n := len(u) / 2
 		if n < realFFTUnpackMinN {
 			return
 		}
-		zRe := v[:n]
-		zIm := v[n : 2*n]
+		zRe := u[:n]
+		zIm := u[n : 2*n]
 		twRe := make([]float64, n-1)
 		twIm := make([]float64, n-1)
 		makePowerTwiddles(twRe, twIm, n)
 
-		// Go reference vs an independent unpack-then-square, bit-for-bit on all bins.
+		dst := make([]float64, n)
 		refGo := make([]float64, n)
 		outRe := make([]float64, n)
 		outIm := make([]float64, n)
+		RealFFTPower(dst, zRe, zIm, twRe, twIm)
 		realFFTPower64Go(refGo, zRe, zIm, twRe, twIm, n)
 		realFFTUnpack64Go(outRe, outIm, zRe, zIm, twRe, twIm, n)
-		for k := 1; k < n; k++ {
-			want := outRe[k]*outRe[k] + outIm[k]*outIm[k]
-			if !eqF64(refGo[k], want) {
-				t.Fatalf("realFFTPower64Go bin %d (n=%d) got %x want %x", k, n, math.Float64bits(refGo[k]), math.Float64bits(want))
-			}
-		}
 
-		// Dispatched kernel vs the Go reference, tolerance on bounded inputs. With
-		// |z| <= 1 the power is O(1) and the fused-vs-separate rounding gap is a few
-		// ULP (< 1e-15), so 1e-12 absolute is a safe, cancellation-proof bound.
-		bRe := f64sUnit(raw)[:n]
-		bIm := make([]float64, n)
-		for i := range n {
-			bIm[i] = bRe[n-1-i] // a second bounded stream, decorrelated from bRe
-		}
-		dst := make([]float64, n)
-		refB := make([]float64, n)
-		RealFFTPower(dst, bRe, bIm, twRe, twIm)
-		realFFTPower64Go(refB, bRe, bIm, twRe, twIm, n)
-		const powTol = 1e-12
 		for k := 1; k < n; k++ {
-			if d := math.Abs(dst[k] - refB[k]); d > powTol {
-				t.Fatalf("RealFFTPower bin %d (n=%d) got %v want %v |diff|=%g tol=%g", k, n, dst[k], refB[k], d, powTol)
+			unpackSq := outRe[k]*outRe[k] + outIm[k]*outIm[k]
+			if !realFFTPowerClose(refGo[k], unpackSq) {
+				t.Fatalf("realFFTPower64Go bin %d (n=%d) = %v, unpack-square = %v, diff=%g",
+					k, n, refGo[k], unpackSq, refGo[k]-unpackSq)
+			}
+			if !realFFTPowerClose(dst[k], refGo[k]) {
+				t.Fatalf("RealFFTPower bin %d (n=%d) = %v, Go ref = %v, diff=%g",
+					k, n, dst[k], refGo[k], dst[k]-refGo[k])
 			}
 		}
 	})

--- a/f64/fuzz_test.go
+++ b/f64/fuzz_test.go
@@ -454,3 +454,60 @@ func FuzzF64Pow(f *testing.F) {
 		}
 	})
 }
+
+// FuzzF64RealFFTPower differentially tests the fused power kernel at every length.
+// Two checks run per input. First, the pure-Go reference realFFTPower64Go must
+// equal squaring realFFTUnpack64Go's X[k] bit-for-bit on every bin, since both use
+// separate multiply and add; this runs on arbitrary finite inputs (f64sFinite
+// strips NaN/Inf, so the two routes always see identical finite operands). Second,
+// the dispatched kernel (AVX/NEON with a fused magnitude-squared) must agree with
+// the Go reference to within a fixed absolute tolerance on bounded [-1,1] inputs,
+// where the power and its FMA rounding error are both O(1); this is the arm that
+// stresses the SIMD tail/remainder at random n.
+func FuzzF64RealFFTPower(f *testing.F) {
+	addByteLenSeeds(f)
+	f.Fuzz(func(t *testing.T, raw []byte) {
+		v := f64sFinite(raw)
+		n := len(v) / 2
+		if n < realFFTUnpackMinN {
+			return
+		}
+		zRe := v[:n]
+		zIm := v[n : 2*n]
+		twRe := make([]float64, n-1)
+		twIm := make([]float64, n-1)
+		makePowerTwiddles(twRe, twIm, n)
+
+		// Go reference vs an independent unpack-then-square, bit-for-bit on all bins.
+		refGo := make([]float64, n)
+		outRe := make([]float64, n)
+		outIm := make([]float64, n)
+		realFFTPower64Go(refGo, zRe, zIm, twRe, twIm, n)
+		realFFTUnpack64Go(outRe, outIm, zRe, zIm, twRe, twIm, n)
+		for k := 1; k < n; k++ {
+			want := outRe[k]*outRe[k] + outIm[k]*outIm[k]
+			if !eqF64(refGo[k], want) {
+				t.Fatalf("realFFTPower64Go bin %d (n=%d) got %x want %x", k, n, math.Float64bits(refGo[k]), math.Float64bits(want))
+			}
+		}
+
+		// Dispatched kernel vs the Go reference, tolerance on bounded inputs. With
+		// |z| <= 1 the power is O(1) and the fused-vs-separate rounding gap is a few
+		// ULP (< 1e-15), so 1e-12 absolute is a safe, cancellation-proof bound.
+		bRe := f64sUnit(raw)[:n]
+		bIm := make([]float64, n)
+		for i := range n {
+			bIm[i] = bRe[n-1-i] // a second bounded stream, decorrelated from bRe
+		}
+		dst := make([]float64, n)
+		refB := make([]float64, n)
+		RealFFTPower(dst, bRe, bIm, twRe, twIm)
+		realFFTPower64Go(refB, bRe, bIm, twRe, twIm, n)
+		const powTol = 1e-12
+		for k := 1; k < n; k++ {
+			if d := math.Abs(dst[k] - refB[k]); d > powTol {
+				t.Fatalf("RealFFTPower bin %d (n=%d) got %v want %v |diff|=%g tol=%g", k, n, dst[k], refB[k], d, powTol)
+			}
+		}
+	})
+}

--- a/f64/realfftpower_test.go
+++ b/f64/realfftpower_test.go
@@ -1,0 +1,496 @@
+package f64
+
+import (
+	"fmt"
+	"math"
+	"testing"
+)
+
+// =============================================================================
+// REAL FFT POWER TESTS (float64)
+// =============================================================================
+//
+// RealFFTPower is the fused, power-writing counterpart of RealFFTUnpack: it emits
+// dst[k] = |X[k]|^2 for k in [1, n-1] in a single pass, unpacking each bin exactly
+// as RealFFTUnpack does and squaring in registers. The SIMD kernels fuse the
+// magnitude-squared with an FMA, so they agree with the pure-Go reference only to
+// within rounding; the Go reference is bit-for-bit equal to squaring
+// realFFTUnpack64Go's output. See RealFFTPower and realFFTPower64Go.
+
+// realFFTPowerRef is a test-local oracle for RealFFTPower, transcribed
+// independently of realFFTPower64Go: it unpacks every bin through the independently
+// written realFFTUnpackRef and squares. A bug copied into both realFFTPower64Go and
+// its derivation would still be caught here. For k in [1, n-1] it computes |X[k]|^2.
+func realFFTPowerRef(dst, zRe, zIm, twRe, twIm []float64, n int) {
+	outRe := make([]float64, n)
+	outIm := make([]float64, n)
+	realFFTUnpackRef(outRe, outIm, zRe, zIm, twRe, twIm, n)
+	for k := 1; k < n; k++ {
+		dst[k] = outRe[k]*outRe[k] + outIm[k]*outIm[k]
+	}
+}
+
+// Tolerances for realFFTPowerClose. The dispatched kernel fuses the odd term and
+// the magnitude-squared with FMA while the reference uses separate multiply-adds,
+// so the two agree to within rounding rather than exactly.
+//
+// MEASURED by instrumenting the dispatched kernel against realFFTPowerRef over the
+// ramp and sinusoid fixtures this suite uses (sizes 2..2048, powers up to ~1e5):
+// worst relative divergence 1.218e-14 and worst absolute divergence 5.821e-11 (the
+// absolute one on a large-magnitude bin, which the relative arm covers). So
+// realFFTPowerRelTol sits about 800x above the worst relative case, matching the
+// unpack predicate's rel 1e-11 (see realfftunpack_test.go). The absolute floor only
+// guards outputs that cancel to near zero, which these smooth fixtures do not
+// produce, so it is effectively unexercised; the relative arm decides every case.
+const (
+	realFFTPowerAbsTol = 1e-10
+	realFFTPowerRelTol = 1e-11
+)
+
+// realFFTPowerClose reports whether got is within the float64 tolerance of want.
+func realFFTPowerClose(got, want float64) bool {
+	diff := math.Abs(got - want)
+	return diff <= realFFTPowerAbsTol || diff <= math.Abs(want)*realFFTPowerRelTol
+}
+
+// makePowerTwiddles fills a valid unpack twiddle table W[k] = exp(-i*pi*k/n) at
+// index k-1, matching realfftunpack_test.go.
+func makePowerTwiddles(twRe, twIm []float64, n int) {
+	for k := 1; k < n; k++ {
+		angle := -2 * math.Pi * float64(k) / float64(2*n)
+		twRe[k-1] = math.Cos(angle)
+		twIm[k-1] = math.Sin(angle)
+	}
+}
+
+func TestRealFFTPower(t *testing.T) {
+	// 6 and 10 give (n-1) % 4 == 1, the only AVX remainder length not otherwise hit.
+	// n=2 exercises the smallest even case; the odd sizes exercise the odd-n mirror.
+	sizes := []int{2, 3, 4, 5, 6, 8, 9, 10, 16, 17, 31, 32, 33, 63, 64, 65, 128, 256, 512, 1000}
+
+	for _, n := range sizes {
+		t.Run(fmt.Sprintf("n=%d", n), func(t *testing.T) {
+			zRe := make([]float64, n)
+			zIm := make([]float64, n)
+			twRe := make([]float64, n-1)
+			twIm := make([]float64, n-1)
+			dst := make([]float64, n)
+			ref := make([]float64, n)
+
+			for i := range n {
+				zRe[i] = float64(i+1) * 0.1
+				zIm[i] = float64(i+2) * 0.2
+			}
+			makePowerTwiddles(twRe, twIm, n)
+
+			RealFFTPower(dst, zRe, zIm, twRe, twIm)
+			realFFTPowerRef(ref, zRe, zIm, twRe, twIm, n)
+
+			for k := 1; k < n; k++ {
+				if !realFFTPowerClose(dst[k], ref[k]) {
+					t.Errorf("dst[%d] = %v, want %v, diff=%v", k, dst[k], ref[k], dst[k]-ref[k])
+				}
+				if dst[k] < 0 {
+					t.Errorf("dst[%d] = %v is negative; power must be >= 0", k, dst[k])
+				}
+			}
+		})
+	}
+}
+
+// TestRealFFTPower_GoVsSIMD checks the dispatched kernel against the pure-Go
+// reference. n=3 exercises the arm64 NEON path (n>2); the larger sizes exercise the
+// amd64 AVX path (n>4). 5 through 8 is one full (n-1)%4 cycle, so every AVX
+// remainder length is compared. Where the dispatcher declines SIMD this arm goes
+// inert (it then calls realFFTPower64Go on both sides); TestRealFFTPower, which
+// checks the dispatched kernel against the independently transcribed realFFTPowerRef
+// oracle, is the arm that holds on every tier.
+func TestRealFFTPower_GoVsSIMD(t *testing.T) {
+	sizes := []int{3, 5, 6, 7, 8, 9, 16, 17, 32, 64, 128, 256, 512}
+
+	for _, n := range sizes {
+		t.Run(fmt.Sprintf("n=%d", n), func(t *testing.T) {
+			zRe := make([]float64, n)
+			zIm := make([]float64, n)
+			twRe := make([]float64, n-1)
+			twIm := make([]float64, n-1)
+			dstSIMD := make([]float64, n)
+			dstGo := make([]float64, n)
+
+			for i := range n {
+				zRe[i] = math.Sin(float64(i)*0.7) * 10
+				zIm[i] = math.Cos(float64(i)*0.9) * 10
+			}
+			makePowerTwiddles(twRe, twIm, n)
+
+			RealFFTPower(dstSIMD, zRe, zIm, twRe, twIm)
+			realFFTPower64Go(dstGo, zRe, zIm, twRe, twIm, n)
+
+			for k := 1; k < n; k++ {
+				if !realFFTPowerClose(dstSIMD[k], dstGo[k]) {
+					t.Errorf("k=%d: SIMD=%v, Go=%v, diff=%v", k, dstSIMD[k], dstGo[k], dstSIMD[k]-dstGo[k])
+				}
+			}
+		})
+	}
+}
+
+// TestRealFFTPower_GoBitExact pins the pure-Go reference against the documented
+// unpack math with NO tolerance: realFFTPower64Go must equal squaring
+// realFFTUnpack64Go's X[k] bit-for-bit on every bin, because both use separate
+// multiply and add (no FMA). A stray fusion or a reordered even/odd in the Go
+// reference would break this. It holds on every tier since it never touches the
+// dispatched kernel.
+func TestRealFFTPower_GoBitExact(t *testing.T) {
+	sizes := []int{2, 3, 4, 5, 6, 7, 8, 9, 16, 17, 32, 33, 64, 65, 128, 256, 511, 512}
+
+	for _, n := range sizes {
+		t.Run(fmt.Sprintf("n=%d", n), func(t *testing.T) {
+			zRe := make([]float64, n)
+			zIm := make([]float64, n)
+			twRe := make([]float64, n-1)
+			twIm := make([]float64, n-1)
+			dst := make([]float64, n)
+			outRe := make([]float64, n)
+			outIm := make([]float64, n)
+
+			for i := range n {
+				zRe[i] = math.Sin(float64(i)*0.7) * 10
+				zIm[i] = math.Cos(float64(i)*0.9) * 10
+			}
+			makePowerTwiddles(twRe, twIm, n)
+
+			realFFTPower64Go(dst, zRe, zIm, twRe, twIm, n)
+			realFFTUnpack64Go(outRe, outIm, zRe, zIm, twRe, twIm, n)
+
+			for k := 1; k < n; k++ {
+				want := outRe[k]*outRe[k] + outIm[k]*outIm[k]
+				if math.Float64bits(dst[k]) != math.Float64bits(want) {
+					t.Errorf("k=%d dst = %v (%#016x), unpack-square = %v (%#016x)",
+						k, dst[k], math.Float64bits(dst[k]), want, math.Float64bits(want))
+				}
+			}
+		})
+	}
+}
+
+func TestRealFFTPower_EdgeCases(t *testing.T) {
+	// n < 2 must return without doing anything.
+	t.Run("n=0", func(_ *testing.T) {
+		RealFFTPower(nil, nil, nil, nil, nil)
+	})
+
+	t.Run("n=1", func(t *testing.T) {
+		dst := []float64{7}
+		zRe := []float64{1}
+		zIm := []float64{0}
+		// Below realFFTUnpackMinN, so it must return untouched.
+		RealFFTPower(dst, zRe, zIm, nil, nil)
+		if dst[0] != 7 {
+			t.Errorf("n=1 modified output: dst=%v, want unchanged", dst[0])
+		}
+	})
+
+	// The Go reference has its own n < realFFTUnpackMinN guard (the public entry
+	// point rejects small n first, so it is otherwise unreachable). Call it directly
+	// with n=1 to pin that guard against a future direct caller.
+	t.Run("go_ref_small_n", func(t *testing.T) {
+		dst := []float64{7}
+		realFFTPower64Go(dst, []float64{1}, []float64{0}, nil, nil, 1)
+		if dst[0] != 7 {
+			t.Errorf("realFFTPower64Go n=1 modified output: dst=%v, want unchanged", dst[0])
+		}
+	})
+
+	// DC (dst[0]) is the caller's job, so RealFFTPower must never write it.
+	t.Run("dc_untouched", func(t *testing.T) {
+		const n = 8
+		zRe := make([]float64, n)
+		zIm := make([]float64, n)
+		twRe := make([]float64, n-1)
+		twIm := make([]float64, n-1)
+		dst := make([]float64, n)
+		for i := range n {
+			zRe[i], zIm[i] = float64(i+1)*0.1, float64(i+2)*0.2
+		}
+		makePowerTwiddles(twRe, twIm, n)
+		const sentinel = -1.5
+		dst[0] = sentinel
+		RealFFTPower(dst, zRe, zIm, twRe, twIm)
+		if dst[0] != sentinel {
+			t.Errorf("DC bin dst[0] = %v, want untouched %v", dst[0], sentinel)
+		}
+	})
+}
+
+// TestRealFFTPower_KnownValues checks a small case against an independently unpacked
+// and squared spectrum. For n=4 the bins are k=1,2,3.
+func TestRealFFTPower_KnownValues(t *testing.T) {
+	const n = 4
+	zRe := []float64{1, 2, 3, 4}
+	zIm := []float64{0.1, 0.2, 0.3, 0.4}
+	twRe := make([]float64, n-1)
+	twIm := make([]float64, n-1)
+	makePowerTwiddles(twRe, twIm, n)
+
+	dst := make([]float64, n)
+	RealFFTPower(dst, zRe, zIm, twRe, twIm)
+
+	outRe := make([]float64, n)
+	outIm := make([]float64, n)
+	realFFTUnpackRef(outRe, outIm, zRe, zIm, twRe, twIm, n)
+	for k := 1; k < n; k++ {
+		want := outRe[k]*outRe[k] + outIm[k]*outIm[k]
+		if !realFFTPowerClose(dst[k], want) {
+			t.Errorf("k=%d dst = %v, want %v", k, dst[k], want)
+		}
+	}
+}
+
+// TestRealFFTPower_AllocFree pins the zero-allocation guarantee. The direct cpu-flag
+// dispatch keeps //go:noescape effective; routing through an init-time function
+// pointer would reintroduce heap allocations here.
+func TestRealFFTPower_AllocFree(t *testing.T) {
+	const n = 256
+	zRe := make([]float64, n)
+	zIm := make([]float64, n)
+	twRe := make([]float64, n-1)
+	twIm := make([]float64, n-1)
+	dst := make([]float64, n)
+	for i := range n {
+		zRe[i] = float64(i+1) * 0.1
+		zIm[i] = float64(i+2) * 0.2
+	}
+	makePowerTwiddles(twRe, twIm, n)
+	fn := func() { RealFFTPower(dst, zRe, zIm, twRe, twIm) }
+	if a := testing.AllocsPerRun(50, fn); a != 0 {
+		t.Errorf("RealFFTPower allocated %v times per run, want 0", a)
+	}
+}
+
+// TestRealFFTPower_ShortSlices exercises the length-validation guards: with n taken
+// from len(zRe), any operand shorter than required (zIm/dst < n, or twRe/twIm <
+// n-1) must make the call return without writing output or panicking. Each case
+// shortens exactly one operand so every clause of the guard is pinned on its own.
+func TestRealFFTPower_ShortSlices(t *testing.T) {
+	const n = 8
+	makeZ := func() ([]float64, []float64) {
+		zRe := make([]float64, n)
+		zIm := make([]float64, n)
+		for i := range n {
+			zRe[i], zIm[i] = float64(i+1)*0.1, float64(i+2)*0.2
+		}
+		return zRe, zIm
+	}
+	makeTw := func(reLen, imLen int) ([]float64, []float64) {
+		a, b := make([]float64, reLen), make([]float64, imLen)
+		for i := range a {
+			a[i] = 0.5
+		}
+		for i := range b {
+			b[i] = -0.5
+		}
+		return a, b
+	}
+	const sentinel = -1.5
+	makeDst := func(dstLen int) []float64 {
+		s := make([]float64, dstLen)
+		for i := range s {
+			s[i] = sentinel
+		}
+		return s
+	}
+	untouched := func(t *testing.T, name string, s []float64) {
+		t.Helper()
+		for i, v := range s {
+			if v != sentinel {
+				t.Errorf("%s written at [%d]=%v, want untouched (guard should have returned)", name, i, v)
+			}
+		}
+	}
+
+	cases := []struct {
+		name                             string
+		zImLen, dstLen, twReLen, twImLen int
+	}{
+		{"shortZIm", n - 1, n, n - 1, n - 1},
+		{"shortDst", n, n - 1, n - 1, n - 1},
+		{"shortTwRe", n, n, n - 2, n - 1},
+		{"shortTwIm", n, n, n - 1, n - 2},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			zRe, zImFull := makeZ()
+			zIm := zImFull[:c.zImLen]
+			twRe, twIm := makeTw(c.twReLen, c.twImLen)
+			dst := makeDst(c.dstLen)
+			RealFFTPower(dst, zRe, zIm, twRe, twIm)
+			untouched(t, "dst", dst)
+		})
+	}
+}
+
+// TestRealFFTPower_OverRead guards the reversed mirror load. The kernel reads
+// Z[n-k] descending against Z[k] ascending; a reverse pointer sized one block too
+// far (or a forward load past the end) would read outside [0,n). zRe/zIm are backed
+// by padded arrays whose guard bands hold NaN (two AVX blocks = 8 float64 on each
+// side), then sliced to exactly length n. Any out-of-range read pulls a NaN into
+// an output lane, which the parity check catches deterministically instead of a
+// SIGSEGV or a coincidental match. NaN squared is NaN, so it survives the square.
+func TestRealFFTPower_OverRead(t *testing.T) {
+	const pad = 8 // two AVX blocks of NaN guard band on each side of z
+	for _, n := range []int{5, 6, 16, 17, 18, 31, 32, 33, 64, 65} {
+		t.Run(fmt.Sprintf("n=%d", n), func(t *testing.T) {
+			nan := math.NaN()
+			zReBack := make([]float64, pad+n+pad)
+			zImBack := make([]float64, pad+n+pad)
+			for i := range zReBack {
+				zReBack[i], zImBack[i] = nan, nan
+			}
+			zRe := zReBack[pad : pad+n]
+			zIm := zImBack[pad : pad+n]
+			for i := range n {
+				zRe[i] = math.Sin(float64(i)*0.7) * 10
+				zIm[i] = math.Cos(float64(i)*0.9) * 10
+			}
+			twRe := make([]float64, n-1)
+			twIm := make([]float64, n-1)
+			makePowerTwiddles(twRe, twIm, n)
+			dst := make([]float64, n)
+			ref := make([]float64, n)
+
+			RealFFTPower(dst, zRe, zIm, twRe, twIm)
+			realFFTPowerRef(ref, zRe, zIm, twRe, twIm, n)
+
+			for k := 1; k < n; k++ {
+				if math.IsNaN(dst[k]) {
+					t.Fatalf("k=%d: NaN in output -> kernel over-read the zRe/zIm guard band", k)
+				}
+				if !realFFTPowerClose(dst[k], ref[k]) {
+					t.Errorf("k=%d dst = %v, want %v", k, dst[k], ref[k])
+				}
+			}
+		})
+	}
+}
+
+// TestRealFFTPower_SignedZero pins the even/odd sign handling. Every input is a
+// signed zero and every twiddle is +1 or -1, so every intermediate is an exact
+// zero: X[k] is zero and the power is exactly +0 on every bin (squaring collapses
+// the sign of the operands), on both the dispatched and Go paths. A masking or
+// negation bug in the reversed-load conjugate would surface here as a NaN or a
+// non-zero.
+func TestRealFFTPower_SignedZero(t *testing.T) {
+	// (n-1)%4 runs 0..3 over 5..8, so the AVX remainder path is exercised at every
+	// length; 16, 64, 65 add sizes with several full blocks.
+	sizes := []int{5, 6, 7, 8, 16, 64, 65}
+
+	for _, n := range sizes {
+		t.Run(fmt.Sprintf("n=%d", n), func(t *testing.T) {
+			zRe := make([]float64, n)
+			zIm := make([]float64, n)
+			twRe := make([]float64, n-1)
+			twIm := make([]float64, n-1)
+			dst := make([]float64, n)
+			dstGo := make([]float64, n)
+
+			const signBits = 6
+			for pat := range 1 << signBits {
+				sign := func(bit uint) float64 {
+					if pat&(1<<bit) != 0 {
+						return -1
+					}
+					return 1
+				}
+				half := n / 2
+				for i := range n {
+					reBit, imBit := uint(0), uint(1)
+					if i >= half {
+						reBit, imBit = 2, 3
+					}
+					zRe[i] = math.Copysign(0, sign(reBit))
+					zIm[i] = math.Copysign(0, sign(imBit))
+				}
+				for k := 1; k < n; k++ {
+					twRe[k-1] = sign(4)
+					twIm[k-1] = sign(5)
+				}
+
+				RealFFTPower(dst, zRe, zIm, twRe, twIm)
+				realFFTPower64Go(dstGo, zRe, zIm, twRe, twIm, n)
+
+				for k := 1; k < n; k++ {
+					if math.Float64bits(dst[k]) != 0 {
+						t.Errorf("pat=%#02x k=%d: SIMD power = %v (%#016x), want +0",
+							pat, k, dst[k], math.Float64bits(dst[k]))
+					}
+					if math.Float64bits(dstGo[k]) != 0 {
+						t.Errorf("pat=%#02x k=%d: Go power = %v (%#016x), want +0",
+							pat, k, dstGo[k], math.Float64bits(dstGo[k]))
+					}
+				}
+			}
+		})
+	}
+}
+
+// benchRealFFTPower64 runs fn at size n over freshly built inputs.
+func benchRealFFTPower64(b *testing.B, n int, fn func(dst, zRe, zIm, twRe, twIm []float64, n int)) {
+	b.Helper()
+	zRe := make([]float64, n)
+	zIm := make([]float64, n)
+	twRe := make([]float64, n-1)
+	twIm := make([]float64, n-1)
+	dst := make([]float64, n)
+
+	for i := range n {
+		zRe[i] = float64(i) * 0.1
+		zIm[i] = float64(i) * 0.2
+	}
+	makePowerTwiddles(twRe, twIm, n)
+
+	b.ResetTimer()
+	b.SetBytes(int64(n * 8 * 5)) // 5 float64 slices touched (z re/im, tw re/im, dst)
+
+	for range b.N {
+		fn(dst, zRe, zIm, twRe, twIm, n)
+	}
+}
+
+// realFFTPowerDispatched adapts the public entry point to the shared helper's
+// signature.
+func realFFTPowerDispatched(dst, zRe, zIm, twRe, twIm []float64, _ int) {
+	RealFFTPower(dst, zRe, zIm, twRe, twIm)
+}
+
+// realFFTPowerBaseline is the three-pass unpack + Mul + FMA the fused kernel
+// replaces: RealFFTUnpack writes the complex half-spectrum, then the power is
+// squared and summed in two more passes. It carries its own scratch so the
+// benchmark measures the extra traffic, not an allocation.
+type realFFTPowerBaseline struct {
+	outRe, outIm []float64
+}
+
+func (s *realFFTPowerBaseline) run(dst, zRe, zIm, twRe, twIm []float64, _ int) {
+	RealFFTUnpack(s.outRe, s.outIm, zRe, zIm, twRe, twIm)
+	Mul(dst, s.outRe, s.outRe)      // dst = outRe^2
+	FMA(dst, s.outIm, s.outIm, dst) // dst = outIm^2 + outRe^2
+}
+
+// BenchmarkRealFFTPower compares the fused RealFFTPower against the three-pass
+// RealFFTUnpack + Mul + FMA baseline it replaces. n is the half-size (nfft/2), so
+// the rows correspond to nfft 256/512/1024/2048 from issue #198.
+func BenchmarkRealFFTPower(b *testing.B) {
+	sizes := []int{128, 256, 512, 1024}
+
+	for _, n := range sizes {
+		nfft := 2 * n
+		b.Run(fmt.Sprintf("Fused_nfft%d", nfft), func(b *testing.B) {
+			benchRealFFTPower64(b, n, realFFTPowerDispatched)
+		})
+		b.Run(fmt.Sprintf("UnpackMulFMA_nfft%d", nfft), func(b *testing.B) {
+			base := &realFFTPowerBaseline{outRe: make([]float64, n), outIm: make([]float64, n)}
+			benchRealFFTPower64(b, n, base.run)
+		})
+	}
+}

--- a/f64/realfftpower_test.go
+++ b/f64/realfftpower_test.go
@@ -135,13 +135,16 @@ func TestRealFFTPower_GoVsSIMD(t *testing.T) {
 	}
 }
 
-// TestRealFFTPower_GoBitExact pins the pure-Go reference against the documented
-// unpack math with NO tolerance: realFFTPower64Go must equal squaring
-// realFFTUnpack64Go's X[k] bit-for-bit on every bin, because both use separate
-// multiply and add (no FMA). A stray fusion or a reordered even/odd in the Go
-// reference would break this. It holds on every tier since it never touches the
+// TestRealFFTPower_GoMatchesUnpackSquare pins the pure-Go reference against the
+// documented unpack math: realFFTPower64Go must match squaring realFFTUnpack64Go's
+// X[k] on every bin. The comparison is tolerance-based rather than bit-for-bit: the
+// Go compiler contracts the reference's multiply-adds into hardware FMAs on some
+// architectures (arm64) and not others (amd64), so the last bit of dst[k] is not
+// portable, though the value is always |X[k]|^2 to within rounding. A gross error
+// (a wrong index, a dropped 0.5, a swapped even/odd) moves the result well outside
+// tolerance and is still caught. It holds on every tier since it never touches the
 // dispatched kernel.
-func TestRealFFTPower_GoBitExact(t *testing.T) {
+func TestRealFFTPower_GoMatchesUnpackSquare(t *testing.T) {
 	sizes := []int{2, 3, 4, 5, 6, 7, 8, 9, 16, 17, 32, 33, 64, 65, 128, 256, 511, 512}
 
 	for _, n := range sizes {
@@ -165,9 +168,9 @@ func TestRealFFTPower_GoBitExact(t *testing.T) {
 
 			for k := 1; k < n; k++ {
 				want := outRe[k]*outRe[k] + outIm[k]*outIm[k]
-				if math.Float64bits(dst[k]) != math.Float64bits(want) {
-					t.Errorf("k=%d dst = %v (%#016x), unpack-square = %v (%#016x)",
-						k, dst[k], math.Float64bits(dst[k]), want, math.Float64bits(want))
+				if !realFFTPowerClose(dst[k], want) {
+					t.Errorf("k=%d dst = %v, unpack-square = %v, diff=%v",
+						k, dst[k], want, dst[k]-want)
 				}
 			}
 		})


### PR DESCRIPTION
Addresses part 2 of #198 (`RealFFTPower`). The radix-4 butterfly (part 3) stays open on #198.

A spectrogram, mel front end, or PSD consumer wants the power spectrum `|X_k|^2`, not the complex half-spectrum. Getting it today means `RealFFTUnpack` (writes the complex bins) followed by `Mul` and `FMA` to square and sum: three passes over the bins that materialise and re-read the complex output. `RealFFTPower` folds the magnitude-squared into the unpack so the complex bins are never written. Each bin is unpacked exactly as `RealFFTUnpack` does and squared in registers, in one pass.

```go
func RealFFTPower(dst, zRe, zIm, twRe, twIm []float64)
```

Same inputs and same bin range as `RealFFTUnpack` (`dst[k] = |X[k]|^2` for k in `[1, n-1]`, DC and Nyquist left to the caller), just one output array of power instead of two of complex.

## Why single-pass, not the k/n-k symmetry (yet)

The issue sketches reading bins k and n-k together so one load pair yields two power outputs. I measured that first: a pure-Go loop doing exactly that is 1.4-1.6x *slower* than the vectorized three-pass baseline at these cache-resident sizes, because a scalar single pass is compute-bound (~34 GiB/s) while three AVX passes are bandwidth-bound (~50 GiB/s). The traffic win only pays off once the compute is also vectorized. So this PR ships the vectorized single pass, which reuses the proven reversed-load structure of the `RealFFTUnpack` kernels verbatim (AVX2+FMA on amd64, NEON on arm64) with the two complex stores replaced by one fused squared-magnitude store. It beats the baseline on both arches at low risk. The further k/n-k load-halving is a clean follow-up on top of this.

## Numerics

The SIMD kernels fuse the magnitude-squared with an FMA (single rounding) on their vector lanes; the pure-Go reference uses separate multiply and add, so the two agree to within rounding, exactly as the `RealFFTUnpack` odd-term FMA already does. The Go reference is bit-for-bit equal to squaring `realFFTUnpack64Go`'s output on every bin. Measured worst relative divergence of the SIMD path against an independent oracle is 1.2e-14.

## Tests

Go reference (source of truth) plus: parity of the dispatched kernel against an independent unpack-then-square oracle; dispatched-vs-Go parity across the full AVX/NEON remainder cycle; a no-tolerance bit-exact check of the Go reference against unpack-then-square; a reversed-load over-read guard with NaN guard bands; signed-zero pinning; short-slice guards; a zero-allocation assertion; and a differential fuzz. All green on amd64 and on a Raspberry Pi 5 (arm64, NEON), including `go vet`'s asmdecl analyzer on both arches.

## Benchmark

`RealFFTPower` (fused) vs `RealFFTUnpack + Mul + FMA`, GOMAXPROCS=1, benchstat. n is the half-size (nfft/2).

i7-1260P (idle):

| nfft | fused | unpack+Mul+FMA | speedup |
|------|-------|----------------|---------|
| 256  | 55.05n | 83.89n | 1.52x |
| 512  | 107.7n | 157.3n | 1.46x |
| 1024 | 221.8n | 318.6n | 1.44x |
| 2048 | 449.4n | 785.5n | 1.75x |

Raspberry Pi 5 (Cortex-A76, NEON):

| nfft | fused | unpack+Mul+FMA | speedup |
|------|-------|----------------|---------|
| 256  | 400.7n | 525.0n | 1.31x |
| 512  | 781.7n | 1.009µ | 1.29x |
| 1024 | 1.543µ | 1.975µ | 1.28x |
| 2048 | 3.072µ | 3.964µ | 1.29x |

An f32 sibling is deferred to a follow-up (this issue is f64-scoped, and the repo has shipped f32 siblings as separate PRs).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added `f64.RealFFTPower` to calculate real-FFT power-spectrum values directly.
  * Supports optimized execution across supported platforms, with a portable fallback.
  * Validates input sizes and slice lengths without modifying output on invalid input.

* **Documentation**
  * Documented `RealFFTPower` and its role in real-FFT operations.

* **Tests**
  * Added comprehensive correctness, edge-case, compatibility, allocation, and benchmark coverage.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->