### PR TITLE
i8: signed-int8 Quantize/Dequantize/Requantize (Part of #132)

### DIFF
--- a/README.md
+++ b/README.md
@@ -682,7 +682,7 @@ The interleave kernels are pure 16-bit-lane movement (AVX2/SSE2 word unpacks plu
 
 ### `i8` - int8 Operations
 
-SIMD-accelerated int8 operations for quantized numeric pipelines. The narrow `-128..127` range makes element-wise arithmetic overflow almost immediately, so this package does not mirror the wrapping arithmetic of `i16`/`i32`. It ships the operations that are genuinely high-impact and well-defined at 8-bit width: saturating arithmetic, element-wise min/max/clamp and saturating abs/neg/abs-diff, int32-accumulated reductions, signed min/max, the per-tensor abs-max for dynamic quantization, and sign-extending widening.
+SIMD-accelerated int8 operations for quantized numeric pipelines. The narrow `-128..127` range makes element-wise arithmetic overflow almost immediately, so this package does not mirror the wrapping arithmetic of `i16`/`i32`. It ships the operations that are genuinely high-impact and well-defined at 8-bit width: saturating arithmetic, element-wise min/max/clamp and saturating abs/neg/abs-diff, int32-accumulated reductions, signed min/max, the per-tensor abs-max for dynamic quantization, sign-extending widening, and the `float32 <-> int8` affine quantization boundary (`Quantize`/`Dequantize`/`Requantize`).
 
 | Category       | Function                   | Description                                                    | SIMD Width             |
 | -------------- | -------------------------- | -------------------------------------------------------------- | ---------------------- |
@@ -704,6 +704,9 @@ SIMD-accelerated int8 operations for quantized numeric pipelines. The narrow `-1
 |                | `MaxAbs(a) int`            | Per-tensor abs-max (dynamic-quantization scale), range `[0,128]`| 32x (AVX2) / 16x (NEON)|
 |                | `SumAbs(a) int32`          | Sum of absolute values (L1 norm)                               | 32x (AVX2) / 16x (NEON)|
 |                | `SAD(a, b) int32`          | Sum of absolute differences (block matching / feature distance)| 32x (AVX2) / 16x (NEON)|
+| **Quantization**| `Quantize(dst, src, scale, zp)` | `float32 -> int8`: `clamp(rne(src/scale) + zp, -128, 127)` | 16x (AVX2) / 16x (NEON)|
+|                | `Dequantize(dst, src, scale, zp)`| `int8 -> float32`: `float32(src - zp) * scale`             | 8x (AVX2) / 8x (NEON)  |
+|                | `Requantize(dst, acc, mul, shift, zp)`| `int32 -> int8`: gemmlowp fixed-point rescale (Q31 multiplier + shift)| 8x (AVX2) / 8x (NEON)  |
 
 ```go
 import "github.com/tphakala/simd/i8"
@@ -733,11 +736,23 @@ dist := i8.SAD(a, b)       // sum of absolute differences |a[i]-b[i]|
 
 w16 := make([]int16, len(a))
 i8.ToInt16(w16, a) // sign-extend to int16 (exact)
+
+// Per-tensor affine quantization (ONNX / PyTorch / TFLite convention).
+f := []float32{ /* ... */ }
+acc := []int32{ /* matmul/conv accumulators */ }
+q := make([]int8, len(f))
+i8.Quantize(q, f, 0.05, -3)      // float32 -> int8: round(f/scale) + zeroPoint
+back := make([]float32, len(q))
+i8.Dequantize(back, q, 0.05, -3) // int8 -> float32: (q - zeroPoint) * scale
+out := make([]int8, len(acc))
+i8.Requantize(out, acc, 0x40000000, -2, 0) // int32 accumulator -> int8
 ```
 
 `AddSaturate`/`SubSaturate` (and the scalar-broadcast `AddScalarSaturate`/`SubScalarSaturate`) use single saturating instructions (`VPADDSB`/`VPSUBSB` on AVX2, `SQADD`/`SQSUB` on NEON) and clamp instead of wrapping, which is what 8-bit arithmetic almost always wants. The element-wise group is single-instruction too: `Min`/`Max` map to `VPMINSB`/`VPMAXSB` (`SMIN`/`SMAX` on NEON), `Clamp` broadcasts the bounds and applies max-then-min, and `Abs`/`Neg` saturate so `-128` maps to `127` (`SQABS`/`SQNEG` on NEON; `max(a, saturating(0-a))` and `saturating(0-a)` on AVX2). `AbsDiff` saturates `|a - b|` to `[0, 127]` (`SABD` then an unsigned min with 127 on NEON; `max(saturating(a-b), saturating(b-a))` on AVX2), and `MaxAbs` returns the per-tensor abs-max as `int` (range `[0, 128]`, since `|-128| = 128` does not fit `int8`) via `PABSB`+unsigned `PMAXUB` on AVX2 and `ABS`+`UMAXV` on NEON, which is the scale a dynamic quantizer needs. `SumAbs` (L1 norm) and `SAD` (sum of absolute differences, the block-matching reduction) accumulate in int32 via `PSADBW` on AVX2 (`SAD` offsets both operands by 128 so the unsigned `PSADBW` yields the true signed `|a-b|`) and `ABS`/`SABD` + `UADDLP`/`UADALP` on NEON. `Sum` and `DotProduct` accumulate in int32 with two's-complement wraparound; since int32 wrapping addition is associative, the lane-parallel SIMD reductions are bit-identical to the scalar reference regardless of summation order, and the int8 products never overflow their lane (`|int8 * int8| <= 16384`). `DotProduct` is the inner loop of quantized matmul/convolution: on AVX2 it widens with `VPMOVSXBW` and reduces with `VPMADDWD`; on ARM64 with `FEAT_DotProd` it uses `SDOT` (16 multiply-accumulates per instruction), falling back to a `SMULL`/`SADALP` base-NEON path on cores without it. All operations are zero-allocation and bit-exact against the pure-Go reference.
 
-> **Planned follow-ups:** `float32 <-> int8` affine `Quantize`/`Dequantize` (scale + zero-point), an AVX-512 VNNI (`VPDPBUSD`) `DotProduct` fast path, and 8-bit channel `Interleave2`/`Deinterleave2`.
+`Quantize`/`Dequantize`/`Requantize` are the signed per-tensor affine boundary of a quantized pipeline (the ONNX / PyTorch / TFLite convention `q = round(r/scale) + zeroPoint`, `r = (q - zeroPoint) * scale`). `Quantize` uses a genuine IEEE-754 float32 divide (not a reciprocal multiply) and round-half-to-even, so the documented formula is literally true and the result is bit-identical across Go, AVX2 (`VDIVPS` + `VCVTPS2DQ`) and NEON (`FDIV` + `FCVTNS`); NaN maps to the zero point, `+Inf` saturates to `127` and `-Inf` to `-128`. `Dequantize` is an exact int subtract plus a single multiply (the only rounding), also bit-identical across all three. `Requantize` rescales an int32 accumulator with the gemmlowp / TFLite double-rounding epilogue: a left shift, `SaturatingRoundingDoublingHighMul` against a Q31 multiplier (`SQRDMULH` on NEON; the `i32` `VPMULDQ` high-mul recipe with a rounding nudge on AVX2), then `RoundingDivideByPOT` with ties away from zero, and a final clamp to int8. Out-of-contract inputs (`multiplier == math.MinInt32`, or a shift outside `[-31, 30]`) fall back to the full-width Go path. All three are validated bit-exact against their pure-Go references by parity sweeps, known-answer tables and differential fuzzing on both architectures.
+
+> **Planned follow-ups:** per-channel `Quantize`/`Dequantize` (per-axis scale + zero-point) and a fused `DotProduct`-plus-`Requantize` matmul epilogue, an AVX-512 VNNI (`VPDPBUSD`) `DotProduct` fast path, and 8-bit channel `Interleave2`/`Deinterleave2`.
 
 ## Performance
 

--- a/i8/benchmark_test.go
+++ b/i8/benchmark_test.go
@@ -245,3 +245,33 @@ func BenchmarkSAD_N(b *testing.B) {
 		})
 	}
 }
+
+func BenchmarkQuantize(b *testing.B) {
+	src := genF32(benchN, 1)
+	dst := make([]int8, benchN)
+	b.SetBytes(benchN * 4) // float32 input
+	b.ResetTimer()
+	for b.Loop() {
+		Quantize(dst, src, 0.05, -3)
+	}
+}
+
+func BenchmarkDequantize(b *testing.B) {
+	src := genI8(benchN, 1)
+	dst := make([]float32, benchN)
+	b.SetBytes(benchN) // int8 input
+	b.ResetTimer()
+	for b.Loop() {
+		Dequantize(dst, src, 0.05, -3)
+	}
+}
+
+func BenchmarkRequantize(b *testing.B) {
+	acc := genI32(benchN, 1)
+	dst := make([]int8, benchN)
+	b.SetBytes(benchN * 4) // int32 input
+	b.ResetTimer()
+	for b.Loop() {
+		Requantize(dst, acc, 0x40000000, -2, 0)
+	}
+}

--- a/i8/example_test.go
+++ b/i8/example_test.go
@@ -27,3 +27,31 @@ func ExampleMinMax() {
 	fmt.Println(lo, hi)
 	// Output: -128 127
 }
+
+func ExampleQuantize() {
+	// scale 0.5, zeroPoint 0: q = round_to_even(src/0.5) + 0, clamped.
+	src := []float32{0.25, 0.75, 1.25, -0.25, 64.0, -100.0}
+	dst := make([]int8, len(src))
+	i8.Quantize(dst, src, 0.5, 0)
+	// 0.5 and 2.5 round to even (0 and 2); 128 and -200 saturate.
+	fmt.Println(dst)
+	// Output: [0 2 2 0 127 -128]
+}
+
+func ExampleDequantize() {
+	// dst = float32(src - zeroPoint) * scale.
+	dst := make([]float32, 4)
+	i8.Dequantize(dst, []int8{5, -128, 127, 3}, 0.5, 3)
+	fmt.Println(dst)
+	// Output: [1 -65.5 62 0]
+}
+
+func ExampleRequantize() {
+	// multiplier 0x40000000 is 0.5 in Q31 and shift 0, so each accumulator is
+	// halved with round-half-up, then the zero point is added.
+	acc := []int32{5, 4, -3, -4, 200}
+	dst := make([]int8, len(acc))
+	i8.Requantize(dst, acc, 0x40000000, 0, 0)
+	fmt.Println(dst)
+	// Output: [3 2 -1 -2 100]
+}

--- a/i8/i8.go
+++ b/i8/i8.go
@@ -22,6 +22,12 @@
 //     abs-max for dynamic quantization, returned as int because |-128| = 128).
 //   - Sign-extending widening (ToInt16, ToInt32) to hand off to the wider
 //     integer or float packages.
+//   - Per-tensor affine quantization (Quantize, Dequantize, Requantize): the
+//     float32<->int8 boundary of a quantized pipeline, following the ONNX /
+//     PyTorch / TFLite convention. Quantize is a true float32 divide plus
+//     round-to-nearest-even; Dequantize is an exact subtract and single
+//     multiply; Requantize is the gemmlowp fixed-point rescale (Q31 multiplier
+//     and shift) that turns an int32 accumulator back into int8.
 //
 // Sum and DotProduct accumulate in int32 with two's-complement wraparound,
 // exactly like their pure-Go references. int32 wrapping addition is associative

--- a/i8/i8_amd64.go
+++ b/i8/i8_amd64.go
@@ -211,3 +211,18 @@ func sumAbsAVX2(a []int8) int32
 
 //go:noescape
 func sadAVX2(a, b []int8) int32
+
+// Quantization dispatch (Part of #132). Go-only for now; the AVX2 kernels are
+// wired in a later step.
+
+func quantizeI8(dst []int8, src []float32, scale float32, zeroPoint int8) {
+	quantizeGo(dst, src, scale, zeroPoint)
+}
+
+func dequantizeI8(dst []float32, src []int8, scale float32, zeroPoint int8) {
+	dequantizeGo(dst, src, scale, zeroPoint)
+}
+
+func requantizeI8(dst []int8, acc []int32, multiplier int32, shift int, zeroPoint int8) {
+	requantizeGo(dst, acc, multiplier, shift, zeroPoint)
+}

--- a/i8/i8_amd64.go
+++ b/i8/i8_amd64.go
@@ -212,17 +212,45 @@ func sumAbsAVX2(a []int8) int32
 //go:noescape
 func sadAVX2(a, b []int8) int32
 
-// Quantization dispatch (Part of #132). Go-only for now; the AVX2 kernels are
-// wired in a later step.
+// Quantization dispatch (Part of #132). The AVX2 kernels process 16/8/8 lanes
+// per iteration; shorter slices use the pure-Go reference. Requantize also
+// routes out-of-contract inputs (multiplier == math.MinInt32, or shift outside
+// [-31, 30]) to Go, since the kernel assumes the sane domain.
+const (
+	blockQuant   = 16 // quantizeAVX2 packs 16 int8 per iteration
+	blockDequant = 8  // dequantizeAVX2 widens 8 int8 per iteration
+	blockRequant = 8  // requantizeAVX2 processes 8 int32 per iteration
+)
 
 func quantizeI8(dst []int8, src []float32, scale float32, zeroPoint int8) {
+	if hasAVX2 && len(dst) >= blockQuant {
+		quantizeAVX2(dst, src, scale, zeroPoint)
+		return
+	}
 	quantizeGo(dst, src, scale, zeroPoint)
 }
 
 func dequantizeI8(dst []float32, src []int8, scale float32, zeroPoint int8) {
+	if hasAVX2 && len(dst) >= blockDequant {
+		dequantizeAVX2(dst, src, scale, zeroPoint)
+		return
+	}
 	dequantizeGo(dst, src, scale, zeroPoint)
 }
 
 func requantizeI8(dst []int8, acc []int32, multiplier int32, shift int, zeroPoint int8) {
+	if hasAVX2 && !requantizeOutOfContract(multiplier, shift) && len(dst) >= blockRequant {
+		requantizeAVX2(dst, acc, multiplier, shift, zeroPoint)
+		return
+	}
 	requantizeGo(dst, acc, multiplier, shift, zeroPoint)
 }
+
+//go:noescape
+func quantizeAVX2(dst []int8, src []float32, scale float32, zeroPoint int8)
+
+//go:noescape
+func dequantizeAVX2(dst []float32, src []int8, scale float32, zeroPoint int8)
+
+//go:noescape
+func requantizeAVX2(dst []int8, acc []int32, multiplier int32, shift int, zeroPoint int8)

--- a/i8/i8_amd64.s
+++ b/i8/i8_amd64.s
@@ -1230,3 +1230,291 @@ sad_done:
     MOVL AX, ret+48(FP)
     VZEROUPPER
     RET
+
+// -----------------------------------------------------------------------------
+// Quantization kernels (Part of #132). All three are AVX2 and gate on hasAVX2
+// in i8_amd64.go; the dispatch guards the minimum length, so each runs at least
+// one full vector block and absorbs the (n mod block) tail with an overlapping
+// final block (dst and src have distinct element types and cannot alias, so the
+// re-store of identical values is safe). The Go assembler's 3-operand AVX order
+// is dst-last. No hand-encoded directives; every mnemonic is assembler-native.
+// -----------------------------------------------------------------------------
+
+// func quantizeAVX2(dst []int8, src []float32, scale float32, zeroPoint int8)
+// dst[i] = clamp(rne(src[i]/scale) + zeroPoint, -128, 127), 16 lanes/iteration.
+// The clamp bounds lo=-128-zp and hi=127-zp are built as int32 then converted to
+// float32 (exact, both in [-255,255]); clamping the float before VCVTPS2DQ is
+// equivalent to rounding then clamping because RNE is monotone and the bounds are
+// exactly representable integers. NaN is scrubbed to 0.0 (self-compare + AND) so
+// it lands on zeroPoint; +Inf clamps to hi (=127 after +zp), -Inf to lo (=-128).
+// The int8 pack is written fresh (not reused from f32's int16 packer): VPACKSSDW
+// then VPERMQ linearizes the int16, VPACKSSWB then VPERMQ linearizes the int8, so
+// the 16 output bytes are in source order (proven by the caution-B ramp test).
+TEXT ·quantizeAVX2(SB), NOSPLIT, $0-53
+    MOVQ dst_base+0(FP), DX
+    MOVQ dst_len+8(FP), CX
+    MOVQ src_base+24(FP), SI
+
+    VBROADCASTSS scale+48(FP), Y3   // scale x8
+    MOVBLSX zeroPoint+52(FP), BX    // zp (sign-extended int32)
+    MOVL $-128, AX
+    SUBL BX, AX                     // AX = -128 - zp = lo (int32)
+    VMOVD AX, X4
+    VPBROADCASTD X4, Y4
+    VCVTDQ2PS Y4, Y4                // loVec (float32)
+    MOVL $127, AX
+    SUBL BX, AX                     // AX = 127 - zp = hi (int32)
+    VMOVD AX, X5
+    VPBROADCASTD X5, Y5
+    VCVTDQ2PS Y5, Y5                // hiVec (float32)
+    VMOVD BX, X6
+    VPBROADCASTD X6, Y6             // zpVec (int32)
+
+    MOVQ CX, AX
+    SHRQ $4, AX                     // AX = n / 16
+    JZ   quant_tail
+
+quant_loop16:
+    VMOVUPS (SI), Y0                // src[0..7]
+    VMOVUPS 32(SI), Y1             // src[8..15]
+    VDIVPS Y3, Y0, Y0              // src / scale
+    VDIVPS Y3, Y1, Y1
+    VCMPPS $0, Y0, Y0, Y7         // EQ_OQ self: 0 for NaN lanes
+    VANDPS Y7, Y0, Y0             // NaN -> 0.0
+    VCMPPS $0, Y1, Y1, Y7
+    VANDPS Y7, Y1, Y1
+    VMAXPS Y4, Y0, Y0             // max(x, lo)
+    VMINPS Y5, Y0, Y0             // min(., hi)
+    VMAXPS Y4, Y1, Y1
+    VMINPS Y5, Y1, Y1
+    VCVTPS2DQ Y0, Y0              // round nearest-even -> int32
+    VCVTPS2DQ Y1, Y1
+    VPADDD Y6, Y0, Y0            // + zeroPoint
+    VPADDD Y6, Y1, Y1
+    VPACKSSDW Y1, Y0, Y2         // int32 -> int16 (lane-interleaved)
+    VPERMQ $0xD8, Y2, Y2         // linearize int16
+    VPACKSSWB Y2, Y2, Y2         // int16 -> int8
+    VPERMQ $0xD8, Y2, Y2         // linearize: low 128 = 16 int8 in order
+    VMOVDQU X2, (DX)
+    ADDQ $64, SI
+    ADDQ $16, DX
+    DECQ AX
+    JNZ  quant_loop16
+
+quant_tail:
+    ANDQ $15, CX                  // n % 16
+    JZ   quant_done
+    MOVQ src_base+24(FP), SI      // reload bases
+    MOVQ dst_len+8(FP), AX        // n
+    LEAQ -16(AX), BX              // n - 16
+    LEAQ (SI)(BX*4), SI          // &src[n-16]
+    MOVQ dst_base+0(FP), DX
+    ADDQ BX, DX                  // &dst[n-16]
+    VMOVUPS (SI), Y0
+    VMOVUPS 32(SI), Y1
+    VDIVPS Y3, Y0, Y0
+    VDIVPS Y3, Y1, Y1
+    VCMPPS $0, Y0, Y0, Y7
+    VANDPS Y7, Y0, Y0
+    VCMPPS $0, Y1, Y1, Y7
+    VANDPS Y7, Y1, Y1
+    VMAXPS Y4, Y0, Y0
+    VMINPS Y5, Y0, Y0
+    VMAXPS Y4, Y1, Y1
+    VMINPS Y5, Y1, Y1
+    VCVTPS2DQ Y0, Y0
+    VCVTPS2DQ Y1, Y1
+    VPADDD Y6, Y0, Y0
+    VPADDD Y6, Y1, Y1
+    VPACKSSDW Y1, Y0, Y2
+    VPERMQ $0xD8, Y2, Y2
+    VPACKSSWB Y2, Y2, Y2
+    VPERMQ $0xD8, Y2, Y2
+    VMOVDQU X2, (DX)
+
+quant_done:
+    VZEROUPPER
+    RET
+
+// func dequantizeAVX2(dst []float32, src []int8, scale float32, zeroPoint int8)
+// dst[i] = float32(int32(src[i]) - zeroPoint) * scale, 8 lanes/iteration. The
+// subtraction is exact and the int->float convert is exact (|x-zp| <= 255), so
+// the single VMULPS is the only rounding.
+TEXT ·dequantizeAVX2(SB), NOSPLIT, $0-53
+    MOVQ dst_base+0(FP), DX
+    MOVQ dst_len+8(FP), CX
+    MOVQ src_base+24(FP), SI
+
+    VBROADCASTSS scale+48(FP), Y3   // scale x8
+    MOVBLSX zeroPoint+52(FP), BX
+    VMOVD BX, X4
+    VPBROADCASTD X4, Y4             // zpVec (int32)
+
+    MOVQ CX, AX
+    SHRQ $3, AX                     // AX = n / 8
+    JZ   dequant_tail
+
+dequant_loop8:
+    VPMOVSXBD (SI), Y0             // 8 int8 -> 8 int32
+    VPSUBD Y4, Y0, Y0             // - zeroPoint
+    VCVTDQ2PS Y0, Y0             // -> float32
+    VMULPS Y3, Y0, Y0           // * scale
+    VMOVUPS Y0, (DX)
+    ADDQ $8, SI
+    ADDQ $32, DX
+    DECQ AX
+    JNZ  dequant_loop8
+
+dequant_tail:
+    ANDQ $7, CX                   // n % 8
+    JZ   dequant_done
+    MOVQ src_base+24(FP), SI
+    MOVQ dst_len+8(FP), AX        // n
+    LEAQ -8(AX), BX              // n - 8
+    ADDQ BX, SI                 // &src[n-8]
+    MOVQ dst_base+0(FP), DX
+    LEAQ (DX)(BX*4), DX         // &dst[n-8]
+    VPMOVSXBD (SI), Y0
+    VPSUBD Y4, Y0, Y0
+    VCVTDQ2PS Y0, Y0
+    VMULPS Y3, Y0, Y0
+    VMOVUPS Y0, (DX)
+
+dequant_done:
+    VZEROUPPER
+    RET
+
+// func requantizeAVX2(dst []int8, acc []int32, multiplier int32, shift int, zeroPoint int8)
+// The gemmlowp double-rounding epilogue, 8 lanes/iteration. left = max(shift,0)
+// and right = max(-shift,0); the out-of-contract reroute in i8_amd64.go keeps
+// multiplier != MinInt32 and shift in [-31,30], so the SRDHM saturation guard is
+// never needed and the products cannot wrap. SRDHM reuses i32 scaleQ31AVX2's
+// VPMULDQ even/odd recipe with a (1<<30) nudge added before VPSRLQ $31 (the low
+// 32 bits of the logical shift equal the arithmetic shift at shift 31).
+// RoundingDivideByPOT is done branch-free: q = y>>right (VPSRAVD), and the
+// round-half-away increment is q - ((y&mask) > (mask>>1) - sign(y)). At right==0
+// the mask is 0 so the remainder is 0 and no increment fires, giving the exact
+// identity. The clamp is applied BEFORE the +zp (VPADDD wraps, so z+zp could
+// overflow int32); the bounds are -128-zp and 127-zp.
+TEXT ·requantizeAVX2(SB), NOSPLIT, $0-65
+    MOVQ dst_base+0(FP), DX
+    MOVQ dst_len+8(FP), DI          // n
+    MOVQ acc_base+24(FP), SI
+
+    MOVL multiplier+48(FP), AX
+    VMOVD AX, X0
+    VPBROADCASTD X0, Y6            // multiplier x8 (int32)
+
+    MOVQ shift+56(FP), BX          // shift (int64)
+    XORQ CX, CX
+    MOVQ BX, R9
+    CMPQ R9, CX
+    CMOVQLT CX, R9                // R9 = max(shift, 0) = left
+    MOVQ CX, R10
+    SUBQ BX, R10                  // -shift
+    CMPQ R10, CX
+    CMOVQLT CX, R10               // R10 = max(-shift, 0) = right
+
+    VMOVD R9, X1
+    VPBROADCASTD X1, Y7           // leftVec (int32, all lanes = left)
+    VMOVD R10, X2
+    VPBROADCASTD X2, Y8           // rightVec (int32, all lanes = right)
+
+    MOVQ $0x40000000, AX          // 1<<30 nudge
+    VMOVQ AX, X3
+    VPBROADCASTQ X3, Y9           // nudgeVec (int64 x4)
+
+    MOVL $1, AX
+    MOVQ R10, CX                  // CX = right (shift count in CL)
+    SHLL CX, AX                   // 1 << right
+    DECL AX                       // mask = (1<<right) - 1
+    MOVL AX, BX
+    SARL $1, BX                   // halfmask = mask >> 1
+    VMOVD AX, X4
+    VPBROADCASTD X4, Y10          // maskVec (int32)
+    VMOVD BX, X5
+    VPBROADCASTD X5, Y11          // halfVec (int32)
+
+    MOVBLSX zeroPoint+64(FP), BX  // zp (int32)
+    MOVL $-128, AX
+    SUBL BX, AX
+    VMOVD AX, X0
+    VPBROADCASTD X0, Y12          // loVec = -128 - zp
+    MOVL $127, AX
+    SUBL BX, AX
+    VMOVD AX, X1
+    VPBROADCASTD X1, Y13          // hiVec = 127 - zp
+    VMOVD BX, X2
+    VPBROADCASTD X2, Y14          // zpVec
+
+    MOVQ DI, AX
+    SHRQ $3, AX                   // AX = n / 8
+    JZ   requant_tail
+
+requant_loop8:
+    VMOVDQU (SI), Y0              // acc[0..7]
+    VPSLLVD Y7, Y0, Y0           // x = acc << left
+    VPMULDQ Y6, Y0, Y1          // even-lane products (int64)
+    VPSRLQ $32, Y0, Y2          // slide odd lanes into even positions
+    VPMULDQ Y6, Y2, Y2          // odd-lane products (int64)
+    VPADDQ Y9, Y1, Y1           // + nudge (even)
+    VPADDQ Y9, Y2, Y2           // + nudge (odd)
+    VPSRLQ $31, Y1, Y1          // low 32 = even SRDHM results
+    VPSRLQ $31, Y2, Y2          // low 32 = odd SRDHM results
+    VPSLLQ $32, Y2, Y2          // lift odd results to positions 1,3,5,7
+    VPBLENDD $0xAA, Y2, Y1, Y0  // y = merge even/odd
+    VPSRAVD Y8, Y0, Y1          // q = y >> right (arithmetic)
+    VPAND Y10, Y0, Y2           // rem = y & mask
+    VPSRAD $31, Y0, Y3          // sign = y >> 31 (all ones if negative)
+    VPSUBD Y3, Y11, Y3          // thr = halfmask - sign  (+1 when y<0)
+    VPCMPGTD Y3, Y2, Y2         // cmp = (rem > thr) ? -1 : 0
+    VPSUBD Y2, Y1, Y0           // z = q - cmp  (+1 when rem>thr)
+    VPMAXSD Y12, Y0, Y0         // clamp low  (>= -128-zp)
+    VPMINSD Y13, Y0, Y0         // clamp high (<= 127-zp)
+    VPADDD Y14, Y0, Y0          // + zeroPoint -> [-128,127]
+    VPACKSSDW Y0, Y0, Y0        // int32 -> int16
+    VPERMQ $0x08, Y0, Y0        // low 128 = [z0..z7] int16
+    VPACKSSWB Y0, Y0, Y0        // low 64 = [z0..z7] int8
+    VMOVQ X0, (DX)
+    ADDQ $32, SI
+    ADDQ $8, DX
+    DECQ AX
+    JNZ  requant_loop8
+
+requant_tail:
+    MOVQ DI, AX
+    ANDQ $7, AX                  // n % 8
+    JZ   requant_done
+    MOVQ acc_base+24(FP), SI
+    MOVQ dst_base+0(FP), DX
+    LEAQ -8(DI), BX             // n - 8
+    LEAQ (SI)(BX*4), SI        // &acc[n-8]
+    ADDQ BX, DX                // &dst[n-8]
+    VMOVDQU (SI), Y0
+    VPSLLVD Y7, Y0, Y0
+    VPMULDQ Y6, Y0, Y1
+    VPSRLQ $32, Y0, Y2
+    VPMULDQ Y6, Y2, Y2
+    VPADDQ Y9, Y1, Y1
+    VPADDQ Y9, Y2, Y2
+    VPSRLQ $31, Y1, Y1
+    VPSRLQ $31, Y2, Y2
+    VPSLLQ $32, Y2, Y2
+    VPBLENDD $0xAA, Y2, Y1, Y0
+    VPSRAVD Y8, Y0, Y1
+    VPAND Y10, Y0, Y2
+    VPSRAD $31, Y0, Y3
+    VPSUBD Y3, Y11, Y3
+    VPCMPGTD Y3, Y2, Y2
+    VPSUBD Y2, Y1, Y0
+    VPMAXSD Y12, Y0, Y0
+    VPMINSD Y13, Y0, Y0
+    VPADDD Y14, Y0, Y0
+    VPACKSSDW Y0, Y0, Y0
+    VPERMQ $0x08, Y0, Y0
+    VPACKSSWB Y0, Y0, Y0
+    VMOVQ X0, (DX)
+
+requant_done:
+    VZEROUPPER
+    RET

--- a/i8/i8_arm64.go
+++ b/i8/i8_arm64.go
@@ -215,17 +215,45 @@ func sumAbsNEON(a []int8) int32
 //go:noescape
 func sadNEON(a, b []int8) int32
 
-// Quantization dispatch (Part of #132). Go-only for now; the NEON kernels are
-// wired in a later step.
+// Quantization dispatch (Part of #132). NEON processes 16/8/8 lanes per
+// iteration; shorter slices use the pure-Go reference. Requantize also routes
+// out-of-contract inputs (multiplier == math.MinInt32, or shift outside
+// [-31, 30]) to Go, since the kernel assumes the sane domain.
+const (
+	minNEONQuant   = 16 // quantizeNEON packs 16 int8 per iteration
+	minNEONDequant = 8  // dequantizeNEON widens 8 int8 per iteration
+	minNEONRequant = 8  // requantizeNEON processes 8 int32 per iteration
+)
 
 func quantizeI8(dst []int8, src []float32, scale float32, zeroPoint int8) {
+	if hasNEON && len(dst) >= minNEONQuant {
+		quantizeNEON(dst, src, scale, zeroPoint)
+		return
+	}
 	quantizeGo(dst, src, scale, zeroPoint)
 }
 
 func dequantizeI8(dst []float32, src []int8, scale float32, zeroPoint int8) {
+	if hasNEON && len(dst) >= minNEONDequant {
+		dequantizeNEON(dst, src, scale, zeroPoint)
+		return
+	}
 	dequantizeGo(dst, src, scale, zeroPoint)
 }
 
 func requantizeI8(dst []int8, acc []int32, multiplier int32, shift int, zeroPoint int8) {
+	if hasNEON && !requantizeOutOfContract(multiplier, shift) && len(dst) >= minNEONRequant {
+		requantizeNEON(dst, acc, multiplier, shift, zeroPoint)
+		return
+	}
 	requantizeGo(dst, acc, multiplier, shift, zeroPoint)
 }
+
+//go:noescape
+func quantizeNEON(dst []int8, src []float32, scale float32, zeroPoint int8)
+
+//go:noescape
+func dequantizeNEON(dst []float32, src []int8, scale float32, zeroPoint int8)
+
+//go:noescape
+func requantizeNEON(dst []int8, acc []int32, multiplier int32, shift int, zeroPoint int8)

--- a/i8/i8_arm64.go
+++ b/i8/i8_arm64.go
@@ -214,3 +214,18 @@ func sumAbsNEON(a []int8) int32
 
 //go:noescape
 func sadNEON(a, b []int8) int32
+
+// Quantization dispatch (Part of #132). Go-only for now; the NEON kernels are
+// wired in a later step.
+
+func quantizeI8(dst []int8, src []float32, scale float32, zeroPoint int8) {
+	quantizeGo(dst, src, scale, zeroPoint)
+}
+
+func dequantizeI8(dst []float32, src []int8, scale float32, zeroPoint int8) {
+	dequantizeGo(dst, src, scale, zeroPoint)
+}
+
+func requantizeI8(dst []int8, acc []int32, multiplier int32, shift int, zeroPoint int8) {
+	requantizeGo(dst, acc, multiplier, shift, zeroPoint)
+}

--- a/i8/i8_arm64.s
+++ b/i8/i8_arm64.s
@@ -920,8 +920,8 @@ quant_done:
 // (|x-zp| <= 255), so the single FMUL is the only rounding.
 TEXT ·dequantizeNEON(SB), NOSPLIT, $0-53
     MOVD dst_base+0(FP), R0
+    MOVD dst_len+8(FP), R3    // n (== len(src); the two kernels agree with quantize/requantize)
     MOVD src_base+24(FP), R1
-    MOVD src_len+32(FP), R3
 
     MOVWU scale+48(FP), R5
     WORD $0x4E040CA4              // DUP V4.4S, W5    (scale x4)

--- a/i8/i8_arm64.s
+++ b/i8/i8_arm64.s
@@ -803,3 +803,253 @@ sad_scalar:
 sad_done:
     MOVW R5, ret+48(FP)
     RET
+
+// -----------------------------------------------------------------------------
+// Quantization kernels (Part of #132). All three are baseline NEON (ASIMD) and
+// gate on hasNEON; the dispatch guards the minimum length, so each runs at least
+// one full vector block and absorbs the (n mod block) tail with an overlapping
+// final block (dst and src have distinct element types and cannot alias, so the
+// re-store of identical values is safe). Every new vector op is hand-encoded as
+// WORD with its decoded GNU mnemonic; TestArm64WordEncodings cross-checks each.
+// -----------------------------------------------------------------------------
+
+// func quantizeNEON(dst []int8, src []float32, scale float32, zeroPoint int8)
+// dst[i] = clamp(rne(src[i]/scale) + zeroPoint, -128, 127), 16 lanes/iteration.
+// The clamp bounds lo=-128-zp and hi=127-zp are built as int32 then converted to
+// float32 (SCVTF, exact); FMAX/FMIN propagate NaN so FCVTNS(NaN)=0 lands on
+// zeroPoint, and they map +Inf to hi (=127 after +zp) and -Inf to lo (=-128).
+// FCVTNS rounds to nearest even. The int32 lanes are narrowed to int8 with
+// SQXTN/SQXTN2 (saturation is a no-op since they are already in range).
+TEXT ·quantizeNEON(SB), NOSPLIT, $0-53
+    MOVD dst_base+0(FP), R0
+    MOVD dst_len+8(FP), R3
+    MOVD src_base+24(FP), R1
+
+    MOVWU scale+48(FP), R5
+    WORD $0x4E040CA4              // DUP V4.4S, W5    (scale x4)
+    MOVB zeroPoint+52(FP), R6
+    WORD $0x4E040CC7              // DUP V7.4S, W6    (zeroPoint int32 x4)
+    MOVD $-128, R7
+    SUB  R6, R7, R7              // R7 = -128 - zp
+    WORD $0x4E040CE5              // DUP V5.4S, W7    (lo int32 x4)
+    WORD $0x4E21D8A5              // SCVTF V5.4S, V5.4S  (lo -> float32)
+    MOVD $127, R8
+    SUB  R6, R8, R8             // R8 = 127 - zp
+    WORD $0x4E040D06             // DUP V6.4S, W8    (hi int32 x4)
+    WORD $0x4E21D8C6             // SCVTF V6.4S, V6.4S  (hi -> float32)
+
+    LSR  $4, R3, R4             // R4 = n / 16
+    CBZ  R4, quant_tail
+
+quant_loop16:
+    VLD1.P 64(R1), [V0.S4, V1.S4, V2.S4, V3.S4]  // 16 float32
+    WORD $0x6E24FC00             // FDIV V0.4S, V0.4S, V4.4S
+    WORD $0x6E24FC21             // FDIV V1.4S, V1.4S, V4.4S
+    WORD $0x6E24FC42             // FDIV V2.4S, V2.4S, V4.4S
+    WORD $0x6E24FC63             // FDIV V3.4S, V3.4S, V4.4S
+    WORD $0x4E25F400             // FMAX V0.4S, V0.4S, V5.4S
+    WORD $0x4E25F421             // FMAX V1.4S, V1.4S, V5.4S
+    WORD $0x4E25F442             // FMAX V2.4S, V2.4S, V5.4S
+    WORD $0x4E25F463             // FMAX V3.4S, V3.4S, V5.4S
+    WORD $0x4EA6F400             // FMIN V0.4S, V0.4S, V6.4S
+    WORD $0x4EA6F421             // FMIN V1.4S, V1.4S, V6.4S
+    WORD $0x4EA6F442             // FMIN V2.4S, V2.4S, V6.4S
+    WORD $0x4EA6F463             // FMIN V3.4S, V3.4S, V6.4S
+    WORD $0x4E21A800             // FCVTNS V0.4S, V0.4S
+    WORD $0x4E21A821             // FCVTNS V1.4S, V1.4S
+    WORD $0x4E21A842             // FCVTNS V2.4S, V2.4S
+    WORD $0x4E21A863             // FCVTNS V3.4S, V3.4S
+    WORD $0x4EA78400             // ADD V0.4S, V0.4S, V7.4S
+    WORD $0x4EA78421             // ADD V1.4S, V1.4S, V7.4S
+    WORD $0x4EA78442             // ADD V2.4S, V2.4S, V7.4S
+    WORD $0x4EA78463             // ADD V3.4S, V3.4S, V7.4S
+    WORD $0x0E614800             // SQXTN V0.4H, V0.4S
+    WORD $0x4E614820             // SQXTN2 V0.8H, V1.4S
+    WORD $0x0E614841             // SQXTN V1.4H, V2.4S
+    WORD $0x4E614861             // SQXTN2 V1.8H, V3.4S
+    WORD $0x0E214800             // SQXTN V0.8B, V0.8H
+    WORD $0x4E214820             // SQXTN2 V0.16B, V1.8H
+    VST1.P [V0.B16], 16(R0)     // 16 int8
+    SUB  $1, R4
+    CBNZ R4, quant_loop16
+
+quant_tail:
+    AND  $15, R3, R5           // n % 16
+    CBZ  R5, quant_done
+    SUB  $16, R3, R6           // n - 16
+    LSL  $2, R6, R7            // (n-16) * 4 src bytes
+    MOVD src_base+24(FP), R1
+    ADD  R7, R1, R1           // &src[n-16]
+    MOVD dst_base+0(FP), R0
+    ADD  R6, R0, R0           // &dst[n-16]
+    VLD1.P 64(R1), [V0.S4, V1.S4, V2.S4, V3.S4]
+    WORD $0x6E24FC00             // FDIV V0.4S, V0.4S, V4.4S
+    WORD $0x6E24FC21             // FDIV V1.4S, V1.4S, V4.4S
+    WORD $0x6E24FC42             // FDIV V2.4S, V2.4S, V4.4S
+    WORD $0x6E24FC63             // FDIV V3.4S, V3.4S, V4.4S
+    WORD $0x4E25F400             // FMAX V0.4S, V0.4S, V5.4S
+    WORD $0x4E25F421             // FMAX V1.4S, V1.4S, V5.4S
+    WORD $0x4E25F442             // FMAX V2.4S, V2.4S, V5.4S
+    WORD $0x4E25F463             // FMAX V3.4S, V3.4S, V5.4S
+    WORD $0x4EA6F400             // FMIN V0.4S, V0.4S, V6.4S
+    WORD $0x4EA6F421             // FMIN V1.4S, V1.4S, V6.4S
+    WORD $0x4EA6F442             // FMIN V2.4S, V2.4S, V6.4S
+    WORD $0x4EA6F463             // FMIN V3.4S, V3.4S, V6.4S
+    WORD $0x4E21A800             // FCVTNS V0.4S, V0.4S
+    WORD $0x4E21A821             // FCVTNS V1.4S, V1.4S
+    WORD $0x4E21A842             // FCVTNS V2.4S, V2.4S
+    WORD $0x4E21A863             // FCVTNS V3.4S, V3.4S
+    WORD $0x4EA78400             // ADD V0.4S, V0.4S, V7.4S
+    WORD $0x4EA78421             // ADD V1.4S, V1.4S, V7.4S
+    WORD $0x4EA78442             // ADD V2.4S, V2.4S, V7.4S
+    WORD $0x4EA78463             // ADD V3.4S, V3.4S, V7.4S
+    WORD $0x0E614800             // SQXTN V0.4H, V0.4S
+    WORD $0x4E614820             // SQXTN2 V0.8H, V1.4S
+    WORD $0x0E614841             // SQXTN V1.4H, V2.4S
+    WORD $0x4E614861             // SQXTN2 V1.8H, V3.4S
+    WORD $0x0E214800             // SQXTN V0.8B, V0.8H
+    WORD $0x4E214820             // SQXTN2 V0.16B, V1.8H
+    VST1 [V0.B16], (R0)
+
+quant_done:
+    RET
+
+// func dequantizeNEON(dst []float32, src []int8, scale float32, zeroPoint int8)
+// dst[i] = float32(int32(src[i]) - zeroPoint) * scale, 8 lanes/iteration. SXTL
+// widens int8 -> int16 -> int32; the subtract is exact and SCVTF is exact
+// (|x-zp| <= 255), so the single FMUL is the only rounding.
+TEXT ·dequantizeNEON(SB), NOSPLIT, $0-53
+    MOVD dst_base+0(FP), R0
+    MOVD src_base+24(FP), R1
+    MOVD src_len+32(FP), R3
+
+    MOVWU scale+48(FP), R5
+    WORD $0x4E040CA4              // DUP V4.4S, W5    (scale x4)
+    MOVB zeroPoint+52(FP), R6
+    WORD $0x4E040CC5              // DUP V5.4S, W6    (zeroPoint int32 x4)
+
+    LSR  $3, R3, R4             // R4 = n / 8
+    CBZ  R4, dequant_tail
+
+dequant_loop8:
+    VLD1.P 8(R1), [V0.B8]       // 8 int8
+    WORD $0x0F08A400             // SXTL V0.8H, V0.8B   (8 int8 -> 8 int16)
+    WORD $0x0F10A401             // SXTL V1.4S, V0.4H   (low 4 -> int32)
+    WORD $0x4F10A402             // SXTL2 V2.4S, V0.8H  (high 4 -> int32)
+    WORD $0x6EA58421             // SUB V1.4S, V1.4S, V5.4S   (- zeroPoint)
+    WORD $0x6EA58442             // SUB V2.4S, V2.4S, V5.4S
+    WORD $0x4E21D821             // SCVTF V1.4S, V1.4S  (-> float32)
+    WORD $0x4E21D842             // SCVTF V2.4S, V2.4S
+    WORD $0x6E24DC21             // FMUL V1.4S, V1.4S, V4.4S  (* scale)
+    WORD $0x6E24DC42             // FMUL V2.4S, V2.4S, V4.4S
+    VST1.P [V1.S4, V2.S4], 32(R0)  // 8 float32
+    SUB  $1, R4
+    CBNZ R4, dequant_loop8
+
+dequant_tail:
+    AND  $7, R3, R5            // n % 8
+    CBZ  R5, dequant_done
+    SUB  $8, R3, R6           // n - 8
+    MOVD src_base+24(FP), R1
+    ADD  R6, R1, R1          // &src[n-8]
+    LSL  $2, R6, R7          // (n-8) * 4 dst bytes
+    MOVD dst_base+0(FP), R0
+    ADD  R7, R0, R0         // &dst[n-8]
+    VLD1 (R1), [V0.B8]
+    WORD $0x0F08A400             // SXTL V0.8H, V0.8B
+    WORD $0x0F10A401             // SXTL V1.4S, V0.4H
+    WORD $0x4F10A402             // SXTL2 V2.4S, V0.8H
+    WORD $0x6EA58421             // SUB V1.4S, V1.4S, V5.4S
+    WORD $0x6EA58442             // SUB V2.4S, V2.4S, V5.4S
+    WORD $0x4E21D821             // SCVTF V1.4S, V1.4S
+    WORD $0x4E21D842             // SCVTF V2.4S, V2.4S
+    WORD $0x6E24DC21             // FMUL V1.4S, V1.4S, V4.4S
+    WORD $0x6E24DC42             // FMUL V2.4S, V2.4S, V4.4S
+    VST1 [V1.S4, V2.S4], (R0)
+
+dequant_done:
+    RET
+
+// func requantizeNEON(dst []int8, acc []int32, multiplier int32, shift int, zeroPoint int8)
+// The gemmlowp double-rounding epilogue, 8 lanes/iteration. left = max(shift,0)
+// feeds SSHL; -right = min(shift,0) feeds SRSHL. SQRDMULH is exactly SRDHM
+// (including the saturation guard). RoundingDivideByPOT is the gemmlowp NEON
+// trick: fixup = (y & shiftVec) >> 31 (SSHR), which is -1 for negative y only
+// when right > 0 (shiftVec = -right is 0 at right==0, so the AND zeroes the
+// fixup and the divide is an exact identity, per caution A); then SQADD the
+// fixup and SRSHL by -right. The zeroPoint SQADD plus the SQXTN/SQXTN2
+// narrow-saturate is the clamp to int8.
+TEXT ·requantizeNEON(SB), NOSPLIT, $0-65
+    MOVD dst_base+0(FP), R0
+    MOVD dst_len+8(FP), R3
+    MOVD acc_base+24(FP), R1
+
+    MOVW multiplier+48(FP), R5
+    WORD $0x4E040CA4              // DUP V4.4S, W5    (multiplier x4)
+    MOVD shift+56(FP), R6
+    MOVD $0, R7
+    CMP  $0, R6
+    CSEL GT, R6, R7, R8          // R8 = max(shift, 0) = left
+    CSEL LT, R6, R7, R11         // R11 = min(shift, 0) = -right
+    MOVB zeroPoint+64(FP), R12
+    WORD $0x4E040D05             // DUP V5.4S, W8    (left x4)
+    WORD $0x4E040D66             // DUP V6.4S, W11   (-right x4)
+    WORD $0x4E040D87             // DUP V7.4S, W12   (zeroPoint int32 x4)
+
+    LSR  $3, R3, R4             // R4 = n / 8
+    CBZ  R4, requant_tail
+
+requant_loop8:
+    VLD1.P 32(R1), [V0.S4, V1.S4]  // 8 int32
+    WORD $0x4EA54400             // SSHL V0.4S, V0.4S, V5.4S    (x = acc << left)
+    WORD $0x4EA54421             // SSHL V1.4S, V1.4S, V5.4S
+    WORD $0x6EA4B400             // SQRDMULH V0.4S, V0.4S, V4.4S  (y = SRDHM)
+    WORD $0x6EA4B421             // SQRDMULH V1.4S, V1.4S, V4.4S
+    WORD $0x4E261C10             // AND V16.16B, V0.16B, V6.16B   (y & shiftVec)
+    WORD $0x4E261C31             // AND V17.16B, V1.16B, V6.16B
+    WORD $0x4F210610             // SSHR V16.4S, V16.4S, #31      (fixup)
+    WORD $0x4F210631             // SSHR V17.4S, V17.4S, #31
+    WORD $0x4EB00C00             // SQADD V0.4S, V0.4S, V16.4S    (y + fixup)
+    WORD $0x4EB10C21             // SQADD V1.4S, V1.4S, V17.4S
+    WORD $0x4EA65400             // SRSHL V0.4S, V0.4S, V6.4S     (rounding >> right)
+    WORD $0x4EA65421             // SRSHL V1.4S, V1.4S, V6.4S
+    WORD $0x4EA70C00             // SQADD V0.4S, V0.4S, V7.4S     (+ zeroPoint)
+    WORD $0x4EA70C21             // SQADD V1.4S, V1.4S, V7.4S
+    WORD $0x0E614800             // SQXTN V0.4H, V0.4S            (narrow-saturate)
+    WORD $0x4E614820             // SQXTN2 V0.8H, V1.4S
+    WORD $0x0E214800             // SQXTN V0.8B, V0.8H
+    VST1.P [V0.B8], 8(R0)       // 8 int8
+    SUB  $1, R4
+    CBNZ R4, requant_loop8
+
+requant_tail:
+    AND  $7, R3, R5            // n % 8
+    CBZ  R5, requant_done
+    SUB  $8, R3, R6           // n - 8
+    LSL  $2, R6, R7           // (n-8) * 4 acc bytes
+    MOVD acc_base+24(FP), R1
+    ADD  R7, R1, R1          // &acc[n-8]
+    MOVD dst_base+0(FP), R0
+    ADD  R6, R0, R0         // &dst[n-8]
+    VLD1 (R1), [V0.S4, V1.S4]
+    WORD $0x4EA54400             // SSHL V0.4S, V0.4S, V5.4S
+    WORD $0x4EA54421             // SSHL V1.4S, V1.4S, V5.4S
+    WORD $0x6EA4B400             // SQRDMULH V0.4S, V0.4S, V4.4S
+    WORD $0x6EA4B421             // SQRDMULH V1.4S, V1.4S, V4.4S
+    WORD $0x4E261C10             // AND V16.16B, V0.16B, V6.16B
+    WORD $0x4E261C31             // AND V17.16B, V1.16B, V6.16B
+    WORD $0x4F210610             // SSHR V16.4S, V16.4S, #31
+    WORD $0x4F210631             // SSHR V17.4S, V17.4S, #31
+    WORD $0x4EB00C00             // SQADD V0.4S, V0.4S, V16.4S
+    WORD $0x4EB10C21             // SQADD V1.4S, V1.4S, V17.4S
+    WORD $0x4EA65400             // SRSHL V0.4S, V0.4S, V6.4S
+    WORD $0x4EA65421             // SRSHL V1.4S, V1.4S, V6.4S
+    WORD $0x4EA70C00             // SQADD V0.4S, V0.4S, V7.4S
+    WORD $0x4EA70C21             // SQADD V1.4S, V1.4S, V7.4S
+    WORD $0x0E614800             // SQXTN V0.4H, V0.4S
+    WORD $0x4E614820             // SQXTN2 V0.8H, V1.4S
+    WORD $0x0E214800             // SQXTN V0.8B, V0.8H
+    VST1 [V0.B8], (R0)
+
+requant_done:
+    RET

--- a/i8/i8_go.go
+++ b/i8/i8_go.go
@@ -228,10 +228,12 @@ func rdbpot(x int32, exponent int) int32 {
 }
 
 // requantizeOutOfContract reports whether (multiplier, shift) fall outside the
-// domain the SIMD kernels assume. multiplier == math.MinInt32 would trip the
-// srdhm saturation guard, and a shift outside [-31, 30] would need a vector
-// shift count >= 32 (undefined for the shift instructions). Such inputs route to
-// requantizeGo, which handles them with full-width Go arithmetic.
+// domain the SIMD kernels support. multiplier == math.MinInt32 would trip the
+// srdhm saturation guard the kernels omit. shift is restricted to [-31, 30]: the
+// vector shift instructions leave a count of 32 or more undefined, and the upper
+// bound is held at 30, one step below the largest count (31) they still accept,
+// as a conservative margin rather than a hard hardware requirement. Out-of-domain
+// inputs route to requantizeGo, which handles them with full-width Go arithmetic.
 func requantizeOutOfContract(multiplier int32, shift int) bool {
 	return multiplier == math.MinInt32 || shift < -31 || shift > 30
 }

--- a/i8/i8_go.go
+++ b/i8/i8_go.go
@@ -173,3 +173,117 @@ func minMaxGo(a []int8) (minVal, maxVal int8) {
 	}
 	return lo, hi
 }
+
+// -----------------------------------------------------------------------------
+// Quantization references (Part of #132).
+//
+// These pure-Go implementations are the source of truth for the Quantize,
+// Dequantize and Requantize kernels; every SIMD path is validated bit-exact
+// against them. The semantics follow the ONNX / PyTorch / TFLite per-tensor
+// affine convention: a real value r maps to a quantized value q via
+// q = clamp(round(r/scale) + zeroPoint, -128, 127), and back via
+// r = (q - zeroPoint) * scale.
+// -----------------------------------------------------------------------------
+
+// srdhmNudge is the rounding constant added before the Q31 shift in
+// SaturatingRoundingDoublingHighMul: it rounds the doubled high-multiply to
+// nearest, ties toward +infinity (gemmlowp semantics).
+const srdhmNudge = 1 << 30
+
+// srdhmShift is the Q31 fixed-point position: the doubled 64-bit product is
+// shifted right by 31 to land its high half back in int32 range.
+const srdhmShift = 31
+
+// srdhm is gemmlowp's SaturatingRoundingDoublingHighMul: the high 32 bits of
+// 2*x*multiplier, rounded to nearest with ties toward +infinity. The only
+// saturating case is x == multiplier == math.MinInt32, whose true value 2^31
+// saturates to math.MaxInt32. For every other input the doubled product fits in
+// int64, and the Go arithmetic shift computes the floor gemmlowp specifies.
+func srdhm(x, multiplier int32) int32 {
+	if x == math.MinInt32 && multiplier == math.MinInt32 {
+		return math.MaxInt32
+	}
+	return int32((int64(x)*int64(multiplier) + srdhmNudge) >> srdhmShift)
+}
+
+// rdbpot is gemmlowp's RoundingDivideByPOT: x divided by 2^exponent, rounded to
+// nearest with ties AWAY from zero. exponent is in [0, 31]. At exponent == 0 it
+// is the identity (the SIMD kernels depend on this being an exact pass-through,
+// including for negative x; see the NEON rounding-shift fixup).
+func rdbpot(x int32, exponent int) int32 {
+	if exponent == 0 {
+		return x
+	}
+	mask := int32(1)<<uint(exponent) - 1
+	remainder := x & mask
+	threshold := mask >> 1
+	if x < 0 {
+		threshold++
+	}
+	q := x >> uint(exponent)
+	if remainder > threshold {
+		q++
+	}
+	return q
+}
+
+// requantizeOutOfContract reports whether (multiplier, shift) fall outside the
+// domain the SIMD kernels assume. multiplier == math.MinInt32 would trip the
+// srdhm saturation guard, and a shift outside [-31, 30] would need a vector
+// shift count >= 32 (undefined for the shift instructions). Such inputs route to
+// requantizeGo, which handles them with full-width Go arithmetic.
+func requantizeOutOfContract(multiplier int32, shift int) bool {
+	return multiplier == math.MinInt32 || shift < -31 || shift > 30
+}
+
+// quantizeGo is the source of truth for Quantize: divide by scale, round to
+// nearest even, add the zero point and saturate to int8. NaN maps to zeroPoint;
+// +Inf saturates to 127 and -Inf to -128. Rounding then clamping is equivalent
+// to the kernels' clamp-then-round because round-to-even is monotone and the
+// bounds are exactly representable integers.
+func quantizeGo(dst []int8, src []float32, scale float32, zeroPoint int8) {
+	zp := int(zeroPoint)
+	lo, hi := float64(math.MinInt8-zp), float64(math.MaxInt8-zp)
+	for i := range dst {
+		q := src[i] / scale
+		if q != q { // NaN
+			dst[i] = zeroPoint
+			continue
+		}
+		r := math.RoundToEven(float64(q))
+		dst[i] = int8(int(min(max(r, lo), hi)) + zp)
+	}
+}
+
+// dequantizeGo is the source of truth for Dequantize: subtract the zero point
+// (exact int) then multiply by scale (the single rounding). |q - zeroPoint| is
+// at most 255, so the int-to-float conversion is exact.
+func dequantizeGo(dst []float32, src []int8, scale float32, zeroPoint int8) {
+	zp := int32(zeroPoint)
+	for i := range dst {
+		dst[i] = float32(int32(src[i])-zp) * scale
+	}
+}
+
+// requantizeGo is the source of truth for Requantize: the gemmlowp
+// double-rounding epilogue (left shift, SaturatingRoundingDoublingHighMul,
+// RoundingDivideByPOT), then add the zero point and saturate to int8. shift > 0
+// left-shifts the accumulator before the multiply; shift < 0 rounding-divides
+// after it.
+func requantizeGo(dst []int8, acc []int32, multiplier int32, shift int, zeroPoint int8) {
+	left := uint(0)
+	if shift > 0 {
+		left = uint(shift)
+	}
+	right := 0
+	if shift < 0 {
+		right = -shift
+	}
+	zp := int(zeroPoint)
+	for i := range dst {
+		x := acc[i] << left // wrapping int32 left shift
+		y := srdhm(x, multiplier)
+		z := rdbpot(y, right)
+		dst[i] = clampI8(int(z) + zp)
+	}
+}

--- a/i8/i8_other.go
+++ b/i8/i8_other.go
@@ -25,3 +25,15 @@ func addScalarSatI8(dst, a []int8, s int8) { addScalarSatGo(dst, a, s) }
 func subScalarSatI8(dst, a []int8, s int8) { subScalarSatGo(dst, a, s) }
 func sumAbsI8(a []int8) int32              { return sumAbsGo(a) }
 func sadI8(a, b []int8) int32              { return sadGo(a, b) }
+
+func quantizeI8(dst []int8, src []float32, scale float32, zeroPoint int8) {
+	quantizeGo(dst, src, scale, zeroPoint)
+}
+
+func dequantizeI8(dst []float32, src []int8, scale float32, zeroPoint int8) {
+	dequantizeGo(dst, src, scale, zeroPoint)
+}
+
+func requantizeI8(dst []int8, acc []int32, multiplier int32, shift int, zeroPoint int8) {
+	requantizeGo(dst, acc, multiplier, shift, zeroPoint)
+}

--- a/i8/quantize.go
+++ b/i8/quantize.go
@@ -1,0 +1,68 @@
+package i8
+
+// Per-tensor affine int8 quantization (Part of #132).
+//
+// These three functions cover the fixed-point boundary of a quantized pipeline:
+// Quantize maps float32 activations to int8, Dequantize maps them back, and
+// Requantize rescales an int32 accumulator (the output of a quantized matmul or
+// convolution) to int8 with a Q31 multiplier and a shift. The signed,
+// per-tensor affine convention matches ONNX / PyTorch / TFLite: a real value r
+// and its quantized value q relate by q = round(r/scale) + zeroPoint and
+// r = (q - zeroPoint) * scale.
+//
+// dst and src always have distinct element types, so in safe Go they cannot
+// alias; the kernels rely on that to reprocess an overlapping final block
+// instead of a scalar tail. Callers must not construct aliasing views through
+// unsafe.
+
+// Quantize writes dst[i] = clamp(rne(src[i]/scale) + zeroPoint, -128, 127) for i
+// in [0, n), n = min(len(dst), len(src)). The divide is a true IEEE-754 float32
+// division (not a reciprocal multiply) and rne is round-half-to-even, so the
+// result is bit-identical across the Go, AVX2 and NEON paths and matches the
+// documented formula literally.
+//
+// Saturation follows from the clamp: +Inf maps to 127, -Inf to -128. NaN maps to
+// zeroPoint. scale is expected to be finite and positive; that is the caller's
+// contract, not enforced here. Any trailing capacity in dst is left untouched.
+func Quantize(dst []int8, src []float32, scale float32, zeroPoint int8) {
+	n := min(len(dst), len(src))
+	if n == 0 {
+		return
+	}
+	quantizeI8(dst[:n], src[:n], scale, zeroPoint)
+}
+
+// Dequantize writes dst[i] = float32(int32(src[i]) - int32(zeroPoint)) * scale
+// for i in [0, n), n = min(len(dst), len(src)). The subtraction is exact and the
+// int-to-float conversion is exact (the difference is at most 255 in magnitude),
+// so the single multiply is the only rounding and the result is bit-identical
+// across the Go, AVX2 and NEON paths. Any trailing capacity in dst is left
+// untouched.
+func Dequantize(dst []float32, src []int8, scale float32, zeroPoint int8) {
+	n := min(len(dst), len(src))
+	if n == 0 {
+		return
+	}
+	dequantizeI8(dst[:n], src[:n], scale, zeroPoint)
+}
+
+// Requantize rescales an int32 accumulator to int8 using the gemmlowp / TFLite
+// double-rounding epilogue, writing dst[i] for i in [0, n),
+// n = min(len(dst), len(acc)). multiplier is a Q31 fixed-point value (normally
+// in [2^30, 2^31)) and shift is a power-of-two exponent. Per element:
+//
+//	x = acc[i] << max(shift, 0)                       (wrapping int32)
+//	y = SaturatingRoundingDoublingHighMul(x, multiplier)
+//	z = RoundingDivideByPOT(y, max(-shift, 0))        (ties away from zero)
+//	dst[i] = clamp(z + zeroPoint, -128, 127)
+//
+// Inputs outside the SIMD kernels' domain (multiplier == math.MinInt32, or shift
+// outside [-31, 30]) are handled by the full-width Go reference. Any trailing
+// capacity in dst is left untouched.
+func Requantize(dst []int8, acc []int32, multiplier int32, shift int, zeroPoint int8) {
+	n := min(len(dst), len(acc))
+	if n == 0 {
+		return
+	}
+	requantizeI8(dst[:n], acc[:n], multiplier, shift, zeroPoint)
+}

--- a/i8/quantize_test.go
+++ b/i8/quantize_test.go
@@ -2,8 +2,78 @@ package i8
 
 import (
 	"math"
+	"math/rand"
 	"testing"
 )
+
+// TestQuantizeRandomizedDifferential runs many random cases through the public
+// path and the Go reference and asserts bit-exact agreement. It gives the active
+// SIMD kernel (AVX2 or NEON) broad differential coverage beyond the deterministic
+// parity sweep; on the rpi5 it is the on-device stress for the NEON kernels.
+func TestQuantizeRandomizedDifferential(t *testing.T) {
+	r := rand.New(rand.NewSource(0x132))
+	for iter := range 4000 {
+		n := r.Intn(200)
+
+		// Quantize: random float32 bit patterns (NaN/Inf/subnormal included).
+		fsrc := make([]float32, n)
+		for i := range fsrc {
+			fsrc[i] = math.Float32frombits(r.Uint32())
+		}
+		fscale := math.Float32frombits(r.Uint32())
+		fzp := int8(r.Intn(256) - 128)
+		gq := make([]int8, n)
+		wq := make([]int8, n)
+		Quantize(gq, fsrc, fscale, fzp)
+		quantizeGo(wq, fsrc, fscale, fzp)
+		for i := range fsrc {
+			if gq[i] != wq[i] {
+				t.Fatalf("Quantize[%d]=%d want %d (src=%v scale=%v zp=%d n=%d iter=%d)",
+					i, gq[i], wq[i], fsrc[i], fscale, fzp, n, iter)
+			}
+		}
+
+		// Dequantize.
+		isrc := make([]int8, n)
+		for i := range isrc {
+			isrc[i] = int8(r.Intn(256) - 128)
+		}
+		dscale := math.Float32frombits(r.Uint32())
+		dzp := int8(r.Intn(256) - 128)
+		gd := make([]float32, n)
+		wd := make([]float32, n)
+		Dequantize(gd, isrc, dscale, dzp)
+		dequantizeGo(wd, isrc, dscale, dzp)
+		assertF32Bits(t, "Dequantize", n, gd, wd)
+
+		// Requantize: random accumulators (with extremes), Q31-ish multipliers
+		// and shifts spanning the in-domain and reroute ranges.
+		acc := make([]int32, n)
+		for i := range acc {
+			switch r.Intn(8) {
+			case 0:
+				acc[i] = math.MaxInt32
+			case 1:
+				acc[i] = math.MinInt32
+			default:
+				acc[i] = int32(r.Uint32())
+			}
+		}
+		mul := int32(r.Uint32())
+		shift := r.Intn(80) - 40 // covers [-31,30] plus reroute on both ends
+		rzp := int8(r.Intn(256) - 128)
+		gr := make([]int8, n)
+		wr := make([]int8, n)
+		Requantize(gr, acc, mul, shift, rzp)
+		requantizeGo(wr, acc, mul, shift, rzp)
+		for i := range acc {
+			if gr[i] != wr[i] {
+				t.Fatalf("Requantize[%d]=%d want %d (acc=%d mul=%d shift=%d zp=%d n=%d iter=%d)",
+					i, gr[i], wr[i], acc[i], mul, shift, rzp, n, iter)
+			}
+		}
+	}
+}
 
 // Tests for the Part-of-#132 quantization vertical (Quantize, Dequantize,
 // Requantize). The pure-Go references in i8_go.go are the source of truth; the

--- a/i8/quantize_test.go
+++ b/i8/quantize_test.go
@@ -1,0 +1,429 @@
+package i8
+
+import (
+	"math"
+	"testing"
+)
+
+// Tests for the Part-of-#132 quantization vertical (Quantize, Dequantize,
+// Requantize). The pure-Go references in i8_go.go are the source of truth; the
+// SIMD kernels are validated bit-exact against them by the parity sweeps and the
+// differential fuzzers here. The known-answer tables lock the semantics down so
+// a reference bug cannot hide behind a self-consistent SIMD/Go pair.
+
+// genF32 produces deterministic float32 data mixing exact half-integers (to
+// exercise round-to-even ties, and the kernels' clamp-then-round vs the
+// reference's round-then-clamp), fractional values that span the saturation
+// bounds, and small integers.
+func genF32(n int, seed uint32) []float32 {
+	s := make([]float32, n)
+	x := seed*2654435761 + 1
+	for i := range s {
+		x = x*1664525 + 1013904223
+		switch i % 3 {
+		case 0:
+			s[i] = float32(int32(x)>>16) * 0.5 // half-integers: RNE ties
+		case 1:
+			s[i] = float32(int32(x)) / 700.0 // fractional, spans the clamp
+		default:
+			s[i] = float32(int32(x) >> 20) // small integers
+		}
+	}
+	return s
+}
+
+// genI32 produces deterministic int32 accumulators across the full range.
+func genI32(n int, seed uint32) []int32 {
+	s := make([]int32, n)
+	x := seed*2654435761 + 1
+	for i := range s {
+		x = x*1664525 + 1013904223
+		s[i] = int32(x)
+	}
+	return s
+}
+
+// quantizeCombos and requantizeCombos are the parameter sets swept alongside the
+// length sweep.
+var (
+	quantizeScales = []float32{1.0, 0.5, 2.0, 127.0, 0.007}
+	quantizeZPs    = []int8{0, -5, 7, 127, -128}
+
+	requantizeMuls = []int32{
+		0x40000000, // 0.5 in Q31
+		0x7FFFFFFF, // ~1.0 in Q31 (MaxInt32)
+		0x60000000,
+		0x40000001,
+		0x2000_0000,
+	}
+	requantizeShifts = []int{-31, -8, -1, 0, 1, 8, 30}
+	requantizeZPs    = []int8{0, -5, 7, 127, -128}
+)
+
+// TestQuantizeParity sweeps lengths and (scale, zeroPoint) combos, asserting the
+// public path is bit-exact with the Go reference.
+func TestQuantizeParity(t *testing.T) {
+	for _, n := range lengths {
+		src := genF32(n, uint32(n)+1)
+		for _, scale := range quantizeScales {
+			for _, zp := range quantizeZPs {
+				got := make([]int8, n)
+				want := make([]int8, n)
+				Quantize(got, src, scale, zp)
+				quantizeGo(want, src, scale, zp)
+				assertI8Eq(t, "Quantize", n, got, want)
+			}
+		}
+	}
+}
+
+// TestDequantizeParity sweeps lengths and (scale, zeroPoint) combos, asserting
+// the public path is bit-exact (bit-for-bit float32) with the Go reference.
+func TestDequantizeParity(t *testing.T) {
+	for _, n := range lengths {
+		src := genI8(n, uint32(n)+3)
+		for _, scale := range quantizeScales {
+			for _, zp := range quantizeZPs {
+				got := make([]float32, n)
+				want := make([]float32, n)
+				Dequantize(got, src, scale, zp)
+				dequantizeGo(want, src, scale, zp)
+				assertF32Bits(t, "Dequantize", n, got, want)
+			}
+		}
+	}
+}
+
+// TestRequantizeParity sweeps lengths and (multiplier, shift, zeroPoint) combos,
+// asserting the public path is bit-exact with the Go reference.
+func TestRequantizeParity(t *testing.T) {
+	for _, n := range lengths {
+		acc := genI32(n, uint32(n)+7)
+		if n > 0 {
+			acc[0] = math.MaxInt32
+			acc[n-1] = math.MinInt32
+		}
+		for _, mul := range requantizeMuls {
+			for _, shift := range requantizeShifts {
+				for _, zp := range requantizeZPs {
+					got := make([]int8, n)
+					want := make([]int8, n)
+					Requantize(got, acc, mul, shift, zp)
+					requantizeGo(want, acc, mul, shift, zp)
+					assertI8Eq(t, "Requantize", n, got, want)
+				}
+			}
+		}
+	}
+}
+
+// TestQuantizeSemantics is the known-answer table for Quantize: ties round to
+// even, NaN maps to zeroPoint, +/-Inf saturate, and tiny/huge scales clamp both
+// ways.
+func TestQuantizeSemantics(t *testing.T) {
+	inf := float32(math.Inf(1))
+	nan := float32(math.NaN())
+	cases := []struct {
+		name  string
+		src   []float32
+		scale float32
+		zp    int8
+		want  []int8
+	}{
+		{"ties_to_even_scale1", []float32{0.5, 1.5, 2.5, 3.5, -0.5, -1.5, -2.5}, 1.0, 0, []int8{0, 2, 2, 4, 0, -2, -2}},
+		{"ties_to_even_scale2", []float32{3, 5, 7, -3, -5, -7}, 2.0, 0, []int8{2, 2, 4, -2, -2, -4}},
+		{"nan_to_zeropoint", []float32{nan, nan, nan}, 1.0, 7, []int8{7, 7, 7}},
+		{"pos_inf_saturates", []float32{inf, inf}, 1.0, 5, []int8{127, 127}},
+		{"neg_inf_saturates", []float32{-inf, -inf}, 1.0, 5, []int8{-128, -128}},
+		{"huge_scale_to_zero", []float32{1, -1, 1e9}, 1e30, 0, []int8{0, 0, 0}},
+		{"tiny_scale_clamps", []float32{1, -1}, 1e-30, 0, []int8{127, -128}},
+		{"zp_max", []float32{0, 1, -1, -255}, 1.0, 127, []int8{127, 127, 126, -128}},
+		{"zp_min", []float32{0, 1, 255}, 1.0, -128, []int8{-128, -127, 127}},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			got := make([]int8, len(c.src))
+			Quantize(got, c.src, c.scale, c.zp)
+			assertI8Eq(t, c.name, len(c.src), got, c.want)
+			// The reference must agree with the hand-computed answer too.
+			ref := make([]int8, len(c.src))
+			quantizeGo(ref, c.src, c.scale, c.zp)
+			assertI8Eq(t, c.name+"/ref", len(c.src), ref, c.want)
+		})
+	}
+}
+
+// TestDequantizeSemantics is the known-answer table for Dequantize.
+func TestDequantizeSemantics(t *testing.T) {
+	cases := []struct {
+		name  string
+		src   []int8
+		scale float32
+		zp    int8
+		want  []float32
+	}{
+		{"scale2_zp3", []int8{5, -128, 127}, 2.0, 3, []float32{4, -262, 248}},
+		{"scale_half_zp0", []int8{7, -1, 0}, 0.5, 0, []float32{3.5, -0.5, 0}},
+		{"zp_min_extremes", []int8{127, -128}, 2.0, -128, []float32{510, 0}},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			got := make([]float32, len(c.src))
+			Dequantize(got, c.src, c.scale, c.zp)
+			assertF32Bits(t, c.name, len(c.src), got, c.want)
+		})
+	}
+}
+
+// TestRequantizeSemantics is the known-answer table for Requantize, including
+// the SRDHM saturation extremes and the round-half-up identity at multiplier =
+// 1<<30, shift = 0.
+func TestRequantizeSemantics(t *testing.T) {
+	const half = int32(1) << 30 // 0.5 in Q31
+	cases := []struct {
+		name  string
+		acc   []int32
+		mul   int32
+		shift int
+		zp    int8
+		want  []int8
+	}{
+		// multiplier 1<<30, shift 0 == round-half-up(acc/2).
+		{"half_shift0", []int32{5, 4, -3, -4, 1, -1, 2, 0}, half, 0, 0, []int8{3, 2, -1, -2, 1, 0, 1, 0}},
+		// ~1.0 multiplier, shift 0: value passes through, then saturates.
+		{"unit_shift0", []int32{100, 127, 200, -200}, 0x7FFFFFFF, 0, 0, []int8{100, 127, 127, -128}},
+		// Accumulator extremes with a ~1.0 multiplier saturate.
+		{"acc_extremes", []int32{math.MaxInt32, math.MinInt32}, 0x7FFFFFFF, 0, 0, []int8{127, -128}},
+		// shift 30 with a zero accumulator is exactly the zero point.
+		{"shift30_zero", []int32{0, 0}, half, 30, 5, []int8{5, 5}},
+		// zeroPoint offset is added after the rescale.
+		{"half_shift0_zp", []int32{5, -3}, half, 0, 10, []int8{13, 9}},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			got := make([]int8, len(c.acc))
+			Requantize(got, c.acc, c.mul, c.shift, c.zp)
+			assertI8Eq(t, c.name, len(c.acc), got, c.want)
+			ref := make([]int8, len(c.acc))
+			requantizeGo(ref, c.acc, c.mul, c.shift, c.zp)
+			assertI8Eq(t, c.name+"/ref", len(c.acc), ref, c.want)
+		})
+	}
+}
+
+// TestRequantizeCautionA is the mandatory guard for the NEON RoundingDivideByPOT
+// identity at right == 0. With shift == 0 the rounding-divide is a pass-through,
+// so negative odd pre-divide accumulators must survive unchanged; a naive
+// sign-fixup (pre-adding -1 to negatives) would turn -3 into -4. multiplier =
+// 1<<30 makes SRDHM(acc) = floor((acc+1)/2), so acc = -6 and -7 both reach a
+// pre-divide value of -3, which must stay -3.
+func TestRequantizeCautionA(t *testing.T) {
+	const half = int32(1) << 30
+	acc := []int32{-6, -7, -3, -5, -1, -2, 3, 5}
+	want := []int8{-3, -3, -1, -2, 0, -1, 2, 3}
+
+	got := make([]int8, len(acc))
+	Requantize(got, acc, half, 0, 0)
+	assertI8Eq(t, "Requantize/cautionA", len(acc), got, want)
+
+	// Also assert against the reference so the check is a differential too.
+	ref := make([]int8, len(acc))
+	requantizeGo(ref, acc, half, 0, 0)
+	assertI8Eq(t, "Requantize/cautionA-ref", len(acc), ref, want)
+
+	// Sweep a longer run of negatives at shift == 0 to exercise the SIMD tail as
+	// well as the head block.
+	for _, n := range []int{8, 15, 16, 17, 31, 33, 64} {
+		big := make([]int32, n)
+		for i := range big {
+			big[i] = int32(-(2*i + 1)) // negative, odd
+		}
+		g := make([]int8, n)
+		w := make([]int8, n)
+		Requantize(g, big, half, 0, 3)
+		requantizeGo(w, big, half, 0, 3)
+		assertI8Eq(t, "Requantize/cautionA-sweep", n, g, w)
+	}
+}
+
+// TestQuantizeCautionB proves the int8 pack keeps lane order: a distinct,
+// in-range ascending ramp must come out in the same order. A cross-lane
+// permutation bug in the AVX2 VPACKSSDW/VPERMQ/VPACKSSWB sequence would scramble
+// it. The lengths straddle the 8/16-wide pack boundaries.
+func TestQuantizeCautionB(t *testing.T) {
+	for _, n := range []int{8, 15, 16, 17, 31, 32, 33, 64, 96} {
+		base := -n / 2 // center the ramp so every value is a distinct int8
+		src := make([]float32, n)
+		want := make([]int8, n)
+		for i := range src {
+			v := base + i
+			src[i] = float32(v)
+			want[i] = int8(v)
+		}
+		got := make([]int8, n)
+		Quantize(got, src, 1.0, 0)
+		assertI8Eq(t, "Quantize/cautionB", n, got, want)
+	}
+}
+
+// TestQuantizeZeroAllocations asserts the three new functions allocate nothing.
+func TestQuantizeZeroAllocations(t *testing.T) {
+	const n = 1024
+	f := genF32(n, 5)
+	q := genI8(n, 6)
+	acc := genI32(n, 8)
+	d8 := make([]int8, n)
+	d32 := make([]float32, n)
+
+	checks := []struct {
+		name string
+		fn   func()
+	}{
+		{"Quantize", func() { Quantize(d8, f, 0.5, 3) }},
+		{"Dequantize", func() { Dequantize(d32, q, 0.5, 3) }},
+		{"Requantize", func() { Requantize(d8, acc, 0x40000000, -2, 3) }},
+	}
+	for _, c := range checks {
+		if got := testing.AllocsPerRun(10, c.fn); got != 0 {
+			t.Errorf("%s allocated %v times per run, want 0", c.name, got)
+		}
+	}
+}
+
+// TestQuantizeTrailingCapacity verifies each function writes exactly n elements
+// and leaves trailing dst capacity untouched, at sizes above and below the SIMD
+// dispatch thresholds.
+func TestQuantizeTrailingCapacity(t *testing.T) {
+	for _, n := range []int{3, 20, 40} {
+		f := genF32(n, 2)
+		q := genI8(n, 4)
+		acc := genI32(n, 9)
+
+		d8 := fillI8(n+2, 42)
+		Quantize(d8[:n], f, 0.5, 1)
+		if d8[n] != 42 || d8[n+1] != 42 {
+			t.Errorf("Quantize (n=%d) clobbered trailing capacity: %v", n, d8[n:])
+		}
+
+		d8 = fillI8(n+2, 42)
+		Requantize(d8[:n], acc, 0x40000000, -1, 1)
+		if d8[n] != 42 || d8[n+1] != 42 {
+			t.Errorf("Requantize (n=%d) clobbered trailing capacity: %v", n, d8[n:])
+		}
+
+		d32 := make([]float32, n+2)
+		d32[n], d32[n+1] = 42, 42
+		Dequantize(d32[:n], q, 0.5, 1)
+		if d32[n] != 42 || d32[n+1] != 42 {
+			t.Errorf("Dequantize (n=%d) clobbered trailing capacity: %v", n, d32[n:])
+		}
+	}
+}
+
+// assertF32Bits compares two float32 slices bit-for-bit, treating two NaNs as
+// equal regardless of payload (a hardware multiply and Go's may differ there).
+func assertF32Bits(t *testing.T, op string, n int, got, want []float32) {
+	t.Helper()
+	for i := range n {
+		g, w := got[i], want[i]
+		if g != g && w != w { // both NaN
+			continue
+		}
+		if math.Float32bits(g) != math.Float32bits(w) {
+			t.Fatalf("%s[%d] = %v (0x%08x), want %v (0x%08x) (len=%d)",
+				op, i, g, math.Float32bits(g), w, math.Float32bits(w), n)
+		}
+	}
+}
+
+// --- Differential fuzzers (public path vs Go reference) ---
+
+// f32sFromBytes reinterprets raw bytes as float32s via Float32frombits, so NaN,
+// Inf and subnormals all appear.
+func f32sFromBytes(raw []byte) []float32 {
+	out := make([]float32, len(raw)/4)
+	for i := range out {
+		b := raw[i*4:]
+		bits := uint32(b[0]) | uint32(b[1])<<8 | uint32(b[2])<<16 | uint32(b[3])<<24
+		out[i] = math.Float32frombits(bits)
+	}
+	return out
+}
+
+// i32sFromBytes reinterprets raw bytes as int32s.
+func i32sFromBytes(raw []byte) []int32 {
+	out := make([]int32, len(raw)/4)
+	for i := range out {
+		b := raw[i*4:]
+		out[i] = int32(uint32(b[0]) | uint32(b[1])<<8 | uint32(b[2])<<16 | uint32(b[3])<<24)
+	}
+	return out
+}
+
+func lenSeeds4(f *testing.F) {
+	f.Helper()
+	lens := []int{0, 4, 8, 12, 28, 32, 36, 60, 64, 68, 128, 260, 512}
+	for _, n := range lens {
+		raw := make([]byte, n)
+		for i := range raw {
+			raw[i] = byte(i*37 + 11)
+		}
+		f.Add(raw, uint32(0x40000000), byte(3))
+	}
+}
+
+func FuzzI8Quantize(f *testing.F) {
+	lenSeeds4(f)
+	f.Fuzz(func(t *testing.T, raw []byte, scaleBits uint32, zpByte byte) {
+		src := f32sFromBytes(raw)
+		scale := math.Float32frombits(scaleBits)
+		zp := int8(zpByte)
+		got := make([]int8, len(src))
+		want := make([]int8, len(src))
+		Quantize(got, src, scale, zp)
+		quantizeGo(want, src, scale, zp)
+		for i := range src {
+			if got[i] != want[i] {
+				t.Fatalf("Quantize[%d] = %d, want %d (src=%v scale=%v zp=%d len=%d)",
+					i, got[i], want[i], src[i], scale, zp, len(src))
+			}
+		}
+	})
+}
+
+func FuzzI8Dequantize(f *testing.F) {
+	lenSeeds4(f)
+	f.Fuzz(func(t *testing.T, raw []byte, scaleBits uint32, zpByte byte) {
+		src := make([]int8, len(raw))
+		for i, b := range raw {
+			src[i] = int8(b)
+		}
+		scale := math.Float32frombits(scaleBits)
+		zp := int8(zpByte)
+		got := make([]float32, len(src))
+		want := make([]float32, len(src))
+		Dequantize(got, src, scale, zp)
+		dequantizeGo(want, src, scale, zp)
+		assertF32Bits(t, "Dequantize", len(src), got, want)
+	})
+}
+
+func FuzzI8Requantize(f *testing.F) {
+	f.Add([]byte{1, 2, 3, 4, 5, 6, 7, 8}, int32(0x40000000), 0, byte(3))
+	f.Add(make([]byte, 64), int32(0x7FFFFFFF), -8, byte(0))
+	f.Add(make([]byte, 33*4), int32(0x60000000), 5, byte(127))
+	f.Fuzz(func(t *testing.T, raw []byte, mul int32, shift int, zpByte byte) {
+		acc := i32sFromBytes(raw)
+		zp := int8(zpByte)
+		got := make([]int8, len(acc))
+		want := make([]int8, len(acc))
+		Requantize(got, acc, mul, shift, zp)
+		requantizeGo(want, acc, mul, shift, zp)
+		for i := range acc {
+			if got[i] != want[i] {
+				t.Fatalf("Requantize[%d] = %d, want %d (acc=%d mul=%d shift=%d zp=%d len=%d)",
+					i, got[i], want[i], acc[i], mul, shift, zp, len(acc))
+			}
+		}
+	})
+}

--- a/i8/quantize_test.go
+++ b/i8/quantize_test.go
@@ -246,8 +246,9 @@ func TestDequantizeSemantics(t *testing.T) {
 }
 
 // TestRequantizeSemantics is the known-answer table for Requantize, including
-// the SRDHM saturation extremes and the round-half-up identity at multiplier =
-// 1<<30, shift = 0.
+// the accumulator extremes (output saturation) and the round-half-up identity at
+// multiplier = 1<<30, shift = 0. The SRDHM internal saturation extreme
+// (multiplier == math.MinInt32) is covered by TestRequantizeSRDHMSaturation.
 func TestRequantizeSemantics(t *testing.T) {
 	const half = int32(1) << 30 // 0.5 in Q31
 	cases := []struct {
@@ -313,6 +314,39 @@ func TestRequantizeCautionA(t *testing.T) {
 		Requantize(g, big, half, 0, 3)
 		requantizeGo(w, big, half, 0, 3)
 		assertI8Eq(t, "Requantize/cautionA-sweep", n, g, w)
+	}
+}
+
+// TestRequantizeSRDHMSaturation covers the single saturating case of SRDHM
+// (x == multiplier == math.MinInt32 -> math.MaxInt32), the one branch of the
+// source of truth the broad sweeps never reach, and it guards the
+// multiplier == math.MinInt32 reroute at a length above the SIMD dispatch
+// threshold. Without the reroute the AVX2 kernel (VPMULDQ has no saturation)
+// would wrap MinInt32*MinInt32 and clamp to -128 instead of +127, so on amd64
+// this discriminates a dropped reroute; NEON's SQRDMULH saturates on its own, but
+// the reroute is the guarantee on both. This asserts the exact +127 answer.
+func TestRequantizeSRDHMSaturation(t *testing.T) {
+	// Reference branch coverage plus the hand-computed answer.
+	if got := srdhm(math.MinInt32, math.MinInt32); got != math.MaxInt32 {
+		t.Fatalf("srdhm(MinInt32, MinInt32) = %d, want MaxInt32", got)
+	}
+
+	// Above the dispatch threshold so every element would hit a SIMD kernel were
+	// the multiplier == MinInt32 reroute missing.
+	const n = 20
+	acc := make([]int32, n)
+	for i := range acc {
+		acc[i] = math.MinInt32
+	}
+	got := make([]int8, n)
+	want := make([]int8, n)
+	Requantize(got, acc, math.MinInt32, 0, 0)
+	requantizeGo(want, acc, math.MinInt32, 0, 0)
+	assertI8Eq(t, "Requantize/srdhmSat", n, got, want)
+	for i := range want {
+		if want[i] != 127 { // MinInt32*MinInt32 -> MaxInt32 -> clamp to 127
+			t.Fatalf("Requantize/srdhmSat[%d] = %d, want 127", i, want[i])
+		}
 	}
 }
 


### PR DESCRIPTION
Part of #132.

Adds the signed-int8 per-tensor affine quantization vertical to package `i8`: `Quantize` (float32 -> int8), `Dequantize` (int8 -> float32) and `Requantize` (int32 accumulator -> int8, the gemmlowp double-rounding epilogue). Pure-Go references are the source of truth; AVX2 and NEON kernels are validated bit-exact against them.

## Semantics

Per-tensor affine, signed only, following the ONNX / PyTorch / TFLite convention (`q = round(r/scale) + zeroPoint`, `r = (q - zeroPoint) * scale`). Symmetric (zeroPoint 0) and asymmetric are the same three functions.

- **Quantize**: `dst[i] = clamp(rne(src[i]/scale) + zeroPoint, -128, 127)`. A genuine IEEE-754 float32 divide (not a reciprocal multiply) and round-half-to-even, so the documented formula is literally true and the result is bit-identical across Go, AVX2 (`VDIVPS` + `VCVTPS2DQ`) and NEON (`FDIV` + `FCVTNS`). NaN maps to the zero point, `+Inf` saturates to 127, `-Inf` to -128. This is division-bound by design.
- **Dequantize**: `float32(int32(src[i]) - int32(zeroPoint)) * scale`. Exact int subtract, exact int-to-float, a single multiply as the only rounding. Bit-identical across all three.
- **Requantize**: `x = acc << max(shift,0)` (wrapping int32); `y = SaturatingRoundingDoublingHighMul(x, multiplier)`; `z = RoundingDivideByPOT(y, max(-shift,0))` (ties away from zero); `dst = clamp(z + zeroPoint, -128, 127)`. `multiplier` is Q31. Inputs outside the kernels' domain (`multiplier == math.MinInt32`, or a shift outside `[-31, 30]`) fall back to the full-width Go path.

## Implementation notes

- The AVX2 Requantize reuses the `i32` `scaleQ31` `VPMULDQ` even/odd Q31 high-mul recipe with a `1<<30` nudge added before `VPSRLQ $31` for SRDHM, then a branch-free `RoundingDivideByPOT` (`VPSRAVD` plus a remainder-vs-threshold increment) that is an exact identity at shift 0. The clamp is applied before the `+zeroPoint` (VPADDD wraps). The int8 pack is written fresh (the f32 packer stops at int16): `VPACKSSDW` / `VPERMQ` / `VPACKSSWB` / `VPERMQ`, with a test asserting lane order via an ascending ramp.
- The NEON Requantize uses `SQRDMULH` as the exact SRDHM and the gemmlowp `RoundingDivideByPOT` trick (`AND` with the `-right` shift vector, `SSHR #31`, `SQADD`, `SRSHL`), an exact identity for negative accumulators at shift 0. Every new NEON op is hand-encoded as a `WORD` directive with its decoded mnemonic and cross-checked by the repo's `arm64asm` + `objdump` suite.
- amd64 kernels are named `...AVX2` and gate on `hasAVX2`, so the ISA-level check passes. No `VFMADD` anywhere; no hand-encoded amd64 directives.

## Testing

- length-sweep parity and a seeded randomized differential (4000 cases spanning NaN/Inf/subnormals, int32 extremes, and both in-domain and reroute shifts),
- known-answer semantic tables (round-to-even ties, NaN/Inf saturation, SRDHM extremes, the round-half-up identity at `multiplier = 1<<30`),
- two targeted regression tests: the RoundingDivideByPOT identity at shift 0 for negative accumulators, and the int8 pack lane-order ramp,
- zero-allocation and trailing-capacity checks,
- differential fuzzers (tens of millions of executions on amd64).

Verified on amd64 (native, AVX2) and on an aarch64 Raspberry Pi 5 (native NEON): full parity, both regression tests, and the randomized differential pass on both.

Benchmarks (4096 elements): amd64 AVX2 Quantize 726 ns (22.5 GB/s), Dequantize 252 ns (16.2 GB/s), Requantize 1852 ns (8.8 GB/s); arm64 NEON (Pi 5) Quantize 2927 ns, Dequantize 1555 ns, Requantize 3130 ns.

## Scope and deferred work

This is the signed-only, per-tensor Tier 1 of #132. Deliberately out of scope here, left for follow-ups so this PR stays reviewable: per-channel (per-axis) Quantize/Dequantize; `QuantizeInv`; a `DotProductBatch`/GEMM path with Requantize fused as its epilogue; UDOT and all unsigned/u8 work (the Tier 3 blends and Tier 4 byte/string decisions); and AVX-512 VNNI. A follow-up can also unroll the Requantize kernels (a review pass estimates ~1.3-2x, pending benchmarking) and add tail-length benchmarks for the vertical. #132 stays open to track these.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added affine quantization APIs for converting between float32, int8, and int32 representations.
  * Added rounding, scaling, zero-point adjustment, clamping, and saturation support.
  * Added optimized processing on supported hardware with automatic fallback behavior.

* **Documentation**
  * Added API documentation and examples covering quantization workflows and numerical behavior.

* **Tests**
  * Added comprehensive correctness, edge-case, fuzz, allocation, and performance coverage.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->