### PR TITLE
i8,f64: address review findings from #233 and #234

### DIFF
--- a/README.md
+++ b/README.md
@@ -1078,7 +1078,7 @@ because the kernels behind it keep the `...AVX` name and only their dispatch
 guard names AVX2. Both packages gate `Sigmoid`, `Tanh`, `Exp`, `Log`, `Pow`,
 `InterleaveN` and `DeinterleaveN` on it; `f32` adds `MinIdxOfSumRows` (unit
 slides), `Int16ToFloat32Scale` and `Float32ToInt16Scale`, and `f64` adds
-`Autocorrelate` and `RealFFTUnpack`. `cpu.Info()` cannot show this: it collapses
+`Autocorrelate`, `RealFFTUnpack` and `RealFFTPower`. `cpu.Info()` cannot show this: it collapses
 AVX2 into `AMD64 AVX+FMA`, so an AVX+FMA host without AVX2 (AMD Piledriver and
 Steamroller) reports the same string while taking the Go path for those
 operations. `TestAmd64KernelISALevel` and `TestAmd64KernelDispatchRequiresAVX2`

--- a/README.md
+++ b/README.md
@@ -220,8 +220,8 @@ roughly 30x to under 2x, so the small-span stages stop dominating the transform.
 |                 | `Autocorrelate(autoc, x, maxLag)`   | LPC autocorrelation Σ x[i]·x[i-lag] (bit-exact) | 4x (AVX2) / 2x (NEON)     |
 | **Complex/FFT** | `ButterflyComplex(uRe,uIm,lRe,lIm,twRe,twIm)` | FFT butterfly with twiddle multiply | 4x (AVX+FMA) / 2x (NEON)   |
 |                 | `ButterflyComplexStage(re,im,span,twRe,twIm)` | One whole radix-2 DIT stage (any span) | 4x (AVX+FMA) / 2x (NEON)   |
-|                 | `RealFFTUnpack(outRe,outIm,zRe,zIm,twRe,twIm)` | Real-FFT even/odd unpack step | 4x (AVX2) / 2x (NEON)       |
-|                 | `RealFFTPower(dst,zRe,zIm,twRe,twIm)`         | Fused real-FFT power spectrum \|X_k\|^2 (single pass) | 4x (AVX2) / 2x (NEON)       |
+|                 | `RealFFTUnpack(outRe,outIm,zRe,zIm,twRe,twIm)` | Real-FFT even/odd unpack step | 4x (AVX2+FMA) / 2x (NEON)   |
+|                 | `RealFFTPower(dst,zRe,zIm,twRe,twIm)`         | Fused real-FFT power spectrum \|X_k\|^2 (single pass) | 4x (AVX2+FMA) / 2x (NEON)   |
 | **Audio**       | `Interleave2(dst, a, b)`            | Pack stereo: [L,R,L,R,...]    | 4x / 2x                             |
 |                 | `Deinterleave2(a, b, src)`          | Unpack stereo to channels     | 4x / 2x                             |
 |                 | `InterleaveN(dst, srcs)`            | Pack N planar streams (any N; N-stream Interleave2) | N=2,4,8 AVX, N=3,6 AVX2 / N=2,3,4 NEON; else Go |

