### PR TITLE
cpu: scale TestSIMDDisableAllIntegration timeout under emulation

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -322,6 +322,12 @@ jobs:
       - name: Run amd64 tests under the qemu CPU model
         env:
           MODEL: ${{ matrix.model }}
+          # See the SDE leg below: cpu.TestSIMDDisableAllIntegration re-execs the
+          # test binary and waits on the child, which qemu-user emulates far
+          # slower than native. Signal the emulated environment so the test
+          # widens its subprocess timeout rather than blowing the native 30s
+          # bound (#237).
+          SIMD_TEST_EMULATED: '1'
         run: |
           set -uo pipefail
           fail=0
@@ -465,6 +471,14 @@ jobs:
           rm -f /tmp/cpu.test
 
       - name: Run the test suite under SDE with AVX-512 enabled
+        env:
+          # cpu.TestSIMDDisableAllIntegration re-execs the test binary and waits
+          # on it under a context timeout. Whole-instruction SDE emulation runs
+          # that child two orders of magnitude slower than native, so the test
+          # widens its budget when this flag is set instead of blowing the native
+          # 30s bound (#237). Only the emulated legs export it; the native legs
+          # keep the tight bound so a real hang is still caught quickly.
+          SIMD_TEST_EMULATED: '1'
         run: |
           set -uo pipefail
           fail=0

--- a/cpu/disable_test.go
+++ b/cpu/disable_test.go
@@ -113,11 +113,27 @@ func TestHelperInfo(t *testing.T) {
 	fmt.Printf("CPUINFO=%s\n", Info())
 }
 
+// subprocessTimeout bounds the SIMD_DISABLE=all re-exec below. Natively the
+// helper finishes in a few milliseconds, so 30s is a generous ceiling that
+// still trips on a genuine hang. Under whole-program CPU emulation the child's
+// runtime init and CPUID probe are interpreted instruction by instruction,
+// inflating wall time by orders of magnitude; the AVX-512 (Intel SDE) and
+// cross-isa (qemu-user) CI legs occasionally blew the fixed 30s budget for
+// exactly this reason (#237). Those legs export SIMD_TEST_EMULATED=1, so key a
+// larger budget off that one signal. The native path never sets it and keeps
+// the tight 30s bound, so a real native hang is still caught quickly.
+func subprocessTimeout() time.Duration {
+	if os.Getenv("SIMD_TEST_EMULATED") == "1" {
+		return 5 * time.Minute
+	}
+	return 30 * time.Second
+}
+
 // TestSIMDDisableAllIntegration re-execs the test binary with SIMD_DISABLE=all
 // and asserts cpu.Info() reports the no-SIMD string for this architecture, which
 // proves the env var is read and applied during package init.
 func TestSIMDDisableAllIntegration(t *testing.T) {
-	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	ctx, cancel := context.WithTimeout(context.Background(), subprocessTimeout())
 	defer cancel()
 	cmd := exec.CommandContext(ctx, os.Args[0], "-test.run=^TestHelperInfo$", "-test.v")
 	cmd.Env = append(os.Environ(), "SIMD_DISABLE_HELPER=1", "SIMD_DISABLE=all")


### PR DESCRIPTION
Fixes #237.

`cpu.TestSIMDDisableAllIntegration` re-execs the test binary with `SIMD_DISABLE=all` and waits on the child under a `context.WithTimeout`, asserting `cpu.Info()` reports the no-SIMD tier (proving `SIMD_DISABLE` is applied at package init). The bound was a hardcoded 30s. That is comfortable natively, where the child finishes in a few milliseconds, but too tight under whole-instruction CPU emulation: the AVX-512 (Intel SDE) leg interprets the child's runtime init and CPUID probe instruction by instruction, inflating wall time by orders of magnitude, so the 30s budget was occasionally blown. It passes on re-run, which is the signature of a timing flake rather than a real failure, and it has left the SDE check stuck/failing and delayed merges.

## Fix

Add a `subprocessTimeout` helper that returns 5 minutes when `SIMD_TEST_EMULATED=1` and the tight 30s otherwise. The two emulated CI legs export that flag on the step that runs the full suite:

- `avx512-sde` -> "Run the test suite under SDE with AVX-512 enabled"
- `cross-isa` -> "Run amd64 tests under the qemu CPU model"

The native legs leave the flag unset, so their behavior and coverage are byte-identical to before (still 30s, still the same subprocess + assertion), and a genuine native hang is still caught quickly. The two "Assert ... reports the tier" probe steps run only `-test.run=^TestHelperInfo$`, which never enters this test, so they correctly do not set the flag.

## Why scale, not skip

Scaling keeps the subprocess assertion running under SDE, where the AVX-512 package-init `SIMD_DISABLE` handling most needs the coverage. `t.Skip` under emulation would delete exactly that coverage. Only the emulated budget is widened, so the native path keeps its tight hang-detection bound rather than a blanket increase that would mask a real native hang. 5 minutes is a generous ceiling (the whole SDE suite runs in ~33s, and this child runs one tiny test) that still trips a true hang.

## Testing

- `go test ./cpu/ -run TestSIMDDisableAllIntegration -count=1` passes natively in ~0.003s (unchanged).
- Exercised the emulated branch locally with `SIMD_TEST_EMULATED=1 go test ./cpu/ -run TestSIMDDisableAllIntegration -count=1`: passes, takes the 5-minute branch.
- `go build ./...`, `go vet ./...`, `gofmt` clean, YAML validated.