### PR TITLE
f32: radix-4 butterfly stage ButterflyComplexStage4 (Fixes #242)

### DIFF
--- a/README.md
+++ b/README.md
@@ -357,6 +357,8 @@ Results are identical to the per-row path either way.
 |            | `MulConjComplex(dstRe,dstIm,aRe,aIm,bRe,bIm)` | Multiply by conjugate      | 8x / 4x          |
 |            | `AbsSqComplex(dst,aRe,aIm)`           | Magnitude squared                  | 8x / 4x          |
 |            | `ButterflyComplex(uRe,uIm,lRe,lIm,twRe,twIm)` | FFT butterfly with twiddle | 8x / 4x          |
+|            | `ButterflyComplexStage(re,im,span,twRe,twIm)` | One whole radix-2 DIT stage (any span) | 8x / 4x |
+|            | `ButterflyComplexStage4(re,im,span,tw1..tw3)` | One whole radix-4 DIT stage (two radix-2 stages in one pass) | 8x / 4x |
 |            | `RealFFTUnpack(outRe,outIm,zRe,zIm,twRe,twIm)` | Real FFT unpack step     | 8x / 4x          |
 | **Utility**| `Reverse(dst, src)`                   | Reverse slice order                | 8x / 4x          |
 |            | `AddSub(sum, diff, a, b)`             | Fused sum and difference           | 8x / 4x          |

--- a/f32/butterfly_complex_stage4_test.go
+++ b/f32/butterfly_complex_stage4_test.go
@@ -1,0 +1,729 @@
+package f32
+
+import (
+	"fmt"
+	"math"
+	"math/bits"
+	"math/rand/v2"
+	"testing"
+)
+
+// =============================================================================
+// BUTTERFLY COMPLEX STAGE4 TESTS (float32, radix-4)
+// =============================================================================
+//
+// These reuse closeEnough, stageAbsTol/stageRelTol and stageFFTTolPerN2 from
+// butterfly_complex_stage_test.go: both stages combine the same butterflies and
+// round the same way, so one tolerance policy covers both.
+
+// stage4FillTwiddles writes the three radix-4 twiddle powers for one span into
+// caller-provided buffers of length span:
+//
+//	w = exp(-2*pi*i/(4*span)); tw1 = w^(2j), tw2 = w^j, tw3 = w^(3j).
+//
+// The powers are computed in float64 (math.Sincos) and rounded to float32, the
+// same precision a real caller's twiddle tables carry. math.Sincos returns
+// (sin, cos); the twiddle real part is cos, the imaginary part is sin.
+func stage4FillTwiddles(t1r, t1i, t2r, t2i, t3r, t3i []float32, span int) {
+	base := -math.Pi / float64(2*span) // = -2*pi/(4*span)
+	for j := range span {
+		s1, c1 := math.Sincos(base * float64(2*j))
+		t1r[j], t1i[j] = float32(c1), float32(s1)
+		s2, c2 := math.Sincos(base * float64(j))
+		t2r[j], t2i[j] = float32(c2), float32(s2)
+		s3, c3 := math.Sincos(base * float64(3*j))
+		t3r[j], t3i[j] = float32(c3), float32(s3)
+	}
+}
+
+// stage4Twiddles allocates and returns the three radix-4 twiddle powers for one
+// span. See stage4FillTwiddles for the values.
+//
+//nolint:gocritic // the six twiddle-power arrays are one group, matching the six-slice kernel signature under test
+func stage4Twiddles(span int) (t1r, t1i, t2r, t2i, t3r, t3i []float32) {
+	t1r = make([]float32, span)
+	t1i = make([]float32, span)
+	t2r = make([]float32, span)
+	t2i = make([]float32, span)
+	t3r = make([]float32, span)
+	t3i = make([]float32, span)
+	stage4FillTwiddles(t1r, t1i, t2r, t2i, t3r, t3i, span)
+	return t1r, t1i, t2r, t2i, t3r, t3i
+}
+
+// stage4FillRadix2Twiddle writes the radix-2 twiddle table exp(-i*pi*j/span) for
+// one span into caller-provided buffers of length span. This is the twiddle the
+// existing ButterflyComplexStage consumes, used to build the two-radix-2 arm that
+// a radix-4 stage must reproduce.
+func stage4FillRadix2Twiddle(twRe, twIm []float32, span int) {
+	for j := range span {
+		sin, cos := math.Sincos(-math.Pi * float64(j) / float64(span))
+		twRe[j], twIm[j] = float32(cos), float32(sin)
+	}
+}
+
+// stage4Data fills split-complex arrays with deterministic pseudo-random values.
+// A seeded generator keeps the run reproducible while covering a wider spread of
+// magnitudes and signs than a fixed trig filler.
+func stage4Data(n int, seed uint64) (re, im []float32) {
+	r := rand.New(rand.NewPCG(seed, 0x9E3779B97F4A7C15))
+	re = make([]float32, n)
+	im = make([]float32, n)
+	for i := range n {
+		re[i] = float32(r.NormFloat64())
+		im[i] = float32(r.NormFloat64())
+	}
+	return re, im
+}
+
+// butterflyComplexStage4Ref is an independent reference for one radix-4
+// decimation-in-time stage. It works in complex128 and indexes re/im directly,
+// so it shares no code with butterflyComplexStage4x32Go. The -1i and +1i factors
+// are the forward-DFT cross-adds on the second and fourth outputs.
+func butterflyComplexStage4Ref(re, im []float32, span int, t1r, t1i, t2r, t2i, t3r, t3i []float32) {
+	if span <= 0 ||
+		len(t1r) < span || len(t1i) < span ||
+		len(t2r) < span || len(t2i) < span ||
+		len(t3r) < span || len(t3i) < span {
+		return
+	}
+	n := min(len(re), len(im))
+	for k := 0; k+butterflyStage4Radix*span <= n; k += butterflyStage4Radix * span {
+		for j := range span {
+			i0 := k + j
+			i1 := i0 + span
+			i2 := i1 + span
+			i3 := i2 + span
+
+			x0 := complex(float64(re[i0]), float64(im[i0]))
+			x1 := complex(float64(re[i1]), float64(im[i1]))
+			x2 := complex(float64(re[i2]), float64(im[i2]))
+			x3 := complex(float64(re[i3]), float64(im[i3]))
+
+			t1 := x1 * complex(float64(t1r[j]), float64(t1i[j]))
+			t2 := x2 * complex(float64(t2r[j]), float64(t2i[j]))
+			t3 := x3 * complex(float64(t3r[j]), float64(t3i[j]))
+
+			a := x0 + t1
+			b := x0 - t1
+			c := t2 + t3
+			d := t2 - t3
+
+			y0 := a + c
+			y1 := b - 1i*d
+			y2 := a - c
+			y3 := b + 1i*d
+
+			re[i0], im[i0] = float32(real(y0)), float32(imag(y0))
+			re[i1], im[i1] = float32(real(y1)), float32(imag(y1))
+			re[i2], im[i2] = float32(real(y2)), float32(imag(y2))
+			re[i3], im[i3] = float32(real(y3)), float32(imag(y3))
+		}
+	}
+}
+
+// stage4Spans covers every dispatch path. span 1 is the block-axis path; spans 2
+// and 3 fill neither vector axis and run the j-axis scalar tail (a radix-4
+// Cooley-Tukey schedule never lands on them). span 4 takes the dedicated
+// block-axis contingency on AVX (two blocks per YMM via VPERM2F128); 5,6,7 are one
+// 4-wide XMM sub-iteration plus a 1..3 scalar tail; 8 and 16 fill the 8-wide YMM
+// path exactly; 12 is one YMM iteration plus the XMM sub-iteration; 64 walks the
+// YMM path. On NEON span 4 fills the 4-wide axis and 5..7 add a scalar tail.
+var stage4Spans = []int{1, 2, 3, 4, 5, 6, 7, 8, 12, 16, 64}
+
+// stage4BlockCounts exercise the block-axis remainder tail: the span-1 path
+// consumes 8 blocks per iteration on AMD64 and 4 on NEON, so these counts cover
+// every block-remainder case for both (mod 8: every residue 0..7 via 8,1,2,3,4,5,6,7
+// plus 9 and 16; mod 4: every residue via 4,1,2,3).
+var stage4BlockCounts = []int{1, 2, 3, 4, 5, 6, 7, 8, 9, 16}
+
+// TestButterflyComplexStage4_MatchesTwoRadix2Stages is the pinning test. One
+// radix-4 stage at span s with the canonical twiddles must reproduce two radix-2
+// stages, first at span s then at span 2*s, over the same data. This is the
+// mathematical identity the whole primitive rests on; if it holds, the twiddle
+// powers and the -i/+i cross-adds are all correct.
+//
+// Tolerance, not exact equality: the radix-4 combine and the two-pass form group
+// and fuse their multiply-adds differently, so they agree only to within rounding.
+func TestButterflyComplexStage4_MatchesTwoRadix2Stages(t *testing.T) {
+	for _, span := range stage4Spans {
+		for _, blocks := range stage4BlockCounts {
+			t.Run(fmt.Sprintf("span=%d/blocks=%d", span, blocks), func(t *testing.T) {
+				n := butterflyStage4Radix * span * blocks
+				re, im := stage4Data(n, uint64(span*1000+blocks))
+
+				// Arm A: one radix-4 stage with the canonical twiddles.
+				reA := append([]float32(nil), re...)
+				imA := append([]float32(nil), im...)
+				t1r, t1i, t2r, t2i, t3r, t3i := stage4Twiddles(span)
+				ButterflyComplexStage4(reA, imA, span, t1r, t1i, t2r, t2i, t3r, t3i)
+
+				// Arm B: radix-2 at span, then radix-2 at 2*span.
+				reB := append([]float32(nil), re...)
+				imB := append([]float32(nil), im...)
+				twRe1 := make([]float32, span)
+				twIm1 := make([]float32, span)
+				stage4FillRadix2Twiddle(twRe1, twIm1, span)
+				ButterflyComplexStage(reB, imB, span, twRe1, twIm1)
+				twRe2 := make([]float32, 2*span)
+				twIm2 := make([]float32, 2*span)
+				stage4FillRadix2Twiddle(twRe2, twIm2, 2*span)
+				ButterflyComplexStage(reB, imB, 2*span, twRe2, twIm2)
+
+				for i := range n {
+					if !closeEnough(reA[i], reB[i]) {
+						t.Errorf("re[%d]: radix4=%v, two-radix2=%v", i, reA[i], reB[i])
+					}
+					if !closeEnough(imA[i], imB[i]) {
+						t.Errorf("im[%d]: radix4=%v, two-radix2=%v", i, imA[i], imB[i])
+					}
+				}
+			})
+		}
+	}
+}
+
+// TestButterflyComplexStage4 checks the dispatched stage against the independent
+// complex128 reference over the full span x blocks grid. The reference indexes
+// re/im directly rather than delegating, so it does not share code with the
+// implementation under test.
+func TestButterflyComplexStage4(t *testing.T) {
+	for _, span := range stage4Spans {
+		for _, blocks := range stage4BlockCounts {
+			t.Run(fmt.Sprintf("span=%d/blocks=%d", span, blocks), func(t *testing.T) {
+				n := butterflyStage4Radix * span * blocks
+				re, im := stage4Data(n, uint64(span*7919+blocks))
+				t1r, t1i, t2r, t2i, t3r, t3i := stage4Twiddles(span)
+
+				reRef := append([]float32(nil), re...)
+				imRef := append([]float32(nil), im...)
+
+				ButterflyComplexStage4(re, im, span, t1r, t1i, t2r, t2i, t3r, t3i)
+				butterflyComplexStage4Ref(reRef, imRef, span, t1r, t1i, t2r, t2i, t3r, t3i)
+
+				for i := range n {
+					if !closeEnough(re[i], reRef[i]) {
+						t.Errorf("re[%d] = %v, want %v", i, re[i], reRef[i])
+					}
+					if !closeEnough(im[i], imRef[i]) {
+						t.Errorf("im[%d] = %v, want %v", i, im[i], imRef[i])
+					}
+				}
+			})
+		}
+	}
+}
+
+// TestButterflyComplexStage4_SIMDvsGo compares the dispatched kernel against the
+// Go reference over an explicit (span, blocks) grid, entering below the public
+// wrapper so blocks is fixed rather than derived from the slice lengths.
+func TestButterflyComplexStage4_SIMDvsGo(t *testing.T) {
+	for _, span := range stage4Spans {
+		for _, blocks := range stage4BlockCounts {
+			t.Run(fmt.Sprintf("span=%d/blocks=%d", span, blocks), func(t *testing.T) {
+				n := butterflyStage4Radix * span * blocks
+				re, im := stage4Data(n, uint64(span*104729+blocks))
+				t1r, t1i, t2r, t2i, t3r, t3i := stage4Twiddles(span)
+
+				reGo := append([]float32(nil), re...)
+				imGo := append([]float32(nil), im...)
+
+				butterflyComplexStage4x32(re, im, span, blocks, t1r, t1i, t2r, t2i, t3r, t3i)
+				butterflyComplexStage4x32Go(reGo, imGo, span, blocks, t1r, t1i, t2r, t2i, t3r, t3i)
+
+				for i := range n {
+					if !closeEnough(re[i], reGo[i]) {
+						t.Errorf("re[%d]: SIMD=%v, Go=%v", i, re[i], reGo[i])
+					}
+					if !closeEnough(im[i], imGo[i]) {
+						t.Errorf("im[%d]: SIMD=%v, Go=%v", i, im[i], imGo[i])
+					}
+				}
+			})
+		}
+	}
+}
+
+// TestButterflyComplexStage4_Span1SyntheticTwiddle makes span==1 twiddle-multiply
+// sign errors observable. At span==1 the only twiddle index is j==0, so the
+// canonical powers are all (1, 0); with a zero imaginary part every term that a
+// sign flip in the twiddle multiply would touch (VSUBPS vs VADDPS on AMD64, FMLS
+// vs FMLA on NEON) evaluates to the same bits, and the block-axis kernels, which
+// are the whole point of the primitive, run their twiddle multiply unpinned.
+//
+// The kernel is documented value-agnostic, so it must agree with the Go reference
+// for an arbitrary twiddle. Feeding a synthetic twiddle whose real and imaginary
+// parts are both non-trivial exposes the masked mutation. This is the radix-4
+// analogue of the radix-2 stageTwiddlePhase defense.
+func TestButterflyComplexStage4_Span1SyntheticTwiddle(t *testing.T) {
+	const span = 1
+	// Non-identity twiddles, both components well away from zero so a dropped or
+	// sign-flipped cross-term changes the result. Magnitudes need not be unit.
+	t1r, t1i := []float32{0.5}, []float32{0.7}
+	t2r, t2i := []float32{-0.3}, []float32{0.9}
+	t3r, t3i := []float32{0.8}, []float32{-0.4}
+
+	// Block counts that exercise both the block-axis vector loop (8 blocks/iter on
+	// AMD64, 4 on NEON) and its leftover scalar tail.
+	for _, blocks := range []int{2, 4, 5, 7, 8, 9, 16} {
+		t.Run(fmt.Sprintf("blocks=%d", blocks), func(t *testing.T) {
+			n := butterflyStage4Radix * span * blocks
+			re, im := stage4Data(n, uint64(blocks*99991))
+
+			reSIMD := append([]float32(nil), re...)
+			imSIMD := append([]float32(nil), im...)
+			reGo := append([]float32(nil), re...)
+			imGo := append([]float32(nil), im...)
+			reRef := append([]float32(nil), re...)
+			imRef := append([]float32(nil), im...)
+
+			ButterflyComplexStage4(reSIMD, imSIMD, span, t1r, t1i, t2r, t2i, t3r, t3i)
+			butterflyComplexStage4x32Go(reGo, imGo, span, blocks, t1r, t1i, t2r, t2i, t3r, t3i)
+			butterflyComplexStage4Ref(reRef, imRef, span, t1r, t1i, t2r, t2i, t3r, t3i)
+
+			for i := range n {
+				if !closeEnough(reSIMD[i], reGo[i]) {
+					t.Errorf("re[%d]: SIMD=%v, Go=%v", i, reSIMD[i], reGo[i])
+				}
+				if !closeEnough(imSIMD[i], imGo[i]) {
+					t.Errorf("im[%d]: SIMD=%v, Go=%v", i, imSIMD[i], imGo[i])
+				}
+				if !closeEnough(reGo[i], reRef[i]) {
+					t.Errorf("re[%d]: Go=%v, complex128 ref=%v", i, reGo[i], reRef[i])
+				}
+				if !closeEnough(imGo[i], imRef[i]) {
+					t.Errorf("im[%d]: Go=%v, complex128 ref=%v", i, imGo[i], imRef[i])
+				}
+			}
+		})
+	}
+}
+
+// TestButterflyComplexStage4_FullFFT drives a complete iterative Cooley-Tukey
+// transform through ButterflyComplexStage4 and checks it against a naive DFT. A
+// radix-4 schedule runs spans 1, 4, 16, ... and, when n is not a power of 4,
+// finishes with a single radix-2 stage at span n/2. One run therefore walks every
+// radix-4 path in sequence plus the trailing radix-2 stage, which catches a path
+// that is individually self-consistent but wrong relative to the others. Sizes are
+// capped at 512 to stay inside float32's usable precision, matching the radix-2
+// sibling's FullFFT.
+func TestButterflyComplexStage4_FullFFT(t *testing.T) {
+	for _, n := range []int{8, 16, 32, 64, 128, 256, 512} {
+		t.Run(fmt.Sprintf("n=%d", n), func(t *testing.T) {
+			srcRe := make([]float32, n)
+			srcIm := make([]float32, n)
+			for i := range n {
+				srcRe[i] = float32(math.Sin(float64(i)*0.21) + 0.5*math.Cos(float64(i)*1.7))
+				srcIm[i] = float32(math.Cos(float64(i) * 0.13))
+			}
+
+			// Bit-reversal permutation into the working buffers.
+			re := make([]float32, n)
+			im := make([]float32, n)
+			nbits := 0
+			for 1<<nbits < n {
+				nbits++
+			}
+			for i := range n {
+				r := 0
+				for b := range nbits {
+					if i&(1<<b) != 0 {
+						r |= 1 << (nbits - 1 - b)
+					}
+				}
+				re[r] = srcRe[i]
+				im[r] = srcIm[i]
+			}
+
+			// Radix-4 stages while a full 4*span block fits, then one radix-2 stage
+			// at span n/2 when n is not a power of 4.
+			t1r := make([]float32, n/butterflyStage4Radix)
+			t1i := make([]float32, n/butterflyStage4Radix)
+			t2r := make([]float32, n/butterflyStage4Radix)
+			t2i := make([]float32, n/butterflyStage4Radix)
+			t3r := make([]float32, n/butterflyStage4Radix)
+			t3i := make([]float32, n/butterflyStage4Radix)
+			span := 1
+			for butterflyStage4Radix*span <= n {
+				stage4FillTwiddles(t1r, t1i, t2r, t2i, t3r, t3i, span)
+				ButterflyComplexStage4(re, im, span,
+					t1r[:span], t1i[:span], t2r[:span], t2i[:span], t3r[:span], t3i[:span])
+				span *= butterflyStage4Radix
+			}
+			if span < n {
+				// span == n/2 here; one radix-2 stage completes the transform.
+				twRe := make([]float32, span)
+				twIm := make([]float32, span)
+				stage4FillRadix2Twiddle(twRe, twIm, span)
+				ButterflyComplexStage(re, im, span, twRe, twIm)
+			}
+
+			// Naive DFT reference, accumulated in float64 then compared in float32
+			// magnitude: the reference must be at least as accurate as the transform
+			// under test, so its accumulation is not itself the error source.
+			for k := range n {
+				var wantRe, wantIm float64
+				for i := range n {
+					ang := -2 * math.Pi * float64(k) * float64(i) / float64(n)
+					c, s := math.Cos(ang), math.Sin(ang)
+					wantRe += float64(srcRe[i])*c - float64(srcIm[i])*s
+					wantIm += float64(srcRe[i])*s + float64(srcIm[i])*c
+				}
+				// Accumulated rounding, dominated by the float32 transform, grows as
+				// n^2; see stageFFTTolPerN2.
+				tol := stageFFTTolPerN2 * float64(n) * float64(n)
+				if math.Abs(float64(re[k])-wantRe) > tol || math.Abs(float64(im[k])-wantIm) > tol {
+					t.Fatalf("bin %d = (%v, %v), want (%v, %v), tol %v",
+						k, re[k], im[k], wantRe, wantIm, tol)
+				}
+			}
+		})
+	}
+}
+
+// TestButterflyComplexStage4_PartialBlockUntouched pins the documented boundary:
+// blocks are processed while k+4*span <= n, so a trailing run shorter than a full
+// block must be left exactly as it was, and the complete blocks must have been
+// transformed.
+func TestButterflyComplexStage4_PartialBlockUntouched(t *testing.T) {
+	const sentinel = -12345.5
+
+	for _, span := range stage4Spans {
+		blockLen := butterflyStage4Radix * span
+		seen := map[int]bool{}
+		extras := make([]int, 0, 4)
+		for _, extra := range []int{1, span, blockLen - 1} {
+			if extra <= 0 || extra >= blockLen || seen[extra] {
+				continue
+			}
+			seen[extra] = true
+			extras = append(extras, extra)
+		}
+
+		// blocks 8 and 9 as well as 3 and 4: the span-1 path consumes eight blocks
+		// per vector iteration on AVX, so at blocks < 8 it never runs its vector loop
+		// and a trailing partial block is only ever seen by the scalar tail; blocks 8
+		// lands the vector loop exactly on the boundary and 9 adds one tail block.
+		for _, blocks := range []int{3, 4, 8, 9} {
+			for _, extra := range extras {
+				t.Run(fmt.Sprintf("span=%d/blocks=%d/extra=%d", span, blocks, extra), func(t *testing.T) {
+					checkStage4PartialUntouched(t, span, blocks, extra, sentinel)
+				})
+			}
+		}
+	}
+}
+
+func checkStage4PartialUntouched(t *testing.T, span, blocks, extra int, sentinel float32) {
+	t.Helper()
+
+	used := butterflyStage4Radix * span * blocks
+	n := used + extra
+	re, im := stage4Data(n, uint64(span*31+blocks))
+	t1r, t1i, t2r, t2i, t3r, t3i := stage4Twiddles(span)
+	beforeRe := append([]float32(nil), re...)
+	beforeIm := append([]float32(nil), im...)
+	for i := used; i < n; i++ {
+		re[i] = sentinel
+		im[i] = sentinel
+	}
+
+	ButterflyComplexStage4(re, im, span, t1r, t1i, t2r, t2i, t3r, t3i)
+
+	for i := used; i < n; i++ {
+		if re[i] != sentinel {
+			t.Errorf("re[%d] = %v, want untouched sentinel %v", i, re[i], sentinel)
+		}
+		if im[i] != sentinel {
+			t.Errorf("im[%d] = %v, want untouched sentinel %v", i, im[i], sentinel)
+		}
+	}
+
+	for i := range used {
+		if re[i] != beforeRe[i] || im[i] != beforeIm[i] {
+			return
+		}
+	}
+	t.Errorf("no element in the %d complete-block elements changed; the stage did nothing", used)
+}
+
+// TestButterflyComplexStage4_Degenerate covers every input the public wrapper is
+// documented to reject and asserts a no-op rather than a panic. Each twiddle slice
+// gets its own short-slice row: the asm kernels derive every address from span and
+// blocks, so a short twiddle that slipped past the guard would read out of bounds
+// silently instead of panicking the way the Go fallback would.
+func TestButterflyComplexStage4_Degenerate(t *testing.T) {
+	const span = 4
+	n := butterflyStage4Radix * span * 2
+
+	cases := []struct {
+		name string
+		span int
+		nRe  int
+		nIm  int
+		// twLen[k] is the length of twiddle slice k in {t1r,t1i,t2r,t2i,t3r,t3i};
+		// -1 means "use span".
+		twLen [6]int
+	}{
+		{"span=0", 0, n, n, [6]int{-1, -1, -1, -1, -1, -1}},
+		{"span=-1", -1, n, n, [6]int{-1, -1, -1, -1, -1, -1}},
+		{"nil slices", span, 0, 0, [6]int{-1, -1, -1, -1, -1, -1}},
+		{"tw1Re short", span, n, n, [6]int{span - 1, -1, -1, -1, -1, -1}},
+		{"tw1Im short", span, n, n, [6]int{-1, span - 1, -1, -1, -1, -1}},
+		{"tw2Re short", span, n, n, [6]int{-1, -1, span - 1, -1, -1, -1}},
+		{"tw2Im short", span, n, n, [6]int{-1, -1, -1, span - 1, -1, -1}},
+		{"tw3Re short", span, n, n, [6]int{-1, -1, -1, -1, span - 1, -1}},
+		{"tw3Im short", span, n, n, [6]int{-1, -1, -1, -1, -1, span - 1}},
+		{"all twiddles nil", span, n, n, [6]int{0, 0, 0, 0, 0, 0}},
+		{"re shorter than one block", span, butterflyStage4Radix*span - 1, n, [6]int{-1, -1, -1, -1, -1, -1}},
+		{"im shorter than one block", span, n, butterflyStage4Radix*span - 1, [6]int{-1, -1, -1, -1, -1, -1}},
+		{"exactly one element", span, 1, 1, [6]int{-1, -1, -1, -1, -1, -1}},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			full, fullIm := stage4Data(n, 12345)
+			re := append([]float32(nil), full[:tc.nRe]...)
+			im := append([]float32(nil), fullIm[:tc.nIm]...)
+			wantRe := append([]float32(nil), re...)
+			wantIm := append([]float32(nil), im...)
+
+			t1r, t1i, t2r, t2i, t3r, t3i := stage4Twiddles(span)
+			tws := [6][]float32{t1r, t1i, t2r, t2i, t3r, t3i}
+			for k := range tws {
+				if tc.twLen[k] >= 0 {
+					tws[k] = tws[k][:tc.twLen[k]]
+				}
+			}
+
+			// Must not panic.
+			ButterflyComplexStage4(re, im, tc.span, tws[0], tws[1], tws[2], tws[3], tws[4], tws[5])
+
+			for i := range re {
+				if re[i] != wantRe[i] {
+					t.Errorf("re[%d] = %v, want unchanged %v", i, re[i], wantRe[i])
+				}
+			}
+			for i := range im {
+				if im[i] != wantIm[i] {
+					t.Errorf("im[%d] = %v, want unchanged %v", i, im[i], wantIm[i])
+				}
+			}
+		})
+	}
+}
+
+func TestButterflyComplexStage4_AllocFree(t *testing.T) {
+	// One case per vectorization path, so an allocation introduced in any of them
+	// fails here rather than only in the one shape a single case happens to take:
+	// span 1 (block-axis), 2 and 3 (j-axis scalar tail), 4 (the dedicated span-4
+	// block-axis path), 8 (YMM path) and 12 (YMM plus the XMM sub-iteration).
+	for _, span := range []int{1, 2, 3, 4, 8, 12} {
+		t.Run(fmt.Sprintf("span=%d", span), func(t *testing.T) {
+			n := butterflyStage4Radix * span * 16
+			re, im := stage4Data(n, uint64(span))
+			t1r, t1i, t2r, t2i, t3r, t3i := stage4Twiddles(span)
+			fn := func() {
+				ButterflyComplexStage4(re, im, span, t1r, t1i, t2r, t2i, t3r, t3i)
+			}
+			if a := testing.AllocsPerRun(50, fn); a != 0 {
+				t.Errorf("ButterflyComplexStage4 allocated %v times per run, want 0", a)
+			}
+		})
+	}
+}
+
+// FuzzButterflyComplexStage4 checks two contracts at once for arbitrary data: the
+// dispatched kernel agrees with the Go reference, and the Go reference agrees with
+// the two-radix-2 composition it is defined to reproduce.
+func FuzzButterflyComplexStage4(f *testing.F) {
+	addByteLenSeeds(f)
+	f.Fuzz(func(t *testing.T, raw []byte) {
+		u := f32sUnit(raw)
+		if len(u) < 2 {
+			return
+		}
+		// Pick a small span from the first byte, then split the rest into re/im.
+		spanChoices := []int{1, 2, 3, 4, 5, 8, 12}
+		span := spanChoices[int(raw[0])%len(spanChoices)]
+		m := len(u) / 2
+		blockLen := butterflyStage4Radix * span
+		blocks := m / blockLen
+		if blocks == 0 {
+			return
+		}
+		used := blocks * blockLen
+		re := u[:m]
+		im := u[m : 2*m]
+
+		t1r, t1i, t2r, t2i, t3r, t3i := stage4Twiddles(span)
+
+		// Dispatched kernel vs Go reference.
+		reDisp := append([]float32(nil), re...)
+		imDisp := append([]float32(nil), im...)
+		reGo := append([]float32(nil), re...)
+		imGo := append([]float32(nil), im...)
+		ButterflyComplexStage4(reDisp, imDisp, span, t1r, t1i, t2r, t2i, t3r, t3i)
+		butterflyComplexStage4x32Go(reGo[:used], imGo[:used], span, blocks, t1r, t1i, t2r, t2i, t3r, t3i)
+		for i := range used {
+			if !closeEnough(reDisp[i], reGo[i]) {
+				t.Fatalf("dispatched vs Go re[%d] (span=%d, blocks=%d): %v vs %v", i, span, blocks, reDisp[i], reGo[i])
+			}
+			if !closeEnough(imDisp[i], imGo[i]) {
+				t.Fatalf("dispatched vs Go im[%d] (span=%d, blocks=%d): %v vs %v", i, span, blocks, imDisp[i], imGo[i])
+			}
+		}
+
+		// Go reference vs two-radix-2 composition.
+		reTwo := append([]float32(nil), re[:used]...)
+		imTwo := append([]float32(nil), im[:used]...)
+		twRe1 := make([]float32, span)
+		twIm1 := make([]float32, span)
+		stage4FillRadix2Twiddle(twRe1, twIm1, span)
+		ButterflyComplexStage(reTwo, imTwo, span, twRe1, twIm1)
+		twRe2 := make([]float32, 2*span)
+		twIm2 := make([]float32, 2*span)
+		stage4FillRadix2Twiddle(twRe2, twIm2, 2*span)
+		ButterflyComplexStage(reTwo, imTwo, 2*span, twRe2, twIm2)
+		for i := range used {
+			if !closeEnough(reGo[i], reTwo[i]) {
+				t.Fatalf("Go vs two-radix2 re[%d] (span=%d, blocks=%d): %v vs %v", i, span, blocks, reGo[i], reTwo[i])
+			}
+			if !closeEnough(imGo[i], imTwo[i]) {
+				t.Fatalf("Go vs two-radix2 im[%d] (span=%d, blocks=%d): %v vs %v", i, span, blocks, imGo[i], imTwo[i])
+			}
+		}
+	})
+}
+
+// stage4TwSet holds one span's three radix-4 twiddle-power pairs, so a full
+// transform's schedule can be precomputed once outside a timed benchmark loop.
+type stage4TwSet struct {
+	span                         int
+	t1r, t1i, t2r, t2i, t3r, t3i []float32
+}
+
+// radix2TwSet holds one span's radix-2 twiddle pair for the same purpose.
+type radix2TwSet struct {
+	span       int
+	twRe, twIm []float32
+}
+
+// buildStage4Schedule returns the radix-4 stage schedule for an n-point transform:
+// spans 1, 4, 16, ... while a full 4*span block fits.
+func buildStage4Schedule(n int) []*stage4TwSet {
+	// bits.Len(n) (about log2 n) is a safe upper bound on the stage count.
+	sched := make([]*stage4TwSet, 0, bits.Len(uint(n)))
+	for span := 1; butterflyStage4Radix*span <= n; span *= butterflyStage4Radix {
+		t1r, t1i, t2r, t2i, t3r, t3i := stage4Twiddles(span)
+		sched = append(sched, &stage4TwSet{span, t1r, t1i, t2r, t2i, t3r, t3i})
+	}
+	return sched
+}
+
+// buildRadix2Schedule returns the radix-2 stage schedule for an n-point transform:
+// spans 1, 2, 4, ... up to n/2.
+func buildRadix2Schedule(n int) []*radix2TwSet {
+	sched := make([]*radix2TwSet, 0, bits.Len(uint(n)))
+	for span := 1; span < n; span *= 2 {
+		twRe := make([]float32, span)
+		twIm := make([]float32, span)
+		stage4FillRadix2Twiddle(twRe, twIm, span)
+		sched = append(sched, &radix2TwSet{span, twRe, twIm})
+	}
+	return sched
+}
+
+// BenchmarkButterflyComplexStage4 measures the decision behind issue #242: does one
+// radix-4 stage beat the two radix-2 stages it replaces? The per-span sweep holds a
+// fixed 1024-point transform's worth of work (blocks*span near 256) and varies only
+// how short the runs are; the three arms are one radix-4 stage, the two radix-2
+// stages at span then 2*span, and the pure-Go radix-4 reference. Methodology matches
+// BenchmarkButterflyComplexStage: idle host, one sweep per process at -count=1,
+// aggregate across rounds with benchstat and read the Stage4-vs-TwoRadix2 ratio.
+//
+// The in-place butterfly grows its operands to non-finite within a few thousand
+// iterations, which costs nothing (Inf/NaN run at full rate) and hits all three arms
+// identically, so the ratio is unaffected.
+func BenchmarkButterflyComplexStage4(b *testing.B) {
+	const n = 1024
+
+	// 6 is in the sweep because it leaves span%4 == 2, the only shape that measures
+	// the j-axis scalar tail; every power-of-two span skips it.
+	for _, span := range []int{1, 2, 3, 4, 6, 12, 16, 64, 256} {
+		blocks := n / (butterflyStage4Radix * span)
+
+		b.Run(fmt.Sprintf("Stage4/span=%d", span), func(b *testing.B) {
+			re, im := stage4Data(n, uint64(span))
+			t1r, t1i, t2r, t2i, t3r, t3i := stage4Twiddles(span)
+			for b.Loop() {
+				ButterflyComplexStage4(re, im, span, t1r, t1i, t2r, t2i, t3r, t3i)
+			}
+		})
+
+		b.Run(fmt.Sprintf("TwoRadix2/span=%d", span), func(b *testing.B) {
+			re, im := stage4Data(n, uint64(span))
+			twRe1 := make([]float32, span)
+			twIm1 := make([]float32, span)
+			stage4FillRadix2Twiddle(twRe1, twIm1, span)
+			twRe2 := make([]float32, 2*span)
+			twIm2 := make([]float32, 2*span)
+			stage4FillRadix2Twiddle(twRe2, twIm2, 2*span)
+			for b.Loop() {
+				ButterflyComplexStage(re, im, span, twRe1, twIm1)
+				ButterflyComplexStage(re, im, 2*span, twRe2, twIm2)
+			}
+		})
+
+		b.Run(fmt.Sprintf("Go/span=%d", span), func(b *testing.B) {
+			re, im := stage4Data(n, uint64(span))
+			t1r, t1i, t2r, t2i, t3r, t3i := stage4Twiddles(span)
+			for b.Loop() {
+				butterflyComplexStage4x32Go(re, im, span, blocks, t1r, t1i, t2r, t2i, t3r, t3i)
+			}
+		})
+	}
+
+	// FullCore1024 is a complete power-of-4 transform: 5 radix-4 stages vs the 10
+	// radix-2 stages that do the same work.
+	benchStage4FullCore(b, "FullCore1024", 1024, false)
+	// FullCore2048 is 2*4^5: 5 radix-4 stages plus one trailing radix-2 stage at
+	// span n/2, vs 11 radix-2 stages. It exercises the trailing-radix-2 shape.
+	benchStage4FullCore(b, "FullCore2048", 2048, true)
+}
+
+// benchStage4FullCore runs the radix-4 and radix-2 full-transform arms for one size.
+// When trailingRadix2 is set (n is not a power of 4), the radix-4 arm finishes with a
+// single radix-2 stage at span n/2, the schedule a Cooley-Tukey radix-4 transform of
+// such an n uses.
+func benchStage4FullCore(b *testing.B, name string, n int, trailingRadix2 bool) {
+	b.Helper()
+	sched4 := buildStage4Schedule(n)
+	sched2 := buildRadix2Schedule(n)
+	trailRe := make([]float32, n/2)
+	trailIm := make([]float32, n/2)
+	if trailingRadix2 {
+		stage4FillRadix2Twiddle(trailRe, trailIm, n/2)
+	}
+
+	b.Run(name+"/Radix4", func(b *testing.B) {
+		re, im := stage4Data(n, 1)
+		for b.Loop() {
+			for _, s := range sched4 {
+				ButterflyComplexStage4(re, im, s.span, s.t1r, s.t1i, s.t2r, s.t2i, s.t3r, s.t3i)
+			}
+			if trailingRadix2 {
+				ButterflyComplexStage(re, im, n/2, trailRe, trailIm)
+			}
+		}
+	})
+
+	b.Run(name+"/Radix2", func(b *testing.B) {
+		re, im := stage4Data(n, 1)
+		for b.Loop() {
+			for _, s := range sched2 {
+				ButterflyComplexStage(re, im, s.span, s.twRe, s.twIm)
+			}
+		}
+	})
+}

