### PR TITLE
f64: radix-4 butterfly stage ButterflyComplexStage4 (Fixes #198)

### DIFF
--- a/README.md
+++ b/README.md
@@ -157,7 +157,8 @@ sum := crc.Checksum16(p) // bit-identical to the scalar reference, zero-alloc
 **Scope:** `f64` carries the FLAC/LPC and scientific double-precision surface,
 including `Autocorrelate` (lag-vectorized LPC autocorrelation) and the split-format
 FFT butterfly building blocks (`ButterflyComplex`, `ButterflyComplexStage`,
-`RealFFTUnpack`, `RealFFTPower`) that a double-precision FFT/STFT path needs. The broader
+`ButterflyComplexStage4`, `RealFFTUnpack`, `RealFFTPower`) that a
+double-precision FFT/STFT path needs. The broader
 audio/ML helpers (PCM conversions, the general split-format complex ops such as
 `MulComplex` / `AbsSqComplex`, indexed/strided dot products) live in `f32`
 instead, so the two float surfaces remain intentionally asymmetric.
@@ -220,6 +221,7 @@ roughly 30x to under 2x, so the small-span stages stop dominating the transform.
 |                 | `Autocorrelate(autoc, x, maxLag)`   | LPC autocorrelation Σ x[i]·x[i-lag] (bit-exact) | 4x (AVX2) / 2x (NEON)     |
 | **Complex/FFT** | `ButterflyComplex(uRe,uIm,lRe,lIm,twRe,twIm)` | FFT butterfly with twiddle multiply | 4x (AVX+FMA) / 2x (NEON)   |
 |                 | `ButterflyComplexStage(re,im,span,twRe,twIm)` | One whole radix-2 DIT stage (any span) | 4x (AVX+FMA) / 2x (NEON)   |
+|                 | `ButterflyComplexStage4(re,im,span,tw1..tw3)` | One whole radix-4 DIT stage (two radix-2 stages in one pass) | 4x (AVX+FMA) / 2x (NEON)   |
 |                 | `RealFFTUnpack(outRe,outIm,zRe,zIm,twRe,twIm)` | Real-FFT even/odd unpack step | 4x (AVX2+FMA) / 2x (NEON)   |
 |                 | `RealFFTPower(dst,zRe,zIm,twRe,twIm)`         | Fused real-FFT power spectrum \|X_k\|^2 (single pass) | 4x (AVX2+FMA) / 2x (NEON)   |
 | **Audio**       | `Interleave2(dst, a, b)`            | Pack stereo: [L,R,L,R,...]    | 4x / 2x                             |

