### PR TITLE
f32 arm64: overlapping vector tail for realFFTUnpackNEON (#225)

### DIFF
--- a/f32/f32_arm64.s
+++ b/f32/f32_arm64.s
@@ -3022,7 +3022,12 @@ TEXT ·realFFTUnpackNEON(SB), NOSPLIT, $0-152
     SUB $1, R6, R7                   // R7 = n - 1
     MOVD R7, R14                     // R14 = n - 1 (save for remainder)
     LSR $2, R7                       // R7 = (n-1) / 4 = number of SIMD iterations
-    CBZ R7, realfft_neon_remainder   // Skip SIMD loop if < 4 elements
+    // Dispatch guarantees n > 4, so R7 = (n-1)/4 >= 1 and the main loop always
+    // runs. A caller that ignores the threshold arrives with R7 = 0 (n <= 4),
+    // where the overlapping remainder below would anchor at k = n-4 <= 0 and
+    // over-read z while underflowing the twiddles; writing nothing is the
+    // memory-safe answer. Mirrors realFFTUnpackAVX (#220).
+    CBZ R7, realfft_neon_done        // n <= 4: nothing safe to do
 
     // Set up reverse pointers: zRe[n-4], zIm[n-4]
     SUB $4, R6, R8                   // R8 = n - 4
@@ -3108,11 +3113,25 @@ realfft_neon_loop4:
     CBNZ R7, realfft_neon_loop4
 
 realfft_neon_remainder:
-    // Handle remaining elements (n-1) % 4
-    AND $3, R14
+    // Handle the remaining (n-1) % 4 bins with one more FULL 4-wide block
+    // anchored at k = n-4, overlapping the block just written, rather than
+    // walking the leftovers one at a time. Bin k reads zRe/zIm at k and at the
+    // mirror n-k plus the twiddles at k-1, and nothing a previous bin produced,
+    // so recomputing the last 4 stores identical values. Mirrors the amd64
+    // realFFTUnpackAVX overlap (#220); same idiom as #149/#170.
+    //
+    // Idempotence needs the inputs to still be the inputs, which is why
+    // RealFFTUnpack documents that the output must not overlap zRe/zIm. See #215.
+    AND $3, R14                      // R14 = leftover bins (0..3)
     CBZ R14, realfft_neon_done
 
-    // Reload base pointers for remainder
+    // Zero the leftover count before re-entering the loop: the block below ends
+    // on the loop's own SUB/CBNZ and falls through here a second time, where it
+    // must find nothing left to do.
+    MOVD ZR, R14
+
+    // Reload the six slice bases the main loop advanced. R6 still holds n (the
+    // loop never writes it) and is reloaded only to keep this block self-contained.
     MOVD outRe_base+0(FP), R0
     MOVD outIm_base+24(FP), R1
     MOVD zRe_base+48(FP), R2
@@ -3121,100 +3140,29 @@ realfft_neon_remainder:
     MOVD twIm_base+120(FP), R5
     MOVD n+144(FP), R6
 
-    // Calculate starting k for remainder: 1 + 4 * num_full_iterations
-    SUB $1, R6, R7                   // R7 = n - 1
-    LSR $2, R7                       // R7 = num_full_iterations
-    LSL $2, R7                       // R7 = 4 * num_full_iterations
-    ADD $1, R7                       // R7 = starting k
+    // Mirror pointers first, while R2/R3 still hold the bases. At k = n-4 the
+    // block reads z[n-k-3 .. n-k] = z[1 .. 4], one element in from the start.
+    // Index 4 is why the block needs n >= 5, which the n > 4 threshold gives.
+    ADD $4, R2, R9                   // R9 = &zRe[1]
+    ADD $4, R3, R10                  // R10 = &zIm[1]
 
-    // Offset pointers to starting k
-    LSL $2, R7, R8                   // R8 = k * 4 bytes
-    ADD R8, R0                       // R0 = &outRe[k]
-    ADD R8, R1                       // R1 = &outIm[k]
+    // Forward and output pointers to the anchor k = n-4.
+    SUB $4, R6, R8                   // R8 = n - 4 = k
+    LSL $2, R8                       // R8 = k * 4 = byte offset
     ADD R8, R2                       // R2 = &zRe[k]
     ADD R8, R3                       // R3 = &zIm[k]
+    ADD R8, R0                       // R0 = &outRe[k]
+    ADD R8, R1                       // R1 = &outIm[k]
 
-    // Twiddle offset is (k-1)
-    SUB $1, R7
-    LSL $2, R7, R8
+    // Twiddles are indexed k-1, so they top out at n-2 against a length n-1 slice.
+    SUB $4, R8                       // R8 = (k-1) * 4
     ADD R8, R4                       // R4 = &twRe[k-1]
     ADD R8, R5                       // R5 = &twIm[k-1]
-    ADD $1, R7                       // Restore R7 = k
 
-realfft_neon_scalar:
-    // Calculate mirror index: nk = n - k
-    SUB R7, R6, R8                   // R8 = n - k = nk
-
-    // Load Z[k]
-    FMOVS (R2), F0                   // F0 = zRe[k]
-    FMOVS (R3), F1                   // F1 = zIm[k]
-
-    // Load conj(Z[n-k])
-    MOVD zRe_base+48(FP), R9
-    LSL $2, R8, R10
-    ADD R10, R9
-    FMOVS (R9), F2                   // F2 = zRe[nk]
-
-    MOVD zIm_base+72(FP), R9
-    ADD R10, R9
-    FMOVS (R9), F3                   // F3 = zIm[nk]
-
-    // Negate F3 for conjugate: znkIm = -zIm[nk]
-    FNEGS F3, F3                     // F3 = -zIm[nk] = znkIm
-
-    // Load 0.5 constant
-    MOVW $0x3F000000, R11
-    FMOVS R11, F13                   // F13 = 0.5
-
-    // evenRe = 0.5 * (zkRe + znkRe)
-    FADDS F0, F2, F4                 // F4 = zkRe + znkRe
-    FMULS F4, F13, F4                // F4 = evenRe
-
-    // evenIm = 0.5 * (zkIm + znkIm)
-    FADDS F1, F3, F5                 // F5 = zkIm + znkIm
-    FMULS F5, F13, F5                // F5 = evenIm
-
-    // diffRe = zkRe - znkRe
-    FSUBS F2, F0, F6                 // F6 = diffRe
-
-    // diffIm = zkIm - znkIm
-    FSUBS F3, F1, F7                 // F7 = diffIm
-
-    // Load twiddles
-    FMOVS (R4), F8                   // F8 = wr
-    FMOVS (R5), F9                   // F9 = wi
-
-    // oddRe = 0.5 * (wr*diffIm + wi*diffRe)
-    FMULS F8, F7, F10                // F10 = wr * diffIm
-    FMULS F9, F6, F11                // F11 = wi * diffRe
-    FADDS F10, F11, F10              // F10 = wr*diffIm + wi*diffRe
-    FMULS F10, F13, F10              // F10 = oddRe
-
-    // oddIm = 0.5 * (wi*diffIm - wr*diffRe)
-    FMULS F9, F7, F11                // F11 = wi * diffIm
-    FMULS F8, F6, F12                // F12 = wr * diffRe
-    FSUBS F12, F11, F11              // F11 = wi*diffIm - wr*diffRe
-    FMULS F11, F13, F11              // F11 = oddIm
-
-    // output = even + odd
-    FADDS F4, F10, F0                // F0 = outRe
-    FADDS F5, F11, F1                // F1 = outIm
-
-    // Store
-    FMOVS F0, (R0)
-    FMOVS F1, (R1)
-
-    // Advance pointers
-    ADD $4, R2
-    ADD $4, R3
-    ADD $4, R4
-    ADD $4, R5
-    ADD $4, R0
-    ADD $4, R1
-    ADD $1, R7                       // k++
-
-    SUB $1, R14
-    CBNZ R14, realfft_neon_scalar
+    // V30 still holds 0.5: the main loop above always ran (dispatch needs n > 4)
+    // and its body reads V30 but never writes it, so no reload is needed.
+    MOVD $1, R7                      // exactly one more iteration
+    B    realfft_neon_loop4
 
 realfft_neon_done:
     RET

--- a/f32/f32_test.go
+++ b/f32/f32_test.go
@@ -3267,7 +3267,11 @@ func realFFTUnpackRef(outRe, outIm, zRe, zIm, twRe, twIm []float32, n int) {
 }
 
 func TestRealFFTUnpack(t *testing.T) {
-	sizes := []int{2, 3, 4, 5, 8, 9, 16, 17, 31, 32, 33, 63, 64, 65, 128, 256, 512, 1000}
+	// 6 and 7 sit between 5 and 8 to cover the 4-wide NEON overlapping remainder
+	// block (#225) at its smallest anchors: n = 6 is the lone-leftover case
+	// ((n-1)%4 == 1), n = 7 is (n-1)%4 == 2. Both re-anchor the block at k = n-4
+	// and recompute the last bins, so a mis-anchored block shows up here.
+	sizes := []int{2, 3, 4, 5, 6, 7, 8, 9, 16, 17, 31, 32, 33, 63, 64, 65, 128, 256, 512, 1000}
 
 	for _, n := range sizes {
 		t.Run(fmt.Sprintf("n=%d", n), func(t *testing.T) {
@@ -3512,15 +3516,19 @@ func realFFTUnpack32Close(got, want float32) bool {
 func TestRealFFTUnpack_OverRead(t *testing.T) {
 	const pad = 16 // two 8-wide AVX blocks of NaN guard band on each side of z
 	// n > minAVXElements (8) is what dispatches to AVX. 9 to 16 sweeps (n-1)%8
-	// through all of 0..7, so the 8-wide AVX path is hit at every remainder
-	// length and at its minimum reverse index; that range also covers (n-1)%4 for
-	// the 4-wide NEON path. The larger sizes add multi-iteration reverse walks.
+	// through all of 0..7, so the 8-wide AVX path is hit at every remainder length
+	// and at its minimum reverse index. n = 5..8 does the same for the 4-wide NEON
+	// path: n > 4 is what dispatches to NEON, and that range sweeps (n-1)%4 through
+	// 0..3. The larger sizes add multi-iteration reverse walks.
 	//
-	// This is the test that bounds the overlapping remainder block (#215). That
-	// block re-anchors at k = n-8 and mirror-reads zRe[1..8] whatever n is, so at
-	// n = 9 its forward and mirror windows are the same 8 elements and both sit
-	// hard against the ends of z; a guard band violation would show up here first.
-	for _, n := range []int{9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 31, 32, 33, 64, 65} {
+	// This is the test that bounds the overlapping remainder blocks. On amd64 the
+	// AVX block (#215) re-anchors at k = n-8 and mirror-reads zRe[1..8] whatever n
+	// is, so at n = 9 its forward and mirror windows are the same 8 elements and
+	// both sit hard against the ends of z. On arm64 the NEON block (#225)
+	// re-anchors at k = n-4 and mirror-reads zRe[1..4], so n = 6..8 puts its
+	// windows hard against the ends the same way; a guard band violation on either
+	// path shows up here first.
+	for _, n := range []int{5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 31, 32, 33, 64, 65} {
 		t.Run(fmt.Sprintf("n=%d", n), func(t *testing.T) {
 			nan := float32(math.NaN())
 			zReBack := make([]float32, pad+n+pad)
@@ -3789,18 +3797,23 @@ func BenchmarkRealFFTUnpack(b *testing.B) {
 	}
 }
 
-// BenchmarkRealFFTUnpackTail sweeps one full remainder cycle at the smallest
+// BenchmarkRealFFTUnpackTail sweeps full remainder cycles at the smallest
 // dispatched sizes, so the per-tail-length cost is visible as a slope across
-// adjacent rows. n = 9 is the first size the AVX kernel takes (the guard is
-// n > minAVXElements with minAVXElements == 8) and has an empty remainder,
-// (n-1)%8 == 0; n = 16 has the longest one, (n-1)%8 == 7. The shipped size list
-// in BenchmarkRealFFTUnpack holds only those two extremes and nothing between,
-// which is what makes a change in remainder handling hard to read there.
+// adjacent rows. The range starts at n = 5, the first size the 4-wide NEON
+// kernel takes (its guard is n > 4), and n = 5..8 is one full (n-1)%4 cycle
+// through 0..3. n = 9 is the first size the 8-wide AVX kernel takes (its guard
+// is n > minAVXElements with minAVXElements == 8), and n = 9..16 is one full
+// (n-1)%8 cycle. The shipped size list in BenchmarkRealFFTUnpack holds only the
+// empty and maximal remainders and nothing between, which is what makes a change
+// in remainder handling hard to read there.
 //
-// The NEON kernel is 4 wide, so this range covers two of its cycles rather than
-// one; the same slope reading applies per group of four.
+// Which kernel a row measures is arch-dependent: on arm64 every row from n = 5
+// up dispatches to NEON; on amd64 the SIMD_5..8 rows fall to the Go path (AVX
+// needs n > 8), so they read the same as their Go_ siblings there. Reading the
+// NEON tail slope wants the arm64 numbers at n = 5..8, the amd64 AVX slope the
+// n = 9..16 rows.
 func BenchmarkRealFFTUnpackTail(b *testing.B) {
-	for n := 9; n <= 16; n++ {
+	for n := 5; n <= 16; n++ {
 		b.Run(fmt.Sprintf("SIMD_%d", n), func(b *testing.B) {
 			benchRealFFTUnpack32(b, n, benchRealFFTUnpack32Dispatched)
 		})


### PR DESCRIPTION
## What

Replace the per-element scalar remainder in the f32 ARM64 NEON real-FFT unpack kernel (`realFFTUnpackNEON`) with one more full 4-wide NEON block anchored at `k = n-4`, overlapping the block just written. This is the arm64 half of #215; #220 already did it on amd64 for `realFFTUnpackAVX`, and it was held back here only because there was no arm64 tail-cost measurement at the time.

## Why it is safe

Each output bin is a pure function of the inputs (`zRe`/`zIm` at `k` and the mirror `n-k`, plus the twiddles at `k-1`) and reads nothing a previous bin produced, so recomputing the last few bins stores bit-identical values. The overlap block re-enters the existing main loop body with the counter set to one, then falls through the remainder check a second time with the leftover count zeroed, so it terminates without a separate scalar path. The top-of-function guard now branches straight to the done label when the main loop would not run (undispatched `n <= 4`, where the anchor `k = n-4` would over-read `z` and underflow the twiddles); writing nothing is the memory-safe answer, matching `realFFTUnpackAVX`.

The tail bins move from the old unfused scalar arithmetic to the main loop's fused FMLA/FMLS. That is consistent with the kernel already fusing in its main loop; it is not in `singleRoundingKernels`, so `TestNoFMAContract` does not bind it. The overlap adds no new `WORD` encodings, so the asmcheck cross-check is unaffected.

## Measurement (the decision gate)

Measured on a Raspberry Pi 5 (Cortex-A76), pinned to one core, `GOMAXPROCS=1`, 15 interleaved A/B rounds through `BenchmarkRealFFTUnpackTail`. The remainder cost went from linear in the leftover length to constant. sec/op at the smallest dispatched sizes (one full NEON remainder cycle):

| n | leftover | before | after | delta |
|---|---|---|---|---|
| 5 | 0 | 29.99n | 30.11n | ~ (wash, no overlap) |
| 6 | 1 | 36.28n | 36.01n | -0.74% (wash) |
| 7 | 2 | 40.02n | 34.29n | -14.3% |
| 8 | 3 | 46.61n | 34.01n | -27.0% |

The same flattening repeats across n=9..12 and n=13..16. The lone-leftover size (n=6) is a wash, not a regression, so no `leftover >= 2` gate is needed (unlike #170 on amd64).

## Tests

Extend `BenchmarkRealFFTUnpackTail` to start at n=5 (the smallest NEON-dispatched size), add value-parity coverage at n=6,7, and add over-read coverage at n=5..8, so the overlap block is exercised at its smallest anchors. Full f32 suite passes on amd64 and natively on the arm64 rpi5.

Fixes #225