--- a/f32/f32.go
+++ b/f32/f32.go
@@ -53,9 +53,9 @@
 //   - AddScaled and AccumulateAdd read and rewrite dst in place (they are
 //     accumulators); their source slice must be disjoint from the destination
 //     window, except that AddScaled also permits s==dst exactly.
-//   - ButterflyComplex and ButterflyComplexStage update their data slices in
-//     place; those slices must not overlap one another, and the twiddles must not
-//     overlap them.
+//   - ButterflyComplex, ButterflyComplexStage and ButterflyComplexStage4 update
+//     their data slices in place; those slices must not overlap one another, and
+//     the twiddles must not overlap them.
 //   - The mirror, window, stride, interleave, batch and resample operations
 //     (Interleave2/N, Deinterleave2/N, ConvolveValid and ConvolveValidMulti,
 //     ConvolveDecimate, DotProductBatch, DotProductIndexed, DotProductStrided,
@@ -1505,6 +1505,89 @@ func ButterflyComplexStage(re, im []float32, span int, twRe, twIm []float32) {
 	}
 	used := blocks * blockLen
 	butterflyComplexStage32(re[:used], im[:used], span, blocks, twRe[:span], twIm[:span])
+}
+
+// butterflyStage4Radix is the radix of the radix-4 decimation-in-time stage:
+// every block holds four span-length sub-vectors x0..x3, so a block is
+// butterflyStage4Radix*span elements wide.
+const butterflyStage4Radix = 4
+
+// ButterflyComplexStage4 applies one complete radix-4 decimation-in-time stage in
+// place over split-complex data. For every block k in steps of 4*span, and every
+// j in [0, span), it combines the four sub-vectors x0..x3 at (k+j, k+span+j,
+// k+2*span+j, k+3*span+j) using the three twiddles (tw1[j], tw2[j], tw3[j]):
+//
+//	t1 = x1*tw1[j]; t2 = x2*tw2[j]; t3 = x3*tw3[j]   (full complex multiplies)
+//	a = x0 + t1; b = x0 - t1; c = t2 + t3; d = t2 - t3
+//	re[k+j]        = a.re + c.re; im[k+j]        = a.im + c.im
+//	re[k+span+j]   = b.re + d.im; im[k+span+j]   = b.im - d.re
+//	re[k+2*span+j] = a.re - c.re; im[k+2*span+j] = a.im - c.im
+//	re[k+3*span+j] = b.re - d.im; im[k+3*span+j] = b.im + d.re
+//
+// It is the radix-4 counterpart of [ButterflyComplexStage]: one radix-4 stage at
+// span s does the work of two radix-2 stages, first at span s then at 2*s, in a
+// single pass over the data. Folding two stages into one halves the passes over
+// the array and lets the implementation combine all four points while they are
+// still in registers, which is where a radix-4 core wins over a radix-2 one on a
+// memory-bound transform.
+//
+// # Twiddle convention
+//
+// The three twiddle slices are the powers of w = exp(-2*pi*i/(4*span)):
+//
+//	tw1[j] = w^(2j)   (applied to x1)
+//	tw2[j] = w^j      (applied to x2)
+//	tw3[j] = w^(3j)   (applied to x3)
+//
+// The kernel itself is value-agnostic; those are the values a Cooley-Tukey
+// transform must supply. Two properties are load-bearing and intentional, not
+// mistakes to "fix":
+//
+//   - x1 carries w^(2j), not w^j. The input to a decimation-in-time stage is
+//     radix-2 bit-reversed, which swaps sub-vectors 1 and 2 relative to a plain
+//     radix-4 layout, so x1 takes the square of the base twiddle. With this
+//     convention tw1 is exactly the radix-2 span-s twiddle table (exp(-i*pi*j/s))
+//     and tw2 is the first s entries of the radix-2 span-2s table, so a caller
+//     already holding the radix-2 tables reuses them verbatim.
+//   - The -i and +i cross-adds on the (k+span+j) and (k+3*span+j) outputs
+//     hard-code the FORWARD (negative-exponent) DFT direction. An inverse
+//     transform is a forward pass wrapped in conjugation of the input and output.
+//
+// The stage is a no-op unless span > 0 and all six twiddle slices have length at
+// least span, and it is also a no-op when no complete block fits. Blocks are
+// processed while k+4*span <= n, where n = min(len(re), len(im)); a trailing
+// partial block is left untouched. The span-2 case is never reached by a radix-4
+// Cooley-Tukey schedule (spans run 1, 4, 16, ...), so this stage does not carry a
+// dedicated span-2 or span-3 vector path; such a caller still gets a correct
+// result from the general j-axis path, which for these spans is the per-element
+// scalar tail on both the 8-wide AVX and 4-wide NEON kernels (span/8 and span/4
+// are both zero there, so neither vector loop runs).
+//
+// Aliasing: like ButterflyComplexStage, the stage updates re and im in place; re
+// and im must not overlap each other, and none of the six twiddle slices may
+// overlap them.
+//
+// Uses AVX+FMA on AMD64, NEON on ARM64, with a pure Go fallback. As with
+// [ButterflyComplexStage], results are not guaranteed bit-identical between the
+// vector and fallback paths, so do not depend on exact equality across build
+// targets or across spans.
+func ButterflyComplexStage4(re, im []float32, span int,
+	tw1Re, tw1Im, tw2Re, tw2Im, tw3Re, tw3Im []float32) {
+	if span <= 0 ||
+		len(tw1Re) < span || len(tw1Im) < span ||
+		len(tw2Re) < span || len(tw2Im) < span ||
+		len(tw3Re) < span || len(tw3Im) < span {
+		return
+	}
+	n := min(len(re), len(im))
+	blockLen := butterflyStage4Radix * span
+	blocks := n / blockLen
+	if blocks == 0 {
+		return
+	}
+	used := blocks * blockLen
+	butterflyComplexStage4x32(re[:used], im[:used], span, blocks,
+		tw1Re[:span], tw1Im[:span], tw2Re[:span], tw2Im[:span], tw3Re[:span], tw3Im[:span])
 }
 
 // RealFFTUnpack performs the unpacking step of a real-valued FFT.