--- a/f64/butterfly_complex_stage4_test.go
+++ b/f64/butterfly_complex_stage4_test.go
@@ -1,0 +1,715 @@
+package f64
+
+import (
+	"fmt"
+	"math"
+	"math/rand/v2"
+	"testing"
+)
+
+// =============================================================================
+// BUTTERFLY COMPLEX STAGE4 TESTS (float64, radix-4)
+// =============================================================================
+//
+// These reuse closeEnough, stageAbsTol/stageRelTol and stageFFTTolPerN2 from
+// butterfly_complex_stage_test.go: both stages combine the same butterflies and
+// round the same way, so one tolerance policy covers both.
+
+// stage4FillTwiddles writes the three radix-4 twiddle powers for one span into
+// caller-provided buffers of length span:
+//
+//	w = exp(-2*pi*i/(4*span)); tw1 = w^(2j), tw2 = w^j, tw3 = w^(3j).
+//
+// math.Sincos returns (sin, cos); the twiddle real part is cos, the imaginary
+// part is sin.
+func stage4FillTwiddles(t1r, t1i, t2r, t2i, t3r, t3i []float64, span int) {
+	base := -math.Pi / float64(2*span) // = -2*pi/(4*span)
+	for j := range span {
+		s1, c1 := math.Sincos(base * float64(2*j))
+		t1r[j], t1i[j] = c1, s1
+		s2, c2 := math.Sincos(base * float64(j))
+		t2r[j], t2i[j] = c2, s2
+		s3, c3 := math.Sincos(base * float64(3*j))
+		t3r[j], t3i[j] = c3, s3
+	}
+}
+
+// stage4Twiddles allocates and returns the three radix-4 twiddle powers for one
+// span. See stage4FillTwiddles for the values.
+//
+//nolint:gocritic // the six twiddle-power arrays are one group, matching the six-slice kernel signature under test
+func stage4Twiddles(span int) (t1r, t1i, t2r, t2i, t3r, t3i []float64) {
+	t1r = make([]float64, span)
+	t1i = make([]float64, span)
+	t2r = make([]float64, span)
+	t2i = make([]float64, span)
+	t3r = make([]float64, span)
+	t3i = make([]float64, span)
+	stage4FillTwiddles(t1r, t1i, t2r, t2i, t3r, t3i, span)
+	return t1r, t1i, t2r, t2i, t3r, t3i
+}
+
+// stage4FillRadix2Twiddle writes the radix-2 twiddle table exp(-i*pi*j/span) for
+// one span into caller-provided buffers of length span. This is the twiddle the
+// existing ButterflyComplexStage consumes, used to build the two-radix-2 arm that
+// a radix-4 stage must reproduce.
+func stage4FillRadix2Twiddle(twRe, twIm []float64, span int) {
+	for j := range span {
+		sin, cos := math.Sincos(-math.Pi * float64(j) / float64(span))
+		twRe[j], twIm[j] = cos, sin
+	}
+}
+
+// stage4Data fills split-complex arrays with deterministic pseudo-random values.
+// A seeded generator keeps the run reproducible while covering a wider spread of
+// magnitudes and signs than a fixed trig filler.
+func stage4Data(n int, seed uint64) (re, im []float64) {
+	r := rand.New(rand.NewPCG(seed, 0x9E3779B97F4A7C15))
+	re = make([]float64, n)
+	im = make([]float64, n)
+	for i := range n {
+		re[i] = r.NormFloat64()
+		im[i] = r.NormFloat64()
+	}
+	return re, im
+}
+
+// butterflyComplexStage4Ref is an independent reference for one radix-4
+// decimation-in-time stage. It works in complex128 and indexes re/im directly,
+// so it shares no code with butterflyComplexStage4x64Go. The -1i and +1i factors
+// are the forward-DFT cross-adds on the second and fourth outputs.
+func butterflyComplexStage4Ref(re, im []float64, span int, t1r, t1i, t2r, t2i, t3r, t3i []float64) {
+	if span <= 0 ||
+		len(t1r) < span || len(t1i) < span ||
+		len(t2r) < span || len(t2i) < span ||
+		len(t3r) < span || len(t3i) < span {
+		return
+	}
+	n := min(len(re), len(im))
+	for k := 0; k+butterflyStage4Radix*span <= n; k += butterflyStage4Radix * span {
+		for j := range span {
+			i0 := k + j
+			i1 := i0 + span
+			i2 := i1 + span
+			i3 := i2 + span
+
+			x0 := complex(re[i0], im[i0])
+			x1 := complex(re[i1], im[i1])
+			x2 := complex(re[i2], im[i2])
+			x3 := complex(re[i3], im[i3])
+
+			t1 := x1 * complex(t1r[j], t1i[j])
+			t2 := x2 * complex(t2r[j], t2i[j])
+			t3 := x3 * complex(t3r[j], t3i[j])
+
+			a := x0 + t1
+			b := x0 - t1
+			c := t2 + t3
+			d := t2 - t3
+
+			y0 := a + c
+			y1 := b - 1i*d
+			y2 := a - c
+			y3 := b + 1i*d
+
+			re[i0], im[i0] = real(y0), imag(y0)
+			re[i1], im[i1] = real(y1), imag(y1)
+			re[i2], im[i2] = real(y2), imag(y2)
+			re[i3], im[i3] = real(y3), imag(y3)
+		}
+	}
+}
+
+// stage4Spans covers every dispatch path: span 1 is the block-axis path, span 2
+// and 3 fill neither vector axis and run the j-axis scalar tail (span 2 has no
+// dedicated vector path because a radix-4 Cooley-Tukey schedule never lands on
+// it), and 4..64 walk the j-axis vector path with and without a tail (span%4 != 0).
+var stage4Spans = []int{1, 2, 3, 4, 5, 6, 7, 8, 9, 15, 16, 17, 32, 64}
+
+// stage4BlockCounts exercise the block-axis remainder tail: the span-1 path
+// consumes 4 blocks per iteration on AMD64 and 2 on NEON, so these counts cover
+// every block-remainder case for both (mod 4: 1,2,3,4,5,8; mod 2: 5,7).
+var stage4BlockCounts = []int{1, 2, 3, 4, 5, 7, 8}
+
+// TestButterflyComplexStage4_MatchesTwoRadix2Stages is the pinning test. One
+// radix-4 stage at span s with the canonical twiddles must reproduce two radix-2
+// stages, first at span s then at span 2*s, over the same data. This is the
+// mathematical identity the whole primitive rests on; if it holds, the twiddle
+// powers and the -i/+i cross-adds are all correct.
+//
+// Tolerance, not exact equality: the radix-4 combine and the two-pass form group
+// and fuse their multiply-adds differently, so they agree only to within rounding.
+func TestButterflyComplexStage4_MatchesTwoRadix2Stages(t *testing.T) {
+	for _, span := range stage4Spans {
+		for _, blocks := range stage4BlockCounts {
+			t.Run(fmt.Sprintf("span=%d/blocks=%d", span, blocks), func(t *testing.T) {
+				n := butterflyStage4Radix * span * blocks
+				re, im := stage4Data(n, uint64(span*1000+blocks))
+
+				// Arm A: one radix-4 stage with the canonical twiddles.
+				reA := append([]float64(nil), re...)
+				imA := append([]float64(nil), im...)
+				t1r, t1i, t2r, t2i, t3r, t3i := stage4Twiddles(span)
+				ButterflyComplexStage4(reA, imA, span, t1r, t1i, t2r, t2i, t3r, t3i)
+
+				// Arm B: radix-2 at span, then radix-2 at 2*span.
+				reB := append([]float64(nil), re...)
+				imB := append([]float64(nil), im...)
+				twRe1 := make([]float64, span)
+				twIm1 := make([]float64, span)
+				stage4FillRadix2Twiddle(twRe1, twIm1, span)
+				ButterflyComplexStage(reB, imB, span, twRe1, twIm1)
+				twRe2 := make([]float64, 2*span)
+				twIm2 := make([]float64, 2*span)
+				stage4FillRadix2Twiddle(twRe2, twIm2, 2*span)
+				ButterflyComplexStage(reB, imB, 2*span, twRe2, twIm2)
+
+				for i := range n {
+					if !closeEnough(reA[i], reB[i]) {
+						t.Errorf("re[%d]: radix4=%v, two-radix2=%v", i, reA[i], reB[i])
+					}
+					if !closeEnough(imA[i], imB[i]) {
+						t.Errorf("im[%d]: radix4=%v, two-radix2=%v", i, imA[i], imB[i])
+					}
+				}
+			})
+		}
+	}
+}
+
+// TestButterflyComplexStage4 checks the dispatched stage against the independent
+// complex128 reference over the full span x blocks grid. The reference indexes
+// re/im directly rather than delegating, so it does not share code with the
+// implementation under test.
+func TestButterflyComplexStage4(t *testing.T) {
+	for _, span := range stage4Spans {
+		for _, blocks := range stage4BlockCounts {
+			t.Run(fmt.Sprintf("span=%d/blocks=%d", span, blocks), func(t *testing.T) {
+				n := butterflyStage4Radix * span * blocks
+				re, im := stage4Data(n, uint64(span*7919+blocks))
+				t1r, t1i, t2r, t2i, t3r, t3i := stage4Twiddles(span)
+
+				reRef := append([]float64(nil), re...)
+				imRef := append([]float64(nil), im...)
+
+				ButterflyComplexStage4(re, im, span, t1r, t1i, t2r, t2i, t3r, t3i)
+				butterflyComplexStage4Ref(reRef, imRef, span, t1r, t1i, t2r, t2i, t3r, t3i)
+
+				for i := range n {
+					if !closeEnough(re[i], reRef[i]) {
+						t.Errorf("re[%d] = %v, want %v", i, re[i], reRef[i])
+					}
+					if !closeEnough(im[i], imRef[i]) {
+						t.Errorf("im[%d] = %v, want %v", i, im[i], imRef[i])
+					}
+				}
+			})
+		}
+	}
+}
+
+// TestButterflyComplexStage4_SIMDvsGo compares the dispatched kernel against the
+// Go reference over an explicit (span, blocks) grid, entering below the public
+// wrapper so blocks is fixed rather than derived from the slice lengths.
+func TestButterflyComplexStage4_SIMDvsGo(t *testing.T) {
+	for _, span := range stage4Spans {
+		for _, blocks := range stage4BlockCounts {
+			t.Run(fmt.Sprintf("span=%d/blocks=%d", span, blocks), func(t *testing.T) {
+				n := butterflyStage4Radix * span * blocks
+				re, im := stage4Data(n, uint64(span*104729+blocks))
+				t1r, t1i, t2r, t2i, t3r, t3i := stage4Twiddles(span)
+
+				reGo := append([]float64(nil), re...)
+				imGo := append([]float64(nil), im...)
+
+				butterflyComplexStage4x64(re, im, span, blocks, t1r, t1i, t2r, t2i, t3r, t3i)
+				butterflyComplexStage4x64Go(reGo, imGo, span, blocks, t1r, t1i, t2r, t2i, t3r, t3i)
+
+				for i := range n {
+					if !closeEnough(re[i], reGo[i]) {
+						t.Errorf("re[%d]: SIMD=%v, Go=%v", i, re[i], reGo[i])
+					}
+					if !closeEnough(im[i], imGo[i]) {
+						t.Errorf("im[%d]: SIMD=%v, Go=%v", i, im[i], imGo[i])
+					}
+				}
+			})
+		}
+	}
+}
+
+// TestButterflyComplexStage4_Span1SyntheticTwiddle makes span==1 twiddle-multiply
+// sign errors observable. At span==1 the only twiddle index is j==0, so the
+// canonical powers are all (1, 0); with a zero imaginary part every term that a
+// sign flip in the twiddle multiply would touch (VSUBPD vs VADDPD on AMD64, FMLS
+// vs FMLA on NEON) evaluates to the same bits, and the block-axis kernels, which
+// are the whole point of the primitive, run their twiddle multiply unpinned.
+//
+// The kernel is documented value-agnostic, so it must agree with the Go reference
+// for an arbitrary twiddle. Feeding a synthetic twiddle whose real and imaginary
+// parts are both non-trivial exposes the masked mutation. This is the radix-4
+// analogue of the radix-2 stageTwiddlePhase defense.
+func TestButterflyComplexStage4_Span1SyntheticTwiddle(t *testing.T) {
+	const span = 1
+	// Non-identity twiddles, both components well away from zero so a dropped or
+	// sign-flipped cross-term changes the result. Magnitudes need not be unit.
+	t1r, t1i := []float64{0.5}, []float64{0.7}
+	t2r, t2i := []float64{-0.3}, []float64{0.9}
+	t3r, t3i := []float64{0.8}, []float64{-0.4}
+
+	// Block counts that exercise both the block-axis vector loop (4 blocks/iter on
+	// AMD64, 2 on NEON) and its leftover scalar tail.
+	for _, blocks := range []int{2, 4, 5, 7, 8} {
+		t.Run(fmt.Sprintf("blocks=%d", blocks), func(t *testing.T) {
+			n := butterflyStage4Radix * span * blocks
+			re, im := stage4Data(n, uint64(blocks*99991))
+
+			reSIMD := append([]float64(nil), re...)
+			imSIMD := append([]float64(nil), im...)
+			reGo := append([]float64(nil), re...)
+			imGo := append([]float64(nil), im...)
+			reRef := append([]float64(nil), re...)
+			imRef := append([]float64(nil), im...)
+
+			ButterflyComplexStage4(reSIMD, imSIMD, span, t1r, t1i, t2r, t2i, t3r, t3i)
+			butterflyComplexStage4x64Go(reGo, imGo, span, blocks, t1r, t1i, t2r, t2i, t3r, t3i)
+			butterflyComplexStage4Ref(reRef, imRef, span, t1r, t1i, t2r, t2i, t3r, t3i)
+
+			for i := range n {
+				if !closeEnough(reSIMD[i], reGo[i]) {
+					t.Errorf("re[%d]: SIMD=%v, Go=%v", i, reSIMD[i], reGo[i])
+				}
+				if !closeEnough(imSIMD[i], imGo[i]) {
+					t.Errorf("im[%d]: SIMD=%v, Go=%v", i, imSIMD[i], imGo[i])
+				}
+				if !closeEnough(reGo[i], reRef[i]) {
+					t.Errorf("re[%d]: Go=%v, complex128 ref=%v", i, reGo[i], reRef[i])
+				}
+				if !closeEnough(imGo[i], imRef[i]) {
+					t.Errorf("im[%d]: Go=%v, complex128 ref=%v", i, imGo[i], imRef[i])
+				}
+			}
+		})
+	}
+}
+
+// TestButterflyComplexStage4_FullFFT drives a complete iterative Cooley-Tukey
+// transform through ButterflyComplexStage4 and checks it against a naive DFT. A
+// radix-4 schedule runs spans 1, 4, 16, ... and, when n is not a power of 4,
+// finishes with a single radix-2 stage at span n/2. One run therefore walks every
+// radix-4 path in sequence plus the trailing radix-2 stage, which catches a path
+// that is individually self-consistent but wrong relative to the others.
+func TestButterflyComplexStage4_FullFFT(t *testing.T) {
+	for _, n := range []int{8, 16, 32, 64, 128, 256, 1024, 4096} {
+		t.Run(fmt.Sprintf("n=%d", n), func(t *testing.T) {
+			srcRe := make([]float64, n)
+			srcIm := make([]float64, n)
+			for i := range n {
+				srcRe[i] = math.Sin(float64(i)*0.21) + 0.5*math.Cos(float64(i)*1.7)
+				srcIm[i] = math.Cos(float64(i) * 0.13)
+			}
+
+			// Bit-reversal permutation into the working buffers.
+			re := make([]float64, n)
+			im := make([]float64, n)
+			bits := 0
+			for 1<<bits < n {
+				bits++
+			}
+			for i := range n {
+				r := 0
+				for b := range bits {
+					if i&(1<<b) != 0 {
+						r |= 1 << (bits - 1 - b)
+					}
+				}
+				re[r] = srcRe[i]
+				im[r] = srcIm[i]
+			}
+
+			// Radix-4 stages while a full 4*span block fits, then one radix-2 stage
+			// at span n/2 when n is not a power of 4.
+			t1r := make([]float64, n/butterflyStage4Radix)
+			t1i := make([]float64, n/butterflyStage4Radix)
+			t2r := make([]float64, n/butterflyStage4Radix)
+			t2i := make([]float64, n/butterflyStage4Radix)
+			t3r := make([]float64, n/butterflyStage4Radix)
+			t3i := make([]float64, n/butterflyStage4Radix)
+			span := 1
+			for butterflyStage4Radix*span <= n {
+				stage4FillTwiddles(t1r, t1i, t2r, t2i, t3r, t3i, span)
+				ButterflyComplexStage4(re, im, span,
+					t1r[:span], t1i[:span], t2r[:span], t2i[:span], t3r[:span], t3i[:span])
+				span *= butterflyStage4Radix
+			}
+			if span < n {
+				// span == n/2 here; one radix-2 stage completes the transform.
+				twRe := make([]float64, span)
+				twIm := make([]float64, span)
+				stage4FillRadix2Twiddle(twRe, twIm, span)
+				ButterflyComplexStage(re, im, span, twRe, twIm)
+			}
+
+			// Naive DFT reference.
+			for k := range n {
+				var wantRe, wantIm float64
+				for i := range n {
+					ang := -2 * math.Pi * float64(k) * float64(i) / float64(n)
+					c, s := math.Cos(ang), math.Sin(ang)
+					wantRe += srcRe[i]*c - srcIm[i]*s
+					wantIm += srcRe[i]*s + srcIm[i]*c
+				}
+				// Accumulated rounding, dominated by the naive DFT reference, grows
+				// as n^2; see stageFFTTolPerN2.
+				tol := stageFFTTolPerN2 * float64(n) * float64(n)
+				if math.Abs(re[k]-wantRe) > tol || math.Abs(im[k]-wantIm) > tol {
+					t.Fatalf("bin %d = (%v, %v), want (%v, %v), tol %v",
+						k, re[k], im[k], wantRe, wantIm, tol)
+				}
+			}
+		})
+	}
+}
+
+// TestButterflyComplexStage4_PartialBlockUntouched pins the documented boundary:
+// blocks are processed while k+4*span <= n, so a trailing run shorter than a full
+// block must be left exactly as it was, and the complete blocks must have been
+// transformed.
+func TestButterflyComplexStage4_PartialBlockUntouched(t *testing.T) {
+	const sentinel = -12345.5
+
+	for _, span := range stage4Spans {
+		blockLen := butterflyStage4Radix * span
+		seen := map[int]bool{}
+		extras := make([]int, 0, 4)
+		for _, extra := range []int{1, span, blockLen - 1} {
+			if extra <= 0 || extra >= blockLen || seen[extra] {
+				continue
+			}
+			seen[extra] = true
+			extras = append(extras, extra)
+		}
+
+		// blocks 4 as well as 3: the span-1 path consumes four blocks per vector
+		// iteration, so at blocks == 3 it never runs its vector loop at all and a
+		// trailing partial block is only ever seen by the scalar tail.
+		for _, blocks := range []int{3, 4} {
+			for _, extra := range extras {
+				t.Run(fmt.Sprintf("span=%d/blocks=%d/extra=%d", span, blocks, extra), func(t *testing.T) {
+					checkStage4PartialUntouched(t, span, blocks, extra, sentinel)
+				})
+			}
+		}
+	}
+}
+
+func checkStage4PartialUntouched(t *testing.T, span, blocks, extra int, sentinel float64) {
+	t.Helper()
+
+	used := butterflyStage4Radix * span * blocks
+	n := used + extra
+	re, im := stage4Data(n, uint64(span*31+blocks))
+	t1r, t1i, t2r, t2i, t3r, t3i := stage4Twiddles(span)
+	beforeRe := append([]float64(nil), re...)
+	beforeIm := append([]float64(nil), im...)
+	for i := used; i < n; i++ {
+		re[i] = sentinel
+		im[i] = sentinel
+	}
+
+	ButterflyComplexStage4(re, im, span, t1r, t1i, t2r, t2i, t3r, t3i)
+
+	for i := used; i < n; i++ {
+		if re[i] != sentinel {
+			t.Errorf("re[%d] = %v, want untouched sentinel %v", i, re[i], sentinel)
+		}
+		if im[i] != sentinel {
+			t.Errorf("im[%d] = %v, want untouched sentinel %v", i, im[i], sentinel)
+		}
+	}
+
+	for i := range used {
+		if re[i] != beforeRe[i] || im[i] != beforeIm[i] {
+			return
+		}
+	}
+	t.Errorf("no element in the %d complete-block elements changed; the stage did nothing", used)
+}
+
+// TestButterflyComplexStage4_Degenerate covers every input the public wrapper is
+// documented to reject and asserts a no-op rather than a panic. Each twiddle slice
+// gets its own short-slice row: the asm kernels derive every address from span and
+// blocks, so a short twiddle that slipped past the guard would read out of bounds
+// silently instead of panicking the way the Go fallback would.
+func TestButterflyComplexStage4_Degenerate(t *testing.T) {
+	const span = 4
+	n := butterflyStage4Radix * span * 2
+
+	cases := []struct {
+		name string
+		span int
+		nRe  int
+		nIm  int
+		// twLen[k] is the length of twiddle slice k in {t1r,t1i,t2r,t2i,t3r,t3i};
+		// -1 means "use span".
+		twLen [6]int
+	}{
+		{"span=0", 0, n, n, [6]int{-1, -1, -1, -1, -1, -1}},
+		{"span=-1", -1, n, n, [6]int{-1, -1, -1, -1, -1, -1}},
+		{"nil slices", span, 0, 0, [6]int{-1, -1, -1, -1, -1, -1}},
+		{"tw1Re short", span, n, n, [6]int{span - 1, -1, -1, -1, -1, -1}},
+		{"tw1Im short", span, n, n, [6]int{-1, span - 1, -1, -1, -1, -1}},
+		{"tw2Re short", span, n, n, [6]int{-1, -1, span - 1, -1, -1, -1}},
+		{"tw2Im short", span, n, n, [6]int{-1, -1, -1, span - 1, -1, -1}},
+		{"tw3Re short", span, n, n, [6]int{-1, -1, -1, -1, span - 1, -1}},
+		{"tw3Im short", span, n, n, [6]int{-1, -1, -1, -1, -1, span - 1}},
+		{"all twiddles nil", span, n, n, [6]int{0, 0, 0, 0, 0, 0}},
+		{"re shorter than one block", span, butterflyStage4Radix*span - 1, n, [6]int{-1, -1, -1, -1, -1, -1}},
+		{"im shorter than one block", span, n, butterflyStage4Radix*span - 1, [6]int{-1, -1, -1, -1, -1, -1}},
+		{"exactly one element", span, 1, 1, [6]int{-1, -1, -1, -1, -1, -1}},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			full, fullIm := stage4Data(n, 12345)
+			re := append([]float64(nil), full[:tc.nRe]...)
+			im := append([]float64(nil), fullIm[:tc.nIm]...)
+			wantRe := append([]float64(nil), re...)
+			wantIm := append([]float64(nil), im...)
+
+			t1r, t1i, t2r, t2i, t3r, t3i := stage4Twiddles(span)
+			tws := [6][]float64{t1r, t1i, t2r, t2i, t3r, t3i}
+			for k := range tws {
+				if tc.twLen[k] >= 0 {
+					tws[k] = tws[k][:tc.twLen[k]]
+				}
+			}
+
+			// Must not panic.
+			ButterflyComplexStage4(re, im, tc.span, tws[0], tws[1], tws[2], tws[3], tws[4], tws[5])
+
+			for i := range re {
+				if re[i] != wantRe[i] {
+					t.Errorf("re[%d] = %v, want unchanged %v", i, re[i], wantRe[i])
+				}
+			}
+			for i := range im {
+				if im[i] != wantIm[i] {
+					t.Errorf("im[%d] = %v, want unchanged %v", i, im[i], wantIm[i])
+				}
+			}
+		})
+	}
+}
+
+func TestButterflyComplexStage4_AllocFree(t *testing.T) {
+	// One case per vectorization path, so an allocation introduced in any of them
+	// fails here rather than only in the one shape a single case happens to take.
+	for _, span := range []int{1, 2, 3, 8} {
+		t.Run(fmt.Sprintf("span=%d", span), func(t *testing.T) {
+			n := butterflyStage4Radix * span * 16
+			re, im := stage4Data(n, uint64(span))
+			t1r, t1i, t2r, t2i, t3r, t3i := stage4Twiddles(span)
+			fn := func() {
+				ButterflyComplexStage4(re, im, span, t1r, t1i, t2r, t2i, t3r, t3i)
+			}
+			if a := testing.AllocsPerRun(50, fn); a != 0 {
+				t.Errorf("ButterflyComplexStage4 allocated %v times per run, want 0", a)
+			}
+		})
+	}
+}
+
+// FuzzButterflyComplexStage4 checks two contracts at once for arbitrary data: the
+// dispatched kernel agrees with the Go reference, and the Go reference agrees with
+// the two-radix-2 composition it is defined to reproduce.
+func FuzzButterflyComplexStage4(f *testing.F) {
+	addByteLenSeeds(f)
+	f.Fuzz(func(t *testing.T, raw []byte) {
+		u := f64sUnit(raw)
+		if len(u) < 2 {
+			return
+		}
+		// Pick a small span from the first byte, then split the rest into re/im.
+		spanChoices := []int{1, 2, 3, 4, 5, 8}
+		span := spanChoices[int(raw[0])%len(spanChoices)]
+		m := len(u) / 2
+		blockLen := butterflyStage4Radix * span
+		blocks := m / blockLen
+		if blocks == 0 {
+			return
+		}
+		used := blocks * blockLen
+		re := u[:m]
+		im := u[m : 2*m]
+
+		t1r, t1i, t2r, t2i, t3r, t3i := stage4Twiddles(span)
+
+		// Dispatched kernel vs Go reference.
+		reDisp := append([]float64(nil), re...)
+		imDisp := append([]float64(nil), im...)
+		reGo := append([]float64(nil), re...)
+		imGo := append([]float64(nil), im...)
+		ButterflyComplexStage4(reDisp, imDisp, span, t1r, t1i, t2r, t2i, t3r, t3i)
+		butterflyComplexStage4x64Go(reGo[:used], imGo[:used], span, blocks, t1r, t1i, t2r, t2i, t3r, t3i)
+		for i := range used {
+			if !closeEnough(reDisp[i], reGo[i]) {
+				t.Fatalf("dispatched vs Go re[%d] (span=%d, blocks=%d): %v vs %v", i, span, blocks, reDisp[i], reGo[i])
+			}
+			if !closeEnough(imDisp[i], imGo[i]) {
+				t.Fatalf("dispatched vs Go im[%d] (span=%d, blocks=%d): %v vs %v", i, span, blocks, imDisp[i], imGo[i])
+			}
+		}
+
+		// Go reference vs two-radix-2 composition.
+		reTwo := append([]float64(nil), re[:used]...)
+		imTwo := append([]float64(nil), im[:used]...)
+		twRe1 := make([]float64, span)
+		twIm1 := make([]float64, span)
+		stage4FillRadix2Twiddle(twRe1, twIm1, span)
+		ButterflyComplexStage(reTwo, imTwo, span, twRe1, twIm1)
+		twRe2 := make([]float64, 2*span)
+		twIm2 := make([]float64, 2*span)
+		stage4FillRadix2Twiddle(twRe2, twIm2, 2*span)
+		ButterflyComplexStage(reTwo, imTwo, 2*span, twRe2, twIm2)
+		for i := range used {
+			if !closeEnough(reGo[i], reTwo[i]) {
+				t.Fatalf("Go vs two-radix2 re[%d] (span=%d, blocks=%d): %v vs %v", i, span, blocks, reGo[i], reTwo[i])
+			}
+			if !closeEnough(imGo[i], imTwo[i]) {
+				t.Fatalf("Go vs two-radix2 im[%d] (span=%d, blocks=%d): %v vs %v", i, span, blocks, imGo[i], imTwo[i])
+			}
+		}
+	})
+}
+
+// stage4TwSet holds one span's three radix-4 twiddle-power pairs, so a full
+// transform's schedule can be precomputed once outside a timed benchmark loop.
+type stage4TwSet struct {
+	span                         int
+	t1r, t1i, t2r, t2i, t3r, t3i []float64
+}
+
+// radix2TwSet holds one span's radix-2 twiddle pair for the same purpose.
+type radix2TwSet struct {
+	span       int
+	twRe, twIm []float64
+}
+
+// buildStage4Schedule returns the radix-4 stage schedule for an n-point transform:
+// spans 1, 4, 16, ... while a full 4*span block fits.
+func buildStage4Schedule(n int) []*stage4TwSet {
+	var sched []*stage4TwSet
+	for span := 1; butterflyStage4Radix*span <= n; span *= butterflyStage4Radix {
+		t1r, t1i, t2r, t2i, t3r, t3i := stage4Twiddles(span)
+		sched = append(sched, &stage4TwSet{span, t1r, t1i, t2r, t2i, t3r, t3i})
+	}
+	return sched
+}
+
+// buildRadix2Schedule returns the radix-2 stage schedule for an n-point transform:
+// spans 1, 2, 4, ... up to n/2.
+func buildRadix2Schedule(n int) []*radix2TwSet {
+	var sched []*radix2TwSet
+	for span := 1; span < n; span *= 2 {
+		twRe := make([]float64, span)
+		twIm := make([]float64, span)
+		stage4FillRadix2Twiddle(twRe, twIm, span)
+		sched = append(sched, &radix2TwSet{span, twRe, twIm})
+	}
+	return sched
+}
+
+// BenchmarkButterflyComplexStage4 measures the decision behind issue #198: does one
+// radix-4 stage beat the two radix-2 stages it replaces? The per-span sweep holds a
+// fixed 1024-point transform's worth of work (blocks*span near 256) and varies only
+// how short the runs are; the three arms are one radix-4 stage, the two radix-2
+// stages at span then 2*span, and the pure-Go radix-4 reference. Methodology matches
+// BenchmarkButterflyComplexStage: idle host, one sweep per process at -count=1,
+// aggregate across rounds with benchstat and read the Stage4-vs-TwoRadix2 ratio.
+//
+// The in-place butterfly grows its operands to non-finite within a few thousand
+// iterations, which costs nothing (Inf/NaN run at full rate) and hits all three arms
+// identically, so the ratio is unaffected.
+func BenchmarkButterflyComplexStage4(b *testing.B) {
+	const n = 1024
+
+	// 6 is in the sweep because it leaves span%4 == 2, the only shape that measures
+	// the j-axis scalar tail; every power-of-two span skips it.
+	for _, span := range []int{1, 2, 3, 4, 6, 16, 64, 256} {
+		blocks := n / (butterflyStage4Radix * span)
+
+		b.Run(fmt.Sprintf("Stage4/span=%d", span), func(b *testing.B) {
+			re, im := stage4Data(n, uint64(span))
+			t1r, t1i, t2r, t2i, t3r, t3i := stage4Twiddles(span)
+			for b.Loop() {
+				ButterflyComplexStage4(re, im, span, t1r, t1i, t2r, t2i, t3r, t3i)
+			}
+		})
+
+		b.Run(fmt.Sprintf("TwoRadix2/span=%d", span), func(b *testing.B) {
+			re, im := stage4Data(n, uint64(span))
+			twRe1 := make([]float64, span)
+			twIm1 := make([]float64, span)
+			stage4FillRadix2Twiddle(twRe1, twIm1, span)
+			twRe2 := make([]float64, 2*span)
+			twIm2 := make([]float64, 2*span)
+			stage4FillRadix2Twiddle(twRe2, twIm2, 2*span)
+			for b.Loop() {
+				ButterflyComplexStage(re, im, span, twRe1, twIm1)
+				ButterflyComplexStage(re, im, 2*span, twRe2, twIm2)
+			}
+		})
+
+		b.Run(fmt.Sprintf("Go/span=%d", span), func(b *testing.B) {
+			re, im := stage4Data(n, uint64(span))
+			t1r, t1i, t2r, t2i, t3r, t3i := stage4Twiddles(span)
+			for b.Loop() {
+				butterflyComplexStage4x64Go(re, im, span, blocks, t1r, t1i, t2r, t2i, t3r, t3i)
+			}
+		})
+	}
+
+	// FullCore1024 is a complete power-of-4 transform: 5 radix-4 stages vs the 10
+	// radix-2 stages that do the same work.
+	benchStage4FullCore(b, "FullCore1024", 1024, false)
+	// FullCore2048 is 2*4^5: 5 radix-4 stages plus one trailing radix-2 stage at
+	// span n/2, vs 11 radix-2 stages. It exercises the trailing-radix-2 shape.
+	benchStage4FullCore(b, "FullCore2048", 2048, true)
+}
+
+// benchStage4FullCore runs the radix-4 and radix-2 full-transform arms for one size.
+// When trailingRadix2 is set (n is not a power of 4), the radix-4 arm finishes with a
+// single radix-2 stage at span n/2, the schedule a Cooley-Tukey radix-4 transform of
+// such an n uses.
+func benchStage4FullCore(b *testing.B, name string, n int, trailingRadix2 bool) {
+	b.Helper()
+	sched4 := buildStage4Schedule(n)
+	sched2 := buildRadix2Schedule(n)
+	trailRe := make([]float64, n/2)
+	trailIm := make([]float64, n/2)
+	if trailingRadix2 {
+		stage4FillRadix2Twiddle(trailRe, trailIm, n/2)
+	}
+
+	b.Run(name+"/Radix4", func(b *testing.B) {
+		re, im := stage4Data(n, 1)
+		for b.Loop() {
+			for _, s := range sched4 {
+				ButterflyComplexStage4(re, im, s.span, s.t1r, s.t1i, s.t2r, s.t2i, s.t3r, s.t3i)
+			}
+			if trailingRadix2 {
+				ButterflyComplexStage(re, im, n/2, trailRe, trailIm)
+			}
+		}
+	})
+
+	b.Run(name+"/Radix2", func(b *testing.B) {
+		re, im := stage4Data(n, 1)
+		for b.Loop() {
+			for _, s := range sched2 {
+				ButterflyComplexStage(re, im, s.span, s.twRe, s.twIm)
+			}
+		}
+	})
+}

