### PR TITLE
f32,f64: fused polyphase cubic resampler (PolyphaseResampleCubic)

### DIFF
--- a/README.md
+++ b/README.md
@@ -227,6 +227,7 @@ roughly 30x to under 2x, so the small-span stages stop dominating the transform.
 |                 | `InterleaveN(dst, srcs)`            | Pack N planar streams (any N; N-stream Interleave2) | N=2,4,8 AVX, N=3,6 AVX2 / N=2,3,4 NEON; else Go |
 |                 | `DeinterleaveN(dsts, src)`          | Unpack N interleaved streams (any N) | N=2,4,8 AVX, N=3,6 AVX2 / N=2,3,4 NEON; else Go |
 |                 | `CubicInterpDot(hist,a,b,c,d,x)`    | Fused cubic interp dot product| 4x / 2x                             |
+|                 | `PolyphaseResampleCubic(out,hist,a,b,c,d,at,step,L,taps,fracBits)` | Fused polyphase cubic resampler (whole block in one call) | 4x / 2x |
 
 `DotProductBatch` scores its `[][]float64` rows in groups of four, keeping the
 query vector resident in registers across each group via a fused 4-row kernel on
@@ -884,6 +885,27 @@ a Raspberry Pi 5):
 | 64 taps, 2x decimate  | **2.0x** | **1.9x** | **1.7x** | **1.3x** |
 | 241 taps, 2x decimate | **1.6x** | **1.2x** | **1.2x** | **1.1x** |
 | 241 taps, 4x decimate | **1.3x** | **1.2x** | **1.2x** | **1.1x** |