--- a/f32/f32_amd64.go
+++ b/f32/f32_amd64.go
@@ -1357,6 +1357,31 @@ func butterflyComplexStage32(re, im []float32, span, blocks int, twRe, twIm []fl
 	butterflyComplexStage32Go(re, im, span, blocks, twRe, twIm)
 }
 
+func butterflyComplexStage4x32(re, im []float32, span, blocks int,
+	tw1Re, tw1Im, tw2Re, tw2Im, tw3Re, tw3Im []float32) {
+	// butterflyComplexStage4AVX handles every span: across j when span fills an
+	// 8-wide YMM, then a 4-wide XMM (VEX-128) sub-iteration for the 4..7 remainder,
+	// then a scalar tail; across blocks for span 1. span 4, which a radix-4 schedule
+	// hits every stage (spans run 1, 4, 16, ...) but the 8-wide j-axis cannot fill,
+	// takes a dedicated block-axis path pairing two blocks per YMM with VPERM2F128.
+	// Spans 2 and 3 run the j-axis scalar tail.
+	//
+	// AVX+FMA is the whole requirement, no AVX2: the span-1 block-axis path
+	// transposes an 8x4 float32 tile with VUNPCKLPS/VUNPCKHPS + VUNPCKLPD/VUNPCKHPD
+	// and splats its twiddles with the memory-source form of VBROADCASTSS, and the
+	// complex multiplies use VFMADD231PS. The register-source VBROADCASTSS would be
+	// AVX2, the trap TestAmd64KernelISALevel sweeps for.
+	//
+	// The guard is about total work, not span: a stage carrying fewer than
+	// minAVXElements radix-4 groups goes to Go regardless of its span, matching the
+	// radix-2 stage above.
+	if cpu.X86.AVX && cpu.X86.FMA && blocks*span >= minAVXElements {
+		butterflyComplexStage4AVX(re, im, span, blocks, tw1Re, tw1Im, tw2Re, tw2Im, tw3Re, tw3Im)
+		return
+	}
+	butterflyComplexStage4x32Go(re, im, span, blocks, tw1Re, tw1Im, tw2Re, tw2Im, tw3Re, tw3Im)
+}
+
 func realFFTUnpack32(outRe, outIm, zRe, zIm, twRe, twIm []float32, n int) {
 	// Use AVX+FMA if available and have enough elements. realFFTUnpackAVX needs
 	// nothing above AVX1+FMA3; TestAmd64KernelISALevel enforces the AVX2 half of
@@ -1392,6 +1417,18 @@ func butterflyComplexAVX(upperRe, upperIm, lowerRe, lowerIm, twRe, twIm []float3
 //
 //go:noescape
 func butterflyComplexStageAVX(re, im []float32, span, blocks int, twRe, twIm []float32)
+
+// ButterflyComplexStage4 assembly function declaration.
+//
+// Callers MUST satisfy len(re) == len(im) == 4*span*blocks and
+// len(tw1Re) == len(tw1Im) == len(tw2Re) == len(tw2Im) == len(tw3Re) ==
+// len(tw3Im) >= span, with span >= 1 and blocks >= 1. Every address the kernel
+// forms is derived from span and blocks, never from the slice headers, so a
+// violated precondition reads and writes out of bounds silently rather than
+// panicking the way the Go fallback would. ButterflyComplexStage4 establishes it.
+//
+//go:noescape
+func butterflyComplexStage4AVX(re, im []float32, span, blocks int, tw1Re, tw1Im, tw2Re, tw2Im, tw3Re, tw3Im []float32)
 
 //go:noescape
 func realFFTUnpackAVX(outRe, outIm, zRe, zIm, twRe, twIm []float32, n int)

--- a/f32/f32_amd64.s
+++ b/f32/f32_amd64.s
@@ -5878,6 +5878,678 @@ bfstage_done:
     VZEROUPPER
     RET
 
+// func butterflyComplexStage4AVX(re, im []float32, span, blocks int, tw1Re, tw1Im, tw2Re, tw2Im, tw3Re, tw3Im []float32)
+// One complete radix-4 decimation-in-time stage, in place over split-complex
+// float32. For every block k in steps of 4*span and every j in [0, span), the
+// four sub-vectors x0..x3 at (k+j, k+span+j, k+2*span+j, k+3*span+j) are combined
+// with twiddles tw1[j], tw2[j], tw3[j]:
+//   t1 = x1*tw1; t2 = x2*tw2; t3 = x3*tw3
+//   a = x0+t1; b = x0-t1; c = t2+t3; d = t2-t3
+//   y0 = a+c; y1 = b - i*d; y2 = a-c; y3 = b + i*d
+// where -i*(dr,di) = (di,-dr) and +i*(dr,di) = (-di,dr). Each complex multiply is
+// VMULPS/VMULPS/VSUBPS for the real part and VMULPS/VFMADD231PS for the imaginary
+// part, the same sequence butterflyComplexStageAVX uses. It is the float32 sibling
+// of f64.butterflyComplexStage4AVX.
+//
+// Two vectorization axes, picked by span. span >= 2 vectorizes across j: span/8
+// full 8-wide YMM iterations over each block, THEN one 4-wide XMM (VEX-128)
+// sub-iteration when 4..7 elements remain, then a scalar tail for the final 0..3.
+// The XMM sub-iteration is the one deliberate divergence from the f64 kernel: a
+// radix-4 Cooley-Tukey schedule runs spans 1, 4, 16, ..., and the 8-wide j-axis
+// does not fill at span 4, so without it span 4 (and the 4..7 remainders of spans
+// 5, 6, 7, 12) would run entirely scalar. span == 4 itself takes a dedicated
+// block-axis path instead of that XMM pass: each block's four sub-vectors are one
+// 128-bit lane, so two blocks pair into a full YMM via VPERM2F128, doubling the
+// span-4 throughput a radix-4 schedule leans on (measured on #242's FullCore1024,
+// this block-axis path is what carries the amd64 stage over the two-radix-2 bar).
+// span == 1 has one butterfly per block,
+// so it vectorizes across blocks: eight blocks (32 float32) per iteration are
+// transposed 8x4 -> 4x8 with VUNPCKLPS/VUNPCKHPS then VUNPCKLPD/VUNPCKHPD so that
+// x0..x3 of the eight blocks land one-per-lane (in the permuted block order
+// [0,2,4,6,1,3,5,7], consistent across the four rows and both sides, harmless
+// because the twiddles are scalar broadcasts), the butterfly runs with the three
+// twiddles splatted by memory-source VBROADCASTSS, and a separate unpack sequence
+// (NOT self-inverse, unlike the f64 4x4 transpose) scatters the results back in
+// block order. A radix-4 Cooley-Tukey schedule never lands on span 2 or 3, so
+// there is no dedicated path for them; both are correct through the j-axis scalar
+// tail.
+//
+// AVX+FMA only, no AVX2: the shuffles are VUNPCKLPS/VUNPCKHPS/VUNPCKLPD/VUNPCKHPD,
+// the splats are the memory-source form of VBROADCASTSS, and every arithmetic op
+// is floating point in 256-bit, 128-bit or scalar width. The VFMADD231PS/SS in the
+// complex multiplies is the FMA dependency the dispatch guard carries.
+//
+// Registers, span >= 2 path: DX/R8 re+im block cursors (they walk x0 and so advance
+// by span*4 per block, then +3*span*4 to the next block), R9 span*4 stride (x1/x2/x3
+// reached by R9*1/R9*2/R9*2+R9*1), AX address scratch, CX inner j counter, BX block
+// count, R10-R13/SI/DI the six twiddle cursors (reset from the frame each block). The
+// span == 1 path reuses DX/R8 as the running re+im cursors, R9 as the 8-block group
+// counter, BX as the leftover-block counter, and R10-R13/SI/DI as the twiddle
+// broadcast sources. Neither path touches R14/R15/BP.
+// Frame: re(24)+im(24)+span(8)+blocks(8)+tw1Re(24)+tw1Im(24)+tw2Re(24)+tw2Im(24)
+// +tw3Re(24)+tw3Im(24) = 208 bytes.
+TEXT ·butterflyComplexStage4AVX(SB), NOSPLIT, $0-208
+    MOVQ re_base+0(FP), DX           // DX = re block base
+    MOVQ im_base+24(FP), R8          // R8 = im block base
+    MOVQ span+48(FP), CX             // CX = span
+    MOVQ blocks+56(FP), BX           // BX = block count
+    MOVQ tw1Re_base+64(FP), R10
+    MOVQ tw1Im_base+88(FP), R11
+    MOVQ tw2Re_base+112(FP), R12
+    MOVQ tw2Im_base+136(FP), R13
+    MOVQ tw3Re_base+160(FP), SI
+    MOVQ tw3Im_base+184(FP), DI
+
+    TESTQ BX, BX
+    JZ    bfstage4_done
+    CMPQ  CX, $1
+    JEQ   bfstage4_span1
+    CMPQ  CX, $4
+    JEQ   bfstage4_span4
+
+// ---------------------------------------------------------------------------
+// span >= 2: vectorize across j. DX/R8 walk x0 of the current block; x1/x2/x3 are
+// reached at +span*4, +2*span*4, +3*span*4. Twiddles restart at j=0 every block.
+// span/8 YMM iterations, then one XMM iteration when 4..7 remain, then a scalar
+// tail. Spans 2 and 3 (< 4) fall straight through to the scalar tail.
+// ---------------------------------------------------------------------------
+    MOVQ CX, R9
+    SHLQ $2, R9                      // R9 = span*4
+
+bfstage4_block:
+    MOVQ R9, CX
+    SHRQ $2, CX                      // CX = span = inner counter
+    MOVQ tw1Re_base+64(FP), R10      // reset twiddle cursors for this block
+    MOVQ tw1Im_base+88(FP), R11
+    MOVQ tw2Re_base+112(FP), R12
+    MOVQ tw2Im_base+136(FP), R13
+    MOVQ tw3Re_base+160(FP), SI
+    MOVQ tw3Im_base+184(FP), DI
+    CMPQ CX, $8
+    JLT  bfstage4_xmm_pre
+
+bfstage4_vec:
+    VMOVUPS (DX), Y0                 // x0re[j:j+8]
+    VMOVUPS (DX)(R9*1), Y1           // x1re
+    VMOVUPS (DX)(R9*2), Y2           // x2re
+    LEAQ (DX)(R9*2), AX
+    VMOVUPS (AX)(R9*1), Y3           // x3re = DX + 3*span*4
+    VMOVUPS (R8), Y4                 // x0im
+    VMOVUPS (R8)(R9*1), Y5           // x1im
+    VMOVUPS (R8)(R9*2), Y6           // x2im
+    LEAQ (R8)(R9*2), AX
+    VMOVUPS (AX)(R9*1), Y7           // x3im
+
+    VMOVUPS (R10), Y8                // tw1re
+    VMOVUPS (R11), Y9                // tw1im
+    VMULPS Y1, Y8, Y10
+    VMULPS Y5, Y9, Y11
+    VSUBPS Y11, Y10, Y10             // t1re = x1re*tw1re - x1im*tw1im
+    VMULPS Y1, Y9, Y11
+    VFMADD231PS Y5, Y8, Y11          // t1im = x1re*tw1im + x1im*tw1re
+
+    VMOVUPS (R12), Y8                // tw2re
+    VMOVUPS (R13), Y9                // tw2im
+    VMULPS Y2, Y8, Y1
+    VMULPS Y6, Y9, Y5
+    VSUBPS Y5, Y1, Y1                // t2re
+    VMULPS Y2, Y9, Y5
+    VFMADD231PS Y6, Y8, Y5           // t2im
+
+    VMOVUPS (SI), Y8                 // tw3re
+    VMOVUPS (DI), Y9                 // tw3im
+    VMULPS Y3, Y8, Y2
+    VMULPS Y7, Y9, Y6
+    VSUBPS Y6, Y2, Y2                // t3re
+    VMULPS Y3, Y9, Y6
+    VFMADD231PS Y7, Y8, Y6           // t3im
+
+    VADDPS Y1, Y2, Y3                // cre = t2re+t3re
+    VADDPS Y5, Y6, Y7                // cim = t2im+t3im
+    VSUBPS Y2, Y1, Y8                // dre = t2re-t3re
+    VSUBPS Y6, Y5, Y9                // dim = t2im-t3im
+
+    VADDPS Y0, Y10, Y1               // are = x0re+t1re
+    VSUBPS Y10, Y0, Y2               // bre = x0re-t1re
+    VADDPS Y4, Y11, Y5               // aim = x0im+t1im
+    VSUBPS Y11, Y4, Y6               // bim = x0im-t1im
+
+    VADDPS Y1, Y3, Y0                // y0re = are+cre
+    VADDPS Y5, Y7, Y4                // y0im = aim+cim
+    VMOVUPS Y0, (DX)
+    VMOVUPS Y4, (R8)
+    VSUBPS Y3, Y1, Y0                // y2re = are-cre
+    VSUBPS Y7, Y5, Y4                // y2im = aim-cim
+    VMOVUPS Y0, (DX)(R9*2)
+    VMOVUPS Y4, (R8)(R9*2)
+    VADDPS Y2, Y9, Y0                // y1re = bre+dim
+    VSUBPS Y8, Y6, Y4                // y1im = bim-dre
+    VMOVUPS Y0, (DX)(R9*1)
+    VMOVUPS Y4, (R8)(R9*1)
+    VSUBPS Y9, Y2, Y0                // y3re = bre-dim
+    VADDPS Y8, Y6, Y4                // y3im = bim+dre
+    LEAQ (DX)(R9*2), AX
+    VMOVUPS Y0, (AX)(R9*1)
+    LEAQ (R8)(R9*2), AX
+    VMOVUPS Y4, (AX)(R9*1)
+
+    ADDQ $32, DX
+    ADDQ $32, R8
+    ADDQ $32, R10
+    ADDQ $32, R11
+    ADDQ $32, R12
+    ADDQ $32, R13
+    ADDQ $32, SI
+    ADDQ $32, DI
+    SUBQ $8, CX
+    CMPQ CX, $8
+    JGE  bfstage4_vec
+
+bfstage4_xmm_pre:
+    // One 4-wide XMM (VEX-128) iteration when 4..7 j remain. This closes the span-4
+    // gap: the 8-wide loop above skips span 4 entirely, so span 4 becomes a single
+    // XMM pass with zero shuffles. Same op sequence as the YMM body, X registers.
+    CMPQ CX, $4
+    JLT  bfstage4_tail_pre
+
+    VMOVUPS (DX), X0                 // x0re[j:j+4]
+    VMOVUPS (DX)(R9*1), X1           // x1re
+    VMOVUPS (DX)(R9*2), X2           // x2re
+    LEAQ (DX)(R9*2), AX
+    VMOVUPS (AX)(R9*1), X3           // x3re
+    VMOVUPS (R8), X4                 // x0im
+    VMOVUPS (R8)(R9*1), X5           // x1im
+    VMOVUPS (R8)(R9*2), X6           // x2im
+    LEAQ (R8)(R9*2), AX
+    VMOVUPS (AX)(R9*1), X7           // x3im
+
+    VMOVUPS (R10), X8                // tw1re
+    VMOVUPS (R11), X9                // tw1im
+    VMULPS X1, X8, X10
+    VMULPS X5, X9, X11
+    VSUBPS X11, X10, X10             // t1re
+    VMULPS X1, X9, X11
+    VFMADD231PS X5, X8, X11          // t1im
+
+    VMOVUPS (R12), X8                // tw2re
+    VMOVUPS (R13), X9                // tw2im
+    VMULPS X2, X8, X1
+    VMULPS X6, X9, X5
+    VSUBPS X5, X1, X1                // t2re
+    VMULPS X2, X9, X5
+    VFMADD231PS X6, X8, X5           // t2im
+
+    VMOVUPS (SI), X8                 // tw3re
+    VMOVUPS (DI), X9                 // tw3im
+    VMULPS X3, X8, X2
+    VMULPS X7, X9, X6
+    VSUBPS X6, X2, X2                // t3re
+    VMULPS X3, X9, X6
+    VFMADD231PS X7, X8, X6           // t3im
+
+    VADDPS X1, X2, X3                // cre
+    VADDPS X5, X6, X7                // cim
+    VSUBPS X2, X1, X8                // dre
+    VSUBPS X6, X5, X9                // dim
+
+    VADDPS X0, X10, X1               // are
+    VSUBPS X10, X0, X2               // bre
+    VADDPS X4, X11, X5               // aim
+    VSUBPS X11, X4, X6               // bim
+
+    VADDPS X1, X3, X0                // y0re
+    VADDPS X5, X7, X4                // y0im
+    VMOVUPS X0, (DX)
+    VMOVUPS X4, (R8)
+    VSUBPS X3, X1, X0                // y2re
+    VSUBPS X7, X5, X4                // y2im
+    VMOVUPS X0, (DX)(R9*2)
+    VMOVUPS X4, (R8)(R9*2)
+    VADDPS X2, X9, X0                // y1re = bre+dim
+    VSUBPS X8, X6, X4                // y1im = bim-dre
+    VMOVUPS X0, (DX)(R9*1)
+    VMOVUPS X4, (R8)(R9*1)
+    VSUBPS X9, X2, X0                // y3re = bre-dim
+    VADDPS X8, X6, X4                // y3im = bim+dre
+    LEAQ (DX)(R9*2), AX
+    VMOVUPS X0, (AX)(R9*1)
+    LEAQ (R8)(R9*2), AX
+    VMOVUPS X4, (AX)(R9*1)
+
+    ADDQ $16, DX
+    ADDQ $16, R8
+    ADDQ $16, R10
+    ADDQ $16, R11
+    ADDQ $16, R12
+    ADDQ $16, R13
+    ADDQ $16, SI
+    ADDQ $16, DI
+    SUBQ $4, CX
+
+bfstage4_tail_pre:
+    TESTQ CX, CX
+    JZ   bfstage4_next
+
+bfstage4_tail:
+    LEAQ (DX)(R9*2), AX
+    VMOVSS (DX), X0                  // x0re
+    VMOVSS (DX)(R9*1), X1            // x1re
+    VMOVSS (DX)(R9*2), X2            // x2re
+    VMOVSS (AX)(R9*1), X3            // x3re
+    LEAQ (R8)(R9*2), AX
+    VMOVSS (R8), X4                  // x0im
+    VMOVSS (R8)(R9*1), X5            // x1im
+    VMOVSS (R8)(R9*2), X6            // x2im
+    VMOVSS (AX)(R9*1), X7            // x3im
+
+    VMOVSS (R10), X8
+    VMOVSS (R11), X9
+    VMULSS X1, X8, X10
+    VMULSS X5, X9, X11
+    VSUBSS X11, X10, X10             // t1re
+    VMULSS X1, X9, X11
+    VFMADD231SS X5, X8, X11          // t1im
+    VMOVSS (R12), X8
+    VMOVSS (R13), X9
+    VMULSS X2, X8, X1
+    VMULSS X6, X9, X5
+    VSUBSS X5, X1, X1                // t2re
+    VMULSS X2, X9, X5
+    VFMADD231SS X6, X8, X5           // t2im
+    VMOVSS (SI), X8
+    VMOVSS (DI), X9
+    VMULSS X3, X8, X2
+    VMULSS X7, X9, X6
+    VSUBSS X6, X2, X2                // t3re
+    VMULSS X3, X9, X6
+    VFMADD231SS X7, X8, X6           // t3im
+
+    VADDSS X1, X2, X3                // cre
+    VADDSS X5, X6, X7                // cim
+    VSUBSS X2, X1, X8                // dre
+    VSUBSS X6, X5, X9                // dim
+    VADDSS X0, X10, X1               // are
+    VSUBSS X10, X0, X2               // bre
+    VADDSS X4, X11, X5               // aim
+    VSUBSS X11, X4, X6               // bim
+
+    VADDSS X1, X3, X0                // y0re
+    VMOVSS X0, (DX)
+    VADDSS X5, X7, X0                // y0im
+    VMOVSS X0, (R8)
+    VSUBSS X3, X1, X0                // y2re
+    VMOVSS X0, (DX)(R9*2)
+    VSUBSS X7, X5, X0                // y2im
+    VMOVSS X0, (R8)(R9*2)
+    VADDSS X2, X9, X0                // y1re = bre+dim
+    VMOVSS X0, (DX)(R9*1)
+    VSUBSS X8, X6, X0                // y1im = bim-dre
+    VMOVSS X0, (R8)(R9*1)
+    LEAQ (DX)(R9*2), AX
+    VSUBSS X9, X2, X0                // y3re = bre-dim
+    VMOVSS X0, (AX)(R9*1)
+    LEAQ (R8)(R9*2), AX
+    VADDSS X8, X6, X0                // y3im = bim+dre
+    VMOVSS X0, (AX)(R9*1)
+
+    ADDQ $4, DX
+    ADDQ $4, R8
+    ADDQ $4, R10
+    ADDQ $4, R11
+    ADDQ $4, R12
+    ADDQ $4, R13
+    ADDQ $4, SI
+    ADDQ $4, DI
+    DECQ CX
+    JNZ  bfstage4_tail
+
+bfstage4_next:
+    LEAQ (R9)(R9*2), AX              // AX = 3*span*4 = step to next block
+    ADDQ AX, DX
+    ADDQ AX, R8
+    DECQ BX
+    JNZ  bfstage4_block
+    JMP  bfstage4_done
+
+// ---------------------------------------------------------------------------
+// span == 1: one butterfly per block, so re/im are fully interleaved as
+// [x0,x1,x2,x3] per block. Take eight blocks (32 float32) per iteration, transpose
+// 8x4 -> 4x8 so x0..x3 of the eight blocks land one-per-lane, run the butterfly
+// with the three twiddles splatted, then scatter the results back. Unlike the f64
+// 4x4 transpose the scatter is NOT the load-side sequence; it is its own unpack
+// chain, derived and spot-checked against the Go reference.
+// ---------------------------------------------------------------------------
+bfstage4_span1:
+    MOVQ BX, R9
+    SHRQ $3, R9                      // R9 = blocks/8 = 8-block iterations
+    JZ   bfstage4_span1_tail_pre
+
+bfstage4_span1_vec:
+    VMOVUPS (DX), Y0                 // re: blocks {0,1}, each [x0,x1,x2,x3]
+    VMOVUPS 32(DX), Y1               // blocks {2,3}
+    VMOVUPS 64(DX), Y2               // blocks {4,5}
+    VMOVUPS 96(DX), Y3               // blocks {6,7}
+    VUNPCKLPS Y1, Y0, Y4
+    VUNPCKHPS Y1, Y0, Y5
+    VUNPCKLPS Y3, Y2, Y6
+    VUNPCKHPS Y3, Y2, Y7
+    VUNPCKLPD Y6, Y4, Y0            // X0re = x0 of the eight blocks, order [0,2,4,6,1,3,5,7]
+    VUNPCKHPD Y6, Y4, Y1            // X1re
+    VUNPCKLPD Y7, Y5, Y2            // X2re
+    VUNPCKHPD Y7, Y5, Y3            // X3re
+
+    VMOVUPS (R8), Y4                 // im rows
+    VMOVUPS 32(R8), Y5
+    VMOVUPS 64(R8), Y6
+    VMOVUPS 96(R8), Y7
+    VUNPCKLPS Y5, Y4, Y8
+    VUNPCKHPS Y5, Y4, Y9
+    VUNPCKLPS Y7, Y6, Y10
+    VUNPCKHPS Y7, Y6, Y11
+    VUNPCKLPD Y10, Y8, Y4           // X0im
+    VUNPCKHPD Y10, Y8, Y5           // X1im
+    VUNPCKLPD Y11, Y9, Y6           // X2im
+    VUNPCKHPD Y11, Y9, Y7           // X3im
+
+    VBROADCASTSS (R10), Y8           // tw1re[0]
+    VBROADCASTSS (R11), Y9           // tw1im[0]
+    VMULPS Y1, Y8, Y10
+    VMULPS Y5, Y9, Y11
+    VSUBPS Y11, Y10, Y10             // t1re
+    VMULPS Y1, Y9, Y11
+    VFMADD231PS Y5, Y8, Y11          // t1im
+    VBROADCASTSS (R12), Y8           // tw2re[0]
+    VBROADCASTSS (R13), Y9           // tw2im[0]
+    VMULPS Y2, Y8, Y1
+    VMULPS Y6, Y9, Y5
+    VSUBPS Y5, Y1, Y1                // t2re
+    VMULPS Y2, Y9, Y5
+    VFMADD231PS Y6, Y8, Y5           // t2im
+    VBROADCASTSS (SI), Y8            // tw3re[0]
+    VBROADCASTSS (DI), Y9            // tw3im[0]
+    VMULPS Y3, Y8, Y2
+    VMULPS Y7, Y9, Y6
+    VSUBPS Y6, Y2, Y2                // t3re
+    VMULPS Y3, Y9, Y6
+    VFMADD231PS Y7, Y8, Y6           // t3im
+
+    VADDPS Y1, Y2, Y3                // cre
+    VADDPS Y5, Y6, Y7                // cim
+    VSUBPS Y2, Y1, Y8                // dre
+    VSUBPS Y6, Y5, Y9                // dim
+    VADDPS Y0, Y10, Y1               // are
+    VSUBPS Y10, Y0, Y2               // bre
+    VADDPS Y4, Y11, Y5               // aim
+    VSUBPS Y11, Y4, Y6               // bim
+
+    VADDPS Y1, Y3, Y0                // col0re = y0re
+    VSUBPS Y3, Y1, Y10               // col2re = y2re
+    VADDPS Y2, Y9, Y12               // col1re = y1re = bre+dim
+    VSUBPS Y9, Y2, Y13               // col3re = y3re = bre-dim
+    VADDPS Y5, Y7, Y4                // col0im = y0im
+    VSUBPS Y7, Y5, Y11               // col2im = y2im
+    VSUBPS Y8, Y6, Y14               // col1im = y1im = bim-dre
+    VADDPS Y8, Y6, Y15               // col3im = y3im = bim+dre
+
+    VUNPCKLPS Y12, Y0, Y1            // scatter re: A = [y0,y1] pairs
+    VUNPCKHPS Y12, Y0, Y2            // C
+    VUNPCKLPS Y13, Y10, Y3           // B = [y2,y3] pairs
+    VUNPCKHPS Y13, Y10, Y5           // D
+    VUNPCKLPD Y3, Y1, Y0             // blocks 0,1  [y0,y1,y2,y3]|[...]
+    VUNPCKHPD Y3, Y1, Y12            // blocks 2,3
+    VUNPCKLPD Y5, Y2, Y10            // blocks 4,5
+    VUNPCKHPD Y5, Y2, Y13            // blocks 6,7
+    VMOVUPS Y0, (DX)
+    VMOVUPS Y12, 32(DX)
+    VMOVUPS Y10, 64(DX)
+    VMOVUPS Y13, 96(DX)
+
+    VUNPCKLPS Y14, Y4, Y1            // scatter im
+    VUNPCKHPS Y14, Y4, Y2
+    VUNPCKLPS Y15, Y11, Y3
+    VUNPCKHPS Y15, Y11, Y5
+    VUNPCKLPD Y3, Y1, Y4             // blocks 0,1
+    VUNPCKHPD Y3, Y1, Y14            // blocks 2,3
+    VUNPCKLPD Y5, Y2, Y11            // blocks 4,5
+    VUNPCKHPD Y5, Y2, Y15            // blocks 6,7
+    VMOVUPS Y4, (R8)
+    VMOVUPS Y14, 32(R8)
+    VMOVUPS Y11, 64(R8)
+    VMOVUPS Y15, 96(R8)
+
+    ADDQ $128, DX
+    ADDQ $128, R8
+    DECQ R9
+    JNZ  bfstage4_span1_vec
+
+bfstage4_span1_tail_pre:
+    ANDQ $7, BX                      // leftover blocks (0..7)
+    JZ   bfstage4_done
+
+bfstage4_span1_tail:
+    VMOVSS (DX), X0                  // x0re
+    VMOVSS 4(DX), X1                 // x1re
+    VMOVSS 8(DX), X2                 // x2re
+    VMOVSS 12(DX), X3                // x3re
+    VMOVSS (R8), X4                  // x0im
+    VMOVSS 4(R8), X5                 // x1im
+    VMOVSS 8(R8), X6                 // x2im
+    VMOVSS 12(R8), X7                // x3im
+
+    VMOVSS (R10), X8
+    VMOVSS (R11), X9
+    VMULSS X1, X8, X10
+    VMULSS X5, X9, X11
+    VSUBSS X11, X10, X10             // t1re
+    VMULSS X1, X9, X11
+    VFMADD231SS X5, X8, X11          // t1im
+    VMOVSS (R12), X8
+    VMOVSS (R13), X9
+    VMULSS X2, X8, X1
+    VMULSS X6, X9, X5
+    VSUBSS X5, X1, X1                // t2re
+    VMULSS X2, X9, X5
+    VFMADD231SS X6, X8, X5           // t2im
+    VMOVSS (SI), X8
+    VMOVSS (DI), X9
+    VMULSS X3, X8, X2
+    VMULSS X7, X9, X6
+    VSUBSS X6, X2, X2                // t3re
+    VMULSS X3, X9, X6
+    VFMADD231SS X7, X8, X6           // t3im
+
+    VADDSS X1, X2, X3                // cre
+    VADDSS X5, X6, X7                // cim
+    VSUBSS X2, X1, X8                // dre
+    VSUBSS X6, X5, X9                // dim
+    VADDSS X0, X10, X1               // are
+    VSUBSS X10, X0, X2               // bre
+    VADDSS X4, X11, X5               // aim
+    VSUBSS X11, X4, X6               // bim
+
+    VADDSS X1, X3, X0                // y0re
+    VMOVSS X0, (DX)
+    VADDSS X5, X7, X0                // y0im
+    VMOVSS X0, (R8)
+    VSUBSS X3, X1, X0                // y2re
+    VMOVSS X0, 8(DX)
+    VSUBSS X7, X5, X0                // y2im
+    VMOVSS X0, 8(R8)
+    VADDSS X2, X9, X0                // y1re = bre+dim
+    VMOVSS X0, 4(DX)
+    VSUBSS X8, X6, X0                // y1im = bim-dre
+    VMOVSS X0, 4(R8)
+    VSUBSS X9, X2, X0                // y3re = bre-dim
+    VMOVSS X0, 12(DX)
+    VADDSS X8, X6, X0                // y3im = bim+dre
+    VMOVSS X0, 12(R8)
+
+    ADDQ $16, DX
+    ADDQ $16, R8
+    DECQ BX
+    JNZ  bfstage4_span1_tail
+    JMP  bfstage4_done
+
+// ---------------------------------------------------------------------------
+// span == 4: the block-axis contingency. The 8-wide j-axis cannot fill at span 4,
+// so the j-axis path would run span 4 through the 4-wide XMM sub-iteration, one
+// block per pass. Here instead each block's four sub-vectors x0..x3 are exactly one
+// 128-bit lane, so two blocks pair into a full YMM: VPERM2F128 collects sub-vector
+// xK of two consecutive blocks into one YMM (block0 in the low half, block1 in the
+// high half), the radix-4 butterfly runs 8-wide (two blocks x four j) with the
+// twiddle quads splatted by memory-source VBROADCASTF128, and VPERM2F128 scatters
+// the four outputs back to block layout. The butterfly is the span-1 sequence.
+// VPERM2F128 and VBROADCASTF128 are AVX1, so this stays AVX+FMA. One leftover block
+// (odd block count) runs a single 4-wide XMM pass.
+// ---------------------------------------------------------------------------
+bfstage4_span4:
+    MOVQ BX, R9
+    SHRQ $1, R9                      // R9 = blocks/2 = 2-block iterations
+    JZ   bfstage4_span4_tail_pre
+
+bfstage4_span4_vec:
+    VMOVUPS (DX), Y8                 // block0 re [x0|x1]
+    VMOVUPS 32(DX), Y9               // block0 re [x2|x3]
+    VMOVUPS 64(DX), Y10              // block1 re [x0|x1]
+    VMOVUPS 96(DX), Y11             // block1 re [x2|x3]
+    VPERM2F128 $0x20, Y10, Y8, Y0    // x0re = [b0.x0|b1.x0]
+    VPERM2F128 $0x31, Y10, Y8, Y1    // x1re = [b0.x1|b1.x1]
+    VPERM2F128 $0x20, Y11, Y9, Y2    // x2re
+    VPERM2F128 $0x31, Y11, Y9, Y3    // x3re
+    VMOVUPS (R8), Y8                 // block0 im [x0|x1]
+    VMOVUPS 32(R8), Y9               // block0 im [x2|x3]
+    VMOVUPS 64(R8), Y10              // block1 im [x0|x1]
+    VMOVUPS 96(R8), Y11             // block1 im [x2|x3]
+    VPERM2F128 $0x20, Y10, Y8, Y4    // x0im
+    VPERM2F128 $0x31, Y10, Y8, Y5    // x1im
+    VPERM2F128 $0x20, Y11, Y9, Y6    // x2im
+    VPERM2F128 $0x31, Y11, Y9, Y7    // x3im
+
+    VBROADCASTF128 (R10), Y8         // tw1re[0..3] in both halves
+    VBROADCASTF128 (R11), Y9         // tw1im[0..3]
+    VMULPS Y1, Y8, Y10
+    VMULPS Y5, Y9, Y11
+    VSUBPS Y11, Y10, Y10             // t1re
+    VMULPS Y1, Y9, Y11
+    VFMADD231PS Y5, Y8, Y11          // t1im
+    VBROADCASTF128 (R12), Y8         // tw2re
+    VBROADCASTF128 (R13), Y9         // tw2im
+    VMULPS Y2, Y8, Y1
+    VMULPS Y6, Y9, Y5
+    VSUBPS Y5, Y1, Y1                // t2re
+    VMULPS Y2, Y9, Y5
+    VFMADD231PS Y6, Y8, Y5           // t2im
+    VBROADCASTF128 (SI), Y8          // tw3re
+    VBROADCASTF128 (DI), Y9          // tw3im
+    VMULPS Y3, Y8, Y2
+    VMULPS Y7, Y9, Y6
+    VSUBPS Y6, Y2, Y2                // t3re
+    VMULPS Y3, Y9, Y6
+    VFMADD231PS Y7, Y8, Y6           // t3im
+
+    VADDPS Y1, Y2, Y3                // cre
+    VADDPS Y5, Y6, Y7                // cim
+    VSUBPS Y2, Y1, Y8                // dre
+    VSUBPS Y6, Y5, Y9                // dim
+    VADDPS Y0, Y10, Y1               // are
+    VSUBPS Y10, Y0, Y2               // bre
+    VADDPS Y4, Y11, Y5               // aim
+    VSUBPS Y11, Y4, Y6               // bim
+
+    VADDPS Y1, Y3, Y0                // y0re
+    VSUBPS Y3, Y1, Y10               // y2re
+    VADDPS Y2, Y9, Y12               // y1re = bre+dim
+    VSUBPS Y9, Y2, Y13               // y3re = bre-dim
+    VADDPS Y5, Y7, Y4                // y0im
+    VSUBPS Y7, Y5, Y11               // y2im
+    VSUBPS Y8, Y6, Y14               // y1im = bim-dre
+    VADDPS Y8, Y6, Y15               // y3im = bim+dre
+
+    VPERM2F128 $0x20, Y12, Y0, Y1    // block0 re [x0|x1] = [y0re.lo|y1re.lo]
+    VPERM2F128 $0x20, Y13, Y10, Y2   // block0 re [x2|x3] = [y2re.lo|y3re.lo]
+    VPERM2F128 $0x31, Y12, Y0, Y3    // block1 re [x0|x1]
+    VPERM2F128 $0x31, Y13, Y10, Y5   // block1 re [x2|x3]
+    VMOVUPS Y1, (DX)
+    VMOVUPS Y2, 32(DX)
+    VMOVUPS Y3, 64(DX)
+    VMOVUPS Y5, 96(DX)
+    VPERM2F128 $0x20, Y14, Y4, Y1    // block0 im [x0|x1] = [y0im.lo|y1im.lo]
+    VPERM2F128 $0x20, Y15, Y11, Y2   // block0 im [x2|x3]
+    VPERM2F128 $0x31, Y14, Y4, Y3    // block1 im [x0|x1]
+    VPERM2F128 $0x31, Y15, Y11, Y5   // block1 im [x2|x3]
+    VMOVUPS Y1, (R8)
+    VMOVUPS Y2, 32(R8)
+    VMOVUPS Y3, 64(R8)
+    VMOVUPS Y5, 96(R8)
+
+    ADDQ $128, DX
+    ADDQ $128, R8
+    DECQ R9
+    JNZ  bfstage4_span4_vec
+
+bfstage4_span4_tail_pre:
+    ANDQ $1, BX                      // one leftover block at most
+    JZ   bfstage4_done
+
+    // Single block, 4 lanes wide: XMM butterfly with directly loaded twiddle quads.
+    VMOVUPS (DX), X0                 // x0re[0..3]
+    VMOVUPS 16(DX), X1               // x1re
+    VMOVUPS 32(DX), X2               // x2re
+    VMOVUPS 48(DX), X3               // x3re
+    VMOVUPS (R8), X4                 // x0im
+    VMOVUPS 16(R8), X5               // x1im
+    VMOVUPS 32(R8), X6               // x2im
+    VMOVUPS 48(R8), X7               // x3im
+    VMOVUPS (R10), X8                // tw1re[0..3]
+    VMOVUPS (R11), X9                // tw1im
+    VMULPS X1, X8, X10
+    VMULPS X5, X9, X11
+    VSUBPS X11, X10, X10             // t1re
+    VMULPS X1, X9, X11
+    VFMADD231PS X5, X8, X11          // t1im
+    VMOVUPS (R12), X8                // tw2re
+    VMOVUPS (R13), X9                // tw2im
+    VMULPS X2, X8, X1
+    VMULPS X6, X9, X5
+    VSUBPS X5, X1, X1                // t2re
+    VMULPS X2, X9, X5
+    VFMADD231PS X6, X8, X5           // t2im
+    VMOVUPS (SI), X8                 // tw3re
+    VMOVUPS (DI), X9                 // tw3im
+    VMULPS X3, X8, X2
+    VMULPS X7, X9, X6
+    VSUBPS X6, X2, X2                // t3re
+    VMULPS X3, X9, X6
+    VFMADD231PS X7, X8, X6           // t3im
+    VADDPS X1, X2, X3                // cre
+    VADDPS X5, X6, X7                // cim
+    VSUBPS X2, X1, X8                // dre
+    VSUBPS X6, X5, X9                // dim
+    VADDPS X0, X10, X1               // are
+    VSUBPS X10, X0, X2               // bre
+    VADDPS X4, X11, X5               // aim
+    VSUBPS X11, X4, X6               // bim
+    VADDPS X1, X3, X0                // y0re
+    VMOVUPS X0, (DX)
+    VADDPS X5, X7, X0                // y0im
+    VMOVUPS X0, (R8)
+    VSUBPS X3, X1, X0                // y2re
+    VMOVUPS X0, 32(DX)
+    VSUBPS X7, X5, X0                // y2im
+    VMOVUPS X0, 32(R8)
+    VADDPS X2, X9, X0                // y1re = bre+dim
+    VMOVUPS X0, 16(DX)
+    VSUBPS X8, X6, X0                // y1im = bim-dre
+    VMOVUPS X0, 16(R8)
+    VSUBPS X9, X2, X0                // y3re = bre-dim
+    VMOVUPS X0, 48(DX)
+    VADDPS X8, X6, X0                // y3im = bim+dre
+    VMOVUPS X0, 48(R8)
+
+bfstage4_done:
+    VZEROUPPER
+    RET
+
 // ============================================================================
 // REAL FFT UNPACK - UNPACKING STEP FOR REAL-VALUED FFT
 // ============================================================================

--- a/f32/f32_arm64.go
+++ b/f32/f32_arm64.go
@@ -917,6 +917,19 @@ func butterflyComplexStage32(re, im []float32, span, blocks int, twRe, twIm []fl
 	butterflyComplexStage32Go(re, im, span, blocks, twRe, twIm)
 }
 
+func butterflyComplexStage4x32(re, im []float32, span, blocks int,
+	tw1Re, tw1Im, tw2Re, tw2Im, tw3Re, tw3Im []float32) {
+	// butterflyComplexStage4NEON vectorizes across j for span >= 2 (4-wide .4S, span
+	// 4 filling it exactly, spans 2 and 3 running the scalar tail) and across blocks
+	// for span 1. One 4-wide iteration needs 4 lanes, so anything below 4 total
+	// radix-4 groups falls to Go.
+	if hasNEON && blocks*span >= 4 {
+		butterflyComplexStage4NEON(re, im, span, blocks, tw1Re, tw1Im, tw2Re, tw2Im, tw3Re, tw3Im)
+		return
+	}
+	butterflyComplexStage4x32Go(re, im, span, blocks, tw1Re, tw1Im, tw2Re, tw2Im, tw3Re, tw3Im)
+}
+
 func realFFTUnpack32(outRe, outIm, zRe, zIm, twRe, twIm []float32, n int) {
 	// Use NEON if available and have enough elements
 	// Need at least 5 elements: process k=1..n-1 where n>=5 gives 4+ iterations
@@ -947,6 +960,18 @@ func butterflyComplexNEON(upperRe, upperIm, lowerRe, lowerIm, twRe, twIm []float
 //
 //go:noescape
 func butterflyComplexStageNEON(re, im []float32, span, blocks int, twRe, twIm []float32)
+
+// ButterflyComplexStage4 assembly function declaration.
+//
+// Callers MUST satisfy len(re) == len(im) == 4*span*blocks and
+// len(tw1Re) == len(tw1Im) == len(tw2Re) == len(tw2Im) == len(tw3Re) ==
+// len(tw3Im) >= span, with span >= 1 and blocks >= 1. Every address the kernel
+// forms is derived from span and blocks, never from the slice headers, so a
+// violated precondition reads and writes out of bounds silently rather than
+// panicking the way the Go fallback would. ButterflyComplexStage4 establishes it.
+//
+//go:noescape
+func butterflyComplexStage4NEON(re, im []float32, span, blocks int, tw1Re, tw1Im, tw2Re, tw2Im, tw3Re, tw3Im []float32)
 
 //go:noescape
 func realFFTUnpackNEON(outRe, outIm, zRe, zIm, twRe, twIm []float32, n int)

--- a/f32/f32_arm64.s
+++ b/f32/f32_arm64.s
@@ -3194,6 +3194,390 @@ bfstage_neon_span2_tail_loop:
 bfstage_neon_done:
     RET
 
+// func butterflyComplexStage4NEON(re, im []float32, span, blocks int, tw1Re, tw1Im, tw2Re, tw2Im, tw3Re, tw3Im []float32)
+// One complete radix-4 decimation-in-time stage, in place over split-complex
+// float32, NEON (4 float32 lanes per .4S register). The float32 sibling of
+// f64.butterflyComplexStage4NEON: the vector is 4 wide instead of 2, so span 4
+// fills the j-axis exactly.
+//   t1 = x1*tw1; t2 = x2*tw2; t3 = x3*tw3    (FMUL+FMLS for re, FMUL+FMLA for im)
+//   a = x0+t1; b = x0-t1; c = t2+t3; d = t2-t3
+//   y0 = a+c; y1 = b - i*d; y2 = a-c; y3 = b + i*d
+// where -i*(dr,di) = (di,-dr) and +i*(dr,di) = (-di,dr). Same arithmetic sequence
+// as butterflyComplexStageNEON, extended from a radix-2 pair to a radix-4 group.
+//
+// Two vectorization axes, picked by span. span >= 2 vectorizes across j, four lanes
+// (.4S) per iteration with a scalar tail for span%4; the four sub-vector cursors
+// (R6..R13) and six twiddle cursors (R19..R24) walk their runs, the block bases
+// R0/R1 advance by 4*span*4 per block. span 4 fills the vector exactly; spans 2 and
+// 3 have span/4 == 0 and run entirely in the scalar tail (a radix-4 Cooley-Tukey
+// schedule never lands on them). span == 1 has one butterfly per block, so it
+// vectorizes across blocks: four blocks per iteration, a 4x4 transpose via two
+// rounds of UZP1/UZP2 (.4S) splits the four interleaved [x0,x1,x2,x3] blocks into
+// x0..x3 rows in natural block order, the butterfly runs with the three twiddles
+// splatted (VDUP), and ZIP1/ZIP2 (.4S then .2D) re-interleave the results.
+//
+// The .4S FMUL/FADD/FSUB/FMLA/FMLS and the UZP1/UZP2/ZIP1/ZIP2 permutes are
+// hand-encoded WORDs (Go's assembler has no mnemonics for them); the trailing
+// comment on each is cross-checked against arm64asm by asmcheck_test.go. VLD1/VST1,
+// VDUP and the scalar F-register tail use native mnemonics.
+//
+// Registers: R0/R1 re+im block bases, R2 span, R3 block count, R4 span*4, R5 inner
+// counter, R6..R9 x0..x3 re cursors, R10..R13 x0..x3 im cursors, R19..R24 the six
+// twiddle cursors, R25 block stride (4*span*4). The span == 1 path reuses R0/R1 as
+// running cursors, R5 as the block-quad counter, and V16..V21 as the splatted
+// twiddles. Neither path touches R16/R17/R18/R27/R28. Frame: re(24)+im(24)+span(8)
+// +blocks(8)+tw1Re(24)+tw1Im(24)+tw2Re(24)+tw2Im(24)+tw3Re(24)+tw3Im(24) = 208 bytes.
+TEXT ·butterflyComplexStage4NEON(SB), NOSPLIT, $0-208
+    MOVD re_base+0(FP), R0
+    MOVD im_base+24(FP), R1
+    MOVD span+48(FP), R2
+    MOVD blocks+56(FP), R3
+    MOVD tw1Re_base+64(FP), R19
+    MOVD tw1Im_base+88(FP), R20
+    MOVD tw2Re_base+112(FP), R21
+    MOVD tw2Im_base+136(FP), R22
+    MOVD tw3Re_base+160(FP), R23
+    MOVD tw3Im_base+184(FP), R24
+
+    CBZ  R3, bfstage4_neon_done
+    CMP  $1, R2
+    BEQ  bfstage4_neon_span1
+
+    // ----------------------------------------------------------------------
+    // span >= 2: vectorize across j, four lanes per iteration, scalar tail for
+    // span%4. The four re/im sub-vector cursors are reset from the block bases
+    // every block; the twiddle cursors are reloaded from the frame. Spans 2 and 3
+    // have span/4 == 0 and fall straight into the scalar tail.
+    // ----------------------------------------------------------------------
+    LSL  $2, R2, R4                  // R4 = span*4
+    LSL  $4, R2, R25                 // R25 = span*16 = 4*span*4 block stride
+
+bfstage4_neon_block:
+    MOVD R0, R6                      // x0re
+    ADD  R4, R0, R7                  // x1re
+    ADD  R4, R7, R8                  // x2re
+    ADD  R4, R8, R9                  // x3re
+    MOVD R1, R10                     // x0im
+    ADD  R4, R1, R11                 // x1im
+    ADD  R4, R11, R12                // x2im
+    ADD  R4, R12, R13                // x3im
+    MOVD tw1Re_base+64(FP), R19
+    MOVD tw1Im_base+88(FP), R20
+    MOVD tw2Re_base+112(FP), R21
+    MOVD tw2Im_base+136(FP), R22
+    MOVD tw3Re_base+160(FP), R23
+    MOVD tw3Im_base+184(FP), R24
+    LSR  $2, R2, R5                  // R5 = span/4 vector iterations
+    CBZ  R5, bfstage4_neon_tail_pre
+
+bfstage4_neon_vec:
+    VLD1 (R6), [V0.S4]               // x0re[j:j+4]
+    VLD1 (R7), [V1.S4]               // x1re
+    VLD1 (R8), [V2.S4]               // x2re
+    VLD1 (R9), [V3.S4]               // x3re
+    VLD1 (R10), [V4.S4]              // x0im
+    VLD1 (R11), [V5.S4]              // x1im
+    VLD1 (R12), [V6.S4]              // x2im
+    VLD1 (R13), [V7.S4]              // x3im
+    VLD1.P 16(R19), [V16.S4]         // tw1re
+    VLD1.P 16(R20), [V17.S4]         // tw1im
+    VLD1.P 16(R21), [V18.S4]         // tw2re
+    VLD1.P 16(R22), [V19.S4]         // tw2im
+    VLD1.P 16(R23), [V20.S4]         // tw3re
+    VLD1.P 16(R24), [V21.S4]         // tw3im
+
+    WORD $0x6E30DC36                 // FMUL V22.4S, V1.4S, V16.4S   t1re = x1re*tw1re
+    WORD $0x4EB1CCB6                 // FMLS V22.4S, V5.4S, V17.4S        - x1im*tw1im
+    WORD $0x6E31DC37                 // FMUL V23.4S, V1.4S, V17.4S   t1im = x1re*tw1im
+    WORD $0x4E30CCB7                 // FMLA V23.4S, V5.4S, V16.4S        + x1im*tw1re
+    WORD $0x6E32DC58                 // FMUL V24.4S, V2.4S, V18.4S   t2re
+    WORD $0x4EB3CCD8                 // FMLS V24.4S, V6.4S, V19.4S
+    WORD $0x6E33DC59                 // FMUL V25.4S, V2.4S, V19.4S   t2im
+    WORD $0x4E32CCD9                 // FMLA V25.4S, V6.4S, V18.4S
+    WORD $0x6E34DC7A                 // FMUL V26.4S, V3.4S, V20.4S   t3re
+    WORD $0x4EB5CCFA                 // FMLS V26.4S, V7.4S, V21.4S
+    WORD $0x6E35DC7B                 // FMUL V27.4S, V3.4S, V21.4S   t3im
+    WORD $0x4E34CCFB                 // FMLA V27.4S, V7.4S, V20.4S
+    WORD $0x4E3AD71C                 // FADD V28.4S, V24.4S, V26.4S  cre = t2re+t3re
+    WORD $0x4E3BD73D                 // FADD V29.4S, V25.4S, V27.4S  cim
+    WORD $0x4EBAD71E                 // FSUB V30.4S, V24.4S, V26.4S  dre = t2re-t3re
+    WORD $0x4EBBD73F                 // FSUB V31.4S, V25.4S, V27.4S  dim
+    WORD $0x4E36D408                 // FADD V8.4S, V0.4S, V22.4S    are = x0re+t1re
+    WORD $0x4EB6D409                 // FSUB V9.4S, V0.4S, V22.4S    bre = x0re-t1re
+    WORD $0x4E37D48A                 // FADD V10.4S, V4.4S, V23.4S   aim
+    WORD $0x4EB7D48B                 // FSUB V11.4S, V4.4S, V23.4S   bim
+
+    WORD $0x4E3CD50C                 // FADD V12.4S, V8.4S, V28.4S   y0re = are+cre
+    WORD $0x4E3DD54D                 // FADD V13.4S, V10.4S, V29.4S  y0im = aim+cim
+    VST1.P [V12.S4], 16(R6)
+    VST1.P [V13.S4], 16(R10)
+    WORD $0x4EBCD50C                 // FSUB V12.4S, V8.4S, V28.4S   y2re = are-cre
+    WORD $0x4EBDD54D                 // FSUB V13.4S, V10.4S, V29.4S  y2im = aim-cim
+    VST1.P [V12.S4], 16(R8)
+    VST1.P [V13.S4], 16(R12)
+    WORD $0x4E3FD52C                 // FADD V12.4S, V9.4S, V31.4S   y1re = bre+dim
+    WORD $0x4EBED56D                 // FSUB V13.4S, V11.4S, V30.4S  y1im = bim-dre
+    VST1.P [V12.S4], 16(R7)
+    VST1.P [V13.S4], 16(R11)
+    WORD $0x4EBFD52C                 // FSUB V12.4S, V9.4S, V31.4S   y3re = bre-dim
+    WORD $0x4E3ED56D                 // FADD V13.4S, V11.4S, V30.4S  y3im = bim+dre
+    VST1.P [V12.S4], 16(R9)
+    VST1.P [V13.S4], 16(R13)
+
+    SUB  $1, R5
+    CBNZ R5, bfstage4_neon_vec
+
+bfstage4_neon_tail_pre:
+    AND  $3, R2, R5                  // R5 = span & 3 scalar butterflies
+    CBZ  R5, bfstage4_neon_next
+
+bfstage4_neon_tail:
+    FMOVS (R6), F0                   // x0re
+    FMOVS (R7), F1                   // x1re
+    FMOVS (R8), F2                   // x2re
+    FMOVS (R9), F3                   // x3re
+    FMOVS (R10), F4                  // x0im
+    FMOVS (R11), F5                  // x1im
+    FMOVS (R12), F6                  // x2im
+    FMOVS (R13), F7                  // x3im
+    FMOVS (R19), F16                 // tw1re
+    FMOVS (R20), F17                 // tw1im
+    FMOVS (R21), F18                 // tw2re
+    FMOVS (R22), F19                 // tw2im
+    FMOVS (R23), F20                 // tw3re
+    FMOVS (R24), F21                 // tw3im
+
+    FMULS F1, F16, F22
+    FMULS F5, F17, F23
+    FSUBS F23, F22, F22              // t1re
+    FMULS F1, F17, F23
+    FMULS F5, F16, F24
+    FADDS F23, F24, F23              // t1im
+    FMULS F2, F18, F24
+    FMULS F6, F19, F25
+    FSUBS F25, F24, F24              // t2re
+    FMULS F2, F19, F25
+    FMULS F6, F18, F26
+    FADDS F25, F26, F25              // t2im
+    FMULS F3, F20, F26
+    FMULS F7, F21, F27
+    FSUBS F27, F26, F26              // t3re
+    FMULS F3, F21, F27
+    FMULS F7, F20, F28
+    FADDS F27, F28, F27              // t3im
+    FADDS F24, F26, F28              // cre
+    FADDS F25, F27, F29              // cim
+    FSUBS F26, F24, F30              // dre
+    FSUBS F27, F25, F31              // dim
+    FADDS F0, F22, F1                // are
+    FSUBS F22, F0, F2                // bre
+    FADDS F4, F23, F5                // aim
+    FSUBS F23, F4, F6                // bim
+    FADDS F1, F28, F0                // y0re
+    FMOVS F0, (R6)
+    FADDS F5, F29, F0                // y0im
+    FMOVS F0, (R10)
+    FSUBS F28, F1, F0                // y2re
+    FMOVS F0, (R8)
+    FSUBS F29, F5, F0                // y2im
+    FMOVS F0, (R12)
+    FADDS F2, F31, F0                // y1re = bre+dim
+    FMOVS F0, (R7)
+    FSUBS F30, F6, F0                // y1im = bim-dre
+    FMOVS F0, (R11)
+    FSUBS F31, F2, F0                // y3re = bre-dim
+    FMOVS F0, (R9)
+    FADDS F30, F6, F0                // y3im = bim+dre
+    FMOVS F0, (R13)
+
+    ADD  $4, R6
+    ADD  $4, R7
+    ADD  $4, R8
+    ADD  $4, R9
+    ADD  $4, R10
+    ADD  $4, R11
+    ADD  $4, R12
+    ADD  $4, R13
+    ADD  $4, R19
+    ADD  $4, R20
+    ADD  $4, R21
+    ADD  $4, R22
+    ADD  $4, R23
+    ADD  $4, R24
+    SUB  $1, R5
+    CBNZ R5, bfstage4_neon_tail
+
+bfstage4_neon_next:
+    ADD  R25, R0, R0
+    ADD  R25, R1, R1
+    SUB  $1, R3
+    CBNZ R3, bfstage4_neon_block
+    RET
+
+    // ----------------------------------------------------------------------
+    // span == 1: each block is [x0,x1,x2,x3] contiguous. Take four blocks per
+    // iteration; two UZP rounds transpose them so x0..x3 land one-per-lane in
+    // natural block order, the butterfly runs with the three twiddles splatted,
+    // ZIP1/ZIP2 (.4S then .2D) re-interleave. blocks%4 leftover blocks scalar.
+    // ----------------------------------------------------------------------
+bfstage4_neon_span1:
+    FMOVS (R19), F16
+    VDUP  V16.S[0], V16.S4           // tw1re[0] in all four lanes
+    FMOVS (R20), F17
+    VDUP  V17.S[0], V17.S4           // tw1im[0]
+    FMOVS (R21), F18
+    VDUP  V18.S[0], V18.S4           // tw2re[0]
+    FMOVS (R22), F19
+    VDUP  V19.S[0], V19.S4           // tw2im[0]
+    FMOVS (R23), F20
+    VDUP  V20.S[0], V20.S4           // tw3re[0]
+    FMOVS (R24), F21
+    VDUP  V21.S[0], V21.S4           // tw3im[0]
+
+    LSR  $2, R3, R5                  // R5 = blocks/4 = 4-block iterations
+    CBZ  R5, bfstage4_neon_span1_tail_pre
+
+bfstage4_neon_span1_vec:
+    VLD1 (R0), [V0.S4, V1.S4, V2.S4, V3.S4]  // blocks 0..3 re, each [x0,x1,x2,x3]
+    VLD1 (R1), [V4.S4, V5.S4, V6.S4, V7.S4]  // blocks 0..3 im
+
+    WORD $0x4E811818                 // UZP1 V24.4S, V0.4S, V1.4S    re P
+    WORD $0x4E831859                 // UZP1 V25.4S, V2.4S, V3.4S    re Q
+    WORD $0x4E81581A                 // UZP2 V26.4S, V0.4S, V1.4S    re R
+    WORD $0x4E83585B                 // UZP2 V27.4S, V2.4S, V3.4S    re S
+    WORD $0x4E991B08                 // UZP1 V8.4S, V24.4S, V25.4S   X0re = x0 of blocks 0..3
+    WORD $0x4E995B0A                 // UZP2 V10.4S, V24.4S, V25.4S  X2re
+    WORD $0x4E9B1B49                 // UZP1 V9.4S, V26.4S, V27.4S   X1re
+    WORD $0x4E9B5B4B                 // UZP2 V11.4S, V26.4S, V27.4S  X3re
+    WORD $0x4E851898                 // UZP1 V24.4S, V4.4S, V5.4S    im P
+    WORD $0x4E8718D9                 // UZP1 V25.4S, V6.4S, V7.4S    im Q
+    WORD $0x4E85589A                 // UZP2 V26.4S, V4.4S, V5.4S    im R
+    WORD $0x4E8758DB                 // UZP2 V27.4S, V6.4S, V7.4S    im S
+    WORD $0x4E991B0C                 // UZP1 V12.4S, V24.4S, V25.4S  X0im
+    WORD $0x4E995B0E                 // UZP2 V14.4S, V24.4S, V25.4S  X2im
+    WORD $0x4E9B1B4D                 // UZP1 V13.4S, V26.4S, V27.4S  X1im
+    WORD $0x4E9B5B4F                 // UZP2 V15.4S, V26.4S, V27.4S  X3im
+
+    WORD $0x6E30DD36                 // FMUL V22.4S, V9.4S, V16.4S   t1re
+    WORD $0x4EB1CDB6                 // FMLS V22.4S, V13.4S, V17.4S
+    WORD $0x6E31DD37                 // FMUL V23.4S, V9.4S, V17.4S   t1im
+    WORD $0x4E30CDB7                 // FMLA V23.4S, V13.4S, V16.4S
+    WORD $0x6E32DD58                 // FMUL V24.4S, V10.4S, V18.4S  t2re
+    WORD $0x4EB3CDD8                 // FMLS V24.4S, V14.4S, V19.4S
+    WORD $0x6E33DD59                 // FMUL V25.4S, V10.4S, V19.4S  t2im
+    WORD $0x4E32CDD9                 // FMLA V25.4S, V14.4S, V18.4S
+    WORD $0x6E34DD7A                 // FMUL V26.4S, V11.4S, V20.4S  t3re
+    WORD $0x4EB5CDFA                 // FMLS V26.4S, V15.4S, V21.4S
+    WORD $0x6E35DD7B                 // FMUL V27.4S, V11.4S, V21.4S  t3im
+    WORD $0x4E34CDFB                 // FMLA V27.4S, V15.4S, V20.4S
+    WORD $0x4E3AD71C                 // FADD V28.4S, V24.4S, V26.4S  cre
+    WORD $0x4E3BD73D                 // FADD V29.4S, V25.4S, V27.4S  cim
+    WORD $0x4EBAD71E                 // FSUB V30.4S, V24.4S, V26.4S  dre
+    WORD $0x4EBBD73F                 // FSUB V31.4S, V25.4S, V27.4S  dim
+    WORD $0x4E36D500                 // FADD V0.4S, V8.4S, V22.4S    are
+    WORD $0x4EB6D501                 // FSUB V1.4S, V8.4S, V22.4S    bre
+    WORD $0x4E37D582                 // FADD V2.4S, V12.4S, V23.4S   aim
+    WORD $0x4EB7D583                 // FSUB V3.4S, V12.4S, V23.4S   bim
+    WORD $0x4E3CD404                 // FADD V4.4S, V0.4S, V28.4S    col0re = are+cre
+    WORD $0x4EBCD406                 // FSUB V6.4S, V0.4S, V28.4S    col2re = are-cre
+    WORD $0x4E3FD425                 // FADD V5.4S, V1.4S, V31.4S    col1re = bre+dim
+    WORD $0x4EBFD427                 // FSUB V7.4S, V1.4S, V31.4S    col3re = bre-dim
+    WORD $0x4E3DD448                 // FADD V8.4S, V2.4S, V29.4S    col0im = aim+cim
+    WORD $0x4EBDD44A                 // FSUB V10.4S, V2.4S, V29.4S   col2im = aim-cim
+    WORD $0x4EBED469                 // FSUB V9.4S, V3.4S, V30.4S    col1im = bim-dre
+    WORD $0x4E3ED46B                 // FADD V11.4S, V3.4S, V30.4S   col3im = bim+dre
+
+    WORD $0x4E853896                 // ZIP1 V22.4S, V4.4S, V5.4S    re A = [y0,y1] lo
+    WORD $0x4E857898                 // ZIP2 V24.4S, V4.4S, V5.4S    re C = [y0,y1] hi
+    WORD $0x4E8738D7                 // ZIP1 V23.4S, V6.4S, V7.4S    re B = [y2,y3] lo
+    WORD $0x4E8778D9                 // ZIP2 V25.4S, V6.4S, V7.4S    re D = [y2,y3] hi
+    WORD $0x4ED73AC0                 // ZIP1 V0.2D, V22.2D, V23.2D   block0 re
+    WORD $0x4ED77AC1                 // ZIP2 V1.2D, V22.2D, V23.2D   block1 re
+    WORD $0x4ED93B02                 // ZIP1 V2.2D, V24.2D, V25.2D   block2 re
+    WORD $0x4ED97B03                 // ZIP2 V3.2D, V24.2D, V25.2D   block3 re
+    VST1 [V0.S4, V1.S4, V2.S4, V3.S4], (R0)  // blocks 0..3 re
+
+    WORD $0x4E893916                 // ZIP1 V22.4S, V8.4S, V9.4S    im A
+    WORD $0x4E897918                 // ZIP2 V24.4S, V8.4S, V9.4S    im C
+    WORD $0x4E8B3957                 // ZIP1 V23.4S, V10.4S, V11.4S  im B
+    WORD $0x4E8B7959                 // ZIP2 V25.4S, V10.4S, V11.4S  im D
+    WORD $0x4ED73AC0                 // ZIP1 V0.2D, V22.2D, V23.2D   block0 im
+    WORD $0x4ED77AC1                 // ZIP2 V1.2D, V22.2D, V23.2D   block1 im
+    WORD $0x4ED93B02                 // ZIP1 V2.2D, V24.2D, V25.2D   block2 im
+    WORD $0x4ED97B03                 // ZIP2 V3.2D, V24.2D, V25.2D   block3 im
+    VST1 [V0.S4, V1.S4, V2.S4, V3.S4], (R1)  // blocks 0..3 im
+
+    ADD  $64, R0, R0
+    ADD  $64, R1, R1
+    SUB  $1, R5
+    CBNZ R5, bfstage4_neon_span1_vec
+
+bfstage4_neon_span1_tail_pre:
+    AND  $3, R3, R5                  // leftover blocks (0..3)
+    CBZ  R5, bfstage4_neon_done
+
+bfstage4_neon_span1_tail:
+    FMOVS (R0), F0                   // x0re
+    FMOVS 4(R0), F1                  // x1re
+    FMOVS 8(R0), F2                  // x2re
+    FMOVS 12(R0), F3                 // x3re
+    FMOVS (R1), F4                   // x0im
+    FMOVS 4(R1), F5                  // x1im
+    FMOVS 8(R1), F6                  // x2im
+    FMOVS 12(R1), F7                 // x3im
+    // F16..F21 still hold the splatted twiddles (lane 0 of V16..V21, only read
+    // by the vector loop above), so no reload is needed.
+    FMULS F1, F16, F22
+    FMULS F5, F17, F23
+    FSUBS F23, F22, F22              // t1re
+    FMULS F1, F17, F23
+    FMULS F5, F16, F24
+    FADDS F23, F24, F23              // t1im
+    FMULS F2, F18, F24
+    FMULS F6, F19, F25
+    FSUBS F25, F24, F24              // t2re
+    FMULS F2, F19, F25
+    FMULS F6, F18, F26
+    FADDS F25, F26, F25              // t2im
+    FMULS F3, F20, F26
+    FMULS F7, F21, F27
+    FSUBS F27, F26, F26              // t3re
+    FMULS F3, F21, F27
+    FMULS F7, F20, F28
+    FADDS F27, F28, F27              // t3im
+    FADDS F24, F26, F28              // cre
+    FADDS F25, F27, F29              // cim
+    FSUBS F26, F24, F30              // dre
+    FSUBS F27, F25, F31              // dim
+    FADDS F0, F22, F1                // are
+    FSUBS F22, F0, F2                // bre
+    FADDS F4, F23, F5                // aim
+    FSUBS F23, F4, F6                // bim
+    FADDS F1, F28, F0                // y0re
+    FMOVS F0, (R0)
+    FADDS F5, F29, F0                // y0im
+    FMOVS F0, (R1)
+    FSUBS F28, F1, F0                // y2re
+    FMOVS F0, 8(R0)
+    FSUBS F29, F5, F0                // y2im
+    FMOVS F0, 8(R1)
+    FADDS F2, F31, F0                // y1re = bre+dim
+    FMOVS F0, 4(R0)
+    FSUBS F30, F6, F0                // y1im = bim-dre
+    FMOVS F0, 4(R1)
+    FSUBS F31, F2, F0                // y3re = bre-dim
+    FMOVS F0, 12(R0)
+    FADDS F30, F6, F0                // y3im = bim+dre
+    FMOVS F0, 12(R1)
+
+    ADD  $16, R0
+    ADD  $16, R1
+    SUB  $1, R5
+    CBNZ R5, bfstage4_neon_span1_tail
+
+bfstage4_neon_done:
+    RET
+
 // ============================================================================
 // REAL FFT UNPACK - UNPACKING STEP FOR REAL-VALUED FFT
 // ============================================================================

--- a/f32/f32_go.go
+++ b/f32/f32_go.go
@@ -993,6 +993,64 @@ func butterflyComplexStage32Go(re, im []float32, span, blocks int, twRe, twIm []
 	}
 }
 
+// butterflyComplexStage4x32Go applies one radix-4 decimation-in-time stage in
+// place over split-complex data. blocks is the number of complete 4*span blocks;
+// the caller has already reconciled it against len(re)/len(im). The six twiddle
+// slices carry w^(2j), w^j and w^(3j) with w = exp(-2*pi*i/(4*span)); see
+// ButterflyComplexStage4 for the convention. It is the source of truth for the
+// operation: the SIMD kernels reproduce this arithmetic within rounding. It is
+// the float32 counterpart of f64.butterflyComplexStage4x64Go.
+func butterflyComplexStage4x32Go(re, im []float32, span, blocks int,
+	tw1Re, tw1Im, tw2Re, tw2Im, tw3Re, tw3Im []float32) {
+	// Reslice the twiddles to exactly span so the bounds prover discharges the
+	// inner-loop index from the loop condition alone; the caller has validated
+	// these lengths.
+	t1r, t1i := tw1Re[:span], tw1Im[:span]
+	t2r, t2i := tw2Re[:span], tw2Im[:span]
+	t3r, t3i := tw3Re[:span], tw3Im[:span]
+	for b := range blocks {
+		k := b * butterflyStage4Radix * span
+		// Reslice the four sub-vectors to exactly span so the bounds prover
+		// discharges the inner-loop indices from the loop condition alone, the same
+		// per-block reslice the radix-2 butterflyComplexStage32Go uses. Each reslice
+		// costs one bounds check per block, amortised over span elements, versus
+		// eight per element without it.
+		e1 := k + span
+		e2 := e1 + span
+		e3 := e2 + span
+		e4 := e3 + span
+		x0re, x0im := re[k:e1:e1], im[k:e1:e1]
+		x1re, x1im := re[e1:e2:e2], im[e1:e2:e2]
+		x2re, x2im := re[e2:e3:e3], im[e2:e3:e3]
+		x3re, x3im := re[e3:e4:e4], im[e3:e4:e4]
+		for j := range span {
+			x0r, x0i := x0re[j], x0im[j]
+			x1r, x1i := x1re[j], x1im[j]
+			x2r, x2i := x2re[j], x2im[j]
+			x3r, x3i := x3re[j], x3im[j]
+
+			// Full complex multiplies against the three twiddle powers.
+			t1re := x1r*t1r[j] - x1i*t1i[j]
+			t1im := x1r*t1i[j] + x1i*t1r[j]
+			t2re := x2r*t2r[j] - x2i*t2i[j]
+			t2im := x2r*t2i[j] + x2i*t2r[j]
+			t3re := x3r*t3r[j] - x3i*t3i[j]
+			t3im := x3r*t3i[j] + x3i*t3r[j]
+
+			// Radix-4 butterfly combine.
+			ar, ai := x0r+t1re, x0i+t1im
+			br, bi := x0r-t1re, x0i-t1im
+			cr, ci := t2re+t3re, t2im+t3im
+			dr, di := t2re-t3re, t2im-t3im
+
+			x0re[j], x0im[j] = ar+cr, ai+ci
+			x1re[j], x1im[j] = br+di, bi-dr
+			x2re[j], x2im[j] = ar-cr, ai-ci
+			x3re[j], x3im[j] = br-di, bi+dr
+		}
+	}
+}
+
 // realFFTUnpackHalf is the constant 0.5 used in real FFT unpack computation.
 const realFFTUnpackHalf = 0.5
 

--- a/f32/f32_other.go
+++ b/f32/f32_other.go
@@ -98,6 +98,10 @@ func butterflyComplex32(upperRe, upperIm, lowerRe, lowerIm, twRe, twIm []float32
 func butterflyComplexStage32(re, im []float32, span, blocks int, twRe, twIm []float32) {
 	butterflyComplexStage32Go(re, im, span, blocks, twRe, twIm)
 }
+func butterflyComplexStage4x32(re, im []float32, span, blocks int,
+	tw1Re, tw1Im, tw2Re, tw2Im, tw3Re, tw3Im []float32) {
+	butterflyComplexStage4x32Go(re, im, span, blocks, tw1Re, tw1Im, tw2Re, tw2Im, tw3Re, tw3Im)
+}
 func realFFTUnpack32(outRe, outIm, zRe, zIm, twRe, twIm []float32, n int) {
 	realFFTUnpack32Go(outRe, outIm, zRe, zIm, twRe, twIm, n)
 }


### PR DESCRIPTION
Fixes #242.

The float32 sibling of the merged f64 `ButterflyComplexStage4`. One radix-4 decimation-in-time stage does the work of two radix-2 stages in a single pass over split-complex data, which halves the passes over the array and lets the kernel combine all four points while they are still in registers. The math and twiddle convention are identical to the f64 version; the new work is the f32 lane-width adaptation of the kernels.

## Kernels

AVX+FMA on amd64, NEON on arm64, pure-Go fallback.

- **amd64 j-axis (span >= 2):** 8-wide YMM main loop, then one 4-wide XMM (VEX-128) sub-iteration for the 4..7 remainder, then a scalar tail.
- **amd64 span 1:** block-axis, eight blocks per iteration transposed 8x4 -> 4x8 with `VUNPCKLPS/HPS` then `VUNPCKLPD/HPD`. Unlike the f64 4x4 transpose the scatter is not the load-side sequence; it is a separate unpack chain.
- **amd64 span 4:** a dedicated block-axis path pairing two blocks per YMM with `VPERM2F128` and memory-source `VBROADCASTF128`. A radix-4 schedule hits span 4 every stage, but the 8-wide j-axis cannot fill it; this path is what carries the amd64 stage over the two-radix-2 bar.
- **arm64:** 4-wide `.4S` j-axis with a scalar tail, and a span-1 4x4 transpose via `UZP1/UZP2` with a `ZIP1/ZIP2` scatter. Every new NEON `WORD` carries a decoded-mnemonic comment cross-checked against `arm64asm`.

AVX+FMA only, no AVX2: unpacks, memory-source `VBROADCASTSS`/`VBROADCASTF128`, `VPERM2F128`, `VFMADD231PS/SS`, `VZEROUPPER` on exit. The kernel is named `...AVX` and gated on `cpu.X86.AVX && cpu.X86.FMA`; the source ISA and FMA gates enforce that. Reserved registers are left untouched. Zero allocations.

## Benchmarks

FullCore1024 is a complete power-of-4 transform: five radix-4 stages against the ten radix-2 stages that do the same work. This is the decision behind the issue: does one radix-4 stage beat the two radix-2 stages it replaces across a full transform?

| Benchmark | Arch | Radix4 | Radix2 | Radix2/Radix4 |
| --- | --- | --- | --- | --- |
| FullCore1024 | amd64 (AVX+FMA) | 699 ns | 840 ns | 1.20x |
| FullCore2048 | amd64 (AVX+FMA) | 1.50 us | 1.79 us | 1.19x |
| FullCore1024 | arm64 (NEON, Cortex-A76) | 3.76 us | 5.02 us | 1.33x |
| FullCore2048 | arm64 (NEON, Cortex-A76) | 8.23 us | 10.65 us | 1.29x |

The win comes from the large spans (per-span, radix-4 beats two-radix-2 by 1.3x to 1.45x at span 16/64/256). Span 1 is roughly break-even on amd64 (it is transpose-shuffle-bound), and span 4 is where the block-axis path matters: it turns a 0.92x loss into a 1.29x win, which is what moves FullCore1024 from 1.14x to 1.20x on amd64.

## Testing

- amd64: full `f32` suite green on the AVX path and via the Go fallback (`GODEBUG=cpu.avx=off`).
- arm64: full `f32` suite cross-compiled and run natively on a Cortex-A76.
- Correctness is pinned three ways that share no code: an independent complex128 reference over the full span x blocks grid, the radix-4 == two-radix-2-stages identity, and a full-FFT-vs-naive-DFT end-to-end test. Plus a span-1 synthetic-twiddle test (non-trivial real and imaginary parts) that makes a masked sign flip observable, a fuzz test, `AllocsPerRun == 0` per vectorization path, and degenerate/partial-block no-op checks.
- Machine checks: the amd64 ISA-level and FMA gates, the arm64 `WORD`-encoding cross-check against `arm64asm`, and the reserved-register-clobber check all pass.

Also adds a `ButterflyComplexStage` (radix-2) row to the f32 README Complex table alongside the new `ButterflyComplexStage4` row; the radix-2 row was never added after its own change landed.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a radix-4 complex FFT stage for split-format float32 data.
  * Supports in-place processing with validation for spans, twiddle factors, and complete data blocks.
  * Uses available hardware acceleration on supported systems, with a portable fallback.

* **Documentation**
  * Documented radix-2 and radix-4 complex FFT stage operations and SIMD widths.

* **Tests**
  * Added comprehensive correctness, compatibility, edge-case, fuzz, allocation, and performance coverage.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->