--- a/f64/butterfly_complex_stage4_test.go
+++ b/f64/butterfly_complex_stage4_test.go
@@ -3,6 +3,7 @@ package f64
 import (
 	"fmt"
 	"math"
+	"math/bits"
 	"math/rand/v2"
 	"testing"
 )
@@ -312,15 +313,15 @@ func TestButterflyComplexStage4_FullFFT(t *testing.T) {
 			// Bit-reversal permutation into the working buffers.
 			re := make([]float64, n)
 			im := make([]float64, n)
-			bits := 0
-			for 1<<bits < n {
-				bits++
+			nbits := 0
+			for 1<<nbits < n {
+				nbits++
 			}
 			for i := range n {
 				r := 0
-				for b := range bits {
+				for b := range nbits {
 					if i&(1<<b) != 0 {
-						r |= 1 << (bits - 1 - b)
+						r |= 1 << (nbits - 1 - b)
 					}
 				}
 				re[r] = srcRe[i]
@@ -599,7 +600,8 @@ type radix2TwSet struct {
 // buildStage4Schedule returns the radix-4 stage schedule for an n-point transform:
 // spans 1, 4, 16, ... while a full 4*span block fits.
 func buildStage4Schedule(n int) []*stage4TwSet {
-	var sched []*stage4TwSet
+	// bits.Len(n) (about log2 n) is a safe upper bound on the stage count.
+	sched := make([]*stage4TwSet, 0, bits.Len(uint(n)))
 	for span := 1; butterflyStage4Radix*span <= n; span *= butterflyStage4Radix {
 		t1r, t1i, t2r, t2i, t3r, t3i := stage4Twiddles(span)
 		sched = append(sched, &stage4TwSet{span, t1r, t1i, t2r, t2i, t3r, t3i})
@@ -610,7 +612,7 @@ func buildStage4Schedule(n int) []*stage4TwSet {
 // buildRadix2Schedule returns the radix-2 stage schedule for an n-point transform:
 // spans 1, 2, 4, ... up to n/2.
 func buildRadix2Schedule(n int) []*radix2TwSet {
-	var sched []*radix2TwSet
+	sched := make([]*radix2TwSet, 0, bits.Len(uint(n)))
 	for span := 1; span < n; span *= 2 {
 		twRe := make([]float64, span)
 		twIm := make([]float64, span)

--- a/f64/f64.go
+++ b/f64/f64.go
@@ -949,6 +949,84 @@ func ButterflyComplexStage(re, im []float64, span int, twRe, twIm []float64) {
 	butterflyComplexStage64(re[:used], im[:used], span, blocks, twRe[:span], twIm[:span])
 }
 
+// butterflyStage4Radix is the radix of the radix-4 decimation-in-time stage:
+// every block holds four span-length sub-vectors x0..x3, so a block is
+// butterflyStage4Radix*span elements wide.
+const butterflyStage4Radix = 4
+
+// ButterflyComplexStage4 applies one complete radix-4 decimation-in-time stage in
+// place over split-complex data. For every block k in steps of 4*span, and every
+// j in [0, span), it combines the four sub-vectors x0..x3 at (k+j, k+span+j,
+// k+2*span+j, k+3*span+j) using the three twiddles (tw1[j], tw2[j], tw3[j]):
+//
+//	t1 = x1*tw1[j]; t2 = x2*tw2[j]; t3 = x3*tw3[j]   (full complex multiplies)
+//	a = x0 + t1; b = x0 - t1; c = t2 + t3; d = t2 - t3
+//	re[k+j]        = a.re + c.re; im[k+j]        = a.im + c.im
+//	re[k+span+j]   = b.re + d.im; im[k+span+j]   = b.im - d.re
+//	re[k+2*span+j] = a.re - c.re; im[k+2*span+j] = a.im - c.im
+//	re[k+3*span+j] = b.re - d.im; im[k+3*span+j] = b.im + d.re
+//
+// It is the radix-4 counterpart of [ButterflyComplexStage]: one radix-4 stage at
+// span s does the work of two radix-2 stages, first at span s then at 2*s, in a
+// single pass over the data. Folding two stages into one halves the passes over
+// the array and lets the implementation combine all four points while they are
+// still in registers, which is where a radix-4 core wins over a radix-2 one on a
+// memory-bound transform.
+//
+// # Twiddle convention
+//
+// The three twiddle slices are the powers of w = exp(-2*pi*i/(4*span)):
+//
+//	tw1[j] = w^(2j)   (applied to x1)
+//	tw2[j] = w^j      (applied to x2)
+//	tw3[j] = w^(3j)   (applied to x3)
+//
+// The kernel itself is value-agnostic; those are the values a Cooley-Tukey
+// transform must supply. Two properties are load-bearing and intentional, not
+// mistakes to "fix":
+//
+//   - x1 carries w^(2j), not w^j. The input to a decimation-in-time stage is
+//     radix-2 bit-reversed, which swaps sub-vectors 1 and 2 relative to a plain
+//     radix-4 layout, so x1 takes the square of the base twiddle. With this
+//     convention tw1 is exactly the radix-2 span-s twiddle table (exp(-i*pi*j/s))
+//     and tw2 is the first s entries of the radix-2 span-2s table, so a caller
+//     already holding the radix-2 tables reuses them verbatim.
+//   - The -i and +i cross-adds on the (k+span+j) and (k+3*span+j) outputs
+//     hard-code the FORWARD (negative-exponent) DFT direction. An inverse
+//     transform is a forward pass wrapped in conjugation of the input and output.
+//
+// The stage is a no-op unless span > 0 and all six twiddle slices have length at
+// least span, and it is also a no-op when no complete block fits. Blocks are
+// processed while k+4*span <= n, where n = min(len(re), len(im)); a trailing
+// partial block is left untouched. The span-2 case is never reached by a radix-4
+// Cooley-Tukey schedule (spans run 1, 4, 16, ...), so this stage does not carry a
+// dedicated span-2 vector path; a span-2 caller still gets a correct result from
+// the general j-axis path (a 2-wide NEON iteration, or the scalar tail of the
+// 4-wide AVX path).
+//
+// Uses AVX+FMA on AMD64, NEON on ARM64, with a pure Go fallback. As with
+// [ButterflyComplexStage], results are not guaranteed bit-identical between the
+// vector and fallback paths, so do not depend on exact equality across build
+// targets or across spans.
+func ButterflyComplexStage4(re, im []float64, span int,
+	tw1Re, tw1Im, tw2Re, tw2Im, tw3Re, tw3Im []float64) {
+	if span <= 0 ||
+		len(tw1Re) < span || len(tw1Im) < span ||
+		len(tw2Re) < span || len(tw2Im) < span ||
+		len(tw3Re) < span || len(tw3Im) < span {
+		return
+	}
+	n := min(len(re), len(im))
+	blockLen := butterflyStage4Radix * span
+	blocks := n / blockLen
+	if blocks == 0 {
+		return
+	}
+	used := blocks * blockLen
+	butterflyComplexStage4x64(re[:used], im[:used], span, blocks,
+		tw1Re[:span], tw1Im[:span], tw2Re[:span], tw2Im[:span], tw3Re[:span], tw3Im[:span])
+}
+
 // realFFTUnpackMinN is the minimum n required for RealFFTUnpack (need at least 2 bins).
 const realFFTUnpackMinN = 2
 

--- a/f64/f64_amd64.go
+++ b/f64/f64_amd64.go
@@ -691,6 +691,27 @@ func butterflyComplexStage64(re, im []float64, span, blocks int, twRe, twIm []fl
 	butterflyComplexStage64Go(re, im, span, blocks, twRe, twIm)
 }
 
+func butterflyComplexStage4x64(re, im []float64, span, blocks int,
+	tw1Re, tw1Im, tw2Re, tw2Im, tw3Re, tw3Im []float64) {
+	// butterflyComplexStage4AVX handles every span: across j when span fills a
+	// 4-wide YMM (spans 2 and 3 run its scalar tail), across blocks for span 1.
+	//
+	// AVX+FMA is the whole requirement, no AVX2: the span-1 block-axis path
+	// transposes a 4x4 float64 tile with VUNPCKLPD/VUNPCKHPD and VPERM2F128 and
+	// splats its twiddles with the memory-source form of VBROADCASTSD, and the
+	// complex multiplies use VFMADD231PD. The register-source VBROADCASTSD would be
+	// AVX2, the trap #196/#197 swept for.
+	//
+	// The guard is about total work, not span: a stage carrying fewer than
+	// minAVXElements radix-4 groups goes to Go regardless of its span, matching the
+	// radix-2 stage above.
+	if cpu.X86.AVX && cpu.X86.FMA && blocks*span >= minAVXElements {
+		butterflyComplexStage4AVX(re, im, span, blocks, tw1Re, tw1Im, tw2Re, tw2Im, tw3Re, tw3Im)
+		return
+	}
+	butterflyComplexStage4x64Go(re, im, span, blocks, tw1Re, tw1Im, tw2Re, tw2Im, tw3Re, tw3Im)
+}
+
 func realFFTUnpack64(outRe, outIm, zRe, zIm, twRe, twIm []float64, n int) {
 	// realFFTUnpackAVX needs AVX2, not just AVX+FMA: the reversed load uses VPERMPD
 	// and the constants use register-source VBROADCASTSD plus VPCMPEQD/VPSLLQ on
@@ -1123,6 +1144,18 @@ func butterflyComplexAVX(upperRe, upperIm, lowerRe, lowerIm, twRe, twIm []float6
 //
 //go:noescape
 func butterflyComplexStageAVX(re, im []float64, span, blocks int, twRe, twIm []float64)
+
+// ButterflyComplexStage4 assembly function declaration.
+//
+// Callers MUST satisfy len(re) == len(im) == 4*span*blocks and
+// len(tw1Re) == len(tw1Im) == len(tw2Re) == len(tw2Im) == len(tw3Re) ==
+// len(tw3Im) >= span, with span >= 1 and blocks >= 1. Every address the kernel
+// forms is derived from span and blocks, never from the slice headers, so a
+// violated precondition reads and writes out of bounds silently rather than
+// panicking the way the Go fallback would. ButterflyComplexStage4 establishes it.
+//
+//go:noescape
+func butterflyComplexStage4AVX(re, im []float64, span, blocks int, tw1Re, tw1Im, tw2Re, tw2Im, tw3Re, tw3Im []float64)
 
 // RealFFTUnpack assembly function declaration
 //

--- a/f64/f64_amd64.s
+++ b/f64/f64_amd64.s
@@ -6429,6 +6429,422 @@ bfstage_done:
     VZEROUPPER
     RET
 
+// func butterflyComplexStage4AVX(re, im []float64, span, blocks int, tw1Re, tw1Im, tw2Re, tw2Im, tw3Re, tw3Im []float64)
+// One complete radix-4 decimation-in-time stage, in place over split-complex
+// float64. For every block k in steps of 4*span and every j in [0, span), the
+// four sub-vectors x0..x3 at (k+j, k+span+j, k+2*span+j, k+3*span+j) are combined
+// with twiddles tw1[j], tw2[j], tw3[j]:
+//   t1 = x1*tw1; t2 = x2*tw2; t3 = x3*tw3
+//   a = x0+t1; b = x0-t1; c = t2+t3; d = t2-t3
+//   y0 = a+c; y1 = b - i*d; y2 = a-c; y3 = b + i*d
+// where -i*(dr,di) = (di,-dr) and +i*(dr,di) = (-di,dr). Each complex multiply is
+// VMULPD/VMULPD/VSUBPD for the real part and VMULPD/VFMADD231PD for the imaginary
+// part, the same sequence butterflyComplexStageAVX uses.
+//
+// Two vectorization axes, picked by span. span >= 2 vectorizes across j, where the
+// three twiddles and all four sub-vectors are contiguous runs addressed by the
+// same j index; span/4 full YMM iterations over each block, then a scalar tail for
+// span%4 (spans 2 and 3 run entirely in that tail). span == 1 has one butterfly
+// per block, so it vectorizes across blocks: a 4x4 float64 transpose (VUNPCKLPD/
+// VUNPCKHPD + VPERM2F128, self-inverse) gathers x0..x3 of four consecutive blocks
+// into four YMM, the butterfly runs with the three twiddles splatted by
+// memory-source VBROADCASTSD, and the same transpose scatters the results back.
+// A radix-4 Cooley-Tukey schedule never lands on span 2, so there is no dedicated
+// span-2 block path; a span-2 stage is correct through the j-axis scalar tail.
+//
+// AVX+FMA only, no AVX2: the shuffles are VUNPCKLPD/VUNPCKHPD and VPERM2F128, the
+// splats are the memory-source form of VBROADCASTSD, and every arithmetic op is
+// floating point in 256-bit or scalar width. The VFMADD231PD/SD in the complex
+// multiplies is the FMA dependency the dispatch guard carries.
+//
+// Registers, span >= 2 path: DX/R8 re+im block cursors (they walk x0 and so
+// advance by span*8 per block, then +3*span*8 to the next block), R9 span*8
+// stride (x1/x2/x3 reached by R9*1/R9*2/R9*2+R9*1), AX address scratch, CX inner j
+// counter, BX block count, R10-R13/SI/DI the six twiddle cursors (reset from the
+// frame each block). The span == 1 path reuses DX/R8 as the running re+im cursors,
+// R9 as the 4-block group counter, BX as the leftover-block counter, and R10-R13/
+// SI/DI as the twiddle broadcast sources. Neither path touches R14/R15/BP.
+// Frame: re(24)+im(24)+span(8)+blocks(8)+tw1Re(24)+tw1Im(24)+tw2Re(24)+tw2Im(24)
+// +tw3Re(24)+tw3Im(24) = 208 bytes.
+TEXT ·butterflyComplexStage4AVX(SB), NOSPLIT, $0-208
+    MOVQ re_base+0(FP), DX           // DX = re block base
+    MOVQ im_base+24(FP), R8          // R8 = im block base
+    MOVQ span+48(FP), CX             // CX = span
+    MOVQ blocks+56(FP), BX           // BX = block count
+    MOVQ tw1Re_base+64(FP), R10
+    MOVQ tw1Im_base+88(FP), R11
+    MOVQ tw2Re_base+112(FP), R12
+    MOVQ tw2Im_base+136(FP), R13
+    MOVQ tw3Re_base+160(FP), SI
+    MOVQ tw3Im_base+184(FP), DI
+
+    TESTQ BX, BX
+    JZ    bfstage4_done
+    CMPQ  CX, $1
+    JEQ   bfstage4_span1
+
+// ---------------------------------------------------------------------------
+// span >= 2: vectorize across j. DX/R8 walk x0 of the current block; x1/x2/x3 are
+// reached at +span*8, +2*span*8, +3*span*8. Twiddles restart at j=0 every block.
+// ---------------------------------------------------------------------------
+    MOVQ CX, R9
+    SHLQ $3, R9                      // R9 = span*8
+
+bfstage4_block:
+    MOVQ R9, CX
+    SHRQ $3, CX                      // CX = span = inner counter
+    MOVQ tw1Re_base+64(FP), R10      // reset twiddle cursors for this block
+    MOVQ tw1Im_base+88(FP), R11
+    MOVQ tw2Re_base+112(FP), R12
+    MOVQ tw2Im_base+136(FP), R13
+    MOVQ tw3Re_base+160(FP), SI
+    MOVQ tw3Im_base+184(FP), DI
+    CMPQ CX, $4
+    JLT  bfstage4_tail_pre
+
+bfstage4_vec:
+    VMOVUPD (DX), Y0                 // x0re[j:j+4]
+    VMOVUPD (DX)(R9*1), Y1           // x1re
+    VMOVUPD (DX)(R9*2), Y2           // x2re
+    LEAQ (DX)(R9*2), AX
+    VMOVUPD (AX)(R9*1), Y3           // x3re = DX + 3*span*8
+    VMOVUPD (R8), Y4                 // x0im
+    VMOVUPD (R8)(R9*1), Y5           // x1im
+    VMOVUPD (R8)(R9*2), Y6           // x2im
+    LEAQ (R8)(R9*2), AX
+    VMOVUPD (AX)(R9*1), Y7           // x3im
+
+    VMOVUPD (R10), Y8                // tw1re
+    VMOVUPD (R11), Y9                // tw1im
+    VMULPD Y1, Y8, Y10
+    VMULPD Y5, Y9, Y11
+    VSUBPD Y11, Y10, Y10             // t1re = x1re*tw1re - x1im*tw1im
+    VMULPD Y1, Y9, Y11
+    VFMADD231PD Y5, Y8, Y11          // t1im = x1re*tw1im + x1im*tw1re
+
+    VMOVUPD (R12), Y8                // tw2re
+    VMOVUPD (R13), Y9                // tw2im
+    VMULPD Y2, Y8, Y1
+    VMULPD Y6, Y9, Y5
+    VSUBPD Y5, Y1, Y1                // t2re
+    VMULPD Y2, Y9, Y5
+    VFMADD231PD Y6, Y8, Y5           // t2im
+
+    VMOVUPD (SI), Y8                 // tw3re
+    VMOVUPD (DI), Y9                 // tw3im
+    VMULPD Y3, Y8, Y2
+    VMULPD Y7, Y9, Y6
+    VSUBPD Y6, Y2, Y2                // t3re
+    VMULPD Y3, Y9, Y6
+    VFMADD231PD Y7, Y8, Y6           // t3im
+
+    VADDPD Y1, Y2, Y3                // cre = t2re+t3re
+    VADDPD Y5, Y6, Y7                // cim = t2im+t3im
+    VSUBPD Y2, Y1, Y8                // dre = t2re-t3re
+    VSUBPD Y6, Y5, Y9                // dim = t2im-t3im
+
+    VADDPD Y0, Y10, Y1               // are = x0re+t1re
+    VSUBPD Y10, Y0, Y2               // bre = x0re-t1re
+    VADDPD Y4, Y11, Y5               // aim = x0im+t1im
+    VSUBPD Y11, Y4, Y6               // bim = x0im-t1im
+
+    VADDPD Y1, Y3, Y0                // y0re = are+cre
+    VADDPD Y5, Y7, Y4                // y0im = aim+cim
+    VMOVUPD Y0, (DX)
+    VMOVUPD Y4, (R8)
+    VSUBPD Y3, Y1, Y0                // y2re = are-cre
+    VSUBPD Y7, Y5, Y4                // y2im = aim-cim
+    VMOVUPD Y0, (DX)(R9*2)
+    VMOVUPD Y4, (R8)(R9*2)
+    VADDPD Y2, Y9, Y0                // y1re = bre+dim
+    VSUBPD Y8, Y6, Y4                // y1im = bim-dre
+    VMOVUPD Y0, (DX)(R9*1)
+    VMOVUPD Y4, (R8)(R9*1)
+    VSUBPD Y9, Y2, Y0                // y3re = bre-dim
+    VADDPD Y8, Y6, Y4                // y3im = bim+dre
+    LEAQ (DX)(R9*2), AX
+    VMOVUPD Y0, (AX)(R9*1)
+    LEAQ (R8)(R9*2), AX
+    VMOVUPD Y4, (AX)(R9*1)
+
+    ADDQ $32, DX
+    ADDQ $32, R8
+    ADDQ $32, R10
+    ADDQ $32, R11
+    ADDQ $32, R12
+    ADDQ $32, R13
+    ADDQ $32, SI
+    ADDQ $32, DI
+    SUBQ $4, CX
+    CMPQ CX, $4
+    JGE  bfstage4_vec
+
+bfstage4_tail_pre:
+    TESTQ CX, CX
+    JZ   bfstage4_next
+
+bfstage4_tail:
+    LEAQ (DX)(R9*2), AX
+    VMOVSD (DX), X0                  // x0re
+    VMOVSD (DX)(R9*1), X1            // x1re
+    VMOVSD (DX)(R9*2), X2            // x2re
+    VMOVSD (AX)(R9*1), X3            // x3re
+    LEAQ (R8)(R9*2), AX
+    VMOVSD (R8), X4                  // x0im
+    VMOVSD (R8)(R9*1), X5            // x1im
+    VMOVSD (R8)(R9*2), X6            // x2im
+    VMOVSD (AX)(R9*1), X7            // x3im
+
+    VMOVSD (R10), X8
+    VMOVSD (R11), X9
+    VMULSD X1, X8, X10
+    VMULSD X5, X9, X11
+    VSUBSD X11, X10, X10             // t1re
+    VMULSD X1, X9, X11
+    VFMADD231SD X5, X8, X11          // t1im
+    VMOVSD (R12), X8
+    VMOVSD (R13), X9
+    VMULSD X2, X8, X1
+    VMULSD X6, X9, X5
+    VSUBSD X5, X1, X1                // t2re
+    VMULSD X2, X9, X5
+    VFMADD231SD X6, X8, X5           // t2im
+    VMOVSD (SI), X8
+    VMOVSD (DI), X9
+    VMULSD X3, X8, X2
+    VMULSD X7, X9, X6
+    VSUBSD X6, X2, X2                // t3re
+    VMULSD X3, X9, X6
+    VFMADD231SD X7, X8, X6           // t3im
+
+    VADDSD X1, X2, X3                // cre
+    VADDSD X5, X6, X7                // cim
+    VSUBSD X2, X1, X8                // dre
+    VSUBSD X6, X5, X9                // dim
+    VADDSD X0, X10, X1               // are
+    VSUBSD X10, X0, X2               // bre
+    VADDSD X4, X11, X5               // aim
+    VSUBSD X11, X4, X6               // bim
+
+    VADDSD X1, X3, X0                // y0re
+    VMOVSD X0, (DX)
+    VADDSD X5, X7, X0                // y0im
+    VMOVSD X0, (R8)
+    VSUBSD X3, X1, X0                // y2re
+    VMOVSD X0, (DX)(R9*2)
+    VSUBSD X7, X5, X0                // y2im
+    VMOVSD X0, (R8)(R9*2)
+    VADDSD X2, X9, X0                // y1re = bre+dim
+    VMOVSD X0, (DX)(R9*1)
+    VSUBSD X8, X6, X0                // y1im = bim-dre
+    VMOVSD X0, (R8)(R9*1)
+    LEAQ (DX)(R9*2), AX
+    VSUBSD X9, X2, X0                // y3re = bre-dim
+    VMOVSD X0, (AX)(R9*1)
+    LEAQ (R8)(R9*2), AX
+    VADDSD X8, X6, X0                // y3im = bim+dre
+    VMOVSD X0, (AX)(R9*1)
+
+    ADDQ $8, DX
+    ADDQ $8, R8
+    ADDQ $8, R10
+    ADDQ $8, R11
+    ADDQ $8, R12
+    ADDQ $8, R13
+    ADDQ $8, SI
+    ADDQ $8, DI
+    DECQ CX
+    JNZ  bfstage4_tail
+
+bfstage4_next:
+    LEAQ (R9)(R9*2), AX              // AX = 3*span*8 = step to next block
+    ADDQ AX, DX
+    ADDQ AX, R8
+    DECQ BX
+    JNZ  bfstage4_block
+    JMP  bfstage4_done
+
+// ---------------------------------------------------------------------------
+// span == 1: one butterfly per block, so re/im are fully interleaved as
+// [x0,x1,x2,x3] per block. Take four blocks (16 float64) per iteration, transpose
+// so x0..x3 of the four blocks land one-per-lane, run the butterfly with the three
+// twiddles splatted, then transpose the results back. The transpose is its own
+// inverse, so the store side reuses the load-side sequence.
+// ---------------------------------------------------------------------------
+bfstage4_span1:
+    MOVQ BX, R9
+    SHRQ $2, R9                      // R9 = blocks/4 = 4-block iterations
+    JZ   bfstage4_span1_tail_pre
+
+bfstage4_span1_vec:
+    VMOVUPD (DX), Y0                 // re rows: block0..block3, each [x0,x1,x2,x3]
+    VMOVUPD 32(DX), Y1
+    VMOVUPD 64(DX), Y2
+    VMOVUPD 96(DX), Y3
+    VUNPCKLPD Y1, Y0, Y4
+    VUNPCKHPD Y1, Y0, Y5
+    VUNPCKLPD Y3, Y2, Y6
+    VUNPCKHPD Y3, Y2, Y7
+    VPERM2F128 $0x20, Y6, Y4, Y0     // X0re = x0 of the four blocks
+    VPERM2F128 $0x20, Y7, Y5, Y1     // X1re
+    VPERM2F128 $0x31, Y6, Y4, Y2     // X2re
+    VPERM2F128 $0x31, Y7, Y5, Y3     // X3re
+
+    VMOVUPD (R8), Y4                 // im rows
+    VMOVUPD 32(R8), Y5
+    VMOVUPD 64(R8), Y6
+    VMOVUPD 96(R8), Y7
+    VUNPCKLPD Y5, Y4, Y8
+    VUNPCKHPD Y5, Y4, Y9
+    VUNPCKLPD Y7, Y6, Y10
+    VUNPCKHPD Y7, Y6, Y11
+    VPERM2F128 $0x20, Y10, Y8, Y4    // X0im
+    VPERM2F128 $0x20, Y11, Y9, Y5    // X1im
+    VPERM2F128 $0x31, Y10, Y8, Y6    // X2im
+    VPERM2F128 $0x31, Y11, Y9, Y7    // X3im
+
+    VBROADCASTSD (R10), Y8           // tw1re[0]
+    VBROADCASTSD (R11), Y9           // tw1im[0]
+    VMULPD Y1, Y8, Y10
+    VMULPD Y5, Y9, Y11
+    VSUBPD Y11, Y10, Y10             // t1re
+    VMULPD Y1, Y9, Y11
+    VFMADD231PD Y5, Y8, Y11          // t1im
+    VBROADCASTSD (R12), Y8           // tw2re[0]
+    VBROADCASTSD (R13), Y9           // tw2im[0]
+    VMULPD Y2, Y8, Y1
+    VMULPD Y6, Y9, Y5
+    VSUBPD Y5, Y1, Y1                // t2re
+    VMULPD Y2, Y9, Y5
+    VFMADD231PD Y6, Y8, Y5           // t2im
+    VBROADCASTSD (SI), Y8            // tw3re[0]
+    VBROADCASTSD (DI), Y9            // tw3im[0]
+    VMULPD Y3, Y8, Y2
+    VMULPD Y7, Y9, Y6
+    VSUBPD Y6, Y2, Y2                // t3re
+    VMULPD Y3, Y9, Y6
+    VFMADD231PD Y7, Y8, Y6           // t3im
+
+    VADDPD Y1, Y2, Y3                // cre
+    VADDPD Y5, Y6, Y7                // cim
+    VSUBPD Y2, Y1, Y8                // dre
+    VSUBPD Y6, Y5, Y9                // dim
+    VADDPD Y0, Y10, Y1               // are
+    VSUBPD Y10, Y0, Y2               // bre
+    VADDPD Y4, Y11, Y5               // aim
+    VSUBPD Y11, Y4, Y6               // bim
+
+    VADDPD Y1, Y3, Y0                // col0re = y0re
+    VSUBPD Y3, Y1, Y10               // col2re = y2re
+    VADDPD Y2, Y9, Y12               // col1re = y1re = bre+dim
+    VSUBPD Y9, Y2, Y13               // col3re = y3re = bre-dim
+    VADDPD Y5, Y7, Y4                // col0im = y0im
+    VSUBPD Y7, Y5, Y11               // col2im = y2im
+    VSUBPD Y8, Y6, Y14               // col1im = y1im = bim-dre
+    VADDPD Y8, Y6, Y15               // col3im = y3im = bim+dre
+
+    VUNPCKLPD Y12, Y0, Y1            // transpose results back (re)
+    VUNPCKHPD Y12, Y0, Y2
+    VUNPCKLPD Y13, Y10, Y3
+    VUNPCKHPD Y13, Y10, Y5
+    VPERM2F128 $0x20, Y3, Y1, Y0
+    VPERM2F128 $0x20, Y5, Y2, Y12
+    VPERM2F128 $0x31, Y3, Y1, Y10
+    VPERM2F128 $0x31, Y5, Y2, Y13
+    VMOVUPD Y0, (DX)
+    VMOVUPD Y12, 32(DX)
+    VMOVUPD Y10, 64(DX)
+    VMOVUPD Y13, 96(DX)
+
+    VUNPCKLPD Y14, Y4, Y1            // transpose results back (im)
+    VUNPCKHPD Y14, Y4, Y2
+    VUNPCKLPD Y15, Y11, Y3
+    VUNPCKHPD Y15, Y11, Y5
+    VPERM2F128 $0x20, Y3, Y1, Y4
+    VPERM2F128 $0x20, Y5, Y2, Y14
+    VPERM2F128 $0x31, Y3, Y1, Y11
+    VPERM2F128 $0x31, Y5, Y2, Y15
+    VMOVUPD Y4, (R8)
+    VMOVUPD Y14, 32(R8)
+    VMOVUPD Y11, 64(R8)
+    VMOVUPD Y15, 96(R8)
+
+    ADDQ $128, DX
+    ADDQ $128, R8
+    DECQ R9
+    JNZ  bfstage4_span1_vec
+
+bfstage4_span1_tail_pre:
+    ANDQ $3, BX                      // leftover blocks (0..3)
+    JZ   bfstage4_done
+
+bfstage4_span1_tail:
+    VMOVSD (DX), X0                  // x0re
+    VMOVSD 8(DX), X1                 // x1re
+    VMOVSD 16(DX), X2                // x2re
+    VMOVSD 24(DX), X3                // x3re
+    VMOVSD (R8), X4                  // x0im
+    VMOVSD 8(R8), X5                 // x1im
+    VMOVSD 16(R8), X6               // x2im
+    VMOVSD 24(R8), X7                // x3im
+
+    VMOVSD (R10), X8
+    VMOVSD (R11), X9
+    VMULSD X1, X8, X10
+    VMULSD X5, X9, X11
+    VSUBSD X11, X10, X10             // t1re
+    VMULSD X1, X9, X11
+    VFMADD231SD X5, X8, X11          // t1im
+    VMOVSD (R12), X8
+    VMOVSD (R13), X9
+    VMULSD X2, X8, X1
+    VMULSD X6, X9, X5
+    VSUBSD X5, X1, X1                // t2re
+    VMULSD X2, X9, X5
+    VFMADD231SD X6, X8, X5           // t2im
+    VMOVSD (SI), X8
+    VMOVSD (DI), X9
+    VMULSD X3, X8, X2
+    VMULSD X7, X9, X6
+    VSUBSD X6, X2, X2                // t3re
+    VMULSD X3, X9, X6
+    VFMADD231SD X7, X8, X6           // t3im
+
+    VADDSD X1, X2, X3                // cre
+    VADDSD X5, X6, X7                // cim
+    VSUBSD X2, X1, X8                // dre
+    VSUBSD X6, X5, X9                // dim
+    VADDSD X0, X10, X1               // are
+    VSUBSD X10, X0, X2               // bre
+    VADDSD X4, X11, X5               // aim
+    VSUBSD X11, X4, X6               // bim
+
+    VADDSD X1, X3, X0                // y0re
+    VMOVSD X0, (DX)
+    VADDSD X5, X7, X0                // y0im
+    VMOVSD X0, (R8)
+    VSUBSD X3, X1, X0                // y2re
+    VMOVSD X0, 16(DX)
+    VSUBSD X7, X5, X0                // y2im
+    VMOVSD X0, 16(R8)
+    VADDSD X2, X9, X0                // y1re = bre+dim
+    VMOVSD X0, 8(DX)
+    VSUBSD X8, X6, X0                // y1im = bim-dre
+    VMOVSD X0, 8(R8)
+    VSUBSD X9, X2, X0                // y3re = bre-dim
+    VMOVSD X0, 24(DX)
+    VADDSD X8, X6, X0                // y3im = bim+dre
+    VMOVSD X0, 24(R8)
+
+    ADDQ $32, DX
+    ADDQ $32, R8
+    DECQ BX
+    JNZ  bfstage4_span1_tail
+
+bfstage4_done:
+    VZEROUPPER
+    RET
+
 // func realFFTUnpackAVX(outRe, outIm, zRe, zIm, twRe, twIm []float64, n int)
 // Real-FFT unpack step, 4 float64 lanes per YMM (AVX+FMA). The float64
 // counterpart of f32's realFFTUnpackAVX: 4 lanes/iter instead of 8, so the

--- a/f64/f64_arm64.go
+++ b/f64/f64_arm64.go
@@ -532,6 +532,29 @@ func butterflyComplexStage64(re, im []float64, span, blocks int, twRe, twIm []fl
 //go:noescape
 func butterflyComplexStageNEON(re, im []float64, span, blocks int, twRe, twIm []float64)
 
+func butterflyComplexStage4x64(re, im []float64, span, blocks int,
+	tw1Re, tw1Im, tw2Re, tw2Im, tw3Re, tw3Im []float64) {
+	// butterflyComplexStage4NEON vectorizes across j for span >= 2 and across
+	// blocks for span == 1, so every span has a vector path. One iteration needs
+	// 2 float64 lanes, so anything below 2 total radix-4 groups falls to Go.
+	if hasNEON && blocks*span >= 2 {
+		butterflyComplexStage4NEON(re, im, span, blocks, tw1Re, tw1Im, tw2Re, tw2Im, tw3Re, tw3Im)
+		return
+	}
+	butterflyComplexStage4x64Go(re, im, span, blocks, tw1Re, tw1Im, tw2Re, tw2Im, tw3Re, tw3Im)
+}
+
+// ButterflyComplexStage4 assembly function declaration.
+//
+// Callers MUST satisfy len(re) == len(im) == 4*span*blocks and all six twiddle
+// slices >= span, with span >= 1 and blocks >= 1. Every address the kernel forms
+// is derived from span and blocks, never from the slice headers, so a violated
+// precondition reads and writes out of bounds silently rather than panicking the
+// way the Go fallback would. ButterflyComplexStage4 establishes it.
+//
+//go:noescape
+func butterflyComplexStage4NEON(re, im []float64, span, blocks int, tw1Re, tw1Im, tw2Re, tw2Im, tw3Re, tw3Im []float64)
+
 func realFFTUnpack64(outRe, outIm, zRe, zIm, twRe, twIm []float64, n int) {
 	// One NEON iteration needs 2 float64 lanes; n > 2 means (n-1) >= 2.
 	if hasNEON && n > 2 {

--- a/f64/f64_arm64.s
+++ b/f64/f64_arm64.s
@@ -3046,6 +3046,354 @@ bfstage_neon_span1_tail_pre:
 bfstage_neon_done:
     RET
 
+// func butterflyComplexStage4NEON(re, im []float64, span, blocks int, tw1Re, tw1Im, tw2Re, tw2Im, tw3Re, tw3Im []float64)
+// One complete radix-4 decimation-in-time stage, in place over split-complex
+// float64. For every block k in steps of 4*span and every j in [0, span), the
+// four sub-vectors x0..x3 at (k+j, k+span+j, k+2*span+j, k+3*span+j) are combined
+// with twiddles tw1[j], tw2[j], tw3[j]:
+//   t1 = x1*tw1; t2 = x2*tw2; t3 = x3*tw3    (FMUL+FMLS for re, FMUL+FMLA for im)
+//   a = x0+t1; b = x0-t1; c = t2+t3; d = t2-t3
+//   y0 = a+c; y1 = b - i*d; y2 = a-c; y3 = b + i*d
+// where -i*(dr,di) = (di,-dr) and +i*(dr,di) = (-di,dr). Same arithmetic sequence
+// as butterflyComplexStageNEON, extended from a radix-2 pair to a radix-4 group.
+//
+// Two vectorization axes, picked by span. span >= 2 vectorizes across j, two lanes
+// (.2D) per iteration with a scalar tail for odd span; the four sub-vector cursors
+// (R6..R13) and six twiddle cursors (R19..R24) walk their runs, the block bases
+// R0/R1 advance by 4*span*8 per block. span == 1 has one butterfly per block, so
+// it vectorizes across blocks: UZP1/UZP2 split two interleaved [x0,x1,x2,x3] blocks
+// into x0..x3 rows, the butterfly runs with the three twiddles splatted (VDUP),
+// and ZIP1/ZIP2 re-interleave the results. A radix-4 Cooley-Tukey schedule never
+// lands on span 2, so there is no dedicated span-2 path; span 2 is correct through
+// the j-axis path (a single 2-lane iteration, with no scalar tail since span is
+// even).
+//
+// The .2D FMUL/FADD/FSUB/FMLA/FMLS and the UZP1/UZP2/ZIP1/ZIP2 permutes are
+// hand-encoded WORDs (Go's assembler has no mnemonics for them); the trailing
+// comment on each is cross-checked against arm64asm by asmcheck_test.go. VLD1/VST1,
+// VDUP and the scalar F-register tail use native mnemonics.
+//
+// Registers: R0/R1 re+im block bases, R2 span, R3 block count, R4 span*8, R5 inner
+// counter, R6..R9 x0..x3 re cursors, R10..R13 x0..x3 im cursors, R19..R24 the six
+// twiddle cursors, R25 block stride (4*span*8). The span == 1 path reuses R0/R1 as
+// running cursors, R5 as the block-pair counter, R6/R7 as the second block's
+// addresses, and V16..V21 as the splatted twiddles. Neither path touches R16/R17/
+// R18/R27/R28. Frame: re(24)+im(24)+span(8)+blocks(8)+tw1Re(24)+tw1Im(24)+tw2Re(24)
+// +tw2Im(24)+tw3Re(24)+tw3Im(24) = 208 bytes.
+TEXT ·butterflyComplexStage4NEON(SB), NOSPLIT, $0-208
+    MOVD re_base+0(FP), R0
+    MOVD im_base+24(FP), R1
+    MOVD span+48(FP), R2
+    MOVD blocks+56(FP), R3
+    MOVD tw1Re_base+64(FP), R19
+    MOVD tw1Im_base+88(FP), R20
+    MOVD tw2Re_base+112(FP), R21
+    MOVD tw2Im_base+136(FP), R22
+    MOVD tw3Re_base+160(FP), R23
+    MOVD tw3Im_base+184(FP), R24
+
+    CBZ  R3, bfstage4_neon_done
+    CMP  $1, R2
+    BEQ  bfstage4_neon_span1
+
+    // ----------------------------------------------------------------------
+    // span >= 2: vectorize across j, two lanes per iteration, scalar tail when
+    // span is odd. The four re/im sub-vector cursors are reset from the block
+    // bases every block; the twiddle cursors are reloaded from the frame.
+    // ----------------------------------------------------------------------
+    LSL  $3, R2, R4                  // R4 = span*8
+    LSL  $5, R2, R25                 // R25 = span*32 = 4*span*8 block stride
+
+bfstage4_neon_block:
+    MOVD R0, R6                      // x0re
+    ADD  R4, R0, R7                  // x1re
+    ADD  R4, R7, R8                  // x2re
+    ADD  R4, R8, R9                  // x3re
+    MOVD R1, R10                     // x0im
+    ADD  R4, R1, R11                 // x1im
+    ADD  R4, R11, R12                // x2im
+    ADD  R4, R12, R13                // x3im
+    MOVD tw1Re_base+64(FP), R19
+    MOVD tw1Im_base+88(FP), R20
+    MOVD tw2Re_base+112(FP), R21
+    MOVD tw2Im_base+136(FP), R22
+    MOVD tw3Re_base+160(FP), R23
+    MOVD tw3Im_base+184(FP), R24
+    LSR  $1, R2, R5                  // R5 = span/2 vector iterations
+    CBZ  R5, bfstage4_neon_tail_pre
+
+bfstage4_neon_vec:
+    VLD1 (R6), [V0.D2]               // x0re[j:j+2]
+    VLD1 (R7), [V1.D2]               // x1re
+    VLD1 (R8), [V2.D2]               // x2re
+    VLD1 (R9), [V3.D2]               // x3re
+    VLD1 (R10), [V4.D2]              // x0im
+    VLD1 (R11), [V5.D2]              // x1im
+    VLD1 (R12), [V6.D2]              // x2im
+    VLD1 (R13), [V7.D2]              // x3im
+    VLD1.P 16(R19), [V16.D2]         // tw1re
+    VLD1.P 16(R20), [V17.D2]         // tw1im
+    VLD1.P 16(R21), [V18.D2]         // tw2re
+    VLD1.P 16(R22), [V19.D2]         // tw2im
+    VLD1.P 16(R23), [V20.D2]         // tw3re
+    VLD1.P 16(R24), [V21.D2]         // tw3im
+
+    WORD $0x6E70DC36                 // FMUL V22.2D, V1.2D, V16.2D   t1re = x1re*tw1re
+    WORD $0x4EF1CCB6                 // FMLS V22.2D, V5.2D, V17.2D        - x1im*tw1im
+    WORD $0x6E71DC37                 // FMUL V23.2D, V1.2D, V17.2D   t1im = x1re*tw1im
+    WORD $0x4E70CCB7                 // FMLA V23.2D, V5.2D, V16.2D        + x1im*tw1re
+    WORD $0x6E72DC58                 // FMUL V24.2D, V2.2D, V18.2D   t2re
+    WORD $0x4EF3CCD8                 // FMLS V24.2D, V6.2D, V19.2D
+    WORD $0x6E73DC59                 // FMUL V25.2D, V2.2D, V19.2D   t2im
+    WORD $0x4E72CCD9                 // FMLA V25.2D, V6.2D, V18.2D
+    WORD $0x6E74DC7A                 // FMUL V26.2D, V3.2D, V20.2D   t3re
+    WORD $0x4EF5CCFA                 // FMLS V26.2D, V7.2D, V21.2D
+    WORD $0x6E75DC7B                 // FMUL V27.2D, V3.2D, V21.2D   t3im
+    WORD $0x4E74CCFB                 // FMLA V27.2D, V7.2D, V20.2D
+    WORD $0x4E7AD71C                 // FADD V28.2D, V24.2D, V26.2D  cre = t2re+t3re
+    WORD $0x4E7BD73D                 // FADD V29.2D, V25.2D, V27.2D  cim
+    WORD $0x4EFAD71E                 // FSUB V30.2D, V24.2D, V26.2D  dre = t2re-t3re
+    WORD $0x4EFBD73F                 // FSUB V31.2D, V25.2D, V27.2D  dim
+    WORD $0x4E76D408                 // FADD V8.2D, V0.2D, V22.2D    are = x0re+t1re
+    WORD $0x4EF6D409                 // FSUB V9.2D, V0.2D, V22.2D    bre = x0re-t1re
+    WORD $0x4E77D48A                 // FADD V10.2D, V4.2D, V23.2D   aim
+    WORD $0x4EF7D48B                 // FSUB V11.2D, V4.2D, V23.2D   bim
+
+    WORD $0x4E7CD50C                 // FADD V12.2D, V8.2D, V28.2D   y0re = are+cre
+    WORD $0x4E7DD54D                 // FADD V13.2D, V10.2D, V29.2D  y0im = aim+cim
+    VST1.P [V12.D2], 16(R6)
+    VST1.P [V13.D2], 16(R10)
+    WORD $0x4EFCD50C                 // FSUB V12.2D, V8.2D, V28.2D   y2re = are-cre
+    WORD $0x4EFDD54D                 // FSUB V13.2D, V10.2D, V29.2D  y2im = aim-cim
+    VST1.P [V12.D2], 16(R8)
+    VST1.P [V13.D2], 16(R12)
+    WORD $0x4E7FD52C                 // FADD V12.2D, V9.2D, V31.2D   y1re = bre+dim
+    WORD $0x4EFED56D                 // FSUB V13.2D, V11.2D, V30.2D  y1im = bim-dre
+    VST1.P [V12.D2], 16(R7)
+    VST1.P [V13.D2], 16(R11)
+    WORD $0x4EFFD52C                 // FSUB V12.2D, V9.2D, V31.2D   y3re = bre-dim
+    WORD $0x4E7ED56D                 // FADD V13.2D, V11.2D, V30.2D  y3im = bim+dre
+    VST1.P [V12.D2], 16(R9)
+    VST1.P [V13.D2], 16(R13)
+
+    SUB  $1, R5
+    CBNZ R5, bfstage4_neon_vec
+
+bfstage4_neon_tail_pre:
+    AND  $1, R2, R5                  // R5 = span & 1
+    CBZ  R5, bfstage4_neon_next
+
+    FMOVD (R6), F0                   // x0re
+    FMOVD (R7), F1                   // x1re
+    FMOVD (R8), F2                   // x2re
+    FMOVD (R9), F3                   // x3re
+    FMOVD (R10), F4                  // x0im
+    FMOVD (R11), F5                  // x1im
+    FMOVD (R12), F6                  // x2im
+    FMOVD (R13), F7                  // x3im
+    FMOVD (R19), F16                 // tw1re
+    FMOVD (R20), F17                 // tw1im
+    FMOVD (R21), F18                 // tw2re
+    FMOVD (R22), F19                 // tw2im
+    FMOVD (R23), F20                 // tw3re
+    FMOVD (R24), F21                 // tw3im
+
+    FMULD F1, F16, F22
+    FMULD F5, F17, F23
+    FSUBD F23, F22, F22              // t1re
+    FMULD F1, F17, F23
+    FMULD F5, F16, F24
+    FADDD F23, F24, F23              // t1im
+    FMULD F2, F18, F24
+    FMULD F6, F19, F25
+    FSUBD F25, F24, F24              // t2re
+    FMULD F2, F19, F25
+    FMULD F6, F18, F26
+    FADDD F25, F26, F25              // t2im
+    FMULD F3, F20, F26
+    FMULD F7, F21, F27
+    FSUBD F27, F26, F26              // t3re
+    FMULD F3, F21, F27
+    FMULD F7, F20, F28
+    FADDD F27, F28, F27              // t3im
+    FADDD F24, F26, F28              // cre
+    FADDD F25, F27, F29              // cim
+    FSUBD F26, F24, F30              // dre
+    FSUBD F27, F25, F31              // dim
+    FADDD F0, F22, F1                // are
+    FSUBD F22, F0, F2                // bre
+    FADDD F4, F23, F5                // aim
+    FSUBD F23, F4, F6                // bim
+    FADDD F1, F28, F0                // y0re
+    FMOVD F0, (R6)
+    FADDD F5, F29, F0                // y0im
+    FMOVD F0, (R10)
+    FSUBD F28, F1, F0                // y2re
+    FMOVD F0, (R8)
+    FSUBD F29, F5, F0                // y2im
+    FMOVD F0, (R12)
+    FADDD F2, F31, F0                // y1re = bre+dim
+    FMOVD F0, (R7)
+    FSUBD F30, F6, F0                // y1im = bim-dre
+    FMOVD F0, (R11)
+    FSUBD F31, F2, F0                // y3re = bre-dim
+    FMOVD F0, (R9)
+    FADDD F30, F6, F0                // y3im = bim+dre
+    FMOVD F0, (R13)
+
+bfstage4_neon_next:
+    ADD  R25, R0, R0
+    ADD  R25, R1, R1
+    SUB  $1, R3
+    CBNZ R3, bfstage4_neon_block
+    RET
+
+    // ----------------------------------------------------------------------
+    // span == 1: each block is [x0,x1,x2,x3] contiguous. Take two blocks per
+    // iteration; UZP1/UZP2 gather x0..x3 one-per-lane, the butterfly runs with the
+    // three twiddles splatted, ZIP1/ZIP2 re-interleave. One leftover block scalar.
+    // ----------------------------------------------------------------------
+bfstage4_neon_span1:
+    FMOVD (R19), F16
+    VDUP  V16.D[0], V16.D2           // tw1re[0] in both lanes
+    FMOVD (R20), F17
+    VDUP  V17.D[0], V17.D2           // tw1im[0]
+    FMOVD (R21), F18
+    VDUP  V18.D[0], V18.D2           // tw2re[0]
+    FMOVD (R22), F19
+    VDUP  V19.D[0], V19.D2           // tw2im[0]
+    FMOVD (R23), F20
+    VDUP  V20.D[0], V20.D2           // tw3re[0]
+    FMOVD (R24), F21
+    VDUP  V21.D[0], V21.D2           // tw3im[0]
+
+    LSR  $1, R3, R5                  // R5 = blocks/2 = 2-block iterations
+    CBZ  R5, bfstage4_neon_span1_tail_pre
+
+bfstage4_neon_span1_vec:
+    ADD  $32, R0, R6
+    ADD  $32, R1, R7
+    VLD1 (R0), [V0.D2, V1.D2]        // block0 re = [x0,x1],[x2,x3]
+    VLD1 (R6), [V2.D2, V3.D2]        // block1 re
+    VLD1 (R1), [V4.D2, V5.D2]        // block0 im
+    VLD1 (R7), [V6.D2, V7.D2]        // block1 im
+
+    WORD $0x4EC21808                 // UZP1 V8.2D, V0.2D, V2.2D     X0re = [x0_b0,x0_b1]
+    WORD $0x4EC25809                 // UZP2 V9.2D, V0.2D, V2.2D     X1re
+    WORD $0x4EC3182A                 // UZP1 V10.2D, V1.2D, V3.2D    X2re
+    WORD $0x4EC3582B                 // UZP2 V11.2D, V1.2D, V3.2D    X3re
+    WORD $0x4EC6188C                 // UZP1 V12.2D, V4.2D, V6.2D    X0im
+    WORD $0x4EC6588D                 // UZP2 V13.2D, V4.2D, V6.2D    X1im
+    WORD $0x4EC718AE                 // UZP1 V14.2D, V5.2D, V7.2D    X2im
+    WORD $0x4EC758AF                 // UZP2 V15.2D, V5.2D, V7.2D    X3im
+
+    WORD $0x6E70DD36                 // FMUL V22.2D, V9.2D, V16.2D   t1re
+    WORD $0x4EF1CDB6                 // FMLS V22.2D, V13.2D, V17.2D
+    WORD $0x6E71DD37                 // FMUL V23.2D, V9.2D, V17.2D   t1im
+    WORD $0x4E70CDB7                 // FMLA V23.2D, V13.2D, V16.2D
+    WORD $0x6E72DD58                 // FMUL V24.2D, V10.2D, V18.2D  t2re
+    WORD $0x4EF3CDD8                 // FMLS V24.2D, V14.2D, V19.2D
+    WORD $0x6E73DD59                 // FMUL V25.2D, V10.2D, V19.2D  t2im
+    WORD $0x4E72CDD9                 // FMLA V25.2D, V14.2D, V18.2D
+    WORD $0x6E74DD7A                 // FMUL V26.2D, V11.2D, V20.2D  t3re
+    WORD $0x4EF5CDFA                 // FMLS V26.2D, V15.2D, V21.2D
+    WORD $0x6E75DD7B                 // FMUL V27.2D, V11.2D, V21.2D  t3im
+    WORD $0x4E74CDFB                 // FMLA V27.2D, V15.2D, V20.2D
+    WORD $0x4E7AD71C                 // FADD V28.2D, V24.2D, V26.2D  cre
+    WORD $0x4E7BD73D                 // FADD V29.2D, V25.2D, V27.2D  cim
+    WORD $0x4EFAD71E                 // FSUB V30.2D, V24.2D, V26.2D  dre
+    WORD $0x4EFBD73F                 // FSUB V31.2D, V25.2D, V27.2D  dim
+    WORD $0x4E76D500                 // FADD V0.2D, V8.2D, V22.2D    are
+    WORD $0x4EF6D501                 // FSUB V1.2D, V8.2D, V22.2D    bre
+    WORD $0x4E77D582                 // FADD V2.2D, V12.2D, V23.2D   aim
+    WORD $0x4EF7D583                 // FSUB V3.2D, V12.2D, V23.2D   bim
+    WORD $0x4E7CD404                 // FADD V4.2D, V0.2D, V28.2D    X0re' = are+cre
+    WORD $0x4EFCD406                 // FSUB V6.2D, V0.2D, V28.2D    X2re' = are-cre
+    WORD $0x4E7FD425                 // FADD V5.2D, V1.2D, V31.2D    X1re' = bre+dim
+    WORD $0x4EFFD427                 // FSUB V7.2D, V1.2D, V31.2D    X3re' = bre-dim
+    WORD $0x4E7DD448                 // FADD V8.2D, V2.2D, V29.2D    X0im' = aim+cim
+    WORD $0x4EFDD44A                 // FSUB V10.2D, V2.2D, V29.2D   X2im' = aim-cim
+    WORD $0x4EFED469                 // FSUB V9.2D, V3.2D, V30.2D    X1im' = bim-dre
+    WORD $0x4E7ED46B                 // FADD V11.2D, V3.2D, V30.2D   X3im' = bim+dre
+
+    WORD $0x4EC53880                 // ZIP1 V0.2D, V4.2D, V5.2D     block0 re [x0',x1']
+    WORD $0x4EC738C1                 // ZIP1 V1.2D, V6.2D, V7.2D     block0 re [x2',x3']
+    WORD $0x4EC57882                 // ZIP2 V2.2D, V4.2D, V5.2D     block1 re [x0',x1']
+    WORD $0x4EC778C3                 // ZIP2 V3.2D, V6.2D, V7.2D     block1 re [x2',x3']
+    VST1 [V0.D2, V1.D2], (R0)        // block0 re
+    VST1 [V2.D2, V3.D2], (R6)        // block1 re
+    WORD $0x4EC93900                 // ZIP1 V0.2D, V8.2D, V9.2D     block0 im [x0',x1']
+    WORD $0x4ECB3941                 // ZIP1 V1.2D, V10.2D, V11.2D   block0 im [x2',x3']
+    WORD $0x4EC97902                 // ZIP2 V2.2D, V8.2D, V9.2D     block1 im [x0',x1']
+    WORD $0x4ECB7943                 // ZIP2 V3.2D, V10.2D, V11.2D   block1 im [x2',x3']
+    VST1 [V0.D2, V1.D2], (R1)        // block0 im
+    VST1 [V2.D2, V3.D2], (R7)        // block1 im
+
+    ADD  $64, R0, R0
+    ADD  $64, R1, R1
+    SUB  $1, R5
+    CBNZ R5, bfstage4_neon_span1_vec
+
+bfstage4_neon_span1_tail_pre:
+    AND  $1, R3, R5                  // one leftover block at most
+    CBZ  R5, bfstage4_neon_done
+
+    FMOVD (R0), F0                   // x0re
+    FMOVD 8(R0), F1                  // x1re
+    FMOVD 16(R0), F2                 // x2re
+    FMOVD 24(R0), F3                 // x3re
+    FMOVD (R1), F4                   // x0im
+    FMOVD 8(R1), F5                  // x1im
+    FMOVD 16(R1), F6                 // x2im
+    FMOVD 24(R1), F7                 // x3im
+    // F16..F21 still hold the splatted twiddles (lane 0 of V16..V21, only read
+    // by the vector loop above), so no reload is needed.
+    FMULD F1, F16, F22
+    FMULD F5, F17, F23
+    FSUBD F23, F22, F22              // t1re
+    FMULD F1, F17, F23
+    FMULD F5, F16, F24
+    FADDD F23, F24, F23              // t1im
+    FMULD F2, F18, F24
+    FMULD F6, F19, F25
+    FSUBD F25, F24, F24              // t2re
+    FMULD F2, F19, F25
+    FMULD F6, F18, F26
+    FADDD F25, F26, F25              // t2im
+    FMULD F3, F20, F26
+    FMULD F7, F21, F27
+    FSUBD F27, F26, F26              // t3re
+    FMULD F3, F21, F27
+    FMULD F7, F20, F28
+    FADDD F27, F28, F27              // t3im
+    FADDD F24, F26, F28              // cre
+    FADDD F25, F27, F29              // cim
+    FSUBD F26, F24, F30              // dre
+    FSUBD F27, F25, F31              // dim
+    FADDD F0, F22, F1                // are
+    FSUBD F22, F0, F2                // bre
+    FADDD F4, F23, F5                // aim
+    FSUBD F23, F4, F6                // bim
+    FADDD F1, F28, F0                // y0re
+    FMOVD F0, (R0)
+    FADDD F5, F29, F0                // y0im
+    FMOVD F0, (R1)
+    FSUBD F28, F1, F0                // y2re
+    FMOVD F0, 16(R0)
+    FSUBD F29, F5, F0                // y2im
+    FMOVD F0, 16(R1)
+    FADDD F2, F31, F0                // y1re = bre+dim
+    FMOVD F0, 8(R0)
+    FSUBD F30, F6, F0                // y1im = bim-dre
+    FMOVD F0, 8(R1)
+    FSUBD F31, F2, F0                // y3re = bre-dim
+    FMOVD F0, 24(R0)
+    FADDD F30, F6, F0                // y3im = bim+dre
+    FMOVD F0, 24(R1)
+
+bfstage4_neon_done:
+    RET
+
 // func realFFTUnpackNEON(outRe, outIm, zRe, zIm, twRe, twIm []float64, n int)
 // Real-FFT unpack step, 2 float64 lanes (.2D) per vector register, the float64
 // counterpart of f32's realFFTUnpackNEON: 2 lanes/iter instead of 4, so the

--- a/f64/f64_go.go
+++ b/f64/f64_go.go
@@ -728,6 +728,63 @@ func butterflyComplexStage64Go(re, im []float64, span, blocks int, twRe, twIm []
 	}
 }
 
+// butterflyComplexStage4x64Go applies one radix-4 decimation-in-time stage in
+// place over split-complex data. blocks is the number of complete 4*span blocks;
+// the caller has already reconciled it against len(re)/len(im). The six twiddle
+// slices carry w^(2j), w^j and w^(3j) with w = exp(-2*pi*i/(4*span)); see
+// ButterflyComplexStage4 for the convention. It is the source of truth for the
+// operation: the SIMD kernels reproduce this arithmetic within rounding.
+func butterflyComplexStage4x64Go(re, im []float64, span, blocks int,
+	tw1Re, tw1Im, tw2Re, tw2Im, tw3Re, tw3Im []float64) {
+	// Reslice the twiddles to exactly span so the bounds prover discharges the
+	// inner-loop index from the loop condition alone; the caller has validated
+	// these lengths.
+	t1r, t1i := tw1Re[:span], tw1Im[:span]
+	t2r, t2i := tw2Re[:span], tw2Im[:span]
+	t3r, t3i := tw3Re[:span], tw3Im[:span]
+	for b := range blocks {
+		k := b * butterflyStage4Radix * span
+		// Reslice the four sub-vectors to exactly span so the bounds prover
+		// discharges the inner-loop indices from the loop condition alone, the same
+		// per-block reslice the radix-2 butterflyComplexStage64Go uses. Each reslice
+		// costs one bounds check per block, amortised over span elements, versus
+		// eight per element without it.
+		e1 := k + span
+		e2 := e1 + span
+		e3 := e2 + span
+		e4 := e3 + span
+		x0re, x0im := re[k:e1:e1], im[k:e1:e1]
+		x1re, x1im := re[e1:e2:e2], im[e1:e2:e2]
+		x2re, x2im := re[e2:e3:e3], im[e2:e3:e3]
+		x3re, x3im := re[e3:e4:e4], im[e3:e4:e4]
+		for j := range span {
+			x0r, x0i := x0re[j], x0im[j]
+			x1r, x1i := x1re[j], x1im[j]
+			x2r, x2i := x2re[j], x2im[j]
+			x3r, x3i := x3re[j], x3im[j]
+
+			// Full complex multiplies against the three twiddle powers.
+			t1re := x1r*t1r[j] - x1i*t1i[j]
+			t1im := x1r*t1i[j] + x1i*t1r[j]
+			t2re := x2r*t2r[j] - x2i*t2i[j]
+			t2im := x2r*t2i[j] + x2i*t2r[j]
+			t3re := x3r*t3r[j] - x3i*t3i[j]
+			t3im := x3r*t3i[j] + x3i*t3r[j]
+
+			// Radix-4 butterfly combine.
+			ar, ai := x0r+t1re, x0i+t1im
+			br, bi := x0r-t1re, x0i-t1im
+			cr, ci := t2re+t3re, t2im+t3im
+			dr, di := t2re-t3re, t2im-t3im
+
+			x0re[j], x0im[j] = ar+cr, ai+ci
+			x1re[j], x1im[j] = br+di, bi-dr
+			x2re[j], x2im[j] = ar-cr, ai-ci
+			x3re[j], x3im[j] = br-di, bi+dr
+		}
+	}
+}
+
 // realFFTUnpackHalf is the constant 0.5 used in real FFT unpack computation.
 const realFFTUnpackHalf = 0.5
 

--- a/f64/f64_other.go
+++ b/f64/f64_other.go
@@ -77,6 +77,11 @@ func butterflyComplexStage64(re, im []float64, span, blocks int, twRe, twIm []fl
 	butterflyComplexStage64Go(re, im, span, blocks, twRe, twIm)
 }
 
+func butterflyComplexStage4x64(re, im []float64, span, blocks int,
+	tw1Re, tw1Im, tw2Re, tw2Im, tw3Re, tw3Im []float64) {
+	butterflyComplexStage4x64Go(re, im, span, blocks, tw1Re, tw1Im, tw2Re, tw2Im, tw3Re, tw3Im)
+}
+
 func realFFTUnpack64(outRe, outIm, zRe, zIm, twRe, twIm []float64, n int) {
 	realFFTUnpack64Go(outRe, outIm, zRe, zIm, twRe, twIm, n)
 }


### PR DESCRIPTION
Adds `f64.ButterflyComplexStage4`, a radix-4 decimation-in-time FFT butterfly stage that does the work of two radix-2 stages (at span `s` then `2*s`) in a single pass over the data. This closes #198.

One radix-4 stage combines the four sub-vectors of each block while they are still in registers, so it halves the passes over the array versus running two radix-2 stages. It ships a pure-Go reference (the source of truth), an AMD64 AVX+FMA kernel, and an ARM64 NEON kernel, mirroring the existing `ButterflyComplexStage`.

## Math

For each block `k` in steps of `4*span` and each `j` in `[0, span)`, with `x0..x3` at `(k+j, k+span+j, k+2*span+j, k+3*span+j)`:

```
t1 = x1*tw1[j]; t2 = x2*tw2[j]; t3 = x3*tw3[j]   (full complex multiplies)
a = x0 + t1; b = x0 - t1; c = t2 + t3; d = t2 - t3
y0 = a + c; y1 = b - i*d; y2 = a - c; y3 = b + i*d
```

The three twiddle slices are the powers of `w = exp(-2*pi*i/(4*span))`: `tw1 = w^(2j)`, `tw2 = w^j`, `tw3 = w^(3j)`. `x1` carries `w^(2j)` (not `w^j`) because a decimation-in-time input is radix-2 bit-reversed, which swaps sub-vectors 1 and 2. With this convention `tw1` is exactly the radix-2 span-`s` twiddle table and `tw2` is the first `s` entries of the radix-2 span-`2s` table, so a caller already holding the radix-2 tables reuses them. The `-i`/`+i` cross-adds hard-code the forward DFT direction. A test pins the identity that one radix-4 stage equals the two radix-2 stages it replaces.

## Kernels

AMD64 is AVX+FMA only (no AVX2): the `span == 1` block-axis path transposes a 4x4 float64 tile with `VUNPCKLPD`/`VUNPCKHPD`/`VPERM2F128` and splats its twiddles with the memory-source form of `VBROADCASTSD`; `span >= 2` vectorizes across `j`. ARM64 uses `.2D` NEON with `UZP1`/`UZP2`/`ZIP1`/`ZIP2` for the `span == 1` transpose; the new `.2D` arithmetic and permute encodings are hand-encoded `WORD`s whose decoded-mnemonic comments are cross-checked against `arm64asm`.

## Benchmarks

20 independent rounds per arm, one sweep per process, Mann-Whitney U. `ratio = TwoRadix2 / Stage4` (a value above 1 means the single radix-4 stage beats the two radix-2 stages it replaces). `FullCore` runs a complete transform: 5 radix-4 stages versus the 10 radix-2 stages that do the same work (plus a trailing radix-2 stage for the `2048` size).

AMD64 (AVX+FMA):

| span | ratio | p |
|-----:|------:|--:|
| 1 | 1.00 | 0.54 (tied) |
| 4 | 1.35 | 3e-8 |
| 16 | 1.35 | 2e-7 |
| 64 | 1.45 | 4e-8 |
| 256 | 1.48 | 3e-8 |
| FullCore1024 | 1.23 | 4.5e-7 |
| FullCore2048 | 1.24 | 3e-8 |

ARM64 (Cortex-A76, NEON):

| span | ratio | p |
|-----:|------:|--:|
| 1 | 1.61 | 3e-8 |
| 4 | 1.38 | 3e-8 |
| 16 | 1.28 | 3e-8 |
| 64 | 1.28 | 3e-8 |
| 256 | 1.28 | 3e-8 |
| FullCore1024 | 1.38 | 3e-8 |
| FullCore2048 | 1.32 | 3e-8 |

The full-transform speedup is the metric that matters for #198, and it holds on both architectures. A radix-4 schedule only ever uses spans 1, 4, 16, 64, ..., so spans 2 and 3 are intentionally left to the scalar tail rather than carrying dedicated vector paths. On AMD64 the span-1 stage is statistically tied with the two radix-2 calls in isolation but is not a regression, and the whole transform still wins because the later stages do; on ARM64 the 2-wide NEON path wins span 1 outright.

## Tests

Pinning test (one radix-4 stage == two radix-2 stages), parity against an independent complex128 reference, a full iterative Cooley-Tukey transform checked against a naive DFT, partial-block-untouched and degenerate-input no-op checks, an allocation-free assertion, and a differential fuzz target. All pass on AMD64 (native and with the SIMD path disabled to exercise the Go fallback) and on ARM64 hardware.

## Follow-ups (filed separately, not blockers)

The f32 sibling and adopting radix-4 inside `STFTPlan`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a public float64 radix-4 complex FFT butterfly stage for in-place processing.
  * Supports AVX+FMA, ARM64 NEON, and portable Go execution paths.
  * Handles twiddle factors, partial blocks, span-based processing, and edge cases safely.

* **Tests**
  * Added comprehensive correctness, compatibility, fuzz, allocation, and benchmark coverage.
  * Documented the new FFT building block and its operation details.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->