### PR TITLE
docs,tests: aliasing contracts for f32/f64/i8/c64/c128 (Part of #221)

### DIFF
--- a/c128/aliasing_amd64_test.go
+++ b/c128/aliasing_amd64_test.go
@@ -1,0 +1,24 @@
+//go:build amd64
+
+package c128
+
+import (
+	"testing"
+
+	"github.com/tphakala/simd/cpu"
+	"github.com/tphakala/simd/internal/aliastest"
+)
+
+// forTiers runs the aliasing sweep under every forceable amd64 tier, including
+// the AVX-without-FMA tier (#201). The list is in descending priority so
+// aliastest.ForTiers re-binds the host default on cleanup.
+func forTiers(t *testing.T, run func(t *testing.T)) {
+	t.Helper()
+	aliastest.ForTiers(t, []aliastest.Tier{
+		{Name: "AVX512", Bind: initAVX512, Supported: cpu.X86.AVX512F && cpu.X86.AVX512VL},
+		{Name: "AVX", Bind: initAVX, Supported: cpu.X86.AVX && cpu.X86.FMA},
+		{Name: "AVXNoFMA", Bind: initAVXNoFMA, Supported: cpu.X86.AVX},
+		{Name: "SSE2", Bind: initSSE2, Supported: cpu.X86.SSE2},
+		{Name: "Go", Bind: initGo, Supported: true},
+	}, run)
+}

--- a/c128/aliasing_arm64_test.go
+++ b/c128/aliasing_arm64_test.go
@@ -1,0 +1,16 @@
+//go:build arm64
+
+package c128
+
+import (
+	"testing"
+
+	"github.com/tphakala/simd/internal/aliastest"
+)
+
+// forTiers runs the aliasing sweep on both the Go and NEON arm64 paths by
+// flipping the package hasNEON gate.
+func forTiers(t *testing.T, run func(t *testing.T)) {
+	t.Helper()
+	aliastest.ForGate(t, &hasNEON, "NEON", run)
+}

--- a/c128/aliasing_other_test.go
+++ b/c128/aliasing_other_test.go
@@ -1,0 +1,12 @@
+//go:build !amd64 && !arm64
+
+package c128
+
+import "testing"
+
+// forTiers runs the aliasing sweep once on architectures with only the pure-Go
+// path (no tier to force).
+func forTiers(t *testing.T, run func(t *testing.T)) {
+	t.Helper()
+	run(t)
+}

--- a/c128/aliasing_test.go
+++ b/c128/aliasing_test.go
@@ -10,8 +10,9 @@ import (
 // Aliasing sweep for the c128 exact-overlay contract (issue #221). Each element-
 // wise op is run once into a separate destination and once with the destination
 // overlaid on an input, then bit-compared (real and imaginary parts) under every
-// bound kernel tier. It asserts nothing about the corruption pattern of a
-// non-overlapping op, which is undefined.
+// bound kernel tier. It asserts nothing about how a shifted overlay (dst offset
+// from an input) corrupts: that pattern is undefined and varies with kernel
+// width and length.
 
 func aliasEqC128(x, y complex128) bool {
 	return math.Float64bits(real(x)) == math.Float64bits(real(y)) &&
@@ -19,8 +20,11 @@ func aliasEqC128(x, y complex128) bool {
 }
 
 func aliasHashF64(i int) float64 {
-	u := uint64(i)*2654435761 + 1013904223
-	return float64(u)/float64(1<<64)*8 - 4
+	// A full-width 64-bit mix (the golden-ratio multiplier) so small indices
+	// still spread across [-4,4); a 32-bit step over uint64 would cluster every
+	// practical index near -4.
+	u := uint64(i)*0x9e3779b97f4a7c15 + 1013904223
+	return float64(u>>11)/float64(1<<53)*8 - 4
 }
 
 // aliasGenC128 builds a deterministic complex128 with independent real and
@@ -47,5 +51,14 @@ func TestAliasingSweep(t *testing.T) {
 	forTiers(t, func(t *testing.T) {
 		t.Helper()
 		aliastest.Sweep(t, c128AliasCases())
+	})
+}
+
+// TestAliasingZeroAlloc asserts the in-place overlay path is allocation-free for
+// every swept op under each bound tier.
+func TestAliasingZeroAlloc(t *testing.T) {
+	forTiers(t, func(t *testing.T) {
+		t.Helper()
+		aliastest.SweepAlloc(t, c128AliasCases())
 	})
 }

--- a/c128/aliasing_test.go
+++ b/c128/aliasing_test.go
@@ -1,0 +1,51 @@
+package c128
+
+import (
+	"math"
+	"testing"
+
+	"github.com/tphakala/simd/internal/aliastest"
+)
+
+// Aliasing sweep for the c128 exact-overlay contract (issue #221). Each element-
+// wise op is run once into a separate destination and once with the destination
+// overlaid on an input, then bit-compared (real and imaginary parts) under every
+// bound kernel tier. It asserts nothing about the corruption pattern of a
+// non-overlapping op, which is undefined.
+
+func aliasEqC128(x, y complex128) bool {
+	return math.Float64bits(real(x)) == math.Float64bits(real(y)) &&
+		math.Float64bits(imag(x)) == math.Float64bits(imag(y))
+}
+
+func aliasHashF64(i int) float64 {
+	u := uint64(i)*2654435761 + 1013904223
+	return float64(u)/float64(1<<64)*8 - 4
+}
+
+// aliasGenC128 builds a deterministic complex128 with independent real and
+// imaginary spreads over [-4,4).
+func aliasGenC128(i int) complex128 { return complex(aliasHashF64(i), aliasHashF64(i+9973)) }
+
+// aliasScaleC128 is the scalar for the Scale overlay check; its value does not
+// affect the overlay property.
+const aliasScaleC128 = complex(1.25, -0.5)
+
+func c128AliasCases() []aliastest.Case {
+	return []aliastest.Case{
+		aliastest.BinaryCase("Add", aliasEqC128, aliasGenC128, Add),
+		aliastest.BinaryCase("Sub", aliasEqC128, aliasGenC128, Sub),
+		aliastest.BinaryCase("Mul", aliasEqC128, aliasGenC128, Mul),
+		aliastest.BinaryCase("MulConj", aliasEqC128, aliasGenC128, MulConj),
+		aliastest.UnaryCase("Conj", aliasEqC128, aliasGenC128, Conj),
+		aliastest.UnaryCase("Scale", aliasEqC128, aliasGenC128, func(dst, a []complex128) { Scale(dst, a, aliasScaleC128) }),
+	}
+}
+
+// TestAliasingSweep drives the exact-overlay sweep across every bound kernel.
+func TestAliasingSweep(t *testing.T) {
+	forTiers(t, func(t *testing.T) {
+		t.Helper()
+		aliastest.Sweep(t, c128AliasCases())
+	})
+}

--- a/c128/c128.go
+++ b/c128/c128.go
@@ -14,6 +14,26 @@
 //
 // Thread Safety: All functions are safe for concurrent use.
 // Memory: All functions are zero-allocation (no heap allocations).
+//
+// # Aliasing
+//
+// The element-wise operations may be used fully in place: the destination may
+// alias an input exactly, element for element. Add, Sub, Mul and MulConj accept
+// dst equal to a, to b, or to both; Scale and Conj accept dst equal to a. Each
+// SIMD block reads its whole block of complex inputs into registers before
+// storing any output lane, and the remainder reads each complex element before it
+// writes that element, so an exact overlay is well defined lane by lane on every
+// dispatch path (amd64 SSE2, AVX with and without FMA, AVX-512, arm64 NEON, and
+// the pure-Go fallback).
+//
+// A destination must not overlap an input at a shifted offset: a SIMD load pulls
+// a whole block of an input ahead of the stores, so a shifted overlay clobbers
+// input lanes a later iteration has not yet read; the resulting corruption
+// pattern is undefined and varies with kernel width and length.
+//
+// Abs, AbsSq and FromReal convert between complex128 and float64, so their input
+// and output have distinct element types and cannot alias in safe Go. DotProduct
+// and DotProductConj write no output slice, so aliasing does not apply to them.
 package c128
 
 // Mul computes element-wise complex multiplication: dst[i] = a[i] * b[i].

--- a/c64/aliasing_amd64_test.go
+++ b/c64/aliasing_amd64_test.go
@@ -1,0 +1,24 @@
+//go:build amd64
+
+package c64
+
+import (
+	"testing"
+
+	"github.com/tphakala/simd/cpu"
+	"github.com/tphakala/simd/internal/aliastest"
+)
+
+// forTiers runs the aliasing sweep under every forceable amd64 tier. The
+// SSE-named tier actually uses SSE4.1 (BLENDPS); it is gated on SSE41
+// accordingly. The list is in descending priority so aliastest.ForTiers re-binds
+// the host default on cleanup.
+func forTiers(t *testing.T, run func(t *testing.T)) {
+	t.Helper()
+	aliastest.ForTiers(t, []aliastest.Tier{
+		{Name: "AVX512", Bind: initAVX512, Supported: cpu.X86.AVX512F && cpu.X86.AVX512VL},
+		{Name: "AVX", Bind: initAVX, Supported: cpu.X86.AVX && cpu.X86.FMA},
+		{Name: "SSE41", Bind: initSSE2, Supported: cpu.X86.SSE41},
+		{Name: "Go", Bind: initGo, Supported: true},
+	}, run)
+}

--- a/c64/aliasing_arm64_test.go
+++ b/c64/aliasing_arm64_test.go
@@ -1,0 +1,16 @@
+//go:build arm64
+
+package c64
+
+import (
+	"testing"
+
+	"github.com/tphakala/simd/internal/aliastest"
+)
+
+// forTiers runs the aliasing sweep on both the Go and NEON arm64 paths by
+// flipping the package hasNEON gate.
+func forTiers(t *testing.T, run func(t *testing.T)) {
+	t.Helper()
+	aliastest.ForGate(t, &hasNEON, "NEON", run)
+}

--- a/c64/aliasing_other_test.go
+++ b/c64/aliasing_other_test.go
@@ -1,0 +1,12 @@
+//go:build !amd64 && !arm64
+
+package c64
+
+import "testing"
+
+// forTiers runs the aliasing sweep once on architectures with only the pure-Go
+// path (no tier to force).
+func forTiers(t *testing.T, run func(t *testing.T)) {
+	t.Helper()
+	run(t)
+}

--- a/c64/aliasing_test.go
+++ b/c64/aliasing_test.go
@@ -10,8 +10,9 @@ import (
 // Aliasing sweep for the c64 exact-overlay contract (issue #221). Each element-
 // wise op is run once into a separate destination and once with the destination
 // overlaid on an input, then bit-compared (real and imaginary parts) under every
-// bound kernel tier. It asserts nothing about the corruption pattern of a
-// non-overlapping op, which is undefined.
+// bound kernel tier. It asserts nothing about how a shifted overlay (dst offset
+// from an input) corrupts: that pattern is undefined and varies with kernel
+// width and length.
 
 func aliasEqC64(x, y complex64) bool {
 	return math.Float32bits(real(x)) == math.Float32bits(real(y)) &&
@@ -47,5 +48,14 @@ func TestAliasingSweep(t *testing.T) {
 	forTiers(t, func(t *testing.T) {
 		t.Helper()
 		aliastest.Sweep(t, c64AliasCases())
+	})
+}
+
+// TestAliasingZeroAlloc asserts the in-place overlay path is allocation-free for
+// every swept op under each bound tier.
+func TestAliasingZeroAlloc(t *testing.T) {
+	forTiers(t, func(t *testing.T) {
+		t.Helper()
+		aliastest.SweepAlloc(t, c64AliasCases())
 	})
 }

--- a/c64/aliasing_test.go
+++ b/c64/aliasing_test.go
@@ -1,0 +1,51 @@
+package c64
+
+import (
+	"math"
+	"testing"
+
+	"github.com/tphakala/simd/internal/aliastest"
+)
+
+// Aliasing sweep for the c64 exact-overlay contract (issue #221). Each element-
+// wise op is run once into a separate destination and once with the destination
+// overlaid on an input, then bit-compared (real and imaginary parts) under every
+// bound kernel tier. It asserts nothing about the corruption pattern of a
+// non-overlapping op, which is undefined.
+
+func aliasEqC64(x, y complex64) bool {
+	return math.Float32bits(real(x)) == math.Float32bits(real(y)) &&
+		math.Float32bits(imag(x)) == math.Float32bits(imag(y))
+}
+
+func aliasHashF32(i int) float32 {
+	u := uint32(i)*2654435761 + 1013904223
+	return float32(u)/float32(1<<32)*8 - 4
+}
+
+// aliasGenC64 builds a deterministic complex64 with independent real and
+// imaginary spreads over [-4,4).
+func aliasGenC64(i int) complex64 { return complex(aliasHashF32(i), aliasHashF32(i+9973)) }
+
+// aliasScaleC64 is the scalar for the Scale overlay check; its value does not
+// affect the overlay property.
+const aliasScaleC64 = complex64(complex(1.25, -0.5))
+
+func c64AliasCases() []aliastest.Case {
+	return []aliastest.Case{
+		aliastest.BinaryCase("Add", aliasEqC64, aliasGenC64, Add),
+		aliastest.BinaryCase("Sub", aliasEqC64, aliasGenC64, Sub),
+		aliastest.BinaryCase("Mul", aliasEqC64, aliasGenC64, Mul),
+		aliastest.BinaryCase("MulConj", aliasEqC64, aliasGenC64, MulConj),
+		aliastest.UnaryCase("Conj", aliasEqC64, aliasGenC64, Conj),
+		aliastest.UnaryCase("Scale", aliasEqC64, aliasGenC64, func(dst, a []complex64) { Scale(dst, a, aliasScaleC64) }),
+	}
+}
+
+// TestAliasingSweep drives the exact-overlay sweep across every bound kernel.
+func TestAliasingSweep(t *testing.T) {
+	forTiers(t, func(t *testing.T) {
+		t.Helper()
+		aliastest.Sweep(t, c64AliasCases())
+	})
+}

--- a/c64/c64.go
+++ b/c64/c64.go
@@ -20,6 +20,26 @@
 //
 // Thread Safety: All functions are safe for concurrent use.
 // Memory: All functions are zero-allocation (no heap allocations).
+//
+// # Aliasing
+//
+// The element-wise operations may be used fully in place: the destination may
+// alias an input exactly, element for element. Add, Sub, Mul and MulConj accept
+// dst equal to a, to b, or to both; Scale and Conj accept dst equal to a. Each
+// SIMD block reads its whole block of complex inputs into registers before
+// storing any output lane, and the remainder reads each complex element before it
+// writes that element, so an exact overlay is well defined lane by lane on every
+// dispatch path (amd64 SSE4.1, AVX+FMA and AVX-512, arm64 NEON, and the pure-Go
+// fallback).
+//
+// A destination must not overlap an input at a shifted offset: a SIMD load pulls
+// a whole block of an input ahead of the stores, so a shifted overlay clobbers
+// input lanes a later iteration has not yet read; the resulting corruption
+// pattern is undefined and varies with kernel width and length.
+//
+// Abs, AbsSq and FromReal convert between complex64 and float32, so their input
+// and output have distinct element types and cannot alias in safe Go. DotProduct
+// and DotProductConj write no output slice, so aliasing does not apply to them.
 package c64
 
 // Mul computes element-wise complex multiplication: dst[i] = a[i] * b[i].

--- a/f32/aliasing_amd64_test.go
+++ b/f32/aliasing_amd64_test.go
@@ -1,0 +1,46 @@
+//go:build amd64
+
+package f32
+
+import (
+	"testing"
+
+	"github.com/tphakala/simd/cpu"
+	"github.com/tphakala/simd/internal/aliastest"
+)
+
+// forTiers runs the aliasing sweep under every forceable amd64 tier. The list is
+// in descending priority so aliastest.ForTiers re-binds the host default on
+// cleanup. AVX-512 is exercised only where the host has it.
+func forTiers(t *testing.T, run func(t *testing.T)) {
+	t.Helper()
+	aliastest.ForTiers(t, []aliastest.Tier{
+		{Name: "AVX512", Bind: initAVX512, Supported: cpu.X86.AVX512F && cpu.X86.AVX512VL},
+		{Name: "AVX", Bind: initAVX, Supported: cpu.X86.AVX && cpu.X86.FMA},
+		{Name: "SSE", Bind: initSSE, Supported: cpu.X86.SSE2},
+		{Name: "Go", Bind: initGo, Supported: true},
+	}, run)
+}
+
+// TestAliasingDirectKernels exercises the exact-overlay property of the SSE and
+// Go kernels of CopySign and AbsPow34 directly. Both ops dispatch inline on
+// cpu.X86.AVX with no length guard (f32_amd64.go copySign32, absPow34_32), so on
+// an AVX host the tier-forcing sweep only ever reaches their AVX kernel; their SSE
+// and Go kernels are never covered by TestAliasingSweep. The package doc promises
+// the overlay on the amd64 SSE path, so it is checked here directly. The AVX
+// kernels are included for symmetry (also covered by the main sweep). CopySign is
+// binary (dst, mag, sign); AbsPow34 is unary (dst, src).
+func TestAliasingDirectKernels(t *testing.T) {
+	for _, n := range aliastest.Sizes {
+		aliastest.Binary(t, n, aliasEqF32, genF32, copySign32Go)
+		aliastest.Unary(t, n, aliasEqF32, genF32, absPow34Go)
+		if cpu.X86.SSE2 {
+			aliastest.Binary(t, n, aliasEqF32, genF32, copySignSSE)
+			aliastest.Unary(t, n, aliasEqF32, genF32, absPow34SSE)
+		}
+		if cpu.X86.AVX {
+			aliastest.Binary(t, n, aliasEqF32, genF32, copySignAVX)
+			aliastest.Unary(t, n, aliasEqF32, genF32, absPow34AVX)
+		}
+	}
+}

--- a/f32/aliasing_arm64_test.go
+++ b/f32/aliasing_arm64_test.go
@@ -1,0 +1,18 @@
+//go:build arm64
+
+package f32
+
+import (
+	"testing"
+
+	"github.com/tphakala/simd/internal/aliastest"
+)
+
+// forTiers runs the aliasing sweep on both the Go and NEON arm64 paths by
+// flipping the package hasNEON gate, so the sweep sees the two kernels that #215
+// showed can disagree. On a NEON-less arm64 host the NEON tier is skipped and the
+// Go path runs once.
+func forTiers(t *testing.T, run func(t *testing.T)) {
+	t.Helper()
+	aliastest.ForGate(t, &hasNEON, "NEON", run)
+}

--- a/f32/aliasing_other_test.go
+++ b/f32/aliasing_other_test.go
@@ -1,0 +1,12 @@
+//go:build !amd64 && !arm64
+
+package f32
+
+import "testing"
+
+// forTiers runs the aliasing sweep once on architectures with only the pure-Go
+// path (no tier to force).
+func forTiers(t *testing.T, run func(t *testing.T)) {
+	t.Helper()
+	run(t)
+}

--- a/f32/aliasing_test.go
+++ b/f32/aliasing_test.go
@@ -20,8 +20,8 @@ import (
 // exercises the CopySign and AbsPow34 SSE and Go kernels that an AVX host would
 // otherwise never reach.
 //
-// It asserts nothing about how a non-overlapping op corrupts a shifted overlay:
-// that pattern is undefined and varies with kernel width and length.
+// It asserts nothing about how a shifted overlay (dst offset from an input)
+// corrupts: that pattern is undefined and varies with kernel width and length.
 
 func aliasEqF32(x, y float32) bool { return math.Float32bits(x) == math.Float32bits(y) }
 
@@ -99,6 +99,34 @@ func TestAliasingSweep(t *testing.T) {
 		t.Run("MulConjComplex", func(t *testing.T) { sweepSplitComplex(t, MulConjComplex) })
 		t.Run("AddScaled", sweepAddScaled)
 	})
+}
+
+// TestAliasingZeroAlloc asserts the in-place overlay path is allocation-free for
+// every swept op under each bound tier, enforcing the package zero-allocation
+// contract on the aliasing path specifically (not only the separate-dst path the
+// existing primitive tests cover).
+func TestAliasingZeroAlloc(t *testing.T) {
+	forTiers(t, func(t *testing.T) {
+		t.Helper()
+		aliastest.SweepAlloc(t, f32AliasCases())
+		t.Run("AddScaled", func(t *testing.T) {
+			a := make([]float32, 64)
+			for i := range a {
+				a[i] = genF32(i)
+			}
+			aliastest.ZeroAlloc(t, "AddScaled s==dst", func() { AddScaled(a, 1.5, a) })
+		})
+		t.Run("MulComplex", func(t *testing.T) { allocSplitComplex(t, "MulComplex", MulComplex) })
+		t.Run("MulConjComplex", func(t *testing.T) { allocSplitComplex(t, "MulConjComplex", MulConjComplex) })
+	})
+}
+
+// allocSplitComplex asserts the in-place-over-a overlay of a split-complex product
+// allocates nothing.
+func allocSplitComplex(t *testing.T, name string, op func(dstRe, dstIm, aRe, aIm, bRe, bIm []float32)) {
+	t.Helper()
+	aRe, aIm, bRe, bIm := splitInputs(64)
+	aliastest.ZeroAlloc(t, name+" dstRe=aRe,dstIm=aIm", func() { op(aRe, aIm, aRe, aIm, bRe, bIm) })
 }
 
 // sweepAddScaled checks AddScaled's documented in-place overlay: s may equal dst

--- a/f32/aliasing_test.go
+++ b/f32/aliasing_test.go
@@ -121,12 +121,15 @@ func TestAliasingZeroAlloc(t *testing.T) {
 	})
 }
 
-// allocSplitComplex asserts the in-place-over-a overlay of a split-complex product
-// allocates nothing.
+// allocSplitComplex asserts both claimed in-place overlays of a split-complex
+// product (result over a, and result over b) allocate nothing, each on fresh
+// inputs.
 func allocSplitComplex(t *testing.T, name string, op func(dstRe, dstIm, aRe, aIm, bRe, bIm []float32)) {
 	t.Helper()
 	aRe, aIm, bRe, bIm := splitInputs(64)
 	aliastest.ZeroAlloc(t, name+" dstRe=aRe,dstIm=aIm", func() { op(aRe, aIm, aRe, aIm, bRe, bIm) })
+	aRe, aIm, bRe, bIm = splitInputs(64)
+	aliastest.ZeroAlloc(t, name+" dstRe=bRe,dstIm=bIm", func() { op(bRe, bIm, aRe, aIm, bRe, bIm) })
 }
 
 // sweepAddScaled checks AddScaled's documented in-place overlay: s may equal dst

--- a/f32/aliasing_test.go
+++ b/f32/aliasing_test.go
@@ -1,0 +1,165 @@
+package f32
+
+import (
+	"math"
+	"testing"
+
+	"github.com/tphakala/simd/internal/aliastest"
+)
+
+// Aliasing sweep for the f32 exact-overlay contract (issue #221).
+//
+// For every operation documented as supporting an exact in-place overlay, this
+// runs the operation twice at each length in aliastest.Sizes: once into a
+// separate destination, once with the destination physically overlaid on an
+// input, and asserts the two results are bit-identical. forTiers forces each
+// amd64 function-pointer dispatch tier and both the Go and NEON arm64 paths. A
+// few f32 ops (CopySign, AbsPow34, and the transcendentals) dispatch through an
+// inline CPU-feature branch the harness cannot rebind; the size sweep still runs
+// their Go and native-SIMD kernels, and TestAliasingDirectKernels (amd64)
+// exercises the CopySign and AbsPow34 SSE and Go kernels that an AVX host would
+// otherwise never reach.
+//
+// It asserts nothing about how a non-overlapping op corrupts a shifted overlay:
+// that pattern is undefined and varies with kernel width and length.
+
+func aliasEqF32(x, y float32) bool { return math.Float32bits(x) == math.Float32bits(y) }
+
+// hashF32 is a deterministic pseudo-random value in [0,1) from an index.
+func hashF32(i int) float32 {
+	u := uint32(i)*2654435761 + 1013904223
+	return float32(u) / float32(1<<32)
+}
+
+// genF32 spreads values over [-4,4), including negatives and near-zero.
+func genF32(i int) float32 { return hashF32(i)*8 - 4 }
+
+// genF32Pos spreads values over (0,8] for domain-restricted ops (log, sqrt, pow).
+func genF32Pos(i int) float32 { return hashF32(i)*8 + 0.03125 }
+
+// Scalar parameters for the scalar-taking element-wise ops. The exact values are
+// irrelevant to the overlay property; they only need to exercise the kernel.
+const (
+	aliasScaleK  = 1.5
+	aliasAddK    = 0.75
+	aliasClampLo = -1.25
+	aliasClampHi = 2.5
+	aliasScaleC  = 0.5
+	aliasPowExp  = 0.75
+)
+
+func f32AliasCases() []aliastest.Case {
+	return []aliastest.Case{
+		// Element-wise unary maps (dst may overlay a exactly).
+		aliastest.UnaryCase("Abs", aliasEqF32, genF32, Abs),
+		aliastest.UnaryCase("Neg", aliasEqF32, genF32, Neg),
+		aliastest.UnaryCase("Round", aliasEqF32, genF32, Round),
+		aliastest.UnaryCase("Reciprocal", aliasEqF32, genF32, Reciprocal),
+		aliastest.UnaryCase("ReLU", aliasEqF32, genF32, ReLU),
+		aliastest.UnaryCase("Sigmoid", aliasEqF32, genF32, Sigmoid),
+		aliastest.UnaryCase("Tanh", aliasEqF32, genF32, Tanh),
+		aliastest.UnaryCase("Exp", aliasEqF32, genF32, Exp),
+		aliastest.UnaryCase("Sqrt", aliasEqF32, genF32Pos, Sqrt),
+		aliastest.UnaryCase("Log", aliasEqF32, genF32Pos, Log),
+		aliastest.UnaryCase("Log2", aliasEqF32, genF32Pos, Log2),
+		aliastest.UnaryCase("Log10", aliasEqF32, genF32Pos, Log10),
+		aliastest.UnaryCase("AbsPow34", aliasEqF32, genF32, AbsPow34),
+		aliastest.UnaryCase("CumulativeSum", aliasEqF32, genF32, CumulativeSum),
+		aliastest.UnaryCase("Normalize", aliasEqF32, genF32, Normalize),
+		aliastest.UnaryCase("Reverse", aliasEqF32, genF32, Reverse),
+
+		// Element-wise unary maps with a scalar parameter.
+		aliastest.UnaryCase("Scale", aliasEqF32, genF32, func(dst, a []float32) { Scale(dst, a, aliasScaleK) }),
+		aliastest.UnaryCase("AddScalar", aliasEqF32, genF32, func(dst, a []float32) { AddScalar(dst, a, aliasAddK) }),
+		aliastest.UnaryCase("SubFromScalar", aliasEqF32, genF32, func(dst, a []float32) { SubFromScalar(dst, a, aliasAddK) }),
+		aliastest.UnaryCase("Clamp", aliasEqF32, genF32, func(dst, a []float32) { Clamp(dst, a, aliasClampLo, aliasClampHi) }),
+		aliastest.UnaryCase("ClampScale", aliasEqF32, genF32, func(dst, a []float32) { ClampScale(dst, a, aliasClampLo, aliasClampHi, aliasScaleC) }),
+		aliastest.UnaryCase("Pow", aliasEqF32, genF32Pos, func(dst, a []float32) { Pow(dst, a, aliasPowExp) }),
+
+		// Element-wise binary maps (dst may overlay a, b, or both exactly).
+		aliastest.BinaryCase("Add", aliasEqF32, genF32, Add),
+		aliastest.BinaryCase("Sub", aliasEqF32, genF32, Sub),
+		aliastest.BinaryCase("Mul", aliasEqF32, genF32, Mul),
+		aliastest.BinaryCase("Div", aliasEqF32, genF32, Div),
+		aliastest.BinaryCase("PowElem", aliasEqF32, genF32Pos, PowElem),
+		aliastest.BinaryCase("CopySign", aliasEqF32, genF32, CopySign),
+		aliastest.BinaryCase("AbsSqComplex", aliasEqF32, genF32, AbsSqComplex),
+
+		// Fused multiply-add (dst may overlay a, b, or c exactly).
+		aliastest.TernaryCase("FMA", aliasEqF32, genF32, FMA),
+	}
+}
+
+// TestAliasingSweep drives the exact-overlay sweep across every bound kernel.
+func TestAliasingSweep(t *testing.T) {
+	forTiers(t, func(t *testing.T) {
+		t.Helper()
+		aliastest.Sweep(t, f32AliasCases())
+		t.Run("MulComplex", func(t *testing.T) { sweepSplitComplex(t, MulComplex) })
+		t.Run("MulConjComplex", func(t *testing.T) { sweepSplitComplex(t, MulConjComplex) })
+		t.Run("AddScaled", sweepAddScaled)
+	})
+}
+
+// sweepAddScaled checks AddScaled's documented in-place overlay: s may equal dst
+// exactly (the self-scaling dst[i] += alpha*dst[i]). AddScaled does not fit the
+// generic Unary/Binary shapes because dst is a read-modify-write accumulator, so
+// it gets a bespoke check. AddScaled is function-pointer dispatched, so forTiers
+// forces its tiers.
+func sweepAddScaled(t *testing.T) {
+	t.Helper()
+	const alpha = 1.5
+	for _, n := range aliastest.Sizes {
+		data := make([]float32, n)
+		for i := range data {
+			data[i] = genF32(i)
+		}
+		want := append([]float32(nil), data...)
+		AddScaled(want, alpha, append([]float32(nil), data...))
+		got := append([]float32(nil), data...)
+		AddScaled(got, alpha, got)
+		aliastest.Report(t, n, "AddScaled s==dst", aliasEqF32, want, got)
+	}
+}
+
+func splitInputs(n int) (aRe, aIm, bRe, bIm []float32) {
+	aRe = make([]float32, n)
+	aIm = make([]float32, n)
+	bRe = make([]float32, n)
+	bIm = make([]float32, n)
+	for i := range aRe {
+		aRe[i] = genF32(i)
+		aIm[i] = genF32(i + 11)
+		bRe[i] = genF32(i + 101)
+		bIm[i] = genF32(i + 211)
+	}
+	return
+}
+
+// sweepSplitComplex checks the two per-operand in-place overlays claimed for the
+// split-format complex products: the result may overwrite a (dstRe==aRe,
+// dstIm==aIm) or b (dstRe==bRe, dstIm==bIm). The two output components must stay
+// distinct, so that overlay is never claimed and never tested.
+func sweepSplitComplex(t *testing.T, op func(dstRe, dstIm, aRe, aIm, bRe, bIm []float32)) {
+	t.Helper()
+	for _, n := range aliastest.Sizes {
+		aRe, aIm, bRe, bIm := splitInputs(n)
+		wantRe := make([]float32, n)
+		wantIm := make([]float32, n)
+		op(wantRe, wantIm, aRe, aIm, bRe, bIm)
+
+		// Overwrite a in place.
+		gRe := append([]float32(nil), aRe...)
+		gIm := append([]float32(nil), aIm...)
+		op(gRe, gIm, gRe, gIm, bRe, bIm)
+		aliastest.Report(t, n, "dstRe=aRe,dstIm=aIm", aliasEqF32, wantRe, gRe)
+		aliastest.Report(t, n, "dstRe=aRe,dstIm=aIm", aliasEqF32, wantIm, gIm)
+
+		// Overwrite b in place.
+		gRe = append([]float32(nil), bRe...)
+		gIm = append([]float32(nil), bIm...)
+		op(gRe, gIm, aRe, aIm, gRe, gIm)
+		aliastest.Report(t, n, "dstRe=bRe,dstIm=bIm", aliasEqF32, wantRe, gRe)
+		aliastest.Report(t, n, "dstRe=bRe,dstIm=bIm", aliasEqF32, wantIm, gIm)
+	}
+}

--- a/f32/f32.go
+++ b/f32/f32.go
@@ -21,6 +21,58 @@
 // asmcheck-enforced for the primitives that actually perform a multiply followed
 // by an add (see TestNoFMAContract in the module root); a future optimization
 // that fuses one of them fails that test rather than silently changing bits.
+//
+// # Aliasing
+//
+// The element-wise maps may be used fully in place: the destination may alias an
+// input exactly, element for element. This holds for the unary maps (Abs, Neg,
+// Round, Sqrt, Reciprocal, Exp, Log, Log2, Log10, ReLU, Sigmoid, Tanh, AbsPow34,
+// Scale, AddScalar, SubFromScalar, Clamp, ClampScale, Pow), for the two-pass
+// CumulativeSum and Normalize (dst==a), for the binary maps (Add, Sub, Mul, Div,
+// PowElem, CopySign, AbsSqComplex, where dst may alias any input, or all of them
+// at once), for the fused multiply-add FMA (dst may alias a, b or c), and for the
+// split-complex products MulComplex and MulConjComplex, whose result may
+// overwrite either input vector (dstRe==aRe with dstIm==aIm, or dstRe==bRe with
+// dstIm==bIm). The guarantee is mechanical: each SIMD block reads its whole block
+// of inputs into registers before storing any output lane, and the scalar tail
+// reads each lane before it writes that lane, so an exact overlay is well defined
+// lane by lane on every dispatch path (amd64 SSE, AVX and AVX-512, arm64 NEON, and
+// the pure-Go fallback).
+//
+// A destination must not overlap an input at a shifted offset. A SIMD load pulls
+// a whole block of an input ahead of the stores, so a shifted overlay clobbers
+// input lanes a later iteration has not yet read; the resulting corruption
+// pattern is undefined and varies with kernel width and length.
+//
+// The departures from this default are documented on the functions themselves:
+//   - Reverse reverses in place when dst==src; it must not otherwise overlap src.
+//   - MulComplex and MulConjComplex write two outputs that must be distinct:
+//     dstRe and dstIm may not overlap each other.
+//   - AddSub writes two outputs and supports no output-over-input overlay at all;
+//     pass sumDst and diffDst distinct from a, b and each other.
+//   - AddScaled and AccumulateAdd read and rewrite dst in place (they are
+//     accumulators); their source slice must be disjoint from the destination
+//     window, except that AddScaled also permits s==dst exactly.
+//   - ButterflyComplex and ButterflyComplexStage update their data slices in
+//     place; those slices must be distinct from one another, and the twiddles
+//     must not overlap them.
+//   - The mirror, window, stride, interleave and batch operations (Interleave2/N,
+//     Deinterleave2/N, ConvolveValid and ConvolveValidMulti, ConvolveDecimate,
+//     DotProductBatch, DotProductIndexed, DotProductStrided, MinIdxOfSumRows and
+//     RealFFTUnpack) index inputs and outputs at different positions, so their
+//     outputs must not overlap any input.
+//
+// The float-to-fixed and fixed-to-float conversions (Float32ToInt16Scale,
+// Float32ToInt32ScaleClamp and its Signed form, Int16ToFloat32Scale,
+// Int32ToFloat32Scale) have distinct input and output element types and so cannot
+// alias in safe Go. The reductions (DotProduct, WeightedSum, SumOfSquares, Sum,
+// Mean, Max, Min, MaxAbs, MaxIdx, MinIdx, MinIdxOfSum, Variance, StdDev,
+// EuclideanDistance, ConvolveValidMaxAbs and ConvolveValidMaxAbsMulti,
+// CubicInterpDot) write no output slice, so aliasing does not apply to them. The
+// in-place transcendental variants (ExpInPlace, LogInPlace, PowInPlace,
+// ReLUInPlace, SigmoidInPlace, TanhInPlace) operate on a single slice, so
+// aliasing does not arise, and the Unsafe variants follow the aliasing rules of
+// the checked form they mirror.
 package f32
 
 import "math"
@@ -360,6 +412,10 @@ func ConvolveDecimate(dst, signal, kernel []float32, factor, phase int) {
 // AccumulateAdd adds src to dst starting at offset: dst[offset:offset+len(src)] += src.
 // This is a key primitive for overlap-add in FFT-based convolution.
 //
+// The destination window dst[offset:offset+len(src)] is a read-modify-write
+// accumulator; src must not overlap that window. An overlap-add caller passes a
+// src region disjoint from the destination window, so this is the natural usage.
+//
 // Panics if offset+len(src) > len(dst) or if offset < 0.
 func AccumulateAdd(dst, src []float32, offset int) {
 	if offset < 0 {
@@ -571,6 +627,10 @@ func MaxIdx(a []float32) int {
 // AddScaled adds scaled values to dst: dst[i] += alpha * s[i].
 // This is the AXPY operation from BLAS Level 1.
 // Processes min(len(dst), len(s)) elements.
+//
+// dst is a read-modify-write accumulator. s may overlay dst exactly (the
+// self-scaling dst[i] += alpha*dst[i], since each lane is read before it is
+// rewritten), but s must not overlap dst at a shifted offset.
 func AddScaled(dst []float32, alpha float32, s []float32) {
 	n := min(len(dst), len(s))
 	if n == 0 {
@@ -1309,6 +1369,12 @@ func Float32ToInt32ScaleClampSignedUnsafe(dst []int32, mag, sign []float32, scal
 //
 // This is the core operation for FFT-based convolution in frequency domain.
 // Split format allows direct SIMD loads without deinterleaving overhead.
+//
+// Aliasing: the product may overwrite either input vector in place (dstRe==aRe
+// with dstIm==aIm, or dstRe==bRe with dstIm==bIm); every path reads a full block
+// of all four inputs before storing either output. The two output components
+// must be distinct, though: dstRe and dstIm may not overlap each other, and
+// neither may shift-overlap an input.
 func MulComplex(dstRe, dstIm, aRe, aIm, bRe, bIm []float32) {
 	n := minLen6(len(dstRe), len(dstIm), len(aRe), len(aIm), len(bRe), len(bIm))
 	if n == 0 {
@@ -1325,6 +1391,10 @@ func MulComplex(dstRe, dstIm, aRe, aIm, bRe, bIm []float32) {
 // Processes min(len(dstRe), len(dstIm), len(aRe), len(aIm), len(bRe), len(bIm)) elements.
 //
 // This is used for cross-correlation in frequency domain.
+//
+// Aliasing: the same in-place rule as MulComplex. The product may overwrite
+// either input vector (dstRe==aRe with dstIm==aIm, or dstRe==bRe with dstIm==bIm),
+// but dstRe and dstIm must be distinct and must not shift-overlap an input.
 func MulConjComplex(dstRe, dstIm, aRe, aIm, bRe, bIm []float32) {
 	n := minLen6(len(dstRe), len(dstIm), len(aRe), len(aIm), len(bRe), len(bIm))
 	if n == 0 {
@@ -1341,6 +1411,9 @@ func MulConjComplex(dstRe, dstIm, aRe, aIm, bRe, bIm []float32) {
 //
 // This is faster than computing the full magnitude (no sqrt) and is the
 // core operation for power spectrum computation in spectrograms.
+//
+// dst may alias aRe or aIm exactly (each output depends only on its own index),
+// so the power spectrum can be written over an input in place.
 func AbsSqComplex(dst, aRe, aIm []float32) {
 	n := minLen(len(dst), len(aRe), len(aIm))
 	if n == 0 {
@@ -1365,6 +1438,10 @@ func minLen6(a, b, c, d, e, f int) int {
 //
 // Processes min(len(upperRe), len(upperIm), len(lowerRe), len(lowerIm), len(twRe), len(twIm)) elements.
 // All slices are modified in-place: upper receives upper+temp, lower receives upper-temp.
+//
+// Aliasing: each butterfly reads its inputs before writing either output, so the
+// four data slices are updated in place. They must be four distinct slices, and
+// the twiddles twRe/twIm must not overlap any of them.
 func ButterflyComplex(upperRe, upperIm, lowerRe, lowerIm, twRe, twIm []float32) {
 	n := minLen6(len(upperRe), len(upperIm), len(lowerRe), len(lowerIm), len(twRe), len(twIm))
 	if n == 0 {
@@ -1402,6 +1479,9 @@ const butterflyStageRadix = 2
 // and it is also a no-op when no complete block fits. Blocks are processed while
 // k+2*span <= n, where n = min(len(re), len(im)); a trailing partial block is
 // left untouched.
+//
+// Aliasing: the stage updates re and im in place; they must be distinct buffers,
+// and the twiddles twRe/twIm must not overlap either.
 //
 // Uses AVX+FMA on AMD64, NEON on ARM64, with a pure Go fallback. As with
 // [ButterflyComplex], results are not guaranteed bit-identical between the
@@ -1491,7 +1571,10 @@ func RealFFTUnpack(outRe, outIm, zRe, zIm, twRe, twIm []float32) {
 //   - Signal processing algorithms requiring time reversal
 //   - General array manipulation
 //
-// In-place operation (dst == src) is supported.
+// Aliasing: in-place reversal (dst == src) is supported. The kernels detect exact
+// data-pointer aliasing at entry and reverse by swapping from both ends, loading
+// each pair before it overwrites either lane. dst must not otherwise overlap src
+// (a shifted overlay is not supported).
 //
 // Uses AVX on AMD64 (8x float32), NEON on ARM64 (4x float32), with pure Go fallback.
 func Reverse(dst, src []float32) {
@@ -1511,6 +1594,11 @@ func Reverse(dst, src []float32) {
 // compared to calling Add and Sub separately.
 //
 // Processes min(len(sumDst), len(diffDst), len(a), len(b)) elements.
+//
+// Aliasing: unlike the plain element-wise maps, AddSub does not support an output
+// overlaid on an input. Its pure-Go tail writes sumDst[i] before reading the
+// input again for diffDst[i], so a sumDst overlaid on a or b is corrupted at the
+// tail lanes. Pass sumDst and diffDst distinct from a, b and from each other.
 //
 // Uses AVX on AMD64 (8x float32), NEON on ARM64 (4x float32), with pure Go fallback.
 func AddSub(sumDst, diffDst, a, b []float32) {

--- a/f32/f32.go
+++ b/f32/f32.go
@@ -54,8 +54,8 @@
 //     accumulators); their source slice must be disjoint from the destination
 //     window, except that AddScaled also permits s==dst exactly.
 //   - ButterflyComplex and ButterflyComplexStage update their data slices in
-//     place; those slices must be distinct from one another, and the twiddles
-//     must not overlap them.
+//     place; those slices must not overlap one another, and the twiddles must not
+//     overlap them.
 //   - The mirror, window, stride, interleave and batch operations (Interleave2/N,
 //     Deinterleave2/N, ConvolveValid and ConvolveValidMulti, ConvolveDecimate,
 //     DotProductBatch, DotProductIndexed, DotProductStrided, MinIdxOfSumRows and
@@ -1440,8 +1440,9 @@ func minLen6(a, b, c, d, e, f int) int {
 // All slices are modified in-place: upper receives upper+temp, lower receives upper-temp.
 //
 // Aliasing: each butterfly reads its inputs before writing either output, so the
-// four data slices are updated in place. They must be four distinct slices, and
-// the twiddles twRe/twIm must not overlap any of them.
+// four data slices are updated in place. They must be pairwise non-overlapping
+// (distinct headers are not enough; a shifted sub-slice of one array corrupts),
+// and the twiddles twRe/twIm must not overlap any of them.
 func ButterflyComplex(upperRe, upperIm, lowerRe, lowerIm, twRe, twIm []float32) {
 	n := minLen6(len(upperRe), len(upperIm), len(lowerRe), len(lowerIm), len(twRe), len(twIm))
 	if n == 0 {
@@ -1480,8 +1481,8 @@ const butterflyStageRadix = 2
 // k+2*span <= n, where n = min(len(re), len(im)); a trailing partial block is
 // left untouched.
 //
-// Aliasing: the stage updates re and im in place; they must be distinct buffers,
-// and the twiddles twRe/twIm must not overlap either.
+// Aliasing: the stage updates re and im in place; re and im must not overlap
+// each other, and the twiddles twRe/twIm must not overlap either.
 //
 // Uses AVX+FMA on AMD64, NEON on ARM64, with a pure Go fallback. As with
 // [ButterflyComplex], results are not guaranteed bit-identical between the

--- a/f32/f32.go
+++ b/f32/f32.go
@@ -56,11 +56,11 @@
 //   - ButterflyComplex and ButterflyComplexStage update their data slices in
 //     place; those slices must not overlap one another, and the twiddles must not
 //     overlap them.
-//   - The mirror, window, stride, interleave and batch operations (Interleave2/N,
-//     Deinterleave2/N, ConvolveValid and ConvolveValidMulti, ConvolveDecimate,
-//     DotProductBatch, DotProductIndexed, DotProductStrided, MinIdxOfSumRows and
-//     RealFFTUnpack) index inputs and outputs at different positions, so their
-//     outputs must not overlap any input.
+//   - The mirror, window, stride, interleave, batch and resample operations
+//     (Interleave2/N, Deinterleave2/N, ConvolveValid and ConvolveValidMulti,
+//     ConvolveDecimate, DotProductBatch, DotProductIndexed, DotProductStrided,
+//     MinIdxOfSumRows, RealFFTUnpack and PolyphaseResampleCubic) index inputs and
+//     outputs at different positions, so their outputs must not overlap any input.
 //
 // The float-to-fixed and fixed-to-float conversions (Float32ToInt16Scale,
 // Float32ToInt32ScaleClamp and its Signed form, Int16ToFloat32Scale,
@@ -801,6 +801,10 @@ const polyphaseMaxFracBits32 = 24
 // tapsPerPhase, or an initial window already past the end of hist) also yield
 // (0, at) because no output satisfies the window bound.
 //
+// Aliasing: out and hist are indexed differently (each output reads a sliding
+// window of hist chosen by the accumulator), so out must not overlap hist, nor
+// any of the coefficient banks a, b, c or d.
+//
 // Uses AVX+FMA on AMD64 and NEON on ARM64 for tapsPerPhase past the vector width,
 // gated on the same CPU features and tap threshold as [CubicInterpDot] so the
 // fused result is bit-identical to the per-output form on every CPU; below the
@@ -847,7 +851,8 @@ func PolyphaseResampleCubic(out, hist []float32, a, b, c, d [][]float32, at, ste
 // form, this variant does not reject an overflowing at/step, so a caller that
 // breaks the last precondition can drive the internal accumulator to wrap and
 // read out of range. When the preconditions hold it returns the same (n, atOut)
-// as the safe form.
+// as the safe form. The same aliasing rule applies: out must not overlap hist or
+// the coefficient banks.
 func PolyphaseResampleCubicUnsafe(out, hist []float32, a, b, c, d [][]float32, at, step int64, numPhases, tapsPerPhase, fracBits int) (n int, atOut int64) {
 	n = polyphaseResampleCubic32(out, hist, a, b, c, d, at, step, numPhases, tapsPerPhase, fracBits)
 	return n, at + int64(n)*step

--- a/f64/aliasing_amd64_test.go
+++ b/f64/aliasing_amd64_test.go
@@ -1,0 +1,25 @@
+//go:build amd64
+
+package f64
+
+import (
+	"testing"
+
+	"github.com/tphakala/simd/cpu"
+	"github.com/tphakala/simd/internal/aliastest"
+)
+
+// forTiers runs the aliasing sweep under every forceable amd64 tier, including
+// the AVX-without-FMA tier (#201) that never runs on FMA-capable CI. The list is
+// in descending priority so aliastest.ForTiers re-binds the host default on
+// cleanup.
+func forTiers(t *testing.T, run func(t *testing.T)) {
+	t.Helper()
+	aliastest.ForTiers(t, []aliastest.Tier{
+		{Name: "AVX512", Bind: initAVX512, Supported: cpu.X86.AVX512F && cpu.X86.AVX512VL},
+		{Name: "AVX", Bind: initAVX, Supported: cpu.X86.AVX && cpu.X86.FMA},
+		{Name: "AVXNoFMA", Bind: initAVXNoFMA, Supported: cpu.X86.AVX},
+		{Name: "SSE2", Bind: initSSE2, Supported: cpu.X86.SSE2},
+		{Name: "Go", Bind: initGo, Supported: true},
+	}, run)
+}

--- a/f64/aliasing_amd64_test.go
+++ b/f64/aliasing_amd64_test.go
@@ -12,7 +12,10 @@ import (
 // forTiers runs the aliasing sweep under every forceable amd64 tier, including
 // the AVX-without-FMA tier (#201) that never runs on FMA-capable CI. The list is
 // in descending priority so aliastest.ForTiers re-binds the host default on
-// cleanup.
+// cleanup. Forcing a tier only redirects the function-pointer-dispatched ops; the
+// transcendentals select inline from cpu.X86 and length, so they are not forced
+// per tier (they have no distinct SSE kernel, so the size sweep covers their Go
+// and native-SIMD kernels; see the note in aliasing_test.go).
 func forTiers(t *testing.T, run func(t *testing.T)) {
 	t.Helper()
 	aliastest.ForTiers(t, []aliastest.Tier{

--- a/f64/aliasing_arm64_test.go
+++ b/f64/aliasing_arm64_test.go
@@ -1,0 +1,17 @@
+//go:build arm64
+
+package f64
+
+import (
+	"testing"
+
+	"github.com/tphakala/simd/internal/aliastest"
+)
+
+// forTiers runs the aliasing sweep on both the Go and NEON arm64 paths by
+// flipping the package hasNEON gate, so the sweep sees the two kernels that #215
+// showed can disagree.
+func forTiers(t *testing.T, run func(t *testing.T)) {
+	t.Helper()
+	aliastest.ForGate(t, &hasNEON, "NEON", run)
+}

--- a/f64/aliasing_other_test.go
+++ b/f64/aliasing_other_test.go
@@ -1,0 +1,12 @@
+//go:build !amd64 && !arm64
+
+package f64
+
+import "testing"
+
+// forTiers runs the aliasing sweep once on architectures with only the pure-Go
+// path (no tier to force).
+func forTiers(t *testing.T, run func(t *testing.T)) {
+	t.Helper()
+	run(t)
+}

--- a/f64/aliasing_test.go
+++ b/f64/aliasing_test.go
@@ -14,13 +14,16 @@ import (
 // arm64 paths). The transcendentals dispatch through an inline CPU-feature branch
 // the harness cannot rebind, but they have no distinct SSE kernel, so the size
 // sweep still runs both their Go and native-SIMD kernels. It asserts nothing about
-// the corruption pattern of a non-overlapping op, which is undefined.
+// how a shifted overlay (dst offset from an input) corrupts, which is undefined.
 
 func aliasEqF64(x, y float64) bool { return math.Float64bits(x) == math.Float64bits(y) }
 
 func aliasHashF64(i int) float64 {
-	u := uint64(i)*2654435761 + 1013904223
-	return float64(u) / float64(1<<64)
+	// A full-width 64-bit mix (the golden-ratio multiplier), so small indices
+	// still spread across the whole [0,1) range. A 32-bit step over uint64 would
+	// leave every practical index near 0, clustering aliasGenF64 around -4.
+	u := uint64(i)*0x9e3779b97f4a7c15 + 1013904223
+	return float64(u>>11) / float64(1<<53)
 }
 
 // aliasGenF64 spreads values over [-4,4), including negatives and near-zero.
@@ -80,6 +83,23 @@ func TestAliasingSweep(t *testing.T) {
 		t.Helper()
 		aliastest.Sweep(t, f64AliasCases())
 		t.Run("AddScaled", sweepAddScaled)
+	})
+}
+
+// TestAliasingZeroAlloc asserts the in-place overlay path is allocation-free for
+// every swept op under each bound tier, enforcing the package zero-allocation
+// contract on the aliasing path.
+func TestAliasingZeroAlloc(t *testing.T) {
+	forTiers(t, func(t *testing.T) {
+		t.Helper()
+		aliastest.SweepAlloc(t, f64AliasCases())
+		t.Run("AddScaled", func(t *testing.T) {
+			a := make([]float64, 64)
+			for i := range a {
+				a[i] = aliasGenF64(i)
+			}
+			aliastest.ZeroAlloc(t, "AddScaled s==dst", func() { AddScaled(a, 1.5, a) })
+		})
 	})
 }
 

--- a/f64/aliasing_test.go
+++ b/f64/aliasing_test.go
@@ -1,0 +1,105 @@
+package f64
+
+import (
+	"math"
+	"testing"
+
+	"github.com/tphakala/simd/internal/aliastest"
+)
+
+// Aliasing sweep for the f64 exact-overlay contract (issue #221). See the f32
+// suite for the method: each op is run once into a separate destination and once
+// with the destination overlaid on an input, bit-compared under each kernel tier
+// forTiers can force (every amd64 function-pointer tier; both the Go and NEON
+// arm64 paths). The transcendentals dispatch through an inline CPU-feature branch
+// the harness cannot rebind, but they have no distinct SSE kernel, so the size
+// sweep still runs both their Go and native-SIMD kernels. It asserts nothing about
+// the corruption pattern of a non-overlapping op, which is undefined.
+
+func aliasEqF64(x, y float64) bool { return math.Float64bits(x) == math.Float64bits(y) }
+
+func aliasHashF64(i int) float64 {
+	u := uint64(i)*2654435761 + 1013904223
+	return float64(u) / float64(1<<64)
+}
+
+// aliasGenF64 spreads values over [-4,4), including negatives and near-zero.
+func aliasGenF64(i int) float64 { return aliasHashF64(i)*8 - 4 }
+
+// aliasGenF64Pos spreads values over (0,8] for domain-restricted ops.
+func aliasGenF64Pos(i int) float64 { return aliasHashF64(i)*8 + 0.03125 }
+
+// Scalar parameters for the scalar-taking ops. Their exact values do not affect
+// the overlay property.
+const (
+	aliasScaleK  = 1.5
+	aliasAddK    = 0.75
+	aliasClampLo = -1.25
+	aliasClampHi = 2.5
+	aliasScaleC  = 0.5
+	aliasPowExp  = 0.75
+)
+
+func f64AliasCases() []aliastest.Case {
+	return []aliastest.Case{
+		aliastest.UnaryCase("Abs", aliasEqF64, aliasGenF64, Abs),
+		aliastest.UnaryCase("Neg", aliasEqF64, aliasGenF64, Neg),
+		aliastest.UnaryCase("Round", aliasEqF64, aliasGenF64, Round),
+		aliastest.UnaryCase("Reciprocal", aliasEqF64, aliasGenF64, Reciprocal),
+		aliastest.UnaryCase("ReLU", aliasEqF64, aliasGenF64, ReLU),
+		aliastest.UnaryCase("Sigmoid", aliasEqF64, aliasGenF64, Sigmoid),
+		aliastest.UnaryCase("Tanh", aliasEqF64, aliasGenF64, Tanh),
+		aliastest.UnaryCase("Exp", aliasEqF64, aliasGenF64, Exp),
+		aliastest.UnaryCase("Sqrt", aliasEqF64, aliasGenF64Pos, Sqrt),
+		aliastest.UnaryCase("Log", aliasEqF64, aliasGenF64Pos, Log),
+		aliastest.UnaryCase("Log2", aliasEqF64, aliasGenF64Pos, Log2),
+		aliastest.UnaryCase("Log10", aliasEqF64, aliasGenF64Pos, Log10),
+		aliastest.UnaryCase("CumulativeSum", aliasEqF64, aliasGenF64, CumulativeSum),
+		aliastest.UnaryCase("Normalize", aliasEqF64, aliasGenF64, Normalize),
+
+		aliastest.UnaryCase("Scale", aliasEqF64, aliasGenF64, func(dst, a []float64) { Scale(dst, a, aliasScaleK) }),
+		aliastest.UnaryCase("AddScalar", aliasEqF64, aliasGenF64, func(dst, a []float64) { AddScalar(dst, a, aliasAddK) }),
+		aliastest.UnaryCase("SubFromScalar", aliasEqF64, aliasGenF64, func(dst, a []float64) { SubFromScalar(dst, a, aliasAddK) }),
+		aliastest.UnaryCase("Clamp", aliasEqF64, aliasGenF64, func(dst, a []float64) { Clamp(dst, a, aliasClampLo, aliasClampHi) }),
+		aliastest.UnaryCase("ClampScale", aliasEqF64, aliasGenF64, func(dst, a []float64) { ClampScale(dst, a, aliasClampLo, aliasClampHi, aliasScaleC) }),
+		aliastest.UnaryCase("Pow", aliasEqF64, aliasGenF64Pos, func(dst, a []float64) { Pow(dst, a, aliasPowExp) }),
+
+		aliastest.BinaryCase("Add", aliasEqF64, aliasGenF64, Add),
+		aliastest.BinaryCase("Sub", aliasEqF64, aliasGenF64, Sub),
+		aliastest.BinaryCase("Mul", aliasEqF64, aliasGenF64, Mul),
+		aliastest.BinaryCase("Div", aliasEqF64, aliasGenF64, Div),
+		aliastest.BinaryCase("PowElem", aliasEqF64, aliasGenF64Pos, PowElem),
+
+		aliastest.TernaryCase("FMA", aliasEqF64, aliasGenF64, FMA),
+	}
+}
+
+// TestAliasingSweep drives the exact-overlay sweep across every bound kernel.
+func TestAliasingSweep(t *testing.T) {
+	forTiers(t, func(t *testing.T) {
+		t.Helper()
+		aliastest.Sweep(t, f64AliasCases())
+		t.Run("AddScaled", sweepAddScaled)
+	})
+}
+
+// sweepAddScaled checks AddScaled's documented in-place overlay: s may equal dst
+// exactly (the self-scaling dst[i] += alpha*dst[i]). AddScaled does not fit the
+// generic Unary/Binary shapes because dst is a read-modify-write accumulator, so
+// it gets a bespoke check. AddScaled is function-pointer dispatched, so forTiers
+// forces its tiers.
+func sweepAddScaled(t *testing.T) {
+	t.Helper()
+	const alpha = 1.5
+	for _, n := range aliastest.Sizes {
+		data := make([]float64, n)
+		for i := range data {
+			data[i] = aliasGenF64(i)
+		}
+		want := append([]float64(nil), data...)
+		AddScaled(want, alpha, append([]float64(nil), data...))
+		got := append([]float64(nil), data...)
+		AddScaled(got, alpha, got)
+		aliastest.Report(t, n, "AddScaled s==dst", aliasEqF64, want, got)
+	}
+}

--- a/f64/f64.go
+++ b/f64/f64.go
@@ -30,9 +30,9 @@
 //   - AddScaled and AccumulateAdd read and rewrite dst in place (they are
 //     accumulators); their source slice must be disjoint from the destination
 //     window, except that AddScaled also permits s==dst exactly.
-//   - ButterflyComplex and ButterflyComplexStage update their data slices in
-//     place; those slices must not overlap one another, and the twiddles must not
-//     overlap them.
+//   - ButterflyComplex, ButterflyComplexStage and ButterflyComplexStage4 update
+//     their data slices in place; those slices must not overlap one another, and
+//     the twiddles must not overlap them.
 //   - The mirror, window, stride, interleave and batch operations (Interleave2/N,
 //     Deinterleave2/N, ConvolveValid and ConvolveValidMulti, ConvolveDecimate,
 //     DotProductBatch, Autocorrelate, RealFFTUnpack and RealFFTPower) index inputs
@@ -1158,6 +1158,10 @@ const butterflyStage4Radix = 4
 // dedicated span-2 vector path; a span-2 caller still gets a correct result from
 // the general j-axis path (a 2-wide NEON iteration, or the scalar tail of the
 // 4-wide AVX path).
+//
+// Aliasing: like ButterflyComplexStage, the stage updates re and im in place; re
+// and im must not overlap each other, and none of the six twiddle slices may
+// overlap them.
 //
 // Uses AVX+FMA on AMD64, NEON on ARM64, with a pure Go fallback. As with
 // [ButterflyComplexStage], results are not guaranteed bit-identical between the

--- a/f64/f64.go
+++ b/f64/f64.go
@@ -31,8 +31,8 @@
 //     accumulators); their source slice must be disjoint from the destination
 //     window, except that AddScaled also permits s==dst exactly.
 //   - ButterflyComplex and ButterflyComplexStage update their data slices in
-//     place; those slices must be distinct from one another, and the twiddles
-//     must not overlap them.
+//     place; those slices must not overlap one another, and the twiddles must not
+//     overlap them.
 //   - The mirror, window, stride, interleave and batch operations (Interleave2/N,
 //     Deinterleave2/N, ConvolveValid and ConvolveValidMulti, ConvolveDecimate,
 //     DotProductBatch, Autocorrelate, RealFFTUnpack and RealFFTPower) index inputs
@@ -1041,8 +1041,9 @@ func minLen6(a, b, c, d, e, f int) int {
 // All slices are modified in-place: upper receives upper+temp, lower receives upper-temp.
 //
 // Aliasing: each butterfly reads its inputs before writing either output, so the
-// four data slices are updated in place. They must be four distinct slices, and
-// the twiddles twRe/twIm must not overlap any of them.
+// four data slices are updated in place. They must be pairwise non-overlapping
+// (distinct headers are not enough; a shifted sub-slice of one array corrupts),
+// and the twiddles twRe/twIm must not overlap any of them.
 //
 // Uses AVX+FMA on AMD64, NEON on ARM64, with a pure Go fallback.
 func ButterflyComplex(upperRe, upperIm, lowerRe, lowerIm, twRe, twIm []float64) {
@@ -1082,8 +1083,8 @@ const butterflyStageRadix = 2
 // k+2*span <= n, where n = min(len(re), len(im)); a trailing partial block is
 // left untouched.
 //
-// Aliasing: the stage updates re and im in place; they must be distinct buffers,
-// and the twiddles twRe/twIm must not overlap either.
+// Aliasing: the stage updates re and im in place; re and im must not overlap
+// each other, and the twiddles twRe/twIm must not overlap either.
 //
 // Uses AVX+FMA on AMD64, NEON on ARM64, with a pure Go fallback. As with
 // [ButterflyComplex], results are not guaranteed bit-identical between the

--- a/f64/f64.go
+++ b/f64/f64.go
@@ -33,11 +33,12 @@
 //   - ButterflyComplex, ButterflyComplexStage and ButterflyComplexStage4 update
 //     their data slices in place; those slices must not overlap one another, and
 //     the twiddles must not overlap them.
-//   - The mirror, window, stride, interleave and batch operations (Interleave2/N,
-//     Deinterleave2/N, ConvolveValid and ConvolveValidMulti, ConvolveDecimate,
-//     DotProductBatch, Autocorrelate, RealFFTUnpack and RealFFTPower) index inputs
-//     and outputs at different positions, so their outputs must not overlap any
-//     input; RealFFTUnpack and RealFFTPower carry their own detailed notes.
+//   - The mirror, window, stride, interleave, batch and resample operations
+//     (Interleave2/N, Deinterleave2/N, ConvolveValid and ConvolveValidMulti,
+//     ConvolveDecimate, DotProductBatch, Autocorrelate, RealFFTUnpack, RealFFTPower
+//     and PolyphaseResampleCubic) index inputs and outputs at different positions,
+//     so their outputs must not overlap any input; RealFFTUnpack and RealFFTPower
+//     carry their own detailed notes.
 //
 // The reductions (DotProduct, WeightedSum, SumOfSquares, Sum, Mean, Max, Min,
 // MaxAbs, MaxIdx, MinIdx, Variance, StdDev, EuclideanDistance, ConvolveValidMaxAbs
@@ -687,6 +688,10 @@ const polyphaseMaxFracBits64 = 53
 // tapsPerPhase, or an initial window already past the end of hist) also yield
 // (0, at) because no output satisfies the window bound.
 //
+// Aliasing: out and hist are indexed differently (each output reads a sliding
+// window of hist chosen by the accumulator), so out must not overlap hist, nor
+// any of the coefficient banks a, b, c or d.
+//
 // Uses AVX+FMA on AMD64 and NEON on ARM64 for tapsPerPhase past the vector width,
 // gated on the same CPU features and tap threshold as [CubicInterpDot] so the
 // fused result is bit-identical to the per-output form on every CPU; below the
@@ -733,7 +738,8 @@ func PolyphaseResampleCubic(out, hist []float64, a, b, c, d [][]float64, at, ste
 // form, this variant does not reject an overflowing at/step, so a caller that
 // breaks the last precondition can drive the internal accumulator to wrap and
 // read out of range. When the preconditions hold it returns the same (n, atOut)
-// as the safe form.
+// as the safe form. The same aliasing rule applies: out must not overlap hist or
+// the coefficient banks.
 func PolyphaseResampleCubicUnsafe(out, hist []float64, a, b, c, d [][]float64, at, step int64, numPhases, tapsPerPhase, fracBits int) (n int, atOut int64) {
 	n = polyphaseResampleCubic64(out, hist, a, b, c, d, at, step, numPhases, tapsPerPhase, fracBits)
 	return n, at + int64(n)*step

--- a/f64/f64.go
+++ b/f64/f64.go
@@ -6,6 +6,46 @@
 //
 // Thread Safety: All functions are safe for concurrent use.
 // Memory: All functions are zero-allocation (no heap allocations).
+//
+// # Aliasing
+//
+// The element-wise maps may be used fully in place: the destination may alias an
+// input exactly, element for element. This holds for the unary maps (Abs, Neg,
+// Round, Sqrt, Reciprocal, Exp, Log, Log2, Log10, ReLU, Sigmoid, Tanh, Scale,
+// AddScalar, SubFromScalar, Clamp, ClampScale, Pow), for the two-pass
+// CumulativeSum and Normalize (dst==a), for the binary maps (Add, Sub, Mul, Div,
+// PowElem, where dst may alias any input, or both at once), and for the fused
+// multiply-add FMA (dst may alias a, b or c). The guarantee is mechanical: each
+// SIMD block reads its whole block of inputs into registers before storing any
+// output lane, and the scalar tail reads each lane before it writes that lane, so
+// an exact overlay is well defined lane by lane on every dispatch path (amd64 SSE,
+// AVX with and without FMA, AVX-512, arm64 NEON, and the pure-Go fallback).
+//
+// A destination must not overlap an input at a shifted offset. A SIMD load pulls
+// a whole block of an input ahead of the stores, so a shifted overlay clobbers
+// input lanes a later iteration has not yet read; the resulting corruption
+// pattern is undefined and varies with kernel width and length.
+//
+// The departures from this default are documented on the functions themselves:
+//   - AddScaled and AccumulateAdd read and rewrite dst in place (they are
+//     accumulators); their source slice must be disjoint from the destination
+//     window, except that AddScaled also permits s==dst exactly.
+//   - ButterflyComplex and ButterflyComplexStage update their data slices in
+//     place; those slices must be distinct from one another, and the twiddles
+//     must not overlap them.
+//   - The mirror, window, stride, interleave and batch operations (Interleave2/N,
+//     Deinterleave2/N, ConvolveValid and ConvolveValidMulti, ConvolveDecimate,
+//     DotProductBatch, Autocorrelate, RealFFTUnpack and RealFFTPower) index inputs
+//     and outputs at different positions, so their outputs must not overlap any
+//     input; RealFFTUnpack and RealFFTPower carry their own detailed notes.
+//
+// The reductions (DotProduct, WeightedSum, SumOfSquares, Sum, Mean, Max, Min,
+// MaxAbs, MaxIdx, MinIdx, Variance, StdDev, EuclideanDistance, ConvolveValidMaxAbs
+// and ConvolveValidMaxAbsMulti, CubicInterpDot) write no output slice, so aliasing
+// does not apply to them. The in-place transcendental variants (ExpInPlace,
+// LogInPlace, PowInPlace, ReLUInPlace, SigmoidInPlace, TanhInPlace) operate on a
+// single slice, so aliasing does not arise, and the Unsafe variants follow the
+// aliasing rules of the checked form they mirror.
 package f64
 
 import "math"
@@ -416,6 +456,10 @@ func ConvolveDecimate(dst, signal, kernel []float64, factor, phase int) {
 // AccumulateAdd adds src to dst starting at offset: dst[offset:offset+len(src)] += src.
 // This is a key primitive for overlap-add in FFT-based convolution.
 //
+// The destination window dst[offset:offset+len(src)] is a read-modify-write
+// accumulator; src must not overlap that window. An overlap-add caller passes a
+// src region disjoint from the destination window, so this is the natural usage.
+//
 // Panics if offset+len(src) > len(dst) or if offset < 0.
 func AccumulateAdd(dst, src []float64, offset int) {
 	if offset < 0 {
@@ -463,6 +507,10 @@ func MaxIdx(a []float64) int {
 // AddScaled adds scaled values to dst: dst[i] += alpha * s[i].
 // This is the AXPY operation from BLAS Level 1.
 // Processes min(len(dst), len(s)) elements.
+//
+// dst is a read-modify-write accumulator. s may overlay dst exactly (the
+// self-scaling dst[i] += alpha*dst[i], since each lane is read before it is
+// rewritten), but s must not overlap dst at a shifted offset.
 func AddScaled(dst []float64, alpha float64, s []float64) {
 	n := min(len(dst), len(s))
 	if n == 0 {
@@ -992,6 +1040,10 @@ func minLen6(a, b, c, d, e, f int) int {
 // Processes min(len(upperRe), len(upperIm), len(lowerRe), len(lowerIm), len(twRe), len(twIm)) elements.
 // All slices are modified in-place: upper receives upper+temp, lower receives upper-temp.
 //
+// Aliasing: each butterfly reads its inputs before writing either output, so the
+// four data slices are updated in place. They must be four distinct slices, and
+// the twiddles twRe/twIm must not overlap any of them.
+//
 // Uses AVX+FMA on AMD64, NEON on ARM64, with a pure Go fallback.
 func ButterflyComplex(upperRe, upperIm, lowerRe, lowerIm, twRe, twIm []float64) {
 	n := minLen6(len(upperRe), len(upperIm), len(lowerRe), len(lowerIm), len(twRe), len(twIm))
@@ -1029,6 +1081,9 @@ const butterflyStageRadix = 2
 // and it is also a no-op when no complete block fits. Blocks are processed while
 // k+2*span <= n, where n = min(len(re), len(im)); a trailing partial block is
 // left untouched.
+//
+// Aliasing: the stage updates re and im in place; they must be distinct buffers,
+// and the twiddles twRe/twIm must not overlap either.
 //
 // Uses AVX+FMA on AMD64, NEON on ARM64, with a pure Go fallback. As with
 // [ButterflyComplex], results are not guaranteed bit-identical between the

--- a/i8/aliasing_amd64_test.go
+++ b/i8/aliasing_amd64_test.go
@@ -1,0 +1,18 @@
+//go:build amd64
+
+package i8
+
+import (
+	"testing"
+
+	"github.com/tphakala/simd/internal/aliastest"
+)
+
+// forTiers runs the aliasing sweep on both the pure-Go reference and the AVX2
+// kernels by flipping the package hasAVX2 gate (the i8 kernels dispatch on that
+// var, not a function-pointer table). Forcing it off runs the Go path at every
+// length, not just the sub-block tail.
+func forTiers(t *testing.T, run func(t *testing.T)) {
+	t.Helper()
+	aliastest.ForGate(t, &hasAVX2, "AVX2", run)
+}

--- a/i8/aliasing_arm64_test.go
+++ b/i8/aliasing_arm64_test.go
@@ -1,0 +1,18 @@
+//go:build arm64
+
+package i8
+
+import (
+	"testing"
+
+	"github.com/tphakala/simd/internal/aliastest"
+)
+
+// forTiers runs the aliasing sweep on both the Go and NEON arm64 paths by
+// flipping the package hasNEON gate, so the sweep sees both int8 kernels: the
+// NEON path and the pure-Go fallback can absorb their tail differently, so an
+// in-place overlay must hold on each.
+func forTiers(t *testing.T, run func(t *testing.T)) {
+	t.Helper()
+	aliastest.ForGate(t, &hasNEON, "NEON", run)
+}

--- a/i8/aliasing_other_test.go
+++ b/i8/aliasing_other_test.go
@@ -1,0 +1,12 @@
+//go:build !amd64 && !arm64
+
+package i8
+
+import "testing"
+
+// forTiers runs the aliasing sweep once on architectures with only the pure-Go
+// path (no tier to force).
+func forTiers(t *testing.T, run func(t *testing.T)) {
+	t.Helper()
+	run(t)
+}

--- a/i8/aliasing_test.go
+++ b/i8/aliasing_test.go
@@ -10,8 +10,8 @@ import (
 // wise op is run once into a separate destination and once with the destination
 // overlaid on an input, then compared under both the Go and SIMD kernels. The
 // cross-type conversions (Quantize/Dequantize/Requantize/ToInt16/ToInt32) cannot
-// alias in safe Go and are not swept here. It asserts nothing about the
-// corruption pattern of a non-overlapping op, which is undefined.
+// alias in safe Go and are not swept here. It asserts nothing about how a shifted
+// overlay (dst offset from an input) corrupts, which is undefined.
 
 func aliasEqI8(x, y int8) bool { return x == y }
 
@@ -50,5 +50,14 @@ func TestAliasingSweep(t *testing.T) {
 	forTiers(t, func(t *testing.T) {
 		t.Helper()
 		aliastest.Sweep(t, i8AliasCases())
+	})
+}
+
+// TestAliasingZeroAlloc asserts the in-place overlay path is allocation-free for
+// every swept op under both the Go and SIMD kernels.
+func TestAliasingZeroAlloc(t *testing.T) {
+	forTiers(t, func(t *testing.T) {
+		t.Helper()
+		aliastest.SweepAlloc(t, i8AliasCases())
 	})
 }

--- a/i8/aliasing_test.go
+++ b/i8/aliasing_test.go
@@ -1,0 +1,54 @@
+package i8
+
+import (
+	"testing"
+
+	"github.com/tphakala/simd/internal/aliastest"
+)
+
+// Aliasing sweep for the i8 exact-overlay contract (issue #221). Each element-
+// wise op is run once into a separate destination and once with the destination
+// overlaid on an input, then compared under both the Go and SIMD kernels. The
+// cross-type conversions (Quantize/Dequantize/Requantize/ToInt16/ToInt32) cannot
+// alias in safe Go and are not swept here. It asserts nothing about the
+// corruption pattern of a non-overlapping op, which is undefined.
+
+func aliasEqI8(x, y int8) bool { return x == y }
+
+// aliasGenI8 spreads values over the full int8 range, including -128 (the
+// saturating edge for Abs/Neg).
+func aliasGenI8(i int) int8 {
+	u := uint32(i)*2654435761 + 1013904223
+	return int8(u >> 24) //nolint:gosec // deliberate wrap to cover [-128,127]
+}
+
+// Scalar parameters for the scalar-taking ops. Their exact values do not affect
+// the overlay property.
+const (
+	aliasClampLoI8 = int8(-100)
+	aliasClampHiI8 = int8(100)
+	aliasScalarI8  = int8(50)
+)
+
+func i8AliasCases() []aliastest.Case {
+	return []aliastest.Case{
+		aliastest.UnaryCase("Abs", aliasEqI8, aliasGenI8, Abs),
+		aliastest.UnaryCase("Neg", aliasEqI8, aliasGenI8, Neg),
+		aliastest.BinaryCase("AddSaturate", aliasEqI8, aliasGenI8, AddSaturate),
+		aliastest.BinaryCase("SubSaturate", aliasEqI8, aliasGenI8, SubSaturate),
+		aliastest.BinaryCase("AbsDiff", aliasEqI8, aliasGenI8, AbsDiff),
+		aliastest.BinaryCase("Max", aliasEqI8, aliasGenI8, Max),
+		aliastest.BinaryCase("Min", aliasEqI8, aliasGenI8, Min),
+		aliastest.UnaryCase("AddScalarSaturate", aliasEqI8, aliasGenI8, func(dst, a []int8) { AddScalarSaturate(dst, a, aliasScalarI8) }),
+		aliastest.UnaryCase("SubScalarSaturate", aliasEqI8, aliasGenI8, func(dst, a []int8) { SubScalarSaturate(dst, a, aliasScalarI8) }),
+		aliastest.UnaryCase("Clamp", aliasEqI8, aliasGenI8, func(dst, a []int8) { Clamp(dst, a, aliasClampLoI8, aliasClampHiI8) }),
+	}
+}
+
+// TestAliasingSweep drives the exact-overlay sweep across every bound kernel.
+func TestAliasingSweep(t *testing.T) {
+	forTiers(t, func(t *testing.T) {
+		t.Helper()
+		aliastest.Sweep(t, i8AliasCases())
+	})
+}

--- a/i8/i8.go
+++ b/i8/i8.go
@@ -42,6 +42,31 @@
 //
 // Thread Safety: All functions are safe for concurrent use.
 // Memory: All functions are zero-allocation (no heap allocations).
+//
+// # Aliasing
+//
+// The element-wise operations may be used fully in place: the destination may
+// alias an input exactly, byte for byte. Abs and Neg accept dst equal to a;
+// AddSaturate, SubSaturate, AbsDiff, Max and Min accept dst equal to a, to b, or
+// to both; AddScalarSaturate, SubScalarSaturate and Clamp accept dst equal to the
+// source. Each SIMD block reads its whole block of inputs into registers before
+// storing any output byte, and the scalar tail reads each byte before it writes
+// that byte. The element-wise kernels absorb their sub-block remainder with
+// forward blocks that read then write each byte once, not the idempotent
+// overlapping-final-block trick the reductions and the widening conversions use,
+// so an exact overlay is well defined byte by byte on the AVX2 and NEON kernels
+// and the pure-Go fallback.
+//
+// A destination must not overlap an input at a shifted offset: a SIMD load pulls
+// a whole block of an input ahead of the stores, so a shifted overlay clobbers
+// input bytes a later iteration has not yet read; the resulting corruption
+// pattern is undefined and varies with kernel width and length.
+//
+// Quantize, Dequantize, Requantize, ToInt16 and ToInt32 convert between int8 and
+// float32 or a wider integer, so their input and output have distinct element
+// types and cannot alias in safe Go (see the note on the quantization group). The
+// reductions (DotProduct, Sum, SumAbs, SAD, MaxAbs, MinMax) write no output slice,
+// so aliasing does not apply to them.
 package i8
 
 // AddSaturate writes dst[i] = clamp(int(a[i]) + int(b[i]), -128, 127) for i in

--- a/internal/aliastest/aliastest.go
+++ b/internal/aliastest/aliastest.go
@@ -1,0 +1,221 @@
+// Package aliastest provides generic, bit-exact aliasing sweep helpers shared by
+// the per-package aliasing_test.go suites (issue #221).
+//
+// Each helper computes a reference result into a destination that does not
+// overlap any input, then re-runs the same operation with the destination
+// physically overlaid on one of the inputs, and asserts the two results are
+// bit-identical. Both runs execute on whatever kernel the caller has bound: the
+// per-package suites force each amd64 function-pointer dispatch tier in turn and
+// flip the arm64 hasNEON (or amd64 hasAVX2) gate, so every tier reachable through
+// those mechanisms is measured. An op dispatched by an inline CPU-feature branch
+// that the harness cannot rebind (a few f32/f64 kernels) is still swept across
+// sizes, which runs both its Go and its native-SIMD kernel, and its overlay
+// safety is verified by source audit; where such an op has a distinct SSE kernel
+// the sweep cannot reach on an AVX host, the per-package suite exercises that
+// kernel directly. A bit-exact match is the correct bar because both runs use the
+// same kernel at the same length; a mismatch means the in-place overlay clobbered
+// an input lane the kernel had not finished reading, which is exactly the
+// corruption an "exact overlay supported" contract forbids.
+//
+// The helpers deliberately assert nothing about the corruption pattern of a
+// non-overlapping op: that pattern varies with kernel width and length and is
+// undefined behaviour, so only the supported overlays are exercised here.
+package aliastest
+
+import "testing"
+
+// Sizes sweeps lengths that cross every dispatch boundary: scalar-only tails,
+// whole SIMD blocks, block-plus-remainder, and the AVX-512 widths, plus a few
+// large sizes. It intentionally includes 0 (the empty no-op) and lengths one
+// above each vector width.
+var Sizes = []int{
+	0, 1, 2, 3, 4, 5, 7, 8, 9, 15, 16, 17, 31, 32, 33,
+	63, 64, 65, 127, 128, 129, 255, 256, 257, 1000, 1024, 1031,
+}
+
+// Case pairs an operation name with a closure that runs its full aliasing check
+// at one length.
+type Case struct {
+	// Name is the sub-test name (the operation under test).
+	Name string
+	// Check runs the operation's want-vs-overlay comparison at length n.
+	Check func(t *testing.T, n int)
+}
+
+// Sweep runs every case over every length in Sizes under the currently bound
+// kernel tier.
+func Sweep(t *testing.T, cases []Case) {
+	t.Helper()
+	for _, c := range cases {
+		t.Run(c.Name, func(t *testing.T) {
+			for _, n := range Sizes {
+				c.Check(t, n)
+			}
+		})
+	}
+}
+
+func buildOff[T any](n int, gen func(i int) T, off int) []T {
+	s := make([]T, n)
+	for i := range s {
+		s[i] = gen(i + off)
+	}
+	return s
+}
+
+func clone[T any](s []T) []T {
+	c := make([]T, len(s))
+	copy(c, s)
+	return c
+}
+
+// Report fails t with the first bit-level mismatch between want and got at length
+// n, tagging the failure with mode. eq is the element comparator. It is exported
+// so per-package suites can reuse it for op shapes the generic helpers do not
+// model (the split-format complex products and the AXPY accumulator).
+func Report[T any](t *testing.T, n int, mode string, eq func(x, y T) bool, want, got []T) {
+	t.Helper()
+	for i := range want {
+		if !eq(want[i], got[i]) {
+			t.Errorf("n=%d overlay %s: index %d differs: want %v got %v",
+				n, mode, i, want[i], got[i])
+			return
+		}
+	}
+}
+
+// Unary checks the single overlay dst==a for a one-input operation op(dst, a).
+func Unary[T any](t *testing.T, n int, eq func(x, y T) bool, gen func(i int) T, op func(dst, a []T)) {
+	t.Helper()
+	a := buildOff(n, gen, 0)
+
+	want := make([]T, n)
+	op(want, a)
+
+	got := clone(a)
+	op(got, got)
+	Report(t, n, "dst=a", eq, want, got)
+}
+
+// Binary checks the overlays dst==a, dst==b, and dst==a==b for a two-input
+// operation op(dst, a, b). The two operands are drawn from the same generator at
+// distinct offsets so a and b differ elementwise.
+func Binary[T any](t *testing.T, n int, eq func(x, y T) bool, gen func(i int) T, op func(dst, a, b []T)) {
+	t.Helper()
+	a := buildOff(n, gen, 0)
+	b := buildOff(n, gen, offB)
+
+	want := make([]T, n)
+	op(want, a, b)
+
+	got := clone(a)
+	op(got, got, b)
+	Report(t, n, "dst=a", eq, want, got)
+
+	got = clone(b)
+	op(got, a, got)
+	Report(t, n, "dst=b", eq, want, got)
+
+	// dst == a == b: destination and both operands are the same slice.
+	wantSame := make([]T, n)
+	op(wantSame, a, a)
+	got = clone(a)
+	op(got, got, got)
+	Report(t, n, "dst=a=b", eq, wantSame, got)
+}
+
+// Ternary checks the overlays dst==a, dst==b, and dst==c for a three-input
+// operation op(dst, a, b, c) such as a fused multiply-add. The three operands are
+// drawn from the same generator at distinct offsets so they differ elementwise.
+func Ternary[T any](t *testing.T, n int, eq func(x, y T) bool, gen func(i int) T, op func(dst, a, b, c []T)) {
+	t.Helper()
+	a := buildOff(n, gen, 0)
+	b := buildOff(n, gen, offB)
+	c := buildOff(n, gen, offC)
+
+	want := make([]T, n)
+	op(want, a, b, c)
+
+	got := clone(a)
+	op(got, got, b, c)
+	Report(t, n, "dst=a", eq, want, got)
+
+	got = clone(b)
+	op(got, a, got, c)
+	Report(t, n, "dst=b", eq, want, got)
+
+	got = clone(c)
+	op(got, a, b, got)
+	Report(t, n, "dst=c", eq, want, got)
+}
+
+// Per-index offsets into the generator sequence for the second and third
+// operands of Binary and Ternary, so a, b and c differ elementwise (they are
+// shifted views of the same sequence, not disjoint ranges).
+const (
+	offB = 101
+	offC = 202
+)
+
+// ForGate runs the sweep on both settings of a boolean dispatch gate (an arm64
+// hasNEON or amd64 hasAVX2 var): once with the gate on (named onName) when the
+// host supports it, and once forced off (the pure-Go path), restoring the gate on
+// cleanup. It is the bool-gate counterpart of ForTiers for packages that dispatch
+// on a mutable feature flag rather than a function-pointer table.
+func ForGate(t *testing.T, gate *bool, onName string, run func(t *testing.T)) {
+	t.Helper()
+	saved := *gate
+	ForTiers(t, []Tier{
+		{Name: onName, Bind: func() { *gate = saved }, Supported: saved},
+		{Name: "Go", Bind: func() { *gate = false }, Supported: true},
+	}, run)
+}
+
+// Tier names one bindable kernel configuration (an amd64 SIMD tier, or the arm64
+// Go/NEON gate) together with the CPU support it needs.
+type Tier struct {
+	// Name is the sub-test name for this tier.
+	Name string
+	// Bind installs the tier's kernels (an init* function on amd64, a hasNEON
+	// flip on arm64).
+	Bind func()
+	// Supported reports whether the host can run this tier.
+	Supported bool
+}
+
+// ForTiers binds each supported tier in turn and runs run under it, then restores
+// the host default on cleanup. tiers must be listed in descending priority so the
+// first supported entry is the configuration the package's own init would have
+// chosen; that entry is re-bound on cleanup so the sweep leaves global dispatch
+// state untouched for the rest of the suite.
+func ForTiers(t *testing.T, tiers []Tier, run func(t *testing.T)) {
+	t.Helper()
+	for _, tr := range tiers {
+		if tr.Supported {
+			t.Cleanup(tr.Bind)
+			break
+		}
+	}
+	for _, tr := range tiers {
+		if !tr.Supported {
+			continue
+		}
+		tr.Bind()
+		t.Run(tr.Name, run)
+	}
+}
+
+// UnaryCase builds a Case that runs Unary for op(dst, a).
+func UnaryCase[T any](name string, eq func(x, y T) bool, gen func(i int) T, op func(dst, a []T)) Case {
+	return Case{Name: name, Check: func(t *testing.T, n int) { t.Helper(); Unary(t, n, eq, gen, op) }}
+}
+
+// BinaryCase builds a Case that runs Binary for op(dst, a, b).
+func BinaryCase[T any](name string, eq func(x, y T) bool, gen func(i int) T, op func(dst, a, b []T)) Case {
+	return Case{Name: name, Check: func(t *testing.T, n int) { t.Helper(); Binary(t, n, eq, gen, op) }}
+}
+
+// TernaryCase builds a Case that runs Ternary for op(dst, a, b, c).
+func TernaryCase[T any](name string, eq func(x, y T) bool, gen func(i int) T, op func(dst, a, b, c []T)) Case {
+	return Case{Name: name, Check: func(t *testing.T, n int) { t.Helper(); Ternary(t, n, eq, gen, op) }}
+}

--- a/internal/aliastest/aliastest.go
+++ b/internal/aliastest/aliastest.go
@@ -33,17 +33,19 @@ var Sizes = []int{
 	63, 64, 65, 127, 128, 129, 255, 256, 257, 1000, 1024, 1031,
 }
 
-// Case pairs an operation name with a closure that runs its full aliasing check
-// at one length.
+// Case pairs an operation name with the closures that run its aliasing check and
+// its allocation check.
 type Case struct {
 	// Name is the sub-test name (the operation under test).
 	Name string
 	// Check runs the operation's want-vs-overlay comparison at length n.
 	Check func(t *testing.T, n int)
+	// Alloc asserts the in-place overlay call allocates nothing.
+	Alloc func(t *testing.T)
 }
 
-// Sweep runs every case over every length in Sizes under the currently bound
-// kernel tier.
+// Sweep runs every case's overlay comparison over every length in Sizes under the
+// currently bound kernel tier.
 func Sweep(t *testing.T, cases []Case) {
 	t.Helper()
 	for _, c := range cases {
@@ -52,6 +54,35 @@ func Sweep(t *testing.T, cases []Case) {
 				c.Check(t, n)
 			}
 		})
+	}
+}
+
+// SweepAlloc runs every case's allocation check under the currently bound kernel
+// tier, enforcing the package's zero-allocation contract on the in-place overlay
+// path (a kernel that allocates only when dst aliases an input would pass the
+// value comparison but fail here).
+func SweepAlloc(t *testing.T, cases []Case) {
+	t.Helper()
+	for _, c := range cases {
+		if c.Alloc != nil {
+			t.Run(c.Name, c.Alloc)
+		}
+	}
+}
+
+// zeroAllocRuns is the sample count for the AllocsPerRun measurements. A small
+// count is enough: an allocating call allocates on every invocation.
+const zeroAllocRuns = 4
+
+// allocSize is the fixed length used for allocation checks; it clears every
+// vector width so the measured call runs a real SIMD body, not only a tail.
+const allocSize = 64
+
+// ZeroAlloc asserts run allocates nothing, labelling a failure with name.
+func ZeroAlloc(t *testing.T, name string, run func()) {
+	t.Helper()
+	if a := testing.AllocsPerRun(zeroAllocRuns, run); a != 0 {
+		t.Errorf("%s: %.0f allocs/op on the overlay path, want 0", name, a)
 	}
 }
 
@@ -75,6 +106,10 @@ func clone[T any](s []T) []T {
 // model (the split-format complex products and the AXPY accumulator).
 func Report[T any](t *testing.T, n int, mode string, eq func(x, y T) bool, want, got []T) {
 	t.Helper()
+	if len(want) != len(got) {
+		t.Errorf("n=%d overlay %s: length mismatch: want %d, got %d", n, mode, len(want), len(got))
+		return
+	}
 	for i := range want {
 		if !eq(want[i], got[i]) {
 			t.Errorf("n=%d overlay %s: index %d differs: want %v got %v",
@@ -205,17 +240,47 @@ func ForTiers(t *testing.T, tiers []Tier, run func(t *testing.T)) {
 	}
 }
 
-// UnaryCase builds a Case that runs Unary for op(dst, a).
+// UnaryCase builds a Case that runs Unary for op(dst, a). Its Alloc check runs the
+// dst==a overlay through AllocsPerRun.
 func UnaryCase[T any](name string, eq func(x, y T) bool, gen func(i int) T, op func(dst, a []T)) Case {
-	return Case{Name: name, Check: func(t *testing.T, n int) { t.Helper(); Unary(t, n, eq, gen, op) }}
+	return Case{
+		Name:  name,
+		Check: func(t *testing.T, n int) { t.Helper(); Unary(t, n, eq, gen, op) },
+		Alloc: func(t *testing.T) {
+			t.Helper()
+			a := buildOff(allocSize, gen, 0)
+			ZeroAlloc(t, name+" dst=a", func() { op(a, a) })
+		},
+	}
 }
 
-// BinaryCase builds a Case that runs Binary for op(dst, a, b).
+// BinaryCase builds a Case that runs Binary for op(dst, a, b). Its Alloc check runs
+// the dst==a overlay through AllocsPerRun.
 func BinaryCase[T any](name string, eq func(x, y T) bool, gen func(i int) T, op func(dst, a, b []T)) Case {
-	return Case{Name: name, Check: func(t *testing.T, n int) { t.Helper(); Binary(t, n, eq, gen, op) }}
+	return Case{
+		Name:  name,
+		Check: func(t *testing.T, n int) { t.Helper(); Binary(t, n, eq, gen, op) },
+		Alloc: func(t *testing.T) {
+			t.Helper()
+			a := buildOff(allocSize, gen, 0)
+			b := buildOff(allocSize, gen, offB)
+			ZeroAlloc(t, name+" dst=a", func() { op(a, a, b) })
+		},
+	}
 }
 
-// TernaryCase builds a Case that runs Ternary for op(dst, a, b, c).
+// TernaryCase builds a Case that runs Ternary for op(dst, a, b, c). Its Alloc check
+// runs the dst==a overlay through AllocsPerRun.
 func TernaryCase[T any](name string, eq func(x, y T) bool, gen func(i int) T, op func(dst, a, b, c []T)) Case {
-	return Case{Name: name, Check: func(t *testing.T, n int) { t.Helper(); Ternary(t, n, eq, gen, op) }}
+	return Case{
+		Name:  name,
+		Check: func(t *testing.T, n int) { t.Helper(); Ternary(t, n, eq, gen, op) },
+		Alloc: func(t *testing.T) {
+			t.Helper()
+			a := buildOff(allocSize, gen, 0)
+			b := buildOff(allocSize, gen, offB)
+			c := buildOff(allocSize, gen, offC)
+			ZeroAlloc(t, name+" dst=a", func() { op(a, a, b, c) })
+		},
+	}
 }

--- a/internal/aliastest/aliastest.go
+++ b/internal/aliastest/aliastest.go
@@ -255,32 +255,45 @@ func UnaryCase[T any](name string, eq func(x, y T) bool, gen func(i int) T, op f
 }
 
 // BinaryCase builds a Case that runs Binary for op(dst, a, b). Its Alloc check runs
-// the dst==a overlay through AllocsPerRun.
+// every overlay Binary claims (dst==a, dst==b, dst==a==b), each on fresh inputs, so
+// an allocation reachable only in one overlay mode is still caught.
 func BinaryCase[T any](name string, eq func(x, y T) bool, gen func(i int) T, op func(dst, a, b []T)) Case {
 	return Case{
 		Name:  name,
 		Check: func(t *testing.T, n int) { t.Helper(); Binary(t, n, eq, gen, op) },
 		Alloc: func(t *testing.T) {
 			t.Helper()
-			a := buildOff(allocSize, gen, 0)
-			b := buildOff(allocSize, gen, offB)
+			fresh := func() (a, b []T) {
+				return buildOff(allocSize, gen, 0), buildOff(allocSize, gen, offB)
+			}
+			a, b := fresh()
 			ZeroAlloc(t, name+" dst=a", func() { op(a, a, b) })
+			a, b = fresh()
+			ZeroAlloc(t, name+" dst=b", func() { op(b, a, b) })
+			a, _ = fresh()
+			ZeroAlloc(t, name+" dst=a=b", func() { op(a, a, a) })
 		},
 	}
 }
 
 // TernaryCase builds a Case that runs Ternary for op(dst, a, b, c). Its Alloc check
-// runs the dst==a overlay through AllocsPerRun.
+// runs every overlay Ternary claims (dst==a, dst==b, dst==c), each on fresh inputs,
+// so an allocation reachable only in one overlay mode is still caught.
 func TernaryCase[T any](name string, eq func(x, y T) bool, gen func(i int) T, op func(dst, a, b, c []T)) Case {
 	return Case{
 		Name:  name,
 		Check: func(t *testing.T, n int) { t.Helper(); Ternary(t, n, eq, gen, op) },
 		Alloc: func(t *testing.T) {
 			t.Helper()
-			a := buildOff(allocSize, gen, 0)
-			b := buildOff(allocSize, gen, offB)
-			c := buildOff(allocSize, gen, offC)
+			fresh := func() (a, b, c []T) {
+				return buildOff(allocSize, gen, 0), buildOff(allocSize, gen, offB), buildOff(allocSize, gen, offC)
+			}
+			a, b, c := fresh()
 			ZeroAlloc(t, name+" dst=a", func() { op(a, a, b, c) })
+			a, b, c = fresh()
+			ZeroAlloc(t, name+" dst=b", func() { op(b, a, b, c) })
+			a, b, c = fresh()
+			ZeroAlloc(t, name+" dst=c", func() { op(c, a, b, c) })
 		},
 	}
 }


### PR DESCRIPTION
Part of #221.

## What this does

This documents the aliasing contract for the element-wise operations in `f32`, `f64`, `i8`, `c64` and `c128`, and adds a per-package sweep test that proves every "exact overlay supported" claim on every reachable kernel. It is docs and tests only: no kernel or dispatch code changed. The remaining packages (`i16`, `i32`, `f16`, `crc`) are a follow-up, so this does not close the issue.

Each package gains a `# Aliasing` package-doc section modeled on `cint`: it names the families whose destination may alias an input exactly (element for element), states the load-before-store mechanism that makes that safe, states that a shifted overlay is never safe, and lists the exceptions by name. Per-function notes were added only where a function departs from the package default. A shared generic helper `internal/aliastest` carries the sweep so the five per-package test files stay thin.

## The mechanism

An operation supports an exact overlay when every reachable kernel reads a block or lane's inputs into registers before it stores that block or lane, and the remainder reads each element before it rewrites that element. A shifted overlay is never safe: a SIMD load pulls a whole block of an input ahead of the stores, so a later iteration reads clobbered input. The overlapping-final-block tail trick (re-anchoring at n-width and re-reading already-stored lanes) breaks exact overlay; it is confined to the cross-type conversions, the reductions, and the FFT unpack kernels, which are all documented as no-overlap or are cross-type.

## Audit (op x path x verdict)

For every op documented as overlay-supporting, both halves held: (1) a source read of every reachable kernel confirmed load-before-store, and (2) the sweep test passed. Sweep sizes crossed every dispatch boundary: 0,1,2,3,4,5,7,8,9,15,16,17,31,32,33,63,64,65,127,128,129,255,256,257,1000,1024,1031.

Paths exercised empirically:
- amd64 (this host, AVX2+FMA, no AVX-512): forced Go, SSE/SSE2/SSE4.1, AVX (and AVXNoFMA for f64/c128) via the init-tier harness for pointer-dispatched ops; the size sweep covers Go (small n) and the host SIMD (large n) for inline-branch ops.
- arm64 (native Raspberry Pi 5): both the NEON and Go paths, by flipping the package hasNEON gate. Verified on hardware.
- AVX-512: no hardware on the test host, so its kernels were verified by source read only (same forward-block plus scalar/masked-tail shape as the AVX tier). The harness skips the AVX-512 tier where the CPU lacks it, exactly as the existing tier tests do.

### f32
- Exact overlay supported (dst may alias an input): Abs, Neg, Round, Sqrt, Reciprocal, Exp, Log, Log2, Log10, ReLU, Sigmoid, Tanh, AbsPow34, Scale, AddScalar, SubFromScalar, Clamp, ClampScale, Pow, CumulativeSum, Normalize, Add, Sub, Mul, Div, PowElem, CopySign, AbsSqComplex, FMA, and the split-complex MulComplex / MulConjComplex (result may overwrite either input vector; the two output components must stay distinct). Reverse supports full in-place reversal (dst==src). All PASS on Go/SSE/AVX and NEON.
- Conservative (no output-over-input overlay): AddSub. Finding: its pure-Go remainder loop stores sumDst[i] then re-reads a[i] for diffDst[i], so a sumDst overlaid on a corrupts the tail lanes (sizes with n mod 4 != 0). The vector kernels load-before-store, but the Go path fails, so the claim was withheld and a conservative note added instead.
- Accumulators (source must be disjoint): AddScaled (also permits s==dst exactly), AccumulateAdd.
- No-overlap (mirror/window/stride/interleave/batch): Interleave2/N, Deinterleave2/N, ConvolveValid(+Multi), ConvolveDecimate, DotProductBatch/Indexed/Strided, MinIdxOfSumRows, RealFFTUnpack.
- Cross-type (cannot alias in safe Go): Float32ToInt16Scale, Float32ToInt32ScaleClamp(+Signed), Int16ToFloat32Scale, Int32ToFloat32Scale.
- Reductions (aliasing N/A): DotProduct, WeightedSum, SumOfSquares, Sum, Mean, Max, Min, MaxAbs, MaxIdx, MinIdx, MinIdxOfSum, Variance, StdDev, EuclideanDistance, ConvolveValidMaxAbs(+Multi), CubicInterpDot.

### f64
- Exact overlay supported: Abs, Neg, Round, Sqrt, Reciprocal, Exp, Log, Log2, Log10, ReLU, Sigmoid, Tanh, Scale, AddScalar, SubFromScalar, Clamp, ClampScale, Pow, CumulativeSum, Normalize, Add, Sub, Mul, Div, PowElem, FMA. All PASS on Go/SSE2/AVXNoFMA/AVX and NEON.
- Accumulators: AddScaled (permits s==dst), AccumulateAdd.
- No-overlap: Interleave2/N, Deinterleave2/N, ConvolveValid(+Multi), ConvolveDecimate, DotProductBatch, Autocorrelate, RealFFTUnpack, RealFFTPower (the last two keep their existing detailed notes).
- Reductions (N/A): DotProduct, WeightedSum, SumOfSquares, Sum, Mean, Max, Min, MaxAbs, MaxIdx, MinIdx, Variance, StdDev, EuclideanDistance, ConvolveValidMaxAbs(+Multi), CubicInterpDot.

### i8
- Exact overlay supported: Abs, Neg, AddSaturate, SubSaturate, AbsDiff, Max, Min, AddScalarSaturate, SubScalarSaturate, Clamp. All PASS on Go and AVX2 (amd64) and Go and NEON (arm64). The element-wise kernels absorb their sub-block remainder with forward blocks (read then write each byte once), not the idempotent overlapping-final-block trick the reductions and widening conversions use; the amd64 addSat kernel even documents this in a comment.
- Cross-type (cannot alias in safe Go): Quantize, Dequantize, Requantize, ToInt16, ToInt32.
- Reductions (N/A): DotProduct, Sum, SumAbs, SAD, MaxAbs, MinMax.

### c64 and c128
- Exact overlay supported: Add, Sub, Mul, MulConj (dst may alias a, b or both), Scale, Conj (dst may alias a). All PASS on Go/SSE(4.1 for c64, SSE2/AVXNoFMA for c128)/AVX and NEON.
- Cross-type (cannot alias in safe Go): Abs, AbsSq, FromReal.
- Reductions (N/A): DotProduct, DotProductConj.

## Testing

- `go test ./...` passes on amd64 across every forceable tier.
- The five touched packages' test binaries were cross-compiled to arm64 and run on a native Raspberry Pi 5; the aliasing sweep passes on both the NEON and Go tiers, and the full suites pass.
- `f32.CopySign` and `f32.AbsPow34` dispatch through an inline CPU-feature branch that the tier harness cannot rebind, so their SSE and Go kernels are exercised directly by an amd64-only test rather than through the tier sweep. `AddScaled`'s `s==dst` overlay gets a bespoke case since it does not fit the generic unary/binary shapes.
- `gofmt`, `go vet ./...` clean. `golangci-lint` reports no new issues in the added files.

The sweep helpers live in a shared generic package (`internal/aliastest`) so the five per-package test files stay thin.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Documented exact in-place aliasing support and limitations across numeric operations.
  * Clarified cases requiring separate buffers, including shifted overlaps, conversions, reductions, and specialized operations.

* **Tests**
  * Added comprehensive aliasing coverage for float, complex, and integer operations.
  * Validated behavior across supported CPU implementations and pure-Go fallbacks.
  * Added bit-exact checks for in-place results, operation-specific edge cases, and allocation-free execution.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->