--- a/f32/f32.go
+++ b/f32/f32.go
@@ -1341,8 +1341,8 @@ func ButterflyComplexStage(re, im []float32, span int, twRe, twIm []float32) {
 //	evenIm = 0.5 * (zIm[k] - zIm[n-k])
 //	diffRe = zRe[k] - zRe[n-k]
 //	diffIm = zIm[k] + zIm[n-k]
-//	oddRe  = 0.5 * (twRe[k]*diffIm + twIm[k]*diffRe)
-//	oddIm  = 0.5 * (twIm[k]*diffIm - twRe[k]*diffRe)
+//	oddRe  = 0.5 * (twRe[k-1]*diffIm + twIm[k-1]*diffRe)
+//	oddIm  = 0.5 * (twIm[k-1]*diffIm - twRe[k-1]*diffRe)
 //	outRe[k] = evenRe + oddRe
 //	outIm[k] = evenIm + oddIm
 //

--- a/f64/f64.go
+++ b/f64/f64.go
@@ -969,8 +969,8 @@ const realFFTUnpackMinN = 2
 //	evenIm = 0.5 * (zIm[k] - zIm[n-k])
 //	diffRe = zRe[k] - zRe[n-k]
 //	diffIm = zIm[k] + zIm[n-k]
-//	oddRe  = 0.5 * (twRe[k]*diffIm + twIm[k]*diffRe)
-//	oddIm  = 0.5 * (twIm[k]*diffIm - twRe[k]*diffRe)
+//	oddRe  = 0.5 * (twRe[k-1]*diffIm + twIm[k-1]*diffRe)
+//	oddIm  = 0.5 * (twIm[k-1]*diffIm - twRe[k-1]*diffRe)
 //	outRe[k] = evenRe + oddRe
 //	outIm[k] = evenIm + oddIm
 //
@@ -1024,8 +1024,8 @@ func RealFFTUnpack(outRe, outIm, zRe, zIm, twRe, twIm []float64) {
 //
 //	evenRe = 0.5*(zRe[k] + zRe[n-k]); evenIm = 0.5*(zIm[k] - zIm[n-k])
 //	diffRe = zRe[k] - zRe[n-k];       diffIm = zIm[k] + zIm[n-k]
-//	oddRe  = 0.5*(twRe[k]*diffIm + twIm[k]*diffRe)
-//	oddIm  = 0.5*(twIm[k]*diffIm - twRe[k]*diffRe)
+//	oddRe  = 0.5*(twRe[k-1]*diffIm + twIm[k-1]*diffRe)
+//	oddIm  = 0.5*(twIm[k-1]*diffIm - twRe[k-1]*diffRe)
 //	X[k].re = evenRe + oddRe; X[k].im = evenIm + oddIm
 //	dst[k]  = X[k].re^2 + X[k].im^2
 //

--- a/f64/realfftpower_test.go
+++ b/f64/realfftpower_test.go
@@ -437,8 +437,27 @@ func TestRealFFTPower_SignedZero(t *testing.T) {
 	}
 }
 
-// benchRealFFTPower64 runs fn at size n over freshly built inputs.
-func benchRealFFTPower64(b *testing.B, n int, fn func(dst, zRe, zIm, twRe, twIm []float64, n int)) {
+// Per-arm byte accounting for SetBytes, counting the distinct length-n float64
+// slices each arm touches. This is a working-set proxy, not a full multi-pass
+// traffic count: the baseline re-reads its outRe/outIm scratch across the Mul and
+// FMA passes, so its real memory traffic is higher than the count implies. The
+// point is only to stop charging both arms the same bytes; ns/op stays the
+// apples-to-apples fused-vs-baseline comparison, since the per-arm byte counts
+// make the derived MB/s figures non-comparable across arms.
+const (
+	// fusedSlicesTouched is what the fused RealFFTPower touches per call: it reads
+	// zRe, zIm, twRe, twIm and writes dst (5 distinct slices).
+	fusedSlicesTouched = 5
+	// baselineSlicesTouched is what the unpack+Mul+FMA baseline touches per call:
+	// the same five plus the outRe/outIm scratch RealFFTUnpack writes and the
+	// following Mul/FMA passes re-read (7 distinct slices).
+	baselineSlicesTouched = 7
+)
+
+// benchRealFFTPower64 runs fn at size n over freshly built inputs. slicesTouched
+// is how many length-n float64 slices this arm moves through memory per call, so
+// each arm's reported MB/s reflects its own traffic instead of a shared count.
+func benchRealFFTPower64(b *testing.B, n int, slicesTouched int64, fn func(dst, zRe, zIm, twRe, twIm []float64, n int)) {
 	b.Helper()
 	zRe := make([]float64, n)
 	zIm := make([]float64, n)
@@ -453,7 +472,7 @@ func benchRealFFTPower64(b *testing.B, n int, fn func(dst, zRe, zIm, twRe, twIm 
 	makePowerTwiddles(twRe, twIm, n)
 
 	b.ResetTimer()
-	b.SetBytes(int64(n * 8 * 5)) // 5 float64 slices touched (z re/im, tw re/im, dst)
+	b.SetBytes(int64(n*8) * slicesTouched) // 8 bytes per float64 across slicesTouched slices
 
 	for range b.N {
 		fn(dst, zRe, zIm, twRe, twIm, n)
@@ -489,11 +508,11 @@ func BenchmarkRealFFTPower(b *testing.B) {
 	for _, n := range sizes {
 		nfft := 2 * n
 		b.Run(fmt.Sprintf("Fused_nfft%d", nfft), func(b *testing.B) {
-			benchRealFFTPower64(b, n, realFFTPowerDispatched)
+			benchRealFFTPower64(b, n, fusedSlicesTouched, realFFTPowerDispatched)
 		})
 		b.Run(fmt.Sprintf("UnpackMulFMA_nfft%d", nfft), func(b *testing.B) {
 			base := &realFFTPowerBaseline{outRe: make([]float64, n), outIm: make([]float64, n)}
-			benchRealFFTPower64(b, n, base.run)
+			benchRealFFTPower64(b, n, baselineSlicesTouched, base.run)
 		})
 	}
 }

--- a/i8/i8_go.go
+++ b/i8/i8_go.go
@@ -267,6 +267,29 @@ func dequantizeGo(dst []float32, src []int8, scale float32, zeroPoint int8) {
 	}
 }
 
+// requantizeClampAdd finishes the requantize epilogue in int32 space: it clamps
+// the rounded accumulator z to [MinInt8-zeroPoint, MaxInt8-zeroPoint] and only
+// then adds zeroPoint, so the result lands in [-128, 127] with no wraparound.
+// The whole computation stays in int32 and is bit-identical to the SIMD kernels,
+// which reach the same int8 by different routes: the AVX2 kernel clamps z to
+// [MinInt8-zeroPoint, MaxInt8-zeroPoint] then adds (VPMAXSD/VPMINSD then VPADDD),
+// while the NEON kernel adds with a saturating SQADD then narrow-saturates in
+// SQXTN. Adding first in a platform int (as clampI8(int(z)+zp) did) overflows on
+// 32-bit-int targets (386, 32-bit ARM) when z is near MaxInt32 and zeroPoint is
+// positive: the sum wraps negative and clamps to -128 instead of +127. Doing the
+// arithmetic in int32 keeps every intermediate in range on every platform, so the
+// Go reference stays bit-exact with the kernels.
+func requantizeClampAdd(z int32, zeroPoint int8) int8 {
+	lo := int32(math.MinInt8) - int32(zeroPoint)
+	hi := int32(math.MaxInt8) - int32(zeroPoint)
+	if z < lo {
+		z = lo
+	} else if z > hi {
+		z = hi
+	}
+	return int8(z + int32(zeroPoint))
+}
+
 // requantizeGo is the source of truth for Requantize: the gemmlowp
 // double-rounding epilogue (left shift, SaturatingRoundingDoublingHighMul,
 // RoundingDivideByPOT), then add the zero point and saturate to int8. shift > 0
@@ -281,11 +304,10 @@ func requantizeGo(dst []int8, acc []int32, multiplier int32, shift int, zeroPoin
 	if shift < 0 {
 		right = -shift
 	}
-	zp := int(zeroPoint)
 	for i := range dst {
 		x := acc[i] << left // wrapping int32 left shift
 		y := srdhm(x, multiplier)
 		z := rdbpot(y, right)
-		dst[i] = clampI8(int(z) + zp)
+		dst[i] = requantizeClampAdd(z, zeroPoint)
 	}
 }

--- a/i8/quantize_test.go
+++ b/i8/quantize_test.go
@@ -350,6 +350,61 @@ func TestRequantizeSRDHMSaturation(t *testing.T) {
 	}
 }
 
+// TestRequantizeClampAdd exercises the int32-space clamp-then-add epilogue helper
+// directly, independent of the platform int width. On 32-bit-int targets (386,
+// 32-bit ARM) the old clampI8(int(z)+zeroPoint) overflowed when z was near
+// MaxInt32 and zeroPoint was positive: int(z)+zeroPoint wrapped negative and
+// clamped to -128 instead of +127. requantizeClampAdd clamps z in int32 space
+// first, so it saturates correctly on every platform. The int64 oracle is the
+// wrap-free reference: it computes clamp(z+zeroPoint, -128, 127) in a width that
+// never overflows, and the helper must match it for every case.
+func TestRequantizeClampAdd(t *testing.T) {
+	oracle := func(z int32, zp int8) int8 {
+		v := int64(z) + int64(zp) // wide enough to never wrap
+		switch {
+		case v > math.MaxInt8:
+			return math.MaxInt8
+		case v < math.MinInt8:
+			return math.MinInt8
+		default:
+			return int8(v)
+		}
+	}
+
+	zeroPoints := []int8{math.MinInt8, -100, -1, 0, 1, 100, math.MaxInt8}
+	for _, zp := range zeroPoints {
+		lo := int32(math.MinInt8) - int32(zp)
+		hi := int32(math.MaxInt8) - int32(zp)
+		zs := []int32{
+			math.MinInt32, math.MinInt32 + 1,
+			lo - 1, lo, lo + 1,
+			-1, 0, 1,
+			hi - 1, hi, hi + 1,
+			math.MaxInt32 - 1, math.MaxInt32,
+		}
+		for _, z := range zs {
+			// The oracle returns a value clamped to [-128, 127] computed in int64
+			// (never wraps), so matching it proves the helper saturates without
+			// overflow. The int8 return type makes an explicit range assertion
+			// redundant (staticcheck SA4003).
+			got := requantizeClampAdd(z, zp)
+			if want := oracle(z, zp); got != want {
+				t.Errorf("requantizeClampAdd(%d, %d) = %d, want %d", z, zp, got, want)
+			}
+		}
+	}
+
+	// The exact overflow case the fix targets: z at MaxInt32 with a positive
+	// zeroPoint must saturate to +127, and z at MinInt32 to -128, with no wrap.
+	// The old int()+zeroPoint form wrapped these on a 32-bit int.
+	if got := requantizeClampAdd(math.MaxInt32, math.MaxInt8); got != math.MaxInt8 {
+		t.Errorf("requantizeClampAdd(MaxInt32, 127) = %d, want 127 (no wrap)", got)
+	}
+	if got := requantizeClampAdd(math.MinInt32, math.MinInt8); got != math.MinInt8 {
+		t.Errorf("requantizeClampAdd(MinInt32, -128) = %d, want -128 (no wrap)", got)
+	}
+}
+
 // TestQuantizeCautionB proves the int8 pack keeps lane order: a distinct,
 // in-range ascending ramp must come out in the same order. A cross-lane
 // permutation bug in the AVX2 VPACKSSDW/VPERMQ/VPACKSSWB sequence would scramble


### PR DESCRIPTION
Follow-up on review comments left unaddressed after #233 (RealFFTPower) and #234 (i8 quantization) merged. These are the findings that held up on a closer read; the rest were intentional design or false positives.

## Correctness: requantizeGo 32-bit-int overflow (from #234)

`requantizeGo` ended with `dst[i] = clampI8(int(z) + zp)`, where `z` is `int32` and `zp` is `int(zeroPoint)`. On 32-bit-int targets (386, 32-bit ARM) `int(z) + zp` with `z` near `MaxInt32` and a positive `zeroPoint` overflows and wraps negative before the clamp, so the reference saturates to -128 where it should saturate to +127. The AVX2 and NEON kernels clamp `z` in int32 space and only then add `zeroPoint`, so the Go reference (the bit-exact source of truth every kernel is validated against) diverged from the kernels on 32-bit. Not reachable in CI (all targets are 64-bit), but a real portability bug for a library that advertises clean cross-compilation.

I pulled the epilogue into a small `requantizeClampAdd(z int32, zeroPoint int8) int8` that does the clamp-then-add entirely in int32, and added `TestRequantizeClampAdd` with an int64 oracle covering `MaxInt32`, `MinInt32`, and the `lo`/`hi` clamp edges for several zero points including -128, 0, 127. On 64-bit the new code is bit-identical to the old expression for every input, so nothing regresses; it only fixes 32-bit. The full i8 suite (parity, the differential, fuzz) passes on amd64 and natively on arm64.

## Docs

- README: the `RealFFTUnpack` and `RealFFTPower` rows said `4x (AVX2)`, but both dispatch on `hasAVX2 && cpu.X86.FMA` and both kernels use `VFMADD`/`VFNMADD`. Relabeled both to `4x (AVX2+FMA)`, matching the other FMA-gated rows and each function's own "Uses AVX2+FMA on AMD64" doc line.
- The f64 `RealFFTPower`/`RealFFTUnpack` doc formulas indexed the twiddle as `twRe[k]`, but `W[k]` is stored at index `k-1` in a length `n-1` slice, so `twRe[k]` is out of bounds at `k = n-1`. Fixed both to `twRe[k-1]` to match the param docs and the Go reference. I applied the same one-line correction to the `f32.RealFFTUnpack` doc formula, which had the identical stale index (its own param doc and impl already used `k-1`), so the f32/f64 siblings stay consistent.

## Benchmark

`benchRealFFTPower64` charged every arm `b.SetBytes` for 5 slices, but the unpack+Mul+FMA baseline also touches `outRe`/`outIm` scratch. The helper now takes a per-arm slice count (`fusedSlicesTouched = 5`, `baselineSlicesTouched = 7`, distinct slices touched) so each arm's MB/s reflects its own working set. The comment notes this is a working-set proxy and that ns/op stays the apples-to-apples fused-vs-baseline metric. Benchmark-only.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved int8 requantization near integer limits by clamping values safely before applying the zero point.
  * Added validation for boundary and overflow cases in quantization.

* **Documentation**
  * Corrected real FFT guidance to reference the proper twiddle-factor index.
  * Clarified that selected 64-bit real FFT operations require AVX2 and FMA support.

* **Performance**
  * Improved benchmark accuracy for real FFT implementations by accounting for each implementation’s data usage.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->