+
+#### PolyphaseResampleCubic (fused polyphase cubic resampler)
+
+`PolyphaseResampleCubic` runs a whole block of soxr-style polyphase resampling
+with cubic sub-phase coefficient interpolation in one call. Issue #52 required
+measuring it first: the honest baseline is not the naive per-output loop but the
+best pure-Go resampler-side fix, an incremental phase-stepping accumulator (no
+per-output integer division) that calls the already-SIMD `CubicInterpDot` once
+per output. The fused kernel keeps the div/phase/frac state machine in registers
+across the block and removes the per-output Go-to-asm call, dispatch and
+slice-header overhead, so the win is largest at the short tap counts a real
+resampler runs at. Both paths are bit-identical (the fused dot reuses
+`CubicInterpDot`'s inner body verbatim under the same feature gate). numPhases 80,
+1024-output block, allocation-free, measured against the pure-Go StepLoop (AVX+FMA
+on x86-64, NEON on a Raspberry Pi 5):
+
+| Config             | f32 x86 | f32 NEON |
+| ------------------ | ------- | -------- |
+| 16 taps            | **2.3x** | **2.1x** |
+| 20 taps            | **1.7x** | **2.0x** |
+| 32 taps            | **1.9x** | **1.8x** |
 
 #### ConvolveValidMaxAbs (fused valid convolution + abs-max peak)
 

--- a/doc.go
+++ b/doc.go
@@ -88,7 +88,7 @@
 // Transcendental (f32/f64): Log, Log2, Log10, Pow, PowElem (plus LogInPlace, PowInPlace),
 // SIMD-accelerated on AVX2+FMA and NEON
 //
-// Audio DSP: Interleave2, Deinterleave2, ConvolveValid, ConvolveValidMulti, ConvolveValidMaxAbs, ConvolveValidMaxAbsMulti, ConvolveDecimate, AccumulateAdd, CumulativeSum, CubicInterpDot, Int32ToFloat32Scale, Int16ToFloat32Scale, Float32ToInt16Scale
+// Audio DSP: Interleave2, Deinterleave2, ConvolveValid, ConvolveValidMulti, ConvolveValidMaxAbs, ConvolveValidMaxAbsMulti, ConvolveDecimate, AccumulateAdd, CumulativeSum, CubicInterpDot, PolyphaseResampleCubic, Int32ToFloat32Scale, Int16ToFloat32Scale, Float32ToInt16Scale
 //
 // Sliding-window argmin (f32): MinIdxOfSum, MinIdxOfSumRows (batched sliding-window argmin of a[i]+k[base+r*slide+i], first-index-wins ties, bit-exact across all paths)
 //

--- a/f32/f32.go
+++ b/f32/f32.go
@@ -696,6 +696,103 @@ func minLen5(a, b, c, d, e int) int {
 	return min(a, b, c, d, e)
 }
 
+// polyphaseMaxFracBits32 is the largest sub-phase fractional width for which
+// float32(frac) is exact for every frac in [0, 1<<fracBits). float32 has a 24-bit
+// significand, so integers below 2^24 round-trip exactly; at fracBits == 24 the
+// largest frac is 2^24-1, still exact. Above 24 the frac-to-float conversion
+// would round and x = float32(frac) * fracScale would stop matching the consumer
+// bit-for-bit, so PolyphaseResampleCubic rejects it.
+const polyphaseMaxFracBits32 = 24
+
+// PolyphaseResampleCubic resamples hist into out with soxr-style polyphase FIR
+// filtering and cubic sub-phase coefficient interpolation, running the whole
+// output block in one fused pass. It is the fused form of a per-output loop that
+// calls [CubicInterpDot]: for each output it derives the input window and the
+// interpolation phase from a fixed-point accumulator, evaluates
+//
+//	out[k] = Σ hist[div+i] * (a[phase][i] + x*(b[phase][i] + x*(c[phase][i] + x*d[phase][i])))
+//
+// over tapsPerPhase taps, then advances the accumulator by step. The coefficient
+// banks a, b, c, d are indexed [phase][tap] and hold the Catmull-Rom cubic
+// interpolation coefficients (base, linear, quadratic, cubic); they match
+// go-audio-resampler's bank layout directly. Only the first numPhases rows are
+// read, and only the first tapsPerPhase taps of each; longer rows are fine.
+//
+// The accumulator is fixed-point: at = (inputIndex*numPhases + phase) <<
+// fracBits + frac, and step is the per-output increment in the same units. fracBits
+// is the sub-phase fractional width (soxr uses 16). x = float32(frac) * 2^-fracBits
+// is the sub-phase position in [0, 1). numPhases is soxr's L. Output k is produced
+// only while k < len(out) and div+tapsPerPhase <= len(hist); the first output not
+// satisfying the window bound ends the block.
+//
+// It returns n, the number of outputs written to out[:n], and atOut, the
+// accumulator after n outputs. atOut == at + int64(n)*step exactly, so streaming
+// callers carry atOut into the next call as the new at (rebasing at by
+// consumed*numPhases<<fracBits when they drop consumed input samples from hist, as
+// go-audio-resampler does). The internal (div, phase, frac) are re-derived from
+// the single int64 accumulator on the next call and are never exposed.
+//
+// PolyphaseResampleCubic validates its inputs and is a no-op returning (0, at)
+// (never an error, never a panic) if any of these do not hold: numPhases >= 1,
+// tapsPerPhase >= 1, step >= 1, at >= 0, 0 <= fracBits <= 24, len(a|b|c|d) >=
+// numPhases, every one of the first numPhases rows of each bank has length >=
+// tapsPerPhase, and at + int64(len(out))*step does not overflow int64.
+// Degenerate but valid inputs (len(out) == 0, len(hist) <
+// tapsPerPhase, or an initial window already past the end of hist) also yield
+// (0, at) because no output satisfies the window bound.
+//
+// Uses AVX+FMA on AMD64 and NEON on ARM64 for tapsPerPhase past the vector width,
+// gated on the same CPU features and tap threshold as [CubicInterpDot] so the
+// fused result is bit-identical to the per-output form on every CPU; below the
+// threshold it uses the pure-Go path. It allocates nothing.
+func PolyphaseResampleCubic(out, hist []float32, a, b, c, d [][]float32, at, step int64, numPhases, tapsPerPhase, fracBits int) (n int, atOut int64) {
+	if numPhases < 1 || tapsPerPhase < 1 || step < 1 || at < 0 ||
+		fracBits < 0 || fracBits > polyphaseMaxFracBits32 {
+		return 0, at
+	}
+	if len(a) < numPhases || len(b) < numPhases || len(c) < numPhases || len(d) < numPhases {
+		return 0, at
+	}
+	for p := range numPhases {
+		if len(a[p]) < tapsPerPhase || len(b[p]) < tapsPerPhase ||
+			len(c[p]) < tapsPerPhase || len(d[p]) < tapsPerPhase {
+			return 0, at
+		}
+	}
+	// Reject inputs whose block accumulator could overflow int64. The loop runs
+	// at most len(out) times, so at+len(out)*step bounds every accumulator value;
+	// if that product would overflow, the internal div wraps negative and defeats
+	// the window guard (a panic on the Go path, an out-of-range read on the SIMD
+	// paths), and atOut would no longer equal at+n*step. Real resamplers keep step
+	// and at far below this, so no legitimate input is rejected.
+	if outLen := int64(len(out)); outLen > 0 && step > (math.MaxInt64-at)/outLen {
+		return 0, at
+	}
+	n = polyphaseResampleCubic32(out, hist, a, b, c, d, at, step, numPhases, tapsPerPhase, fracBits)
+	return n, at + int64(n)*step
+}
+
+// PolyphaseResampleCubicUnsafe is [PolyphaseResampleCubic] without input
+// validation, for performance-critical callers that have already checked their
+// arguments.
+//
+// PRECONDITIONS (caller must ensure):
+//   - numPhases >= 1, tapsPerPhase >= 1, step >= 1, at >= 0
+//   - 0 <= fracBits <= 24
+//   - len(a), len(b), len(c), len(d) each >= numPhases
+//   - each of the first numPhases rows of a, b, c, d has length >= tapsPerPhase
+//   - at + int64(len(out))*step does not overflow int64
+//
+// Violating these preconditions results in undefined behavior. Unlike the safe
+// form, this variant does not reject an overflowing at/step, so a caller that
+// breaks the last precondition can drive the internal accumulator to wrap and
+// read out of range. When the preconditions hold it returns the same (n, atOut)
+// as the safe form.
+func PolyphaseResampleCubicUnsafe(out, hist []float32, a, b, c, d [][]float32, at, step int64, numPhases, tapsPerPhase, fracBits int) (n int, atOut int64) {
+	n = polyphaseResampleCubic32(out, hist, a, b, c, d, at, step, numPhases, tapsPerPhase, fracBits)
+	return n, at + int64(n)*step
+}
+
 // ConvolveValidMulti applies multiple kernels to the same signal.
 // dsts[k][i] = sum(signal[i+j] * kernels[k][j]) for each kernel k.
 // All kernels must have the same length.

--- a/f32/f32_amd64.go
+++ b/f32/f32_amd64.go
@@ -1083,6 +1083,25 @@ func cubicInterpDot32(hist, a, b, c, d []float32, x float32) float32 {
 //go:noescape
 func cubicInterpDotAVX(hist, a, b, c, d []float32, x float32) float32
 
+// polyphaseResampleCubic32 dispatches the fused polyphase cubic resampler. The
+// guard matches cubicInterpDot32 exactly (cpu.X86.AVX && cpu.X86.FMA &&
+// tapsPerPhase >= minAVXElements) so the fused kernel's per-output dot always
+// selects the same tier as a standalone CubicInterpDot at the same tap count,
+// making the fused result bit-identical to the per-output form on every CPU.
+func polyphaseResampleCubic32(out, hist []float32, a, b, c, d [][]float32, at, step int64, numPhases, tapsPerPhase, fracBits int) int {
+	if cpu.X86.AVX && cpu.X86.FMA && tapsPerPhase >= minAVXElements {
+		return polyphaseResampleCubicAVX(out, hist, a, b, c, d, at, step, numPhases, tapsPerPhase, fracBits)
+	}
+	return polyphaseResampleCubicGo(out, hist, a, b, c, d, at, step, numPhases, tapsPerPhase, fracBits)
+}
+
+// polyphaseResampleCubicAVX runs the whole output block in one fused AVX+FMA pass,
+// reusing cubicInterpDotAVX's inner dot body per output. Returns the number of
+// outputs written. See f32_amd64.s.
+//
+//go:noescape
+func polyphaseResampleCubicAVX(out, hist []float32, a, b, c, d [][]float32, at, step int64, numPhases, tapsPerPhase, fracBits int) int
+
 func sigmoid32(dst, src []float32) {
 	// Requires AVX2: sigmoidAVX reconstructs 2^k with 256-bit YMM integer ops
 	// (VCVTPS2DQ/VPSLLD/VPADDD) that do not exist on AVX1-only CPUs. Gating on

--- a/f32/f32_amd64.s
+++ b/f32/f32_amd64.s
@@ -3925,6 +3925,237 @@ cubic32_avx_done:
     VZEROUPPER
     RET
 
+// func polyphaseResampleCubicAVX(out, hist []float32, a, b, c, d [][]float32,
+//                                at, step int64, numPhases, tapsPerPhase, fracBits int) int
+//
+// Fused polyphase cubic resampler: runs the whole output block in one pass,
+// reusing cubicInterpDotAVX's inner dot body verbatim for each output. Returns
+// the number of outputs written.
+//
+// The outer stepping state machine keeps div, phase, frac, k and the delta sDiv
+// in registers across the inner dot (which only clobbers SI/DI/R8/R9/R10/CX/AX
+// and Y0-Y7); loop-invariant scalars are reloaded from FP. sPhase and sFrac are
+// re-derived from step per output with a multiply, not a divide, so no division
+// runs in the hot loop. x is splat AVX1-clean (VSHUFPS + VINSERTF128, no
+// register-source VBROADCASTSS). Reserved registers R14/R15/BP are never touched.
+//
+// Persistent registers across the whole loop:
+//   BX  = div
+//   DX  = phase
+//   R11 = frac
+//   R12 = k (output index)
+//   R13 = sDiv
+//   X8  = fracScale (2^-fracBits, scalar)
+//
+// Frame layout (6 slices + 2 int64 + 3 int + 1 return):
+//   out:  base+0,  len+8,  cap+16
+//   hist: base+24, len+32, cap+40
+//   a:    base+48, len+56, cap+64
+//   b:    base+72, len+80, cap+88
+//   c:    base+96, len+104, cap+112
+//   d:    base+120,len+128, cap+136
+//   at:          +144 (int64)
+//   step:        +152 (int64)
+//   numPhases:   +160 (int)
+//   tapsPerPhase:+168 (int)
+//   fracBits:    +176 (int)
+//   ret:         +184 (int)
+TEXT ·polyphaseResampleCubicAVX(SB), NOSPLIT, $0-192
+    MOVQ fracBits+176(FP), CX      // CX = fracBits (shift count)
+    MOVQ numPhases+160(FP), R8     // R8 = numPhases
+
+    // sDiv = (step >> fracBits) / numPhases  (one division, hoisted out of loop)
+    MOVQ step+152(FP), AX
+    SARQ CX, AX                    // AX = sFull = step >> fracBits
+    XORQ DX, DX
+    DIVQ R8                        // AX = sDiv, DX = sPhase (discarded; re-derived)
+    MOVQ AX, R13                   // R13 = sDiv
+
+    // Seed div, phase, frac from at.
+    MOVQ at+144(FP), R11           // R11 = at (reused as frac after masking)
+    MOVQ R11, AX
+    SARQ CX, AX                    // AX = full = at >> fracBits
+    XORQ DX, DX
+    DIVQ R8                        // AX = div, DX = phase
+    MOVQ AX, BX                    // BX = div
+                                   // DX = phase (kept)
+    MOVQ $1, SI
+    SHLQ CX, SI                    // SI = 1 << fracBits
+    DECQ SI                        // SI = fracMask
+    ANDQ SI, R11                   // R11 = frac = at & fracMask
+
+    // fracScale = 2^-fracBits as float32: bits = (127 - fracBits) << 23.
+    MOVQ $127, AX
+    SUBQ CX, AX
+    SHLQ $23, AX
+    VMOVD AX, X8                   // X8 = fracScale (scalar lane 0)
+
+    XORQ R12, R12                  // k = 0
+
+prcubic_loop:
+    // k < len(out) ?
+    MOVQ out_len+8(FP), AX
+    CMPQ R12, AX
+    JGE  prcubic_done
+    // div + tapsPerPhase <= len(hist) ?  (else stop)
+    MOVQ tapsPerPhase+168(FP), CX  // CX = taps (also the inner dot length)
+    MOVQ BX, AX
+    ADDQ CX, AX                    // AX = div + taps
+    MOVQ hist_len+32(FP), SI
+    CMPQ AX, SI
+    JGT  prcubic_done
+
+    // x = float32(frac) * fracScale, broadcast to Y7 (AVX1-clean).
+    VCVTSI2SSQ R11, X7, X7         // X7 = float32(frac)
+    VMULSS   X8, X7, X7            // X7 = x (lane 0)
+    VSHUFPS  $0, X7, X7, X7        // X7 = [x,x,x,x]
+    VINSERTF128 $1, X7, Y7, Y7     // Y7 = [x x x x x x x x]
+
+    // Row pointers for this phase: byte offset = phase*24 (Go slice header size).
+    LEAQ (DX)(DX*2), AX            // AX = 3*phase
+    SHLQ $3, AX                    // AX = 24*phase
+    MOVQ a_base+48(FP), SI
+    MOVQ (SI)(AX*1), DI            // DI = &a[phase][0]
+    MOVQ b_base+72(FP), SI
+    MOVQ (SI)(AX*1), R8            // R8 = &b[phase][0]
+    MOVQ c_base+96(FP), SI
+    MOVQ (SI)(AX*1), R9            // R9 = &c[phase][0]
+    MOVQ d_base+120(FP), SI
+    MOVQ (SI)(AX*1), R10           // R10 = &d[phase][0]
+    // hist window base = &hist[div]
+    MOVQ hist_base+24(FP), SI
+    LEAQ (SI)(BX*4), SI            // SI = &hist[div]
+
+    // ---- inner dot body, verbatim from cubicInterpDotAVX (CX = taps) ----
+    VXORPS Y0, Y0, Y0              // acc0 (re-zeroed per output)
+    VXORPS Y6, Y6, Y6              // acc1
+    MOVQ CX, AX
+    SHRQ $4, AX                    // AX = taps / 16
+    JZ   prcubic_loop8_check
+
+prcubic_loop16:
+    VMOVUPS 0(R9), Y1
+    VMOVUPS 32(R9), Y2
+    VMOVUPS 0(R10), Y5
+    VFMADD231PS Y5, Y7, Y1         // Y1 = d*x + c
+    VMOVUPS 32(R10), Y5
+    VFMADD231PS Y5, Y7, Y2
+    VMOVUPS 0(R8), Y5
+    VFMADD213PS Y5, Y7, Y1         // Y1 = Y1*x + b
+    VMOVUPS 32(R8), Y5
+    VFMADD213PS Y5, Y7, Y2
+    VMOVUPS 0(DI), Y3
+    VFMADD213PS Y3, Y7, Y1         // Y1 = Y1*x + a
+    VMOVUPS 32(DI), Y4
+    VFMADD213PS Y4, Y7, Y2
+    VMOVUPS 0(SI), Y5
+    VFMADD231PS Y5, Y1, Y0         // acc0 += hist * coef
+    VMOVUPS 32(SI), Y5
+    VFMADD231PS Y5, Y2, Y6         // acc1 += hist * coef
+    ADDQ $64, SI
+    ADDQ $64, DI
+    ADDQ $64, R8
+    ADDQ $64, R9
+    ADDQ $64, R10
+    DECQ AX
+    JNZ  prcubic_loop16
+    VADDPS Y6, Y0, Y0
+
+prcubic_loop8_check:
+    ANDQ $15, CX
+    MOVQ CX, AX
+    SHRQ $3, AX
+    JZ   prcubic_remainder
+
+prcubic_loop8:
+    VMOVUPS (R10), Y1
+    VMOVUPS (R9), Y2
+    VMOVUPS (R8), Y3
+    VMOVUPS (DI), Y4
+    VMOVUPS (SI), Y5
+    VFMADD231PS Y1, Y7, Y2         // Y2 = d*x + c
+    VFMADD231PS Y2, Y7, Y3         // Y3 = (d*x+c)*x + b
+    VFMADD231PS Y3, Y7, Y4         // Y4 = coef
+    VFMADD231PS Y5, Y4, Y0         // acc += hist * coef
+    ADDQ $32, SI
+    ADDQ $32, DI
+    ADDQ $32, R8
+    ADDQ $32, R9
+    ADDQ $32, R10
+    DECQ AX
+    JNZ  prcubic_loop8
+
+prcubic_remainder:
+    VEXTRACTF128 $1, Y0, X1
+    VADDPS X1, X0, X0
+    VHADDPS X0, X0, X0
+    VHADDPS X0, X0, X0             // X0[0] = sum of 8 lanes
+    ANDQ $7, CX
+    JZ   prcubic_store
+
+prcubic_scalar:
+    VMOVSS (R10), X1
+    VMOVSS (R9), X2
+    VMOVSS (R8), X3
+    VMOVSS (DI), X4
+    VMOVSS (SI), X5
+    VFMADD231SS X1, X7, X2         // X7 lane0 = x
+    VFMADD231SS X2, X7, X3
+    VFMADD231SS X3, X7, X4
+    VFMADD231SS X5, X4, X0
+    ADDQ $4, SI
+    ADDQ $4, DI
+    ADDQ $4, R8
+    ADDQ $4, R9
+    ADDQ $4, R10
+    DECQ CX
+    JNZ  prcubic_scalar
+
+prcubic_store:
+    MOVQ out_base+0(FP), AX
+    VMOVSS X0, (AX)(R12*4)         // out[k] = result
+
+    // ---- advance the state machine ----
+    // sFrac = step & fracMask;  frac += sFrac
+    MOVQ fracBits+176(FP), CX
+    MOVQ $1, SI
+    SHLQ CX, SI                    // SI = 1 << fracBits
+    MOVQ SI, DI                    // DI = 1 << fracBits (= fracMask+1)
+    DECQ SI                        // SI = fracMask
+    MOVQ step+152(FP), AX
+    ANDQ AX, SI                    // SI = step & fracMask = sFrac
+    ADDQ SI, R11                   // frac += sFrac
+    // if frac > fracMask { frac -= fracMask+1; phase++ }
+    MOVQ DI, SI
+    DECQ SI                        // SI = fracMask
+    CMPQ R11, SI
+    JLE  prcubic_nocarry
+    SUBQ DI, R11                   // frac -= (fracMask+1)
+    INCQ DX                        // phase++
+prcubic_nocarry:
+    // sPhase = (step>>fracBits) - sDiv*numPhases;  phase += sPhase;  div += sDiv
+    MOVQ step+152(FP), AX
+    SARQ CX, AX                    // AX = sFull
+    MOVQ numPhases+160(FP), SI     // SI = numPhases
+    MOVQ R13, DI
+    IMULQ SI, DI                   // DI = sDiv*numPhases
+    SUBQ DI, AX                    // AX = sPhase
+    ADDQ AX, DX                    // phase += sPhase
+    ADDQ R13, BX                   // div += sDiv
+    // if phase >= numPhases { phase -= numPhases; div++ }
+    CMPQ DX, SI
+    JLT  prcubic_nonorm
+    SUBQ SI, DX
+    INCQ BX
+prcubic_nonorm:
+    INCQ R12                       // k++
+    JMP  prcubic_loop
+
+prcubic_done:
+    MOVQ R12, ret+184(FP)
+    VZEROUPPER
+    RET
+
 // Constants for exp/sigmoid computation using range reduction + polynomial
 // exp(x) = 2^k * exp(r) where k = round(x * log2e), r = x - k * ln2
 // Then polynomial approximation for exp(r) on [-ln2/2, ln2/2]

--- a/f32/f32_arm64.go
+++ b/f32/f32_arm64.go
@@ -677,6 +677,25 @@ func cubicInterpDot32(hist, a, b, c, d []float32, x float32) float32 {
 //go:noescape
 func cubicInterpDotNEON(hist, a, b, c, d []float32, x float32) float32
 
+// polyphaseResampleCubic32 dispatches the fused polyphase cubic resampler. The
+// NEON guard matches cubicInterpDot32 (hasNEON && tapsPerPhase >= 4) so the fused
+// kernel's per-output dot selects the same tier as a standalone CubicInterpDot at
+// the same tap count, making the fused result bit-identical to the per-output
+// form.
+func polyphaseResampleCubic32(out, hist []float32, a, b, c, d [][]float32, at, step int64, numPhases, tapsPerPhase, fracBits int) int {
+	if hasNEON && tapsPerPhase >= 4 {
+		return polyphaseResampleCubicNEON(out, hist, a, b, c, d, at, step, numPhases, tapsPerPhase, fracBits)
+	}
+	return polyphaseResampleCubicGo(out, hist, a, b, c, d, at, step, numPhases, tapsPerPhase, fracBits)
+}
+
+// polyphaseResampleCubicNEON runs the whole output block in one fused NEON pass,
+// reusing cubicInterpDotNEON's inner dot body per output. Returns the number of
+// outputs written. See f32_arm64.s.
+//
+//go:noescape
+func polyphaseResampleCubicNEON(out, hist []float32, a, b, c, d [][]float32, at, step int64, numPhases, tapsPerPhase, fracBits int) int
+
 func sigmoid32(dst, src []float32) {
 	// Assumes len(src) >= len(dst); caller ensures this via public API
 	if hasNEON && len(dst) >= 4 {

--- a/f32/f32_arm64.s
+++ b/f32/f32_arm64.s
@@ -1466,6 +1466,205 @@ cubic32_neon_done:
     FMOVS F0, ret+128(FP)
     RET
 
+// func polyphaseResampleCubicNEON(out, hist []float32, a, b, c, d [][]float32,
+//                                 at, step int64, numPhases, tapsPerPhase, fracBits int) int
+//
+// Fused polyphase cubic resampler (float32, NEON): runs the whole output block in
+// one pass, reusing cubicInterpDotNEON's inner dot body (same V registers, same
+// WORD-encoded FMLA/FADD/DUP) for each output so the per-output dot is
+// bit-identical to the standalone kernel. Returns the number of outputs written.
+//
+// The outer stepping state lives in R19-R25 (permanent scratch), which the inner
+// body (R0-R7, V0-V31) never touches. sPhase and sFrac are re-derived from step
+// per output with a multiply, not a divide. x is built with SCVTFS + FMULS and
+// broadcast with the same DUP encoding the standalone kernel uses. Reserved
+// registers R28/R27/R18/R16/R17 are never touched.
+//
+// Persistent registers across the whole loop:
+//   R19 = div
+//   R20 = phase
+//   R21 = frac
+//   R22 = k (output index)
+//   R23 = sDiv
+//   R24 = numPhases
+//   R25 = fracBits
+//   F30 = fracScale (2^-fracBits, scalar)
+//   V31 = x broadcast (F31 lane 0 = x for the scalar tail)
+//
+// Frame layout (6 slices + 2 int64 + 3 int + 1 return):
+//   out:  base+0,  len+8
+//   hist: base+24, len+32
+//   a:    base+48
+//   b:    base+72
+//   c:    base+96
+//   d:    base+120
+//   at:          +144
+//   step:        +152
+//   numPhases:   +160
+//   tapsPerPhase:+168
+//   fracBits:    +176
+//   ret:         +184
+TEXT ·polyphaseResampleCubicNEON(SB), NOSPLIT, $0-192
+    MOVD fracBits+176(FP), R25     // R25 = fracBits
+    MOVD numPhases+160(FP), R24    // R24 = numPhases
+
+    // sDiv = (step >> fracBits) / numPhases  (one division, hoisted)
+    MOVD step+152(FP), R0
+    LSR  R25, R0, R0               // R0 = sFull = step >> fracBits
+    UDIV R24, R0, R23              // R23 = sDiv = sFull / numPhases
+
+    // Seed div, phase, frac from at.
+    MOVD at+144(FP), R21           // R21 = at (masked to frac below)
+    LSR  R25, R21, R0              // R0 = full = at >> fracBits
+    UDIV R24, R0, R19              // R19 = div = full / numPhases
+    MUL  R24, R19, R1              // R1 = div*numPhases
+    SUB  R1, R0, R20               // R20 = phase = full - div*numPhases
+    MOVD $1, R1
+    LSL  R25, R1, R1               // R1 = 1<<fracBits
+    SUB  $1, R1, R1                // R1 = fracMask
+    AND  R1, R21, R21              // R21 = frac = at & fracMask
+
+    // fracScale = 2^-fracBits as float32: bits = (127 - fracBits) << 23.
+    MOVD $127, R0
+    SUB  R25, R0, R0
+    LSL  $23, R0, R0
+    FMOVS R0, F30                  // F30 = fracScale
+
+    MOVD $0, R22                   // k = 0
+
+prcubic_neon_loop:
+    MOVD out_len+8(FP), R7
+    CMP  R7, R22
+    BGE  prcubic_neon_done         // k >= len(out)
+    MOVD tapsPerPhase+168(FP), R6  // R6 = taps (inner dot length)
+    ADD  R6, R19, R8               // R8 = div + taps
+    MOVD hist_len+32(FP), R7
+    CMP  R7, R8
+    BGT  prcubic_neon_done         // div + taps > len(hist)
+
+    // x = float32(frac) * fracScale, broadcast to V31.
+    SCVTFS R21, F31                // F31 = float32(frac)
+    FMULS  F30, F31, F31           // F31 = x (lane 0)
+    WORD $0x4E0407FF               // DUP V31.4S, V31.S[0]
+
+    // Row pointers: byte offset = phase*24.
+    MOVD $24, R7
+    MUL  R7, R20, R8               // R8 = phase*24
+    MOVD a_base+48(FP), R9
+    MOVD (R9)(R8), R1              // R1 = &a[phase][0]
+    MOVD b_base+72(FP), R9
+    MOVD (R9)(R8), R2             // R2 = &b[phase][0]
+    MOVD c_base+96(FP), R9
+    MOVD (R9)(R8), R3             // R3 = &c[phase][0]
+    MOVD d_base+120(FP), R9
+    MOVD (R9)(R8), R4             // R4 = &d[phase][0]
+    MOVD hist_base+24(FP), R9
+    ADD  R19<<2, R9, R0           // R0 = &hist[div]
+
+    // ---- inner dot body, V registers verbatim from cubicInterpDotNEON ----
+    VEOR V0.B16, V0.B16, V0.B16   // acc0 = 0
+    VEOR V1.B16, V1.B16, V1.B16   // acc1 = 0
+    LSR  $3, R6, R5               // R5 = taps / 8
+    CBZ  R5, prcubic_neon_loop4_check
+
+prcubic_neon_loop8:
+    VLD1.P 16(R4), [V2.S4]
+    VLD1.P 16(R3), [V3.S4]
+    VLD1.P 16(R2), [V4.S4]
+    VLD1.P 16(R1), [V5.S4]
+    VLD1.P 16(R0), [V6.S4]
+    VLD1.P 16(R4), [V10.S4]
+    VLD1.P 16(R3), [V11.S4]
+    VLD1.P 16(R2), [V12.S4]
+    VLD1.P 16(R1), [V13.S4]
+    VLD1.P 16(R0), [V14.S4]
+    WORD $0x4E3FCC43              // FMLA V3.4S, V2.4S, V31.4S
+    WORD $0x4E3FCC64              // FMLA V4.4S, V3.4S, V31.4S
+    WORD $0x4E3FCC85              // FMLA V5.4S, V4.4S, V31.4S
+    WORD $0x4E25CCC0              // FMLA V0.4S, V6.4S, V5.4S
+    WORD $0x4E3FCD4B              // FMLA V11.4S, V10.4S, V31.4S
+    WORD $0x4E3FCD6C              // FMLA V12.4S, V11.4S, V31.4S
+    WORD $0x4E3FCD8D              // FMLA V13.4S, V12.4S, V31.4S
+    WORD $0x4E2DCDC1              // FMLA V1.4S, V14.4S, V13.4S
+    SUB  $1, R5
+    CBNZ R5, prcubic_neon_loop8
+    WORD $0x4E21D400             // FADD V0.4S, V0.4S, V1.4S
+
+prcubic_neon_loop4_check:
+    AND  $7, R6, R5
+    LSR  $2, R5, R7              // R7 = remainder / 4
+    CBZ  R7, prcubic_neon_remainder
+    VLD1.P 16(R4), [V2.S4]
+    VLD1.P 16(R3), [V3.S4]
+    VLD1.P 16(R2), [V4.S4]
+    VLD1.P 16(R1), [V5.S4]
+    VLD1.P 16(R0), [V6.S4]
+    WORD $0x4E3FCC43              // FMLA V3.4S, V2.4S, V31.4S
+    WORD $0x4E3FCC64              // FMLA V4.4S, V3.4S, V31.4S
+    WORD $0x4E3FCC85              // FMLA V5.4S, V4.4S, V31.4S
+    WORD $0x4E25CCC0              // FMLA V0.4S, V6.4S, V5.4S
+
+prcubic_neon_remainder:
+    WORD $0x6E20D400             // FADDP V0.4S, V0.4S, V0.4S
+    WORD $0x7E30D800             // FADDP S0, V0.2S
+    AND  $3, R5, R7
+    CBZ  R7, prcubic_neon_store
+
+prcubic_neon_scalar:
+    FMOVS (R4), F2
+    FMOVS (R3), F3
+    FMOVS (R2), F4
+    FMOVS (R1), F5
+    FMOVS (R0), F6
+    FMADDS F31, F3, F2, F3       // F3 = d*x + c
+    FMADDS F31, F4, F3, F4       // F4 = (d*x+c)*x + b
+    FMADDS F31, F5, F4, F5       // F5 = coef
+    FMADDS F5, F0, F6, F0        // F0 = hist*coef + acc
+    ADD  $4, R0
+    ADD  $4, R1
+    ADD  $4, R2
+    ADD  $4, R3
+    ADD  $4, R4
+    SUB  $1, R7
+    CBNZ R7, prcubic_neon_scalar
+
+prcubic_neon_store:
+    MOVD out_base+0(FP), R8
+    ADD  R22<<2, R8, R8
+    FMOVS F0, (R8)                // out[k] = result
+
+    // ---- advance the state machine ----
+    // sFrac = step & fracMask;  frac += sFrac
+    MOVD step+152(FP), R0
+    MOVD $1, R1
+    LSL  R25, R1, R1              // R1 = 1<<fracBits
+    SUB  $1, R1, R2              // R2 = fracMask
+    AND  R2, R0, R0             // R0 = step & fracMask = sFrac
+    ADD  R0, R21, R21            // frac += sFrac
+    CMP  R2, R21                 // frac - fracMask
+    BLE  prcubic_neon_nocarry
+    SUB  R1, R21, R21            // frac -= (1<<fracBits)
+    ADD  $1, R20, R20            // phase++
+prcubic_neon_nocarry:
+    // sPhase = (step>>fracBits) - sDiv*numPhases;  phase += sPhase;  div += sDiv
+    MOVD step+152(FP), R0
+    LSR  R25, R0, R0             // R0 = sFull
+    MUL  R24, R23, R1            // R1 = sDiv*numPhases
+    SUB  R1, R0, R0             // R0 = sPhase
+    ADD  R0, R20, R20           // phase += sPhase
+    ADD  R23, R19, R19          // div += sDiv
+    CMP  R24, R20                // phase - numPhases
+    BLT  prcubic_neon_nonorm
+    SUB  R24, R20, R20
+    ADD  $1, R19, R19
+prcubic_neon_nonorm:
+    ADD  $1, R22, R22            // k++
+    B    prcubic_neon_loop
+
+prcubic_neon_done:
+    MOVD R22, ret+184(FP)
+    RET
+
 // func sigmoidNEON(dst, src []float32)
 // Computes accurate sigmoid: σ(x) = 1 / (1 + exp(-x))
 // Uses range reduction and polynomial approximation for exp.

--- a/f32/f32_go.go
+++ b/f32/f32_go.go
@@ -584,6 +584,64 @@ func cubicInterpDotGo(hist, a, b, c, d []float32, x float32) float32 {
 	return sum
 }
 
+// polyphaseResampleCubicGo is the pure-Go reference for PolyphaseResampleCubic.
+// It runs the incremental phase-stepping state machine (soxr-style fixed-point
+// accumulator) and evaluates every output with the scalar cubic dot
+// (cubicInterpDotGo), so its result is bit-identical to a per-sample loop that
+// calls the Go-tier cubic dot at any tap count. Callers guarantee the inputs are
+// valid; the public wrapper does the validation and this function does none. It
+// returns the number of outputs written to out.
+//
+// State machine, verified invariant ((div*numPhases+phase)<<fracBits)+frac ==
+// at+k*step at the top of iteration k. The one-time divisions seed the
+// incremental deltas; per output only adds and at most two conditional
+// subtracts run. The frac carry folds into phase BEFORE the single phase
+// normalize; one conditional subtract suffices because
+// phase(<=numPhases-1) + carry(<=1) + sPhase(<=numPhases-1) <= 2*numPhases-1.
+func polyphaseResampleCubicGo(out, hist []float32, a, b, c, d [][]float32, at, step int64, numPhases, tapsPerPhase, fracBits int) int {
+	numPhases64 := int64(numPhases)
+	fracMask := int64(1)<<uint(fracBits) - 1
+	fracScale := float32(1.0 / float64(int64(1)<<uint(fracBits)))
+
+	full := at >> uint(fracBits)
+	div := int(full / numPhases64)
+	phase := int(full - int64(div)*numPhases64)
+	frac := at & fracMask
+
+	sFull := step >> uint(fracBits)
+	sDiv := int(sFull / numPhases64)
+	sPhase := int(sFull - int64(sDiv)*numPhases64)
+	sFrac := step & fracMask
+
+	histLen := len(hist)
+	outLen := len(out)
+	k := 0
+	for k < outLen {
+		if div+tapsPerPhase > histLen {
+			break
+		}
+		x := float32(frac) * fracScale
+		out[k] = cubicInterpDotGo(
+			hist[div:div+tapsPerPhase],
+			a[phase][:tapsPerPhase], b[phase][:tapsPerPhase],
+			c[phase][:tapsPerPhase], d[phase][:tapsPerPhase], x)
+		k++
+
+		frac += sFrac
+		if frac > fracMask {
+			frac -= fracMask + 1
+			phase++
+		}
+		phase += sPhase
+		div += sDiv
+		if phase >= numPhases {
+			phase -= numPhases
+			div++
+		}
+	}
+	return k
+}
+
 // sigmoid32Go computes sigmoid(x) = 1 / (1 + e^(-x)) using math.Exp.
 // This is accurate but slower than SIMD approximations.
 func sigmoid32Go(dst, src []float32) {

--- a/f32/f32_other.go
+++ b/f32/f32_other.go
@@ -60,6 +60,9 @@ func euclideanDistance32(a, b []float32) float32   { return euclideanDistance32G
 func cubicInterpDot32(hist, a, b, c, d []float32, x float32) float32 {
 	return cubicInterpDotGo(hist, a, b, c, d, x)
 }
+func polyphaseResampleCubic32(out, hist []float32, a, b, c, d [][]float32, at, step int64, numPhases, tapsPerPhase, fracBits int) int {
+	return polyphaseResampleCubicGo(out, hist, a, b, c, d, at, step, numPhases, tapsPerPhase, fracBits)
+}
 func sigmoid32(dst, src []float32) { sigmoid32Go(dst, src) }
 func relu32(dst, src []float32)    { relu32Go(dst, src) }
 func clampScale32(dst, src []float32, minVal, maxVal, scale float32) {

--- a/f32/polyphase_resample_bench_test.go
+++ b/f32/polyphase_resample_bench_test.go
@@ -1,0 +1,98 @@
+package f32
+
+import (
+	"math/rand"
+	"testing"
+)
+
+// polyStepLoopUnsafe is the best pure-Go resampler-side alternative to the fused
+// kernel: the same incremental phase-stepping state machine, but calling the
+// dispatched CubicInterpDotUnsafe once per output instead of running the whole
+// block in one asm call. It is the baseline the fused kernel must beat to justify
+// the assembly (issue #52). It returns the number of outputs written.
+func polyStepLoopUnsafe(out, hist []float32, a, b, c, d [][]float32, at, step int64, numPhases, taps, fracBits int) int {
+	numPhases64 := int64(numPhases)
+	fracMask := int64(1)<<uint(fracBits) - 1
+	fracScale := float32(1.0 / float64(int64(1)<<uint(fracBits)))
+	full := at >> uint(fracBits)
+	div := int(full / numPhases64)
+	phase := int(full - int64(div)*numPhases64)
+	frac := at & fracMask
+	sFull := step >> uint(fracBits)
+	sDiv := int(sFull / numPhases64)
+	sPhase := int(sFull - int64(sDiv)*numPhases64)
+	sFrac := step & fracMask
+	histLen := len(hist)
+	k := 0
+	for k < len(out) {
+		if div+taps > histLen {
+			break
+		}
+		x := float32(frac) * fracScale
+		out[k] = CubicInterpDotUnsafe(
+			hist[div:div+taps],
+			a[phase][:taps], b[phase][:taps],
+			c[phase][:taps], d[phase][:taps], x)
+		k++
+		frac += sFrac
+		if frac > fracMask {
+			frac -= fracMask + 1
+			phase++
+		}
+		phase += sPhase
+		div += sDiv
+		if phase >= numPhases {
+			phase -= numPhases
+			div++
+		}
+	}
+	return k
+}
+
+// polyBenchConfigs covers the QualityMedium regime that gates issue #52: the tap
+// counts a real polyphase resampler runs at, all at numPhases 80.
+var polyBenchConfigs = []struct{ taps, numPhases int }{
+	{16, 80}, {20, 80}, {32, 80},
+}
+
+const polyBenchOut = 1024
+
+type polyBenchData struct {
+	out, hist  []float32
+	a, b, c, d [][]float32
+	step       int64
+}
+
+func benchPolySetup(taps, numPhases int) polyBenchData {
+	rng := rand.New(rand.NewSource(1))
+	step := polyDeriveStep(44100, 48000, numPhases, polyFracBits)
+	a, b, c, d := polyMakeBanks(numPhases, taps, rng)
+	hist := polyMakeHist(polySizeHist(step, polyBenchOut, numPhases, taps, polyFracBits), rng)
+	return polyBenchData{make([]float32, polyBenchOut), hist, a, b, c, d, step}
+}
+
+// BenchmarkPolyphaseResampleCubicFused measures the fused kernel (dispatched to
+// asm where available) over a 1024-output block.
+func BenchmarkPolyphaseResampleCubicFused(b *testing.B) {
+	for _, cfg := range polyBenchConfigs {
+		d := benchPolySetup(cfg.taps, cfg.numPhases)
+		b.Run(polyLabel(cfg.numPhases, cfg.taps, "44k_to_48k_up"), func(b *testing.B) {
+			for b.Loop() {
+				PolyphaseResampleCubicUnsafe(d.out, d.hist, d.a, d.b, d.c, d.d, 0, d.step, cfg.numPhases, cfg.taps, polyFracBits)
+			}
+		})
+	}
+}
+
+// BenchmarkPolyphaseResampleCubicStepLoop measures the pure-Go per-output
+// StepLoop over the same block, the baseline for the issue #52 merge gate.
+func BenchmarkPolyphaseResampleCubicStepLoop(b *testing.B) {
+	for _, cfg := range polyBenchConfigs {
+		d := benchPolySetup(cfg.taps, cfg.numPhases)
+		b.Run(polyLabel(cfg.numPhases, cfg.taps, "44k_to_48k_up"), func(b *testing.B) {
+			for b.Loop() {
+				polyStepLoopUnsafe(d.out, d.hist, d.a, d.b, d.c, d.d, 0, d.step, cfg.numPhases, cfg.taps, polyFracBits)
+			}
+		})
+	}
+}

--- a/f32/polyphase_resample_test.go
+++ b/f32/polyphase_resample_test.go
@@ -1,0 +1,492 @@
+package f32
+
+import (
+	"fmt"
+	"math"
+	"math/rand"
+	"testing"
+)
+
+// ---------------------------------------------------------------------------
+// Shared helpers for the fused polyphase cubic resampler tests.
+// ---------------------------------------------------------------------------
+
+// polyDeriveStep reproduces go-audio-resampler's fixed-point step derivation:
+// step = round((1/ratio) * numPhases * 2^fracBits), ratio = outRate/inRate.
+func polyDeriveStep(inRate, outRate float64, numPhases, fracBits int) int64 {
+	ratio := outRate / inRate
+	scale := float64(int64(1) << uint(fracBits))
+	return int64(math.Round((1.0 / ratio) * float64(numPhases) * scale))
+}
+
+type polyRate struct {
+	name            string
+	inRate, outRate float64
+}
+
+var polyRates = []polyRate{
+	{"44k_to_48k_up", 44100, 48000},
+	{"48k_to_44k_down", 48000, 44100},
+	{"44k_to_64k_sub", 44100, 64000},
+	{"96k_to_48k_2to1", 96000, 48000},
+	{"16k_to_48k_3x", 16000, 48000},
+}
+
+func polyMakeBanks(numPhases, taps int, rng *rand.Rand) (a, b, c, d [][]float32) {
+	mk := func() [][]float32 {
+		rows := make([][]float32, numPhases)
+		for p := range numPhases {
+			row := make([]float32, taps)
+			for t := range taps {
+				row[t] = float32(rng.NormFloat64()) * 0.25
+			}
+			rows[p] = row
+		}
+		return rows
+	}
+	return mk(), mk(), mk(), mk()
+}
+
+func polyMakeHist(n int, rng *rand.Rand) []float32 {
+	h := make([]float32, n)
+	for i := range h {
+		h[i] = float32(rng.NormFloat64())
+	}
+	return h
+}
+
+// polySizeHist returns a history length guaranteeing numOut outputs are produced
+// (the window bound never fires before out is full), for at==0.
+func polySizeHist(step int64, numOut, numPhases, taps, fracBits int) int {
+	lastDiv := int((int64(numOut-1) * step >> uint(fracBits)) / int64(numPhases))
+	return lastDiv + taps + 8
+}
+
+// polyRefLoop is the faithful per-output div/mod reference. dot selects the tier
+// (CubicInterpDotUnsafe for tier-aware parity, cubicInterpDotGo for the
+// arch-independent Go check). It returns the number of outputs written.
+func polyRefLoop(out, hist []float32, a, b, c, d [][]float32, at, step int64, numPhases, taps, fracBits int, dot func(h, ca, cb, cc, cd []float32, x float32) float32) int {
+	numPhases64 := int64(numPhases)
+	fracMask := int64(1)<<uint(fracBits) - 1
+	fracScale := float32(1.0 / float64(int64(1)<<uint(fracBits)))
+	histLen := len(hist)
+	k := 0
+	for k < len(out) {
+		full := at >> uint(fracBits)
+		div := int(full / numPhases64)
+		phase := int(full % numPhases64)
+		frac := at & fracMask
+		if div+taps > histLen {
+			break
+		}
+		x := float32(frac) * fracScale
+		out[k] = dot(hist[div:div+taps], a[phase][:taps], b[phase][:taps], c[phase][:taps], d[phase][:taps], x)
+		k++
+		at += step
+	}
+	return k
+}
+
+func polyBitsEqual(t *testing.T, label string, got, want []float32) {
+	t.Helper()
+	if len(got) != len(want) {
+		t.Fatalf("%s: length got=%d want=%d", label, len(got), len(want))
+	}
+	for i := range got {
+		if math.Float32bits(got[i]) != math.Float32bits(want[i]) {
+			t.Fatalf("%s: mismatch at %d: got=%v (0x%08x) want=%v (0x%08x)",
+				label, i, got[i], math.Float32bits(got[i]), want[i], math.Float32bits(want[i]))
+		}
+	}
+}
+
+var polyGridPhases = []int{64, 80, 128, 256}
+
+// polyGridTaps spans the tap counts and, within the vectorized kernels, the loop
+// tiers: 16/32/64 are pure 16-wide-block multiples, 20/100 add a scalar tail, and
+// 24 (16+8 on amd64 f32, 16+4+4 on amd64 f64) exercises the secondary
+// 8-wide/4-wide block after the 16-wide block in the fused path directly.
+var polyGridTaps = []int{16, 20, 24, 32, 64, 100}
+
+const polyFracBits = 16
+
+// ---------------------------------------------------------------------------
+// Tier-aware parity: the public fused API vs a div/mod reference loop calling
+// CubicInterpDotUnsafe. The dispatch guards are aligned, so both pick the same
+// dot tier and the results are bit-identical on every CPU.
+// ---------------------------------------------------------------------------
+
+func TestPolyphaseResampleCubicParity(t *testing.T) {
+	const outLen = 1024
+	rng := rand.New(rand.NewSource(0xC0FFEE))
+	for _, numPhases := range polyGridPhases {
+		for _, taps := range polyGridTaps {
+			a, b, c, d := polyMakeBanks(numPhases, taps, rng)
+			for _, r := range polyRates {
+				step := polyDeriveStep(r.inRate, r.outRate, numPhases, polyFracBits)
+				histLen := polySizeHist(step, outLen, numPhases, taps, polyFracBits)
+				hist := polyMakeHist(histLen, rng)
+
+				gotOut := make([]float32, outLen)
+				wantOut := make([]float32, outLen)
+				nGot, atGot := PolyphaseResampleCubic(gotOut, hist, a, b, c, d, 0, step, numPhases, taps, polyFracBits)
+				nWant := polyRefLoop(wantOut, hist, a, b, c, d, 0, step, numPhases, taps, polyFracBits, CubicInterpDotUnsafe)
+
+				label := polyLabel(numPhases, taps, r.name)
+				if nGot != nWant {
+					t.Fatalf("%s: n got=%d want=%d", label, nGot, nWant)
+				}
+				if atGot != int64(nGot)*step {
+					t.Fatalf("%s: atOut got=%d want=%d", label, atGot, int64(nGot)*step)
+				}
+				polyBitsEqual(t, label, gotOut[:nGot], wantOut[:nWant])
+
+				// The Unsafe entry point must produce the identical result and atOut.
+				unsafeOut := make([]float32, outLen)
+				nU, atU := PolyphaseResampleCubicUnsafe(unsafeOut, hist, a, b, c, d, 0, step, numPhases, taps, polyFracBits)
+				if nU != nGot || atU != atGot {
+					t.Fatalf("%s: Unsafe (n=%d,at=%d) != safe (n=%d,at=%d)", label, nU, atU, nGot, atGot)
+				}
+				polyBitsEqual(t, label+"/unsafe", unsafeOut[:nU], gotOut[:nGot])
+			}
+		}
+	}
+}
+
+func polyLabel(numPhases, taps int, rate string) string {
+	return fmt.Sprintf("nP%d_taps%d/%s", numPhases, taps, rate)
+}
+
+// ---------------------------------------------------------------------------
+// Arch-independent Go check: polyphaseResampleCubicGo vs a div/mod reference
+// loop calling cubicInterpDotGo. Both use the scalar Go dot, so they are
+// bit-identical at any tap count on any host, isolating the state machine from
+// the asm.
+// ---------------------------------------------------------------------------
+
+func TestPolyphaseResampleCubicGoStateMachine(t *testing.T) {
+	const outLen = 1024
+	rng := rand.New(rand.NewSource(0x1234))
+	for _, numPhases := range polyGridPhases {
+		for _, taps := range polyGridTaps {
+			a, b, c, d := polyMakeBanks(numPhases, taps, rng)
+			for _, r := range polyRates {
+				step := polyDeriveStep(r.inRate, r.outRate, numPhases, polyFracBits)
+				histLen := polySizeHist(step, outLen, numPhases, taps, polyFracBits)
+				hist := polyMakeHist(histLen, rng)
+
+				gotOut := make([]float32, outLen)
+				wantOut := make([]float32, outLen)
+				nGot := polyphaseResampleCubicGo(gotOut, hist, a, b, c, d, 0, step, numPhases, taps, polyFracBits)
+				nWant := polyRefLoop(wantOut, hist, a, b, c, d, 0, step, numPhases, taps, polyFracBits, cubicInterpDotGo)
+				label := polyLabel(numPhases, taps, r.name)
+				if nGot != nWant {
+					t.Fatalf("%s: n got=%d want=%d", label, nGot, nWant)
+				}
+				polyBitsEqual(t, label, gotOut[:nGot], wantOut[:nWant])
+			}
+		}
+	}
+}
+
+// TestPolyphaseResampleCubicGoHistExhaust drives polyphaseResampleCubicGo directly
+// with a history shorter than the requested block so the window-exhaustion break
+// fires and returns a partial n. On a SIMD host the public-API exhaustion path runs
+// the asm kernel, so this is the only test that reaches the Go state machine's
+// break; it must still match the div/mod oracle (partial n and bit-exact output).
+func TestPolyphaseResampleCubicGoHistExhaust(t *testing.T) {
+	const outLen = 1024
+	rng := rand.New(rand.NewSource(0xE0F))
+	for _, numPhases := range polyGridPhases {
+		for _, taps := range polyGridTaps {
+			a, b, c, d := polyMakeBanks(numPhases, taps, rng)
+			step := polyDeriveStep(44100, 48000, numPhases, polyFracBits)
+			// Short history: enough for some outputs, far fewer than outLen.
+			hist := polyMakeHist(taps+37, rng)
+			gotOut := make([]float32, outLen)
+			wantOut := make([]float32, outLen)
+			nGot := polyphaseResampleCubicGo(gotOut, hist, a, b, c, d, 0, step, numPhases, taps, polyFracBits)
+			nWant := polyRefLoop(wantOut, hist, a, b, c, d, 0, step, numPhases, taps, polyFracBits, cubicInterpDotGo)
+			label := polyLabel(numPhases, taps, "hist_exhaust")
+			if nGot != nWant {
+				t.Fatalf("%s: n got=%d want=%d", label, nGot, nWant)
+			}
+			if nGot >= outLen {
+				t.Fatalf("%s: expected the history to exhaust before outLen, got n=%d", label, nGot)
+			}
+			polyBitsEqual(t, label, gotOut[:nGot], wantOut[:nWant])
+		}
+	}
+}
+
+// TestPolyphaseResampleCubicGoForcedCarries drives configurations where the frac
+// carry and the phase wrap fire, including on the same output, and checks the Go
+// state machine still matches the div/mod reference. Small numPhases and fracBits
+// pack many carries into a short run, and a nonzero starting at exercises the
+// seeding divisions.
+func TestPolyphaseResampleCubicGoForcedCarries(t *testing.T) {
+	rng := rand.New(rand.NewSource(0x9))
+	cases := []struct {
+		numPhases, taps, fracBits int
+		at, step                  int64
+	}{
+		{3, 16, 4, 0, 22},      // fracMask=15; step frac=6, sPhase=1: carries interleave
+		{3, 16, 4, 37, 25},     // nonzero at, both carries recur
+		{5, 20, 8, 0, 617},     // fracMask=255
+		{7, 16, 3, 11, 45},     // fracMask=7, tight
+		{2, 16, 5, 0, 97},      // numPhases=2 so phase wraps almost every step
+		{80, 20, 16, 0, 60073}, // realistic active sub-phase
+	}
+	for ci, tc := range cases {
+		a, b, c, d := polyMakeBanks(tc.numPhases, tc.taps, rng)
+		const outLen = 300
+		lastDiv := int((tc.at + int64(outLen-1)*tc.step) >> uint(tc.fracBits) / int64(tc.numPhases))
+		hist := polyMakeHist(lastDiv+tc.taps+8, rng)
+		gotOut := make([]float32, outLen)
+		wantOut := make([]float32, outLen)
+		nGot := polyphaseResampleCubicGo(gotOut, hist, a, b, c, d, tc.at, tc.step, tc.numPhases, tc.taps, tc.fracBits)
+		nWant := polyRefLoop(wantOut, hist, a, b, c, d, tc.at, tc.step, tc.numPhases, tc.taps, tc.fracBits, cubicInterpDotGo)
+		if nGot != nWant {
+			t.Fatalf("case %d: n got=%d want=%d", ci, nGot, nWant)
+		}
+		polyBitsEqual(t, fmt.Sprintf("forced_carry_case%d", ci), gotOut[:nGot], wantOut[:nWant])
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Streaming continuity: chunked output blocks carrying atOut forward over the
+// same hist must concatenate bit-identically to one shot.
+// ---------------------------------------------------------------------------
+
+func TestPolyphaseResampleCubicStreamingChunks(t *testing.T) {
+	rng := rand.New(rand.NewSource(0x5EED))
+	const numPhases, taps = 80, 32
+	step := polyDeriveStep(44100, 64000, numPhases, polyFracBits) // active sub-phase
+	a, b, c, d := polyMakeBanks(numPhases, taps, rng)
+	const total = 1024
+	histLen := polySizeHist(step, total, numPhases, taps, polyFracBits)
+	hist := polyMakeHist(histLen, rng)
+
+	oneShot := make([]float32, total)
+	nOne, _ := PolyphaseResampleCubic(oneShot, hist, a, b, c, d, 0, step, numPhases, taps, polyFracBits)
+
+	for _, chunk := range []int{1, 7, 64, 1024} {
+		chunked := make([]float32, total)
+		at := int64(0)
+		produced := 0
+		for produced < nOne {
+			end := min(produced+chunk, total)
+			n, atOut := PolyphaseResampleCubic(chunked[produced:end], hist, a, b, c, d, at, step, numPhases, taps, polyFracBits)
+			if n == 0 {
+				break
+			}
+			at = atOut
+			produced += n
+		}
+		if produced != nOne {
+			t.Fatalf("chunk=%d produced=%d want=%d", chunk, produced, nOne)
+		}
+		polyBitsEqual(t, fmt.Sprintf("chunk%d", chunk), chunked[:nOne], oneShot[:nOne])
+	}
+}
+
+// TestPolyphaseResampleCubicConsumerRebase mirrors processZeroCopy: between calls
+// it consumes input from hist and rebases at by consumed*numPhases<<fracBits, and
+// the concatenated output must match the unchunked result over the same stream.
+func TestPolyphaseResampleCubicConsumerRebase(t *testing.T) {
+	rng := rand.New(rand.NewSource(0xABCD))
+	const numPhases, taps, fracBits = 80, 20, 16
+	step := polyDeriveStep(44100, 48000, numPhases, fracBits)
+
+	a, b, c, d := polyMakeBanks(numPhases, taps, rng)
+	const total = 4096
+	fullHist := polyMakeHist(polySizeHist(step, total, numPhases, taps, fracBits)+64, rng)
+
+	// One-shot over the full history.
+	oneShot := make([]float32, total)
+	nOne, _ := PolyphaseResampleCubic(oneShot, fullHist, a, b, c, d, 0, step, numPhases, taps, fracBits)
+
+	// Consumer-style: a sliding window into fullHist with rebasing at.
+	got := make([]float32, 0, nOne)
+	at := int64(0)
+	base := 0 // index in fullHist that the current window starts at
+	block := make([]float32, 200)
+	for len(got) < nOne {
+		window := fullHist[base:]
+		n, atOut := PolyphaseResampleCubic(block, window, a, b, c, d, at, step, numPhases, taps, fracBits)
+		if n == 0 {
+			break
+		}
+		got = append(got, block[:n]...)
+		at = atOut
+		// Consume: drop consumed input samples, rebase at (matches processZeroCopy).
+		consumed := int((at >> uint(fracBits)) / int64(numPhases))
+		if consumed > 0 {
+			base += consumed
+			at -= int64(consumed) * int64(numPhases) << uint(fracBits)
+		}
+	}
+	if len(got) > nOne {
+		got = got[:nOne]
+	}
+	polyBitsEqual(t, "consumer_rebase", got, oneShot[:len(got)])
+	if len(got) != nOne {
+		t.Fatalf("consumer_rebase produced=%d want=%d", len(got), nOne)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Termination and edge cases.
+// ---------------------------------------------------------------------------
+
+func TestPolyphaseResampleCubicTermination(t *testing.T) {
+	rng := rand.New(rand.NewSource(0x7))
+	const numPhases, taps, fracBits = 80, 20, 16
+	step := polyDeriveStep(44100, 48000, numPhases, fracBits)
+	a, b, c, d := polyMakeBanks(numPhases, taps, rng)
+
+	// out full before hist exhausted: big hist, small out.
+	t.Run("out_full_first", func(t *testing.T) {
+		hist := polyMakeHist(polySizeHist(step, 1024, numPhases, taps, fracBits), rng)
+		out := make([]float32, 10)
+		n, atOut := PolyphaseResampleCubic(out, hist, a, b, c, d, 0, step, numPhases, taps, fracBits)
+		if n != 10 {
+			t.Fatalf("n=%d want 10", n)
+		}
+		if atOut != int64(n)*step {
+			t.Fatalf("atOut=%d want %d", atOut, int64(n)*step)
+		}
+	})
+
+	// hist exhausted before out: small hist, big out.
+	t.Run("hist_exhausted_first", func(t *testing.T) {
+		hist := polyMakeHist(taps+30, rng)
+		out := make([]float32, 1024)
+		n, _ := PolyphaseResampleCubic(out, hist, a, b, c, d, 0, step, numPhases, taps, fracBits)
+		want := polyRefLoop(make([]float32, 1024), hist, a, b, c, d, 0, step, numPhases, taps, fracBits, CubicInterpDotUnsafe)
+		if n != want {
+			t.Fatalf("n=%d want %d", n, want)
+		}
+		if n >= 1024 {
+			t.Fatalf("expected early termination, got n=%d", n)
+		}
+	})
+
+	// n==0: empty out, hist shorter than taps, at already past hist.
+	t.Run("zero_outputs", func(t *testing.T) {
+		hist := polyMakeHist(polySizeHist(step, 100, numPhases, taps, fracBits), rng)
+		if n, at := PolyphaseResampleCubic(nil, hist, a, b, c, d, 0, step, numPhases, taps, fracBits); n != 0 || at != 0 {
+			t.Fatalf("empty out: (%d,%d) want (0,0)", n, at)
+		}
+		short := polyMakeHist(taps-1, rng)
+		out := make([]float32, 16)
+		if n, at := PolyphaseResampleCubic(out, short, a, b, c, d, 0, step, numPhases, taps, fracBits); n != 0 || at != 0 {
+			t.Fatalf("short hist: (%d,%d) want (0,0)", n, at)
+		}
+		// at already past hist: start beyond the last valid window.
+		hist2 := polyMakeHist(taps+5, rng)
+		startAt := int64(len(hist2)) * int64(numPhases) << uint(fracBits)
+		if n, at := PolyphaseResampleCubic(out, hist2, a, b, c, d, startAt, step, numPhases, taps, fracBits); n != 0 || at != startAt {
+			t.Fatalf("past-hist at: (%d,%d) want (0,%d)", n, at, startAt)
+		}
+	})
+}
+
+func TestPolyphaseResampleCubicValidation(t *testing.T) {
+	rng := rand.New(rand.NewSource(0x11))
+	const numPhases, taps, fracBits = 8, 16, 16
+	step := polyDeriveStep(44100, 48000, numPhases, fracBits)
+	a, b, c, d := polyMakeBanks(numPhases, taps, rng)
+	hist := polyMakeHist(polySizeHist(step, 64, numPhases, taps, fracBits), rng)
+	out := make([]float32, 64)
+
+	// Each variant must return (0, at) with at unchanged.
+	assertNoop := func(name string, at int64, fn func() (int, int64)) {
+		n, atOut := fn()
+		if n != 0 || atOut != at {
+			t.Fatalf("%s: got (%d,%d) want (0,%d)", name, n, atOut, at)
+		}
+	}
+	assertNoop("numPhases<1", 5, func() (int, int64) {
+		return PolyphaseResampleCubic(out, hist, a, b, c, d, 5, step, 0, taps, fracBits)
+	})
+	assertNoop("taps<1", 5, func() (int, int64) {
+		return PolyphaseResampleCubic(out, hist, a, b, c, d, 5, step, numPhases, 0, fracBits)
+	})
+	assertNoop("step<1", 5, func() (int, int64) {
+		return PolyphaseResampleCubic(out, hist, a, b, c, d, 5, 0, numPhases, taps, fracBits)
+	})
+	assertNoop("at<0", -3, func() (int, int64) {
+		return PolyphaseResampleCubic(out, hist, a, b, c, d, -3, step, numPhases, taps, fracBits)
+	})
+	assertNoop("fracBits<0", 5, func() (int, int64) {
+		return PolyphaseResampleCubic(out, hist, a, b, c, d, 5, step, numPhases, taps, -1)
+	})
+	assertNoop("fracBits>max", 5, func() (int, int64) {
+		return PolyphaseResampleCubic(out, hist, a, b, c, d, 5, step, numPhases, taps, polyphaseMaxFracBits32+1)
+	})
+	assertNoop("short_bank", 5, func() (int, int64) {
+		return PolyphaseResampleCubic(out, hist, a[:numPhases-1], b, c, d, 5, step, numPhases, taps, fracBits)
+	})
+	// short row: shrink one row below taps.
+	shortRows := make([][]float32, numPhases)
+	copy(shortRows, a)
+	shortRows[numPhases-1] = shortRows[numPhases-1][:taps-1]
+	assertNoop("short_row", 5, func() (int, int64) {
+		return PolyphaseResampleCubic(out, hist, shortRows, b, c, d, 5, step, numPhases, taps, fracBits)
+	})
+	// Accumulator overflow: a step so large that at+len(out)*step overflows int64
+	// must be rejected as (0, at) rather than panicking or reading out of range.
+	assertNoop("step_overflow", 5, func() (int, int64) {
+		return PolyphaseResampleCubic(out, hist, a, b, c, d, 5, math.MaxInt64, numPhases, taps, fracBits)
+	})
+}
+
+// TestPolyphaseResampleCubicMaxFracBits checks the valid side of the fracBits
+// boundary: at exactly polyphaseMaxFracBits32 the fused kernel still produces
+// output bit-identical to the div/mod oracle, confirming float32(frac)*2^-fracBits
+// is exact at the maximum (the constant is not off by one).
+func TestPolyphaseResampleCubicMaxFracBits(t *testing.T) {
+	rng := rand.New(rand.NewSource(0x2C))
+	const numPhases, taps, outLen = 80, 32, 256
+	fracBits := polyphaseMaxFracBits32
+	step := polyDeriveStep(44100, 48000, numPhases, fracBits)
+	a, b, c, d := polyMakeBanks(numPhases, taps, rng)
+	hist := polyMakeHist(polySizeHist(step, outLen, numPhases, taps, fracBits), rng)
+	gotOut := make([]float32, outLen)
+	wantOut := make([]float32, outLen)
+	n, _ := PolyphaseResampleCubic(gotOut, hist, a, b, c, d, 0, step, numPhases, taps, fracBits)
+	nWant := polyRefLoop(wantOut, hist, a, b, c, d, 0, step, numPhases, taps, fracBits, CubicInterpDotUnsafe)
+	if n == 0 || n != nWant {
+		t.Fatalf("max fracBits: n got=%d want=%d (expected nonzero)", n, nWant)
+	}
+	polyBitsEqual(t, "max_fracbits", gotOut[:n], wantOut[:nWant])
+}
+
+// ---------------------------------------------------------------------------
+// Zero allocation on the safe path.
+// ---------------------------------------------------------------------------
+
+func TestPolyphaseResampleCubicNoAlloc(t *testing.T) {
+	rng := rand.New(rand.NewSource(0x33))
+	const numPhases, taps, fracBits = 80, 32, 16
+	step := polyDeriveStep(44100, 48000, numPhases, fracBits)
+	a, b, c, d := polyMakeBanks(numPhases, taps, rng)
+	hist := polyMakeHist(polySizeHist(step, 1024, numPhases, taps, fracBits), rng)
+	out := make([]float32, 1024)
+	// Guard against a vacuous pass: confirm this config actually produces output,
+	// so a regression that early-returned (0, at) could not read as zero-alloc.
+	if n, _ := PolyphaseResampleCubic(out, hist, a, b, c, d, 0, step, numPhases, taps, fracBits); n == 0 {
+		t.Fatalf("no-alloc config produced no output; the allocation check would be vacuous")
+	}
+	if allocs := testing.AllocsPerRun(50, func() {
+		PolyphaseResampleCubic(out, hist, a, b, c, d, 0, step, numPhases, taps, fracBits)
+	}); allocs != 0 {
+		t.Fatalf("PolyphaseResampleCubic allocated %v times, want 0", allocs)
+	}
+	if allocs := testing.AllocsPerRun(50, func() {
+		PolyphaseResampleCubicUnsafe(out, hist, a, b, c, d, 0, step, numPhases, taps, fracBits)
+	}); allocs != 0 {
+		t.Fatalf("PolyphaseResampleCubicUnsafe allocated %v times, want 0", allocs)
+	}
+}

--- a/f64/f64.go
+++ b/f64/f64.go
@@ -592,6 +592,105 @@ func minLen5(a, b, c, d, e int) int {
 	return min(a, b, c, d, e)
 }
 
+// polyphaseMaxFracBits64 is the largest sub-phase fractional width for which
+// float64(frac) is exact for every frac in [0, 1<<fracBits). float64 has a 53-bit
+// significand, so every integer below 2^53 round-trips exactly; at fracBits == 53
+// the largest frac is 2^53-1, still below 2^53 and so still exact. Above 53 the
+// frac-to-float conversion would round and x = float64(frac) * fracScale would
+// stop matching the consumer bit-for-bit, so PolyphaseResampleCubic rejects it.
+// This mirrors f32's polyphaseMaxFracBits32 == 24: both use the full significand
+// width p (24 for float32, 53 for float64).
+const polyphaseMaxFracBits64 = 53
+
+// PolyphaseResampleCubic resamples hist into out with soxr-style polyphase FIR
+// filtering and cubic sub-phase coefficient interpolation, running the whole
+// output block in one fused pass. It is the fused form of a per-output loop that
+// calls [CubicInterpDot]: for each output it derives the input window and the
+// interpolation phase from a fixed-point accumulator, evaluates
+//
+//	out[k] = Σ hist[div+i] * (a[phase][i] + x*(b[phase][i] + x*(c[phase][i] + x*d[phase][i])))
+//
+// over tapsPerPhase taps, then advances the accumulator by step. The coefficient
+// banks a, b, c, d are indexed [phase][tap] and hold the Catmull-Rom cubic
+// interpolation coefficients (base, linear, quadratic, cubic); they match
+// go-audio-resampler's bank layout directly. Only the first numPhases rows are
+// read, and only the first tapsPerPhase taps of each; longer rows are fine.
+//
+// The accumulator is fixed-point: at = (inputIndex*numPhases + phase) <<
+// fracBits + frac, and step is the per-output increment in the same units. fracBits
+// is the sub-phase fractional width (soxr uses 16). x = float64(frac) * 2^-fracBits
+// is the sub-phase position in [0, 1). numPhases is soxr's L. Output k is produced
+// only while k < len(out) and div+tapsPerPhase <= len(hist); the first output not
+// satisfying the window bound ends the block.
+//
+// It returns n, the number of outputs written to out[:n], and atOut, the
+// accumulator after n outputs. atOut == at + int64(n)*step exactly, so streaming
+// callers carry atOut into the next call as the new at (rebasing at by
+// consumed*numPhases<<fracBits when they drop consumed input samples from hist, as
+// go-audio-resampler does). The internal (div, phase, frac) are re-derived from
+// the single int64 accumulator on the next call and are never exposed.
+//
+// PolyphaseResampleCubic validates its inputs and is a no-op returning (0, at)
+// (never an error, never a panic) if any of these do not hold: numPhases >= 1,
+// tapsPerPhase >= 1, step >= 1, at >= 0, 0 <= fracBits <= 53, len(a|b|c|d) >=
+// numPhases, every one of the first numPhases rows of each bank has length >=
+// tapsPerPhase, and at + int64(len(out))*step does not overflow int64.
+// Degenerate but valid inputs (len(out) == 0, len(hist) <
+// tapsPerPhase, or an initial window already past the end of hist) also yield
+// (0, at) because no output satisfies the window bound.
+//
+// Uses AVX+FMA on AMD64 and NEON on ARM64 for tapsPerPhase past the vector width,
+// gated on the same CPU features and tap threshold as [CubicInterpDot] so the
+// fused result is bit-identical to the per-output form on every CPU; below the
+// threshold it uses the pure-Go path. It allocates nothing.
+func PolyphaseResampleCubic(out, hist []float64, a, b, c, d [][]float64, at, step int64, numPhases, tapsPerPhase, fracBits int) (n int, atOut int64) {
+	if numPhases < 1 || tapsPerPhase < 1 || step < 1 || at < 0 ||
+		fracBits < 0 || fracBits > polyphaseMaxFracBits64 {
+		return 0, at
+	}
+	if len(a) < numPhases || len(b) < numPhases || len(c) < numPhases || len(d) < numPhases {
+		return 0, at
+	}
+	for p := range numPhases {
+		if len(a[p]) < tapsPerPhase || len(b[p]) < tapsPerPhase ||
+			len(c[p]) < tapsPerPhase || len(d[p]) < tapsPerPhase {
+			return 0, at
+		}
+	}
+	// Reject inputs whose block accumulator could overflow int64. The loop runs
+	// at most len(out) times, so at+len(out)*step bounds every accumulator value;
+	// if that product would overflow, the internal div wraps negative and defeats
+	// the window guard (a panic on the Go path, an out-of-range read on the SIMD
+	// paths), and atOut would no longer equal at+n*step. Real resamplers keep step
+	// and at far below this, so no legitimate input is rejected.
+	if outLen := int64(len(out)); outLen > 0 && step > (math.MaxInt64-at)/outLen {
+		return 0, at
+	}
+	n = polyphaseResampleCubic64(out, hist, a, b, c, d, at, step, numPhases, tapsPerPhase, fracBits)
+	return n, at + int64(n)*step
+}
+
+// PolyphaseResampleCubicUnsafe is [PolyphaseResampleCubic] without input
+// validation, for performance-critical callers that have already checked their
+// arguments.
+//
+// PRECONDITIONS (caller must ensure):
+//   - numPhases >= 1, tapsPerPhase >= 1, step >= 1, at >= 0
+//   - 0 <= fracBits <= 53
+//   - len(a), len(b), len(c), len(d) each >= numPhases
+//   - each of the first numPhases rows of a, b, c, d has length >= tapsPerPhase
+//   - at + int64(len(out))*step does not overflow int64
+//
+// Violating these preconditions results in undefined behavior. Unlike the safe
+// form, this variant does not reject an overflowing at/step, so a caller that
+// breaks the last precondition can drive the internal accumulator to wrap and
+// read out of range. When the preconditions hold it returns the same (n, atOut)
+// as the safe form.
+func PolyphaseResampleCubicUnsafe(out, hist []float64, a, b, c, d [][]float64, at, step int64, numPhases, tapsPerPhase, fracBits int) (n int, atOut int64) {
+	n = polyphaseResampleCubic64(out, hist, a, b, c, d, at, step, numPhases, tapsPerPhase, fracBits)
+	return n, at + int64(n)*step
+}
+
 // ConvolveValidMulti applies multiple kernels to the same signal.
 // dsts[k][i] = sum(signal[i+j] * kernels[k][j]) for each kernel k.
 // All kernels must have the same length.

--- a/f64/f64_amd64.go
+++ b/f64/f64_amd64.go
@@ -1108,6 +1108,25 @@ func deinterleave2SSE2(a, b, src []float64)
 //go:noescape
 func cubicInterpDotAVX(hist, a, b, c, d []float64, x float64) float64
 
+// polyphaseResampleCubic64 dispatches the fused polyphase cubic resampler. The
+// guard matches cubicInterpDot64 exactly (cpu.X86.AVX && cpu.X86.FMA &&
+// tapsPerPhase >= minAVXElements) so the fused kernel's per-output dot always
+// selects the same tier as a standalone CubicInterpDot at the same tap count,
+// making the fused result bit-identical to the per-output form on every CPU.
+func polyphaseResampleCubic64(out, hist []float64, a, b, c, d [][]float64, at, step int64, numPhases, tapsPerPhase, fracBits int) int {
+	if cpu.X86.AVX && cpu.X86.FMA && tapsPerPhase >= minAVXElements {
+		return polyphaseResampleCubicAVX(out, hist, a, b, c, d, at, step, numPhases, tapsPerPhase, fracBits)
+	}
+	return polyphaseResampleCubicGo(out, hist, a, b, c, d, at, step, numPhases, tapsPerPhase, fracBits)
+}
+
+// polyphaseResampleCubicAVX runs the whole output block in one fused AVX+FMA pass,
+// reusing cubicInterpDotAVX's inner dot body per output. Returns the number of
+// outputs written. See f64_amd64.s.
+//
+//go:noescape
+func polyphaseResampleCubicAVX(out, hist []float64, a, b, c, d [][]float64, at, step int64, numPhases, tapsPerPhase, fracBits int) int
+
 // ButterflyComplex assembly function declaration
 //
 //go:noescape

--- a/f64/f64_amd64.s
+++ b/f64/f64_amd64.s
@@ -4224,6 +4224,251 @@ cubic_avx_done:
     VZEROUPPER
     RET
 
+// func polyphaseResampleCubicAVX(out, hist []float64, a, b, c, d [][]float64,
+//                                at, step int64, numPhases, tapsPerPhase, fracBits int) int
+//
+// Fused polyphase cubic resampler (float64): runs the whole output block in one
+// pass, reusing cubicInterpDotAVX's inner dot body for each output. Returns the
+// number of outputs written.
+//
+// The inner loop16 here uses per-pointer advances instead of the shared DX
+// byte-offset the standalone kernel uses, so DX is free to hold phase; the loads,
+// the four accumulators (Y0/Y11/Y12/Y13) and their combine order are unchanged,
+// so each output dot is bit-identical to cubicInterpDotAVX at the same tap count.
+// sPhase and sFrac are re-derived from step per output with a multiply, not a
+// divide. x is splat AVX1-clean (VMOVDDUP + VINSERTF128, no register-source
+// VBROADCASTSD). Reserved registers R14/R15/BP are never touched.
+//
+// Persistent registers across the whole loop:
+//   BX  = div
+//   DX  = phase
+//   R11 = frac
+//   R12 = k (output index)
+//   R13 = sDiv
+//   X8  = fracScale (2^-fracBits, scalar)
+//
+// Frame layout (6 slices + 2 int64 + 3 int + 1 return):
+//   out:  base+0,  len+8,  cap+16
+//   hist: base+24, len+32, cap+40
+//   a:    base+48, len+56, cap+64
+//   b:    base+72, len+80, cap+88
+//   c:    base+96, len+104, cap+112
+//   d:    base+120,len+128, cap+136
+//   at:          +144 (int64)
+//   step:        +152 (int64)
+//   numPhases:   +160 (int)
+//   tapsPerPhase:+168 (int)
+//   fracBits:    +176 (int)
+//   ret:         +184 (int)
+TEXT ·polyphaseResampleCubicAVX(SB), NOSPLIT, $0-192
+    MOVQ fracBits+176(FP), CX      // CX = fracBits
+    MOVQ numPhases+160(FP), R8     // R8 = numPhases
+
+    // sDiv = (step >> fracBits) / numPhases  (one division, hoisted)
+    MOVQ step+152(FP), AX
+    SARQ CX, AX
+    XORQ DX, DX
+    DIVQ R8                        // AX = sDiv
+    MOVQ AX, R13
+
+    // Seed div, phase, frac from at.
+    MOVQ at+144(FP), R11
+    MOVQ R11, AX
+    SARQ CX, AX                    // AX = full = at >> fracBits
+    XORQ DX, DX
+    DIVQ R8                        // AX = div, DX = phase
+    MOVQ AX, BX                    // BX = div
+    MOVQ $1, SI
+    SHLQ CX, SI
+    DECQ SI                        // SI = fracMask
+    ANDQ SI, R11                   // R11 = frac
+
+    // fracScale = 2^-fracBits as float64: bits = (1023 - fracBits) << 52.
+    MOVQ $1023, AX
+    SUBQ CX, AX
+    SHLQ $52, AX
+    MOVQ AX, X8                    // X8 = fracScale (scalar)
+
+    XORQ R12, R12                  // k = 0
+
+prcubic_loop:
+    MOVQ out_len+8(FP), AX
+    CMPQ R12, AX
+    JGE  prcubic_done
+    MOVQ tapsPerPhase+168(FP), CX  // CX = taps (inner dot length)
+    MOVQ BX, AX
+    ADDQ CX, AX
+    MOVQ hist_len+32(FP), SI
+    CMPQ AX, SI
+    JGT  prcubic_done
+
+    // x = float64(frac) * fracScale, broadcast to Y7 (AVX1-clean).
+    VCVTSI2SDQ R11, X7, X7
+    VMULSD   X8, X7, X7            // X7 = x (lane 0)
+    VMOVDDUP X7, X7               // X7 = [x, x]
+    VINSERTF128 $1, X7, Y7, Y7    // Y7 = [x x x x]
+
+    // Row pointers: byte offset = phase*24.
+    LEAQ (DX)(DX*2), AX
+    SHLQ $3, AX                    // AX = 24*phase
+    MOVQ a_base+48(FP), SI
+    MOVQ (SI)(AX*1), DI            // &a[phase][0]
+    MOVQ b_base+72(FP), SI
+    MOVQ (SI)(AX*1), R8            // &b[phase][0]
+    MOVQ c_base+96(FP), SI
+    MOVQ (SI)(AX*1), R9            // &c[phase][0]
+    MOVQ d_base+120(FP), SI
+    MOVQ (SI)(AX*1), R10           // &d[phase][0]
+    MOVQ hist_base+24(FP), SI
+    LEAQ (SI)(BX*8), SI            // &hist[div]
+
+    // ---- inner dot body (CX = taps); loop16 uses per-pointer advances ----
+    VXORPD Y0, Y0, Y0
+    VXORPD Y11, Y11, Y11
+    VXORPD Y12, Y12, Y12
+    VXORPD Y13, Y13, Y13
+    MOVQ CX, AX
+    SHRQ $4, AX                    // AX = taps / 16
+    JZ   prcubic_loop4_check
+
+prcubic_loop16:
+    VMOVUPD 0(R9), Y1
+    VMOVUPD 0(R10), Y5
+    VFMADD231PD Y5, Y7, Y1
+    VMOVUPD 32(R9), Y2
+    VMOVUPD 32(R10), Y5
+    VFMADD231PD Y5, Y7, Y2
+    VMOVUPD 64(R9), Y3
+    VMOVUPD 64(R10), Y5
+    VFMADD231PD Y5, Y7, Y3
+    VMOVUPD 96(R9), Y4
+    VMOVUPD 96(R10), Y5
+    VFMADD231PD Y5, Y7, Y4
+    VMOVUPD 0(R8), Y5
+    VFMADD213PD Y5, Y7, Y1
+    VMOVUPD 32(R8), Y5
+    VFMADD213PD Y5, Y7, Y2
+    VMOVUPD 64(R8), Y5
+    VFMADD213PD Y5, Y7, Y3
+    VMOVUPD 96(R8), Y5
+    VFMADD213PD Y5, Y7, Y4
+    VMOVUPD 0(DI), Y5
+    VFMADD213PD Y5, Y7, Y1
+    VMOVUPD 32(DI), Y5
+    VFMADD213PD Y5, Y7, Y2
+    VMOVUPD 64(DI), Y5
+    VFMADD213PD Y5, Y7, Y3
+    VMOVUPD 96(DI), Y5
+    VFMADD213PD Y5, Y7, Y4
+    VMOVUPD 0(SI), Y5
+    VFMADD231PD Y5, Y1, Y0
+    VMOVUPD 32(SI), Y5
+    VFMADD231PD Y5, Y2, Y11
+    VMOVUPD 64(SI), Y5
+    VFMADD231PD Y5, Y3, Y12
+    VMOVUPD 96(SI), Y5
+    VFMADD231PD Y5, Y4, Y13
+    ADDQ $128, SI
+    ADDQ $128, DI
+    ADDQ $128, R8
+    ADDQ $128, R9
+    ADDQ $128, R10
+    DECQ AX
+    JNZ  prcubic_loop16
+    VADDPD Y11, Y0, Y0
+    VADDPD Y12, Y0, Y0
+    VADDPD Y13, Y0, Y0
+
+prcubic_loop4_check:
+    ANDQ $15, CX
+    MOVQ CX, AX
+    SHRQ $2, AX
+    JZ   prcubic_remainder
+
+prcubic_loop4:
+    VMOVUPD (R10), Y1
+    VMOVUPD (R9), Y2
+    VMOVUPD (R8), Y3
+    VMOVUPD (DI), Y4
+    VMOVUPD (SI), Y5
+    VFMADD231PD Y1, Y7, Y2
+    VFMADD231PD Y2, Y7, Y3
+    VFMADD231PD Y3, Y7, Y4
+    VFMADD231PD Y5, Y4, Y0
+    ADDQ $32, SI
+    ADDQ $32, DI
+    ADDQ $32, R8
+    ADDQ $32, R9
+    ADDQ $32, R10
+    DECQ AX
+    JNZ  prcubic_loop4
+
+prcubic_remainder:
+    VEXTRACTF128 $1, Y0, X1
+    VADDPD X1, X0, X0
+    VHADDPD X0, X0, X0             // X0[0] = sum of 4 lanes
+    ANDQ $3, CX
+    JZ   prcubic_store
+
+prcubic_scalar:
+    VMOVSD (R10), X1
+    VMOVSD (R9), X2
+    VMOVSD (R8), X3
+    VMOVSD (DI), X4
+    VMOVSD (SI), X5
+    VFMADD231SD X1, X7, X2         // X7 lane0 = x
+    VFMADD231SD X2, X7, X3
+    VFMADD231SD X3, X7, X4
+    VFMADD231SD X5, X4, X0
+    ADDQ $8, SI
+    ADDQ $8, DI
+    ADDQ $8, R8
+    ADDQ $8, R9
+    ADDQ $8, R10
+    DECQ CX
+    JNZ  prcubic_scalar
+
+prcubic_store:
+    MOVQ out_base+0(FP), AX
+    VMOVSD X0, (AX)(R12*8)         // out[k] = result
+
+    // ---- advance the state machine ----
+    MOVQ fracBits+176(FP), CX
+    MOVQ $1, SI
+    SHLQ CX, SI
+    MOVQ SI, DI                    // DI = 1 << fracBits (= fracMask+1)
+    DECQ SI                        // SI = fracMask
+    MOVQ step+152(FP), AX
+    ANDQ AX, SI                    // SI = sFrac
+    ADDQ SI, R11                   // frac += sFrac
+    MOVQ DI, SI
+    DECQ SI                        // SI = fracMask
+    CMPQ R11, SI
+    JLE  prcubic_nocarry
+    SUBQ DI, R11                   // frac -= (fracMask+1)
+    INCQ DX                        // phase++
+prcubic_nocarry:
+    MOVQ step+152(FP), AX
+    SARQ CX, AX                    // AX = sFull
+    MOVQ numPhases+160(FP), SI
+    MOVQ R13, DI
+    IMULQ SI, DI                   // DI = sDiv*numPhases
+    SUBQ DI, AX                    // AX = sPhase
+    ADDQ AX, DX                    // phase += sPhase
+    ADDQ R13, BX                   // div += sDiv
+    CMPQ DX, SI
+    JLT  prcubic_nonorm
+    SUBQ SI, DX
+    INCQ BX
+prcubic_nonorm:
+    INCQ R12
+    JMP  prcubic_loop
+
+prcubic_done:
+    MOVQ R12, ret+184(FP)
+    VZEROUPPER
+    RET
+
 // Constants for sigmoid (float64)
 DATA sigmoid_half64<>+0x00(SB)/8, $0x3FE0000000000000  // 0.5
 DATA sigmoid_half64<>+0x08(SB)/8, $0x3FE0000000000000

--- a/f64/f64_arm64.go
+++ b/f64/f64_arm64.go
@@ -500,6 +500,25 @@ func cubicInterpDot64(hist, a, b, c, d []float64, x float64) float64 {
 //go:noescape
 func cubicInterpDotNEON(hist, a, b, c, d []float64, x float64) float64
 
+// polyphaseResampleCubic64 dispatches the fused polyphase cubic resampler. The
+// NEON guard matches cubicInterpDot64 (hasNEON && tapsPerPhase >= 2) so the fused
+// kernel's per-output dot selects the same tier as a standalone CubicInterpDot at
+// the same tap count, making the fused result bit-identical to the per-output
+// form.
+func polyphaseResampleCubic64(out, hist []float64, a, b, c, d [][]float64, at, step int64, numPhases, tapsPerPhase, fracBits int) int {
+	if hasNEON && tapsPerPhase >= 2 {
+		return polyphaseResampleCubicNEON(out, hist, a, b, c, d, at, step, numPhases, tapsPerPhase, fracBits)
+	}
+	return polyphaseResampleCubicGo(out, hist, a, b, c, d, at, step, numPhases, tapsPerPhase, fracBits)
+}
+
+// polyphaseResampleCubicNEON runs the whole output block in one fused NEON pass,
+// reusing cubicInterpDotNEON's inner dot body per output. Returns the number of
+// outputs written. See f64_arm64.s.
+//
+//go:noescape
+func polyphaseResampleCubicNEON(out, hist []float64, a, b, c, d [][]float64, at, step int64, numPhases, tapsPerPhase, fracBits int) int
+
 func butterflyComplex64(upperRe, upperIm, lowerRe, lowerIm, twRe, twIm []float64) {
 	// One NEON iteration needs 2 float64 lanes; anything shorter falls to Go.
 	if hasNEON && len(upperRe) >= 2 {

--- a/f64/f64_arm64.s
+++ b/f64/f64_arm64.s
@@ -1034,6 +1034,176 @@ cubic_neon_done:
     FMOVD F0, ret+128(FP)
     RET
 
+// func polyphaseResampleCubicNEON(out, hist []float64, a, b, c, d [][]float64,
+//                                 at, step int64, numPhases, tapsPerPhase, fracBits int) int
+//
+// Fused polyphase cubic resampler (float64, NEON): runs the whole output block in
+// one pass, reusing cubicInterpDotNEON's inner dot body (same V registers, same
+// WORD-encoded FMLA/FADD/DUP) for each output so the per-output dot is
+// bit-identical to the standalone kernel. Returns the number of outputs written.
+//
+// The outer stepping state lives in R19-R25 (permanent scratch), which the inner
+// body (R0-R7, V0-V31) never touches. sPhase and sFrac are re-derived from step
+// per output with a multiply, not a divide. Reserved registers
+// R28/R27/R18/R16/R17 are never touched.
+//
+// Persistent registers across the whole loop:
+//   R19 = div,  R20 = phase,  R21 = frac,  R22 = k,  R23 = sDiv,
+//   R24 = numPhases,  R25 = fracBits,  F30 = fracScale,  V31 = x broadcast.
+//
+// Frame layout (6 slices + 2 int64 + 3 int + 1 return): out@0, hist@24, a@48,
+// b@72, c@96, d@120, at@144, step@152, numPhases@160, tapsPerPhase@168,
+// fracBits@176, ret@184.
+TEXT ·polyphaseResampleCubicNEON(SB), NOSPLIT, $0-192
+    MOVD fracBits+176(FP), R25     // R25 = fracBits
+    MOVD numPhases+160(FP), R24    // R24 = numPhases
+
+    // sDiv = (step >> fracBits) / numPhases  (one division, hoisted)
+    MOVD step+152(FP), R0
+    LSR  R25, R0, R0
+    UDIV R24, R0, R23              // R23 = sDiv
+
+    // Seed div, phase, frac from at.
+    MOVD at+144(FP), R21
+    LSR  R25, R21, R0              // R0 = full = at >> fracBits
+    UDIV R24, R0, R19              // R19 = div
+    MUL  R24, R19, R1
+    SUB  R1, R0, R20               // R20 = phase
+    MOVD $1, R1
+    LSL  R25, R1, R1
+    SUB  $1, R1, R1               // R1 = fracMask
+    AND  R1, R21, R21             // R21 = frac
+
+    // fracScale = 2^-fracBits as float64: bits = (1023 - fracBits) << 52.
+    MOVD $1023, R0
+    SUB  R25, R0, R0
+    LSL  $52, R0, R0
+    FMOVD R0, F30                  // F30 = fracScale
+
+    MOVD $0, R22                   // k = 0
+
+prcubic_neon_loop:
+    MOVD out_len+8(FP), R7
+    CMP  R7, R22
+    BGE  prcubic_neon_done
+    MOVD tapsPerPhase+168(FP), R6  // R6 = taps
+    ADD  R6, R19, R8
+    MOVD hist_len+32(FP), R7
+    CMP  R7, R8
+    BGT  prcubic_neon_done
+
+    // x = float64(frac) * fracScale, broadcast to V31.
+    SCVTFD R21, F31                // F31 = float64(frac)
+    FMULD  F30, F31, F31           // F31 = x (lane 0)
+    WORD $0x4E0807FF               // DUP V31.2D, V31.D[0]
+
+    // Row pointers: byte offset = phase*24.
+    MOVD $24, R7
+    MUL  R7, R20, R8
+    MOVD a_base+48(FP), R9
+    MOVD (R9)(R8), R1             // &a[phase][0]
+    MOVD b_base+72(FP), R9
+    MOVD (R9)(R8), R2             // &b[phase][0]
+    MOVD c_base+96(FP), R9
+    MOVD (R9)(R8), R3             // &c[phase][0]
+    MOVD d_base+120(FP), R9
+    MOVD (R9)(R8), R4             // &d[phase][0]
+    MOVD hist_base+24(FP), R9
+    ADD  R19<<3, R9, R0           // &hist[div]  (float64 = 8 bytes)
+
+    // ---- inner dot body, V registers verbatim from cubicInterpDotNEON ----
+    VEOR V0.B16, V0.B16, V0.B16
+    VEOR V1.B16, V1.B16, V1.B16
+    LSR  $2, R6, R5              // R5 = taps / 4
+    CBZ  R5, prcubic_neon_loop2_check
+
+prcubic_neon_loop4:
+    VLD1.P 16(R4), [V2.D2]
+    VLD1.P 16(R3), [V3.D2]
+    VLD1.P 16(R2), [V4.D2]
+    VLD1.P 16(R1), [V5.D2]
+    VLD1.P 16(R0), [V6.D2]
+    VLD1.P 16(R4), [V10.D2]
+    VLD1.P 16(R3), [V11.D2]
+    VLD1.P 16(R2), [V12.D2]
+    VLD1.P 16(R1), [V13.D2]
+    VLD1.P 16(R0), [V14.D2]
+    WORD $0x4E7FCC43             // FMLA V3.2D, V2.2D, V31.2D
+    WORD $0x4E7FCC64             // FMLA V4.2D, V3.2D, V31.2D
+    WORD $0x4E7FCC85             // FMLA V5.2D, V4.2D, V31.2D
+    WORD $0x4E65CCC0             // FMLA V0.2D, V6.2D, V5.2D
+    WORD $0x4E7FCD4B             // FMLA V11.2D, V10.2D, V31.2D
+    WORD $0x4E7FCD6C             // FMLA V12.2D, V11.2D, V31.2D
+    WORD $0x4E7FCD8D             // FMLA V13.2D, V12.2D, V31.2D
+    WORD $0x4E6DCDC1             // FMLA V1.2D, V14.2D, V13.2D
+    SUB  $1, R5
+    CBNZ R5, prcubic_neon_loop4
+    WORD $0x4E61D400            // FADD V0.2D, V0.2D, V1.2D
+
+prcubic_neon_loop2_check:
+    AND  $3, R6, R5
+    LSR  $1, R5, R7             // R7 = remainder / 2
+    CBZ  R7, prcubic_neon_remainder1
+    VLD1.P 16(R4), [V2.D2]
+    VLD1.P 16(R3), [V3.D2]
+    VLD1.P 16(R2), [V4.D2]
+    VLD1.P 16(R1), [V5.D2]
+    VLD1.P 16(R0), [V6.D2]
+    WORD $0x4E7FCC43             // FMLA V3.2D, V2.2D, V31.2D
+    WORD $0x4E7FCC64             // FMLA V4.2D, V3.2D, V31.2D
+    WORD $0x4E7FCC85             // FMLA V5.2D, V4.2D, V31.2D
+    WORD $0x4E65CCC0             // FMLA V0.2D, V6.2D, V5.2D
+
+prcubic_neon_remainder1:
+    WORD $0x7E70D800            // FADDP D0, V0.2D
+    AND  $1, R5, R7
+    CBZ  R7, prcubic_neon_store
+
+    FMOVD (R4), F2
+    FMOVD (R3), F3
+    FMOVD (R2), F4
+    FMOVD (R1), F5
+    FMOVD (R0), F6
+    FMADDD F31, F3, F2, F3       // F3 = d*x + c
+    FMADDD F31, F4, F3, F4       // F4 = (d*x+c)*x + b
+    FMADDD F31, F5, F4, F5       // F5 = coef
+    FMADDD F5, F0, F6, F0        // F0 = hist*coef + acc
+
+prcubic_neon_store:
+    MOVD out_base+0(FP), R8
+    ADD  R22<<3, R8, R8
+    FMOVD F0, (R8)               // out[k] = result
+
+    // ---- advance the state machine ----
+    MOVD step+152(FP), R0
+    MOVD $1, R1
+    LSL  R25, R1, R1
+    SUB  $1, R1, R2             // R2 = fracMask
+    AND  R2, R0, R0            // R0 = sFrac
+    ADD  R0, R21, R21           // frac += sFrac
+    CMP  R2, R21
+    BLE  prcubic_neon_nocarry
+    SUB  R1, R21, R21           // frac -= (1<<fracBits)
+    ADD  $1, R20, R20           // phase++
+prcubic_neon_nocarry:
+    MOVD step+152(FP), R0
+    LSR  R25, R0, R0            // sFull
+    MUL  R24, R23, R1           // sDiv*numPhases
+    SUB  R1, R0, R0
+    ADD  R0, R20, R20           // phase += sPhase
+    ADD  R23, R19, R19          // div += sDiv
+    CMP  R24, R20
+    BLT  prcubic_neon_nonorm
+    SUB  R24, R20, R20
+    ADD  $1, R19, R19
+prcubic_neon_nonorm:
+    ADD  $1, R22, R22
+    B    prcubic_neon_loop
+
+prcubic_neon_done:
+    MOVD R22, ret+184(FP)
+    RET
+
 // func sigmoidNEON64(dst, src []float64)
 // Computes accurate sigmoid: sigmoid(x) = 1 / (1 + e^(-x)).
 // Uses the same exp range reduction + degree-5 polynomial core as tanhNEON64,

--- a/f64/f64_go.go
+++ b/f64/f64_go.go
@@ -459,6 +459,64 @@ func cubicInterpDotGo(hist, a, b, c, d []float64, x float64) float64 {
 	return sum
 }
 
+// polyphaseResampleCubicGo is the pure-Go reference for PolyphaseResampleCubic.
+// It runs the incremental phase-stepping state machine (soxr-style fixed-point
+// accumulator) and evaluates every output with the scalar cubic dot
+// (cubicInterpDotGo), so its result is bit-identical to a per-sample loop that
+// calls the Go-tier cubic dot at any tap count. Callers guarantee the inputs are
+// valid; the public wrapper does the validation and this function does none. It
+// returns the number of outputs written to out.
+//
+// State machine, verified invariant ((div*numPhases+phase)<<fracBits)+frac ==
+// at+k*step at the top of iteration k. The one-time divisions seed the
+// incremental deltas; per output only adds and at most two conditional
+// subtracts run. The frac carry folds into phase BEFORE the single phase
+// normalize; one conditional subtract suffices because
+// phase(<=numPhases-1) + carry(<=1) + sPhase(<=numPhases-1) <= 2*numPhases-1.
+func polyphaseResampleCubicGo(out, hist []float64, a, b, c, d [][]float64, at, step int64, numPhases, tapsPerPhase, fracBits int) int {
+	numPhases64 := int64(numPhases)
+	fracMask := int64(1)<<uint(fracBits) - 1
+	fracScale := 1.0 / float64(int64(1)<<uint(fracBits))
+
+	full := at >> uint(fracBits)
+	div := int(full / numPhases64)
+	phase := int(full - int64(div)*numPhases64)
+	frac := at & fracMask
+
+	sFull := step >> uint(fracBits)
+	sDiv := int(sFull / numPhases64)
+	sPhase := int(sFull - int64(sDiv)*numPhases64)
+	sFrac := step & fracMask
+
+	histLen := len(hist)
+	outLen := len(out)
+	k := 0
+	for k < outLen {
+		if div+tapsPerPhase > histLen {
+			break
+		}
+		x := float64(frac) * fracScale
+		out[k] = cubicInterpDotGo(
+			hist[div:div+tapsPerPhase],
+			a[phase][:tapsPerPhase], b[phase][:tapsPerPhase],
+			c[phase][:tapsPerPhase], d[phase][:tapsPerPhase], x)
+		k++
+
+		frac += sFrac
+		if frac > fracMask {
+			frac -= fracMask + 1
+			phase++
+		}
+		phase += sPhase
+		div += sDiv
+		if phase >= numPhases {
+			phase -= numPhases
+			div++
+		}
+	}
+	return k
+}
+
 func convolveValidMultiGo(dsts [][]float64, signal []float64, kernels [][]float64, n, _ int) {
 	// Kernel-major loop order: each kernel stays hot in cache for entire signal pass
 	for k, kernel := range kernels {

--- a/f64/f64_other.go
+++ b/f64/f64_other.go
@@ -57,6 +57,9 @@ func addScaled64(dst []float64, alpha float64, s []float64) { addScaledGo64(dst,
 func cubicInterpDot64(hist, a, b, c, d []float64, x float64) float64 {
 	return cubicInterpDotGo(hist, a, b, c, d, x)
 }
+func polyphaseResampleCubic64(out, hist []float64, a, b, c, d [][]float64, at, step int64, numPhases, tapsPerPhase, fracBits int) int {
+	return polyphaseResampleCubicGo(out, hist, a, b, c, d, at, step, numPhases, tapsPerPhase, fracBits)
+}
 func sigmoid64(dst, src []float64) { sigmoid64Go(dst, src) }
 func relu64(dst, src []float64)    { relu64Go(dst, src) }
 func clampScale64(dst, src []float64, minVal, maxVal, scale float64) {

--- a/f64/polyphase_resample_test.go
+++ b/f64/polyphase_resample_test.go
@@ -1,0 +1,450 @@
+package f64
+
+import (
+	"fmt"
+	"math"
+	"math/rand"
+	"testing"
+)
+
+// ---------------------------------------------------------------------------
+// Shared helpers for the fused polyphase cubic resampler tests.
+// ---------------------------------------------------------------------------
+
+func polyDeriveStep(inRate, outRate float64, numPhases, fracBits int) int64 {
+	ratio := outRate / inRate
+	scale := float64(int64(1) << uint(fracBits))
+	return int64(math.Round((1.0 / ratio) * float64(numPhases) * scale))
+}
+
+type polyRate struct {
+	name            string
+	inRate, outRate float64
+}
+
+var polyRates = []polyRate{
+	{"44k_to_48k_up", 44100, 48000},
+	{"48k_to_44k_down", 48000, 44100},
+	{"44k_to_64k_sub", 44100, 64000},
+	{"96k_to_48k_2to1", 96000, 48000},
+	{"16k_to_48k_3x", 16000, 48000},
+}
+
+func polyMakeBanks(numPhases, taps int, rng *rand.Rand) (a, b, c, d [][]float64) {
+	mk := func() [][]float64 {
+		rows := make([][]float64, numPhases)
+		for p := range numPhases {
+			row := make([]float64, taps)
+			for t := range taps {
+				row[t] = rng.NormFloat64() * 0.25
+			}
+			rows[p] = row
+		}
+		return rows
+	}
+	return mk(), mk(), mk(), mk()
+}
+
+func polyMakeHist(n int, rng *rand.Rand) []float64 {
+	h := make([]float64, n)
+	for i := range h {
+		h[i] = rng.NormFloat64()
+	}
+	return h
+}
+
+func polySizeHist(step int64, numOut, numPhases, taps, fracBits int) int {
+	lastDiv := int((int64(numOut-1) * step >> uint(fracBits)) / int64(numPhases))
+	return lastDiv + taps + 8
+}
+
+func polyRefLoop(out, hist []float64, a, b, c, d [][]float64, at, step int64, numPhases, taps, fracBits int, dot func(h, ca, cb, cc, cd []float64, x float64) float64) int {
+	numPhases64 := int64(numPhases)
+	fracMask := int64(1)<<uint(fracBits) - 1
+	fracScale := 1.0 / float64(int64(1)<<uint(fracBits))
+	histLen := len(hist)
+	k := 0
+	for k < len(out) {
+		full := at >> uint(fracBits)
+		div := int(full / numPhases64)
+		phase := int(full % numPhases64)
+		frac := at & fracMask
+		if div+taps > histLen {
+			break
+		}
+		x := float64(frac) * fracScale
+		out[k] = dot(hist[div:div+taps], a[phase][:taps], b[phase][:taps], c[phase][:taps], d[phase][:taps], x)
+		k++
+		at += step
+	}
+	return k
+}
+
+func polyBitsEqual(t *testing.T, label string, got, want []float64) {
+	t.Helper()
+	if len(got) != len(want) {
+		t.Fatalf("%s: length got=%d want=%d", label, len(got), len(want))
+	}
+	for i := range got {
+		if math.Float64bits(got[i]) != math.Float64bits(want[i]) {
+			t.Fatalf("%s: mismatch at %d: got=%v (0x%016x) want=%v (0x%016x)",
+				label, i, got[i], math.Float64bits(got[i]), want[i], math.Float64bits(want[i]))
+		}
+	}
+}
+
+var polyGridPhases = []int{64, 80, 128, 256}
+
+// polyGridTaps spans the tap counts and, within the vectorized kernels, the loop
+// tiers: 16/32/64 are pure 16-wide-block multiples, 20/100 add a scalar tail, and
+// 24 (16+8 on amd64 f32, 16+4+4 on amd64 f64) exercises the secondary
+// 8-wide/4-wide block after the 16-wide block in the fused path directly.
+var polyGridTaps = []int{16, 20, 24, 32, 64, 100}
+
+const polyFracBits = 16
+
+func polyLabel(numPhases, taps int, rate string) string {
+	return fmt.Sprintf("nP%d_taps%d/%s", numPhases, taps, rate)
+}
+
+// Tier-aware parity: the public fused API vs a div/mod reference loop calling
+// CubicInterpDotUnsafe. Aligned dispatch guards make both pick the same dot tier,
+// so the results are bit-identical on every CPU.
+func TestPolyphaseResampleCubicParity(t *testing.T) {
+	const outLen = 1024
+	rng := rand.New(rand.NewSource(0xC0FFEE))
+	for _, numPhases := range polyGridPhases {
+		for _, taps := range polyGridTaps {
+			a, b, c, d := polyMakeBanks(numPhases, taps, rng)
+			for _, r := range polyRates {
+				step := polyDeriveStep(r.inRate, r.outRate, numPhases, polyFracBits)
+				histLen := polySizeHist(step, outLen, numPhases, taps, polyFracBits)
+				hist := polyMakeHist(histLen, rng)
+
+				gotOut := make([]float64, outLen)
+				wantOut := make([]float64, outLen)
+				nGot, atGot := PolyphaseResampleCubic(gotOut, hist, a, b, c, d, 0, step, numPhases, taps, polyFracBits)
+				nWant := polyRefLoop(wantOut, hist, a, b, c, d, 0, step, numPhases, taps, polyFracBits, CubicInterpDotUnsafe)
+
+				label := polyLabel(numPhases, taps, r.name)
+				if nGot != nWant {
+					t.Fatalf("%s: n got=%d want=%d", label, nGot, nWant)
+				}
+				if atGot != int64(nGot)*step {
+					t.Fatalf("%s: atOut got=%d want=%d", label, atGot, int64(nGot)*step)
+				}
+				polyBitsEqual(t, label, gotOut[:nGot], wantOut[:nWant])
+
+				// The Unsafe entry point must produce the identical result and atOut.
+				unsafeOut := make([]float64, outLen)
+				nU, atU := PolyphaseResampleCubicUnsafe(unsafeOut, hist, a, b, c, d, 0, step, numPhases, taps, polyFracBits)
+				if nU != nGot || atU != atGot {
+					t.Fatalf("%s: Unsafe (n=%d,at=%d) != safe (n=%d,at=%d)", label, nU, atU, nGot, atGot)
+				}
+				polyBitsEqual(t, label+"/unsafe", unsafeOut[:nU], gotOut[:nGot])
+			}
+		}
+	}
+}
+
+// TestPolyphaseResampleCubicGoHistExhaust drives polyphaseResampleCubicGo directly
+// with a history shorter than the requested block so the window-exhaustion break
+// fires and returns a partial n. On a SIMD host the public-API exhaustion path runs
+// the asm kernel, so this is the only test that reaches the Go state machine's
+// break; it must still match the div/mod oracle (partial n and bit-exact output).
+func TestPolyphaseResampleCubicGoHistExhaust(t *testing.T) {
+	const outLen = 1024
+	rng := rand.New(rand.NewSource(0xE0F))
+	for _, numPhases := range polyGridPhases {
+		for _, taps := range polyGridTaps {
+			a, b, c, d := polyMakeBanks(numPhases, taps, rng)
+			step := polyDeriveStep(44100, 48000, numPhases, polyFracBits)
+			hist := polyMakeHist(taps+37, rng)
+			gotOut := make([]float64, outLen)
+			wantOut := make([]float64, outLen)
+			nGot := polyphaseResampleCubicGo(gotOut, hist, a, b, c, d, 0, step, numPhases, taps, polyFracBits)
+			nWant := polyRefLoop(wantOut, hist, a, b, c, d, 0, step, numPhases, taps, polyFracBits, cubicInterpDotGo)
+			label := polyLabel(numPhases, taps, "hist_exhaust")
+			if nGot != nWant {
+				t.Fatalf("%s: n got=%d want=%d", label, nGot, nWant)
+			}
+			if nGot >= outLen {
+				t.Fatalf("%s: expected the history to exhaust before outLen, got n=%d", label, nGot)
+			}
+			polyBitsEqual(t, label, gotOut[:nGot], wantOut[:nWant])
+		}
+	}
+}
+
+// Arch-independent Go check: polyphaseResampleCubicGo vs a div/mod reference loop
+// calling cubicInterpDotGo. Both use the scalar Go dot, so they are bit-identical
+// on any host, isolating the state machine from the asm.
+func TestPolyphaseResampleCubicGoStateMachine(t *testing.T) {
+	const outLen = 1024
+	rng := rand.New(rand.NewSource(0x1234))
+	for _, numPhases := range polyGridPhases {
+		for _, taps := range polyGridTaps {
+			a, b, c, d := polyMakeBanks(numPhases, taps, rng)
+			for _, r := range polyRates {
+				step := polyDeriveStep(r.inRate, r.outRate, numPhases, polyFracBits)
+				histLen := polySizeHist(step, outLen, numPhases, taps, polyFracBits)
+				hist := polyMakeHist(histLen, rng)
+
+				gotOut := make([]float64, outLen)
+				wantOut := make([]float64, outLen)
+				nGot := polyphaseResampleCubicGo(gotOut, hist, a, b, c, d, 0, step, numPhases, taps, polyFracBits)
+				nWant := polyRefLoop(wantOut, hist, a, b, c, d, 0, step, numPhases, taps, polyFracBits, cubicInterpDotGo)
+				label := polyLabel(numPhases, taps, r.name)
+				if nGot != nWant {
+					t.Fatalf("%s: n got=%d want=%d", label, nGot, nWant)
+				}
+				polyBitsEqual(t, label, gotOut[:nGot], wantOut[:nWant])
+			}
+		}
+	}
+}
+
+func TestPolyphaseResampleCubicGoForcedCarries(t *testing.T) {
+	rng := rand.New(rand.NewSource(0x9))
+	cases := []struct {
+		numPhases, taps, fracBits int
+		at, step                  int64
+	}{
+		{3, 16, 4, 0, 22},
+		{3, 16, 4, 37, 25},
+		{5, 20, 8, 0, 617},
+		{7, 16, 3, 11, 45},
+		{2, 16, 5, 0, 97},
+		{80, 20, 16, 0, 60073},
+	}
+	for ci, tc := range cases {
+		a, b, c, d := polyMakeBanks(tc.numPhases, tc.taps, rng)
+		const outLen = 300
+		lastDiv := int((tc.at + int64(outLen-1)*tc.step) >> uint(tc.fracBits) / int64(tc.numPhases))
+		hist := polyMakeHist(lastDiv+tc.taps+8, rng)
+		gotOut := make([]float64, outLen)
+		wantOut := make([]float64, outLen)
+		nGot := polyphaseResampleCubicGo(gotOut, hist, a, b, c, d, tc.at, tc.step, tc.numPhases, tc.taps, tc.fracBits)
+		nWant := polyRefLoop(wantOut, hist, a, b, c, d, tc.at, tc.step, tc.numPhases, tc.taps, tc.fracBits, cubicInterpDotGo)
+		if nGot != nWant {
+			t.Fatalf("case %d: n got=%d want=%d", ci, nGot, nWant)
+		}
+		polyBitsEqual(t, fmt.Sprintf("forced_carry_case%d", ci), gotOut[:nGot], wantOut[:nWant])
+	}
+}
+
+func TestPolyphaseResampleCubicStreamingChunks(t *testing.T) {
+	rng := rand.New(rand.NewSource(0x5EED))
+	const numPhases, taps = 80, 32
+	step := polyDeriveStep(44100, 64000, numPhases, polyFracBits)
+	a, b, c, d := polyMakeBanks(numPhases, taps, rng)
+	const total = 1024
+	histLen := polySizeHist(step, total, numPhases, taps, polyFracBits)
+	hist := polyMakeHist(histLen, rng)
+
+	oneShot := make([]float64, total)
+	nOne, _ := PolyphaseResampleCubic(oneShot, hist, a, b, c, d, 0, step, numPhases, taps, polyFracBits)
+
+	for _, chunk := range []int{1, 7, 64, 1024} {
+		chunked := make([]float64, total)
+		at := int64(0)
+		produced := 0
+		for produced < nOne {
+			end := min(produced+chunk, total)
+			n, atOut := PolyphaseResampleCubic(chunked[produced:end], hist, a, b, c, d, at, step, numPhases, taps, polyFracBits)
+			if n == 0 {
+				break
+			}
+			at = atOut
+			produced += n
+		}
+		if produced != nOne {
+			t.Fatalf("chunk=%d produced=%d want=%d", chunk, produced, nOne)
+		}
+		polyBitsEqual(t, fmt.Sprintf("chunk%d", chunk), chunked[:nOne], oneShot[:nOne])
+	}
+}
+
+func TestPolyphaseResampleCubicConsumerRebase(t *testing.T) {
+	rng := rand.New(rand.NewSource(0xABCD))
+	const numPhases, taps, fracBits = 80, 20, 16
+	step := polyDeriveStep(44100, 48000, numPhases, fracBits)
+
+	a, b, c, d := polyMakeBanks(numPhases, taps, rng)
+	const total = 4096
+	fullHist := polyMakeHist(polySizeHist(step, total, numPhases, taps, fracBits)+64, rng)
+
+	oneShot := make([]float64, total)
+	nOne, _ := PolyphaseResampleCubic(oneShot, fullHist, a, b, c, d, 0, step, numPhases, taps, fracBits)
+
+	got := make([]float64, 0, nOne)
+	at := int64(0)
+	base := 0
+	block := make([]float64, 200)
+	for len(got) < nOne {
+		window := fullHist[base:]
+		n, atOut := PolyphaseResampleCubic(block, window, a, b, c, d, at, step, numPhases, taps, fracBits)
+		if n == 0 {
+			break
+		}
+		got = append(got, block[:n]...)
+		at = atOut
+		consumed := int((at >> uint(fracBits)) / int64(numPhases))
+		if consumed > 0 {
+			base += consumed
+			at -= int64(consumed) * int64(numPhases) << uint(fracBits)
+		}
+	}
+	if len(got) > nOne {
+		got = got[:nOne]
+	}
+	polyBitsEqual(t, "consumer_rebase", got, oneShot[:len(got)])
+	if len(got) != nOne {
+		t.Fatalf("consumer_rebase produced=%d want=%d", len(got), nOne)
+	}
+}
+
+func TestPolyphaseResampleCubicTermination(t *testing.T) {
+	rng := rand.New(rand.NewSource(0x7))
+	const numPhases, taps, fracBits = 80, 20, 16
+	step := polyDeriveStep(44100, 48000, numPhases, fracBits)
+	a, b, c, d := polyMakeBanks(numPhases, taps, rng)
+
+	t.Run("out_full_first", func(t *testing.T) {
+		hist := polyMakeHist(polySizeHist(step, 1024, numPhases, taps, fracBits), rng)
+		out := make([]float64, 10)
+		n, atOut := PolyphaseResampleCubic(out, hist, a, b, c, d, 0, step, numPhases, taps, fracBits)
+		if n != 10 {
+			t.Fatalf("n=%d want 10", n)
+		}
+		if atOut != int64(n)*step {
+			t.Fatalf("atOut=%d want %d", atOut, int64(n)*step)
+		}
+	})
+
+	t.Run("hist_exhausted_first", func(t *testing.T) {
+		hist := polyMakeHist(taps+30, rng)
+		out := make([]float64, 1024)
+		n, _ := PolyphaseResampleCubic(out, hist, a, b, c, d, 0, step, numPhases, taps, fracBits)
+		want := polyRefLoop(make([]float64, 1024), hist, a, b, c, d, 0, step, numPhases, taps, fracBits, CubicInterpDotUnsafe)
+		if n != want {
+			t.Fatalf("n=%d want %d", n, want)
+		}
+		if n >= 1024 {
+			t.Fatalf("expected early termination, got n=%d", n)
+		}
+	})
+
+	t.Run("zero_outputs", func(t *testing.T) {
+		hist := polyMakeHist(polySizeHist(step, 100, numPhases, taps, fracBits), rng)
+		if n, at := PolyphaseResampleCubic(nil, hist, a, b, c, d, 0, step, numPhases, taps, fracBits); n != 0 || at != 0 {
+			t.Fatalf("empty out: (%d,%d) want (0,0)", n, at)
+		}
+		short := polyMakeHist(taps-1, rng)
+		out := make([]float64, 16)
+		if n, at := PolyphaseResampleCubic(out, short, a, b, c, d, 0, step, numPhases, taps, fracBits); n != 0 || at != 0 {
+			t.Fatalf("short hist: (%d,%d) want (0,0)", n, at)
+		}
+		hist2 := polyMakeHist(taps+5, rng)
+		startAt := int64(len(hist2)) * int64(numPhases) << uint(fracBits)
+		if n, at := PolyphaseResampleCubic(out, hist2, a, b, c, d, startAt, step, numPhases, taps, fracBits); n != 0 || at != startAt {
+			t.Fatalf("past-hist at: (%d,%d) want (0,%d)", n, at, startAt)
+		}
+	})
+}
+
+func TestPolyphaseResampleCubicValidation(t *testing.T) {
+	rng := rand.New(rand.NewSource(0x11))
+	const numPhases, taps, fracBits = 8, 16, 16
+	step := polyDeriveStep(44100, 48000, numPhases, fracBits)
+	a, b, c, d := polyMakeBanks(numPhases, taps, rng)
+	hist := polyMakeHist(polySizeHist(step, 64, numPhases, taps, fracBits), rng)
+	out := make([]float64, 64)
+
+	assertNoop := func(name string, at int64, fn func() (int, int64)) {
+		n, atOut := fn()
+		if n != 0 || atOut != at {
+			t.Fatalf("%s: got (%d,%d) want (0,%d)", name, n, atOut, at)
+		}
+	}
+	assertNoop("numPhases<1", 5, func() (int, int64) {
+		return PolyphaseResampleCubic(out, hist, a, b, c, d, 5, step, 0, taps, fracBits)
+	})
+	assertNoop("taps<1", 5, func() (int, int64) {
+		return PolyphaseResampleCubic(out, hist, a, b, c, d, 5, step, numPhases, 0, fracBits)
+	})
+	assertNoop("step<1", 5, func() (int, int64) {
+		return PolyphaseResampleCubic(out, hist, a, b, c, d, 5, 0, numPhases, taps, fracBits)
+	})
+	assertNoop("at<0", -3, func() (int, int64) {
+		return PolyphaseResampleCubic(out, hist, a, b, c, d, -3, step, numPhases, taps, fracBits)
+	})
+	assertNoop("fracBits<0", 5, func() (int, int64) {
+		return PolyphaseResampleCubic(out, hist, a, b, c, d, 5, step, numPhases, taps, -1)
+	})
+	assertNoop("fracBits>max", 5, func() (int, int64) {
+		return PolyphaseResampleCubic(out, hist, a, b, c, d, 5, step, numPhases, taps, polyphaseMaxFracBits64+1)
+	})
+	assertNoop("short_bank", 5, func() (int, int64) {
+		return PolyphaseResampleCubic(out, hist, a[:numPhases-1], b, c, d, 5, step, numPhases, taps, fracBits)
+	})
+	shortRows := make([][]float64, numPhases)
+	copy(shortRows, a)
+	shortRows[numPhases-1] = shortRows[numPhases-1][:taps-1]
+	assertNoop("short_row", 5, func() (int, int64) {
+		return PolyphaseResampleCubic(out, hist, shortRows, b, c, d, 5, step, numPhases, taps, fracBits)
+	})
+	// Accumulator overflow: a step so large that at+len(out)*step overflows int64
+	// must be rejected as (0, at) rather than panicking or reading out of range.
+	assertNoop("step_overflow", 5, func() (int, int64) {
+		return PolyphaseResampleCubic(out, hist, a, b, c, d, 5, math.MaxInt64, numPhases, taps, fracBits)
+	})
+}
+
+// TestPolyphaseResampleCubicMaxFracBits checks the valid side of the fracBits
+// boundary: at exactly polyphaseMaxFracBits64 the fused kernel still produces
+// output bit-identical to the div/mod oracle, confirming float64(frac)*2^-fracBits
+// is exact at the maximum (the constant is not off by one).
+func TestPolyphaseResampleCubicMaxFracBits(t *testing.T) {
+	rng := rand.New(rand.NewSource(0x2C))
+	// At fracBits == 53 the derived step is ~2^53 scale, so even a modest block
+	// would overflow the int64 accumulator (and trip the overflow guard). A short
+	// block stays in range while still exercising the max-width frac conversion.
+	const numPhases, taps, outLen = 80, 32, 8
+	fracBits := polyphaseMaxFracBits64
+	step := polyDeriveStep(44100, 48000, numPhases, fracBits)
+	a, b, c, d := polyMakeBanks(numPhases, taps, rng)
+	hist := polyMakeHist(polySizeHist(step, outLen, numPhases, taps, fracBits), rng)
+	gotOut := make([]float64, outLen)
+	wantOut := make([]float64, outLen)
+	n, _ := PolyphaseResampleCubic(gotOut, hist, a, b, c, d, 0, step, numPhases, taps, fracBits)
+	nWant := polyRefLoop(wantOut, hist, a, b, c, d, 0, step, numPhases, taps, fracBits, CubicInterpDotUnsafe)
+	if n == 0 || n != nWant {
+		t.Fatalf("max fracBits: n got=%d want=%d (expected nonzero)", n, nWant)
+	}
+	polyBitsEqual(t, "max_fracbits", gotOut[:n], wantOut[:nWant])
+}
+
+func TestPolyphaseResampleCubicNoAlloc(t *testing.T) {
+	rng := rand.New(rand.NewSource(0x33))
+	const numPhases, taps, fracBits = 80, 32, 16
+	step := polyDeriveStep(44100, 48000, numPhases, fracBits)
+	a, b, c, d := polyMakeBanks(numPhases, taps, rng)
+	hist := polyMakeHist(polySizeHist(step, 1024, numPhases, taps, fracBits), rng)
+	out := make([]float64, 1024)
+	// Guard against a vacuous pass: confirm this config actually produces output,
+	// so a regression that early-returned (0, at) could not read as zero-alloc.
+	if n, _ := PolyphaseResampleCubic(out, hist, a, b, c, d, 0, step, numPhases, taps, fracBits); n == 0 {
+		t.Fatalf("no-alloc config produced no output; the allocation check would be vacuous")
+	}
+	if allocs := testing.AllocsPerRun(50, func() {
+		PolyphaseResampleCubic(out, hist, a, b, c, d, 0, step, numPhases, taps, fracBits)
+	}); allocs != 0 {
+		t.Fatalf("PolyphaseResampleCubic allocated %v times, want 0", allocs)
+	}
+	if allocs := testing.AllocsPerRun(50, func() {
+		PolyphaseResampleCubicUnsafe(out, hist, a, b, c, d, 0, step, numPhases, taps, fracBits)
+	}); allocs != 0 {
+		t.Fatalf("PolyphaseResampleCubicUnsafe allocated %v times, want 0", allocs)
+	}
+}


### PR DESCRIPTION
Fixes #52

## Fused polyphase cubic resampler

Adds `PolyphaseResampleCubic` (and the `...Unsafe` sibling) to the `f32` and `f64` packages: a fused soxr-style polyphase FIR resampler with cubic sub-phase coefficient interpolation that runs a whole output block in one call. It is the block form of a per-output loop over `CubicInterpDot`.

```go
func PolyphaseResampleCubic(out, hist []float32, a, b, c, d [][]float32, at, step int64, numPhases, tapsPerPhase, fracBits int) (n int, atOut int64)
```

For each output it derives the input window and interpolation phase from a fixed-point accumulator, evaluates `sum(hist[div+i] * (a[i] + x*(b[i] + x*(c[i] + x*d[i]))))` over `tapsPerPhase` taps with Horner's method, then advances the accumulator by `step`. It returns the number of outputs written and the accumulator after them (`atOut == at + n*step`), so a streaming caller carries `atOut` into the next call.

## Measured first, per the issue

Issue #52 asked for this to be justified by profiling, with the div/mod removal prototyped in pure Go first, and #54 places the pure-Go incremental accumulator on the resampler side. So the honest baseline is not the naive per-output div/mod loop but the best pure-Go resampler-side fix: an incremental phase-stepping accumulator (no per-output integer division) that still calls the already-SIMD `CubicInterpDot` once per output. The kernel only earns its place if it beats that.

The fused kernel keeps the `div`/`phase`/`frac` state machine in registers across the block and removes the per-output Go-to-asm call, feature dispatch, and slice-header overhead. Measured directly against the pure-Go StepLoop over a 1024-output block at numPhases 80 (the QualityMedium regime a real resampler runs at), AVX+FMA on an i7-1260P and NEON on a Raspberry Pi 5:

| taps | f32 x86 speedup | f32 NEON speedup |
| ---- | --------------- | ---------------- |
| 16   | 2.3x            | 2.1x             |
| 20   | 1.7x            | 2.0x             |
| 32   | 1.9x            | 1.8x             |

The win is largest at the short tap counts audio resampling uses, where per-output overhead dominates the MAC work, and it shrinks as taps grow.

## Bit-exact, tier-aligned

The fused dot reuses `CubicInterpDot`'s inner body verbatim under the same feature gate (`cpu.X86.AVX && cpu.X86.FMA && tapsPerPhase >= minAVXElements` on amd64, `hasNEON && tapsPerPhase >= 4/2` on arm64), so the fused result is bit-identical to a per-output `CubicInterpDot` on every CPU, tier for tier. The amd64 kernels are AVX1-clean (no AVX2-only encodings under an `...AVX` name; the machine-checked ISA and FMA gates cover this) and the arm64 kernels reuse the existing WORD-encoded NEON body.

## Tests

- Tier-aware parity: the public API vs a per-output div/mod reference loop calling `CubicInterpDotUnsafe`, asserted bit-identical across numPhases {64,80,128,256} x taps {16,20,32,64,100} x five rate regimes (44100->48000, 48000->44100, 44100->64000, 96000->48000 exact 2:1, 16000->48000), on both amd64 and a native Raspberry Pi 5.
- Arch-independent state-machine check: the Go reference vs a scalar div/mod reference, isolating the stepping logic from the assembly, including forced frac-carry and phase-wrap on the same output.
- Streaming continuity (chunked blocks concatenate bit-identically to one shot; a consumer-style rebase mirroring the delay-line consume), termination and no-op edge cases, input validation, and `AllocsPerRun == 0`.

Implementation is Go ref + AVX+FMA (amd64) + NEON (arm64) + pure-Go fallback, all zero-allocation.
