### PR TITLE
f32: fused RealFFTPower (single-pass real-FFT power spectrum) (Fixes #245)

### DIFF
--- a/doc.go
+++ b/doc.go
@@ -94,7 +94,7 @@
 //
 // Spectral (f64, f32): STFTPlan (NewSTFTPlan, STFT, STFTPower, STFTPowerInto, NumFrames) - fused real-input short-time Fourier transform with optional librosa-style center=true framing (PadMode: NoPad/PadZero/PadReflect)
 //
-// FFT primitives (f64, f32): ButterflyComplex (radix-2 butterfly with twiddle multiply, split-complex), RealFFTUnpack (real-FFT even/odd unpack step); f64 additionally has ButterflyComplexStage, one whole radix-2 decimation-in-time stage at any span, which picks its vectorization axis from the span, and RealFFTPower, the fused power-writing counterpart of RealFFTUnpack that emits the |X_k|^2 power spectrum in one pass
+// FFT primitives (f64, f32): ButterflyComplex (radix-2 butterfly with twiddle multiply, split-complex), RealFFTUnpack (real-FFT even/odd unpack step), RealFFTPower (the fused power-writing counterpart of RealFFTUnpack that emits the |X_k|^2 power spectrum in one pass); f64 additionally has ButterflyComplexStage, one whole radix-2 decimation-in-time stage at any span, which picks its vectorization axis from the span
 //
 // Integer DSP (i16): Interleave2, Deinterleave2, DotProduct, DotProductUnsafe, XCorr (widening int16 x int16 -> wrapping int32; ARM64 SMLAL/SMLAL2, amd64 PMADDWD/VPMADDWD; XCorr evaluates 4 correlation lags per kernel call), Abs, MaxAbs, MulQ15 (wrapping 16-bit absolute value, widened abs-max, rounding Q15 multiply)
 //

--- a/f32/f32.go
+++ b/f32/f32.go
@@ -1548,6 +1548,67 @@ func RealFFTUnpack(outRe, outIm, zRe, zIm, twRe, twIm []float32) {
 	realFFTUnpack32(outRe, outIm, zRe, zIm, twRe, twIm, n)
 }
 
+// RealFFTPower is the fused, power-writing counterpart of RealFFTUnpack: for each
+// bin k in [1, n-1] it unpacks X[k] exactly as RealFFTUnpack does and writes the
+// power dst[k] = |X[k]|^2 in a single pass, without materialising the complex
+// half-spectrum. Given Z = FFT(packed real data of size 2n) and the same twiddles
+// RealFFTUnpack takes, each bin is
+//
+//	conj_z = conj(Z[n-k])
+//	even = 0.5 * (Z[k] + conj_z)
+//	diff = Z[k] - conj_z
+//	odd  = W[k] * (-0.5i) * diff
+//	X[k] = even + odd
+//	dst[k] = X[k].real^2 + X[k].imag^2
+//
+// so it makes a single pass over the spectrum with no intermediate complex bins. A
+// spectrogram, mel front end, or PSD consumer wants |X_k|^2, and computing it as
+// RealFFTUnpack + Mul + FMA is three passes over the bins that write and re-read
+// the complex half-spectrum; folding the magnitude-squared into the unpack drops
+// the two extra passes. f32 is the primary path for the audio ML front ends this
+// serves (mel-spectrogram and PCEN pipelines feeding CNN classifiers). See #245,
+// the f32 sibling of the f64 kernel in #233.
+//
+// Parameters:
+//   - dst: output power, dst[k] = |X[k]|^2 written for k in [1, n-1] (length >= n)
+//   - zRe, zIm: half-size complex spectrum Z, length n
+//   - twRe, twIm: twiddle factors W[k] at index k-1 (length n-1), where
+//     W[k] = exp(-i*pi*k/n) = cos(pi*k/n) - i*sin(pi*k/n)
+//
+// The DC bin (k=0) and Nyquist bin (k=n) are the caller's responsibility, exactly
+// as for RealFFTUnpack. Both are real, so their powers are:
+//
+//	|X[0]|^2 = (Z[0].real + Z[0].imag)^2  (DC)
+//	|X[n]|^2 = (Z[0].real - Z[0].imag)^2  (Nyquist)
+//
+// The SIMD kernels fuse the magnitude-squared with a hardware FMA on their vector
+// lanes (single rounding). The pure-Go path writes a separate multiply and add,
+// but the Go compiler contracts that into an FMA on some architectures (arm64) and
+// not others (amd64). So the results agree only to within rounding, not
+// bit-for-bit, and the exact bits can differ across architectures, exactly as the
+// RealFFTUnpack odd-term FMA already does.
+//
+// # Aliasing
+//
+// dst must not overlap zRe, zIm, twRe or twIm in any way, not even as an exact
+// element-for-element overlay. Bin k reads Z at both k and the mirror n-k plus the
+// twiddle at k-1 before it writes dst at k, and the SIMD kernels re-read the tail
+// input with an overlapping block, so any overlay lets a store land on an input a
+// later bin has not read yet. Same precondition as RealFFTUnpack.
+//
+// Uses AVX+FMA on AMD64, NEON on ARM64, with a pure Go fallback.
+func RealFFTPower(dst, zRe, zIm, twRe, twIm []float32) {
+	n := len(zRe)
+	if n < realFFTUnpackMinN {
+		return
+	}
+	// Validate slice lengths.
+	if len(zIm) < n || len(dst) < n || len(twRe) < n-1 || len(twIm) < n-1 {
+		return
+	}
+	realFFTPower32(dst, zRe, zIm, twRe, twIm, n)
+}
+
 // Reverse reverses a slice: dst[i] = src[len(src)-1-i].
 //
 // Processes min(len(dst), len(src)) elements. The result is stored

--- a/f32/f32_amd64.go
+++ b/f32/f32_amd64.go
@@ -1376,6 +1376,20 @@ func realFFTUnpack32(outRe, outIm, zRe, zIm, twRe, twIm []float32, n int) {
 	realFFTUnpack32Go(outRe, outIm, zRe, zIm, twRe, twIm, n)
 }
 
+func realFFTPower32(dst, zRe, zIm, twRe, twIm []float32, n int) {
+	// realFFTPowerAVX shares realFFTUnpackAVX's reversed mirror load (VPERM2F128 +
+	// VPERMILPS) and its RODATA-sourced constants, so it stays on the plain AVX+FMA
+	// tier just like realFFTUnpackAVX; it needs nothing above AVX1+FMA3. It uses
+	// VFMADD for both the odd term and the fused magnitude-squared, so cpu.X86.FMA
+	// is required. n > minAVXElements means n >= 9, so (n-1) >= 8 = one full 8-wide
+	// AVX pass. See #202 and #196.
+	if cpu.X86.AVX && cpu.X86.FMA && n > minAVXElements {
+		realFFTPowerAVX(dst, zRe, zIm, twRe, twIm, n)
+		return
+	}
+	realFFTPower32Go(dst, zRe, zIm, twRe, twIm, n)
+}
+
 // Split-format complex assembly function declarations
 //
 //go:noescape
@@ -1413,6 +1427,9 @@ func butterflyComplexStage4AVX(re, im []float32, span, blocks int, tw1Re, tw1Im,
 
 //go:noescape
 func realFFTUnpackAVX(outRe, outIm, zRe, zIm, twRe, twIm []float32, n int)
+
+//go:noescape
+func realFFTPowerAVX(dst, zRe, zIm, twRe, twIm []float32, n int)
 
 func reverse32(dst, src []float32) {
 	// Use AVX if available and have enough elements

--- a/f32/f32_amd64.s
+++ b/f32/f32_amd64.s
@@ -6515,6 +6515,169 @@ realfft_done:
     RET
 
 // ============================================================================
+// REALFFTPOWER - FUSED REAL-FFT POWER SPECTRUM (|X[k]|^2)
+// ============================================================================
+
+// func realFFTPowerAVX(dst, zRe, zIm, twRe, twIm []float32, n int)
+// Fused power-writing counterpart of realFFTUnpackAVX: unpacks each bin exactly as
+// that kernel does, then writes dst[k] = |X[k]|^2 instead of the complex X[k]. It
+// shares realFFTUnpackAVX's AVX+FMA tier (VPERM2F128 + VPERMILPS reversed load and
+// RODATA-sourced constants, no AVX2 encoding); the magnitude-squared is fused with
+// VFMADD231PS. Processes 8 float32 bins per pass. See #245 and f64 realFFTPowerAVX.
+// Frame: dst(24) + zRe(24) + zIm(24) + twRe(24) + twIm(24) + n(8) = 128 bytes.
+TEXT ·realFFTPowerAVX(SB), NOSPLIT, $0-128
+    // Load parameters
+    MOVQ dst_base+0(FP), DX          // DX = dst pointer
+    MOVQ zRe_base+24(FP), DI         // DI = zRe pointer (forward)
+    MOVQ zIm_base+48(FP), R8         // R8 = zIm pointer (forward)
+    MOVQ twRe_base+72(FP), R11       // R11 = twRe pointer
+    MOVQ twIm_base+96(FP), R12       // R12 = twIm pointer
+    MOVQ n+120(FP), CX               // CX = n
+
+    // Calculate number of iterations: (n-1) / 8
+    MOVQ CX, AX
+    DECQ AX                          // AX = n - 1
+    MOVQ AX, R13                     // R13 = n - 1 (save for remainder)
+    SHRQ $3, AX                      // AX = (n-1) / 8 = number of SIMD iterations
+    // Zero full blocks means n <= 8, which realFFTPower32 never dispatches: its
+    // guard is n > minAVXElements and minAVXElements is 8. The overlapping
+    // remainder block below anchors at k = n-8 and mirror-reads zRe[1..8], so it
+    // needs n >= 9; writing nothing is the memory-safe answer to a caller that
+    // ignores the threshold.
+    JZ   realfftpow_done
+
+    // Set up reverse pointers: R9 = &zRe[n-8], R10 = &zIm[n-8].
+    // BX (not R14) holds byte offsets: R14 is the goroutine g pointer on Go amd64.
+    MOVQ CX, BX                      // BX = n
+    SUBQ $8, BX                      // BX = n - 8
+    SHLQ $2, BX                      // BX = (n-8) * 4 = byte offset
+    MOVQ DI, R9
+    ADDQ BX, R9                      // R9 = &zRe[n-8]
+    MOVQ R8, R10
+    ADDQ BX, R10                     // R10 = &zIm[n-8]
+
+    // Offset forward and output pointers to start at index 1
+    ADDQ $4, DI                      // DI = &zRe[1]
+    ADDQ $4, R8                      // R8 = &zIm[1]
+    ADDQ $4, DX                      // DX = &dst[1]
+
+    // Load constants from RODATA. A register-source VBROADCASTSS and 256-bit integer
+    // ops are AVX2, and this kernel stays on the AVX+FMA tier. See #202.
+    VMOVUPS roundf32_half<>(SB), Y13     // Y13 = 0.5f x8
+    VMOVUPS roundf32_signmask<>(SB), Y14 // Y14 = 0x80000000 x8 (sign bit only)
+
+realfftpow_loop8:
+    // Load forward Z[k:k+8]
+    VMOVUPS (DI), Y0                 // Y0 = zRe[k:k+8] (forward)
+    VMOVUPS (R8), Y1                 // Y1 = zIm[k:k+8] (forward)
+
+    // Load reverse Z[n-k-7:n-k+1] and reverse the order
+    VMOVUPS (R9), Y2                 // Y2 = zRe[n-k-7:n-k+1] (to be reversed)
+    VMOVUPS (R10), Y3                // Y3 = zIm[n-k-7:n-k+1] (to be reversed)
+    VPERM2F128 $0x01, Y2, Y2, Y2     // Swap high/low 128-bit lanes
+    VPERM2F128 $0x01, Y3, Y3, Y3
+    VPERMILPS $0x1B, Y2, Y2          // 0x1B = [3,2,1,0] within each 128-bit lane
+    VPERMILPS $0x1B, Y3, Y3
+
+    // For conjugate: znkIm = -zIm[n-k]
+    VXORPS Y14, Y3, Y3               // Y3 = znkIm = -zIm[n-k]
+
+    // even = 0.5 * (Z[k] + conj(Z[n-k]))
+    VADDPS Y0, Y2, Y4                // Y4 = zkRe + znkRe
+    VMULPS Y4, Y13, Y4               // Y4 = evenRe
+    VADDPS Y1, Y3, Y5                // Y5 = zkIm + znkIm
+    VMULPS Y5, Y13, Y5               // Y5 = evenIm
+
+    // diff = Z[k] - conj(Z[n-k])
+    VSUBPS Y2, Y0, Y6                // Y6 = diffRe
+    VSUBPS Y3, Y1, Y7                // Y7 = diffIm
+
+    // Load twiddles W[k]
+    VMOVUPS (R11), Y8                // Y8 = wr
+    VMOVUPS (R12), Y9                // Y9 = wi
+
+    // oddRe = 0.5 * (wr*diffIm + wi*diffRe)
+    VMULPS Y8, Y7, Y10               // Y10 = wr * diffIm
+    VFMADD231PS Y9, Y6, Y10          // Y10 = wr*diffIm + wi*diffRe
+    VMULPS Y10, Y13, Y10             // Y10 = oddRe
+
+    // oddIm = 0.5 * (wi*diffIm - wr*diffRe)
+    VMULPS Y9, Y7, Y11               // Y11 = wi * diffIm
+    VFNMADD231PS Y8, Y6, Y11         // Y11 = wi*diffIm - wr*diffRe
+    VMULPS Y11, Y13, Y11             // Y11 = oddIm
+
+    // X[k] = even + odd
+    VADDPS Y4, Y10, Y0               // Y0 = outRe = evenRe + oddRe
+    VADDPS Y5, Y11, Y1               // Y1 = outIm = evenIm + oddIm
+
+    // dst[k] = outRe^2 + outIm^2 (fused magnitude-squared)
+    VMULPS Y0, Y0, Y2                // Y2 = outRe^2
+    VFMADD231PS Y1, Y1, Y2           // Y2 = outRe^2 + outIm^2
+    VMOVUPS Y2, (DX)                 // store power[k:k+8]
+
+    // Advance pointers
+    ADDQ $32, DI                     // forward zRe += 8
+    ADDQ $32, R8                     // forward zIm += 8
+    SUBQ $32, R9                     // reverse zRe -= 8
+    SUBQ $32, R10                    // reverse zIm -= 8
+    ADDQ $32, R11                    // twRe += 8
+    ADDQ $32, R12                    // twIm += 8
+    ADDQ $32, DX                     // dst += 8
+
+    DECQ AX
+    JNZ  realfftpow_loop8
+
+realfftpow_remainder:
+    // Handle the remaining (n-1) % 8 bins with one more FULL 8-wide block anchored
+    // at k = n-8, overlapping the block just written. Bin k reads inputs only (z at
+    // k and the mirror n-k, twiddles at k-1) and nothing a previous bin produced, so
+    // recomputing the last 8 stores identical values. Same idiom as realFFTUnpackAVX;
+    // it relies on dst not overlapping the inputs. See #215.
+    ANDQ $7, R13                     // R13 = remainder count
+    JZ   realfftpow_done
+
+    // Zero the remainder before re-entering: the block below ends on the loop's own
+    // DECQ/JNZ, falls through here a second time, and must find nothing left to do.
+    XORL R13, R13
+
+    // Reload the five slice bases the loop advanced. CX still holds n.
+    MOVQ dst_base+0(FP), DX
+    MOVQ zRe_base+24(FP), DI
+    MOVQ zIm_base+48(FP), R8
+    MOVQ twRe_base+72(FP), R11
+    MOVQ twIm_base+96(FP), R12
+    MOVQ n+120(FP), CX
+
+    // Mirror pointers first, while DI and R8 still hold the bases. At k = n-8 the
+    // block reads z[n-k-7 .. n-k] = z[1 .. 8], one element in from the start.
+    MOVQ DI, R9
+    ADDQ $4, R9                      // R9 = &zRe[1]
+    MOVQ R8, R10
+    ADDQ $4, R10                     // R10 = &zIm[1]
+
+    // Forward and output pointers to k = n-8.
+    MOVQ CX, BX
+    SUBQ $8, BX                      // BX = n - 8 = k
+    SHLQ $2, BX                      // BX = k * 4 = byte offset
+    ADDQ BX, DI                      // DI = &zRe[k]
+    ADDQ BX, R8                      // R8 = &zIm[k]
+    ADDQ BX, DX                      // DX = &dst[k]
+
+    // Twiddles are indexed k-1, so they top out at n-2 against a length n-1 slice.
+    SUBQ $4, BX                      // BX = (k-1) * 4
+    ADDQ BX, R11                     // R11 = &twRe[k-1]
+    ADDQ BX, R12                     // R12 = &twIm[k-1]
+
+    // Y13/Y14 still hold 0.5f and the sign mask, so the re-entered loop needs no
+    // fresh constant load.
+    MOVQ $1, AX                      // exactly one more iteration
+    JMP  realfftpow_loop8
+
+realfftpow_done:
+    VZEROUPPER
+    RET
+
+// ============================================================================
 // REVERSE - REVERSE SLICE ELEMENTS
 // ============================================================================
 

--- a/f32/f32_arm64.go
+++ b/f32/f32_arm64.go
@@ -921,6 +921,17 @@ func realFFTUnpack32(outRe, outIm, zRe, zIm, twRe, twIm []float32, n int) {
 	realFFTUnpack32Go(outRe, outIm, zRe, zIm, twRe, twIm, n)
 }
 
+func realFFTPower32(dst, zRe, zIm, twRe, twIm []float32, n int) {
+	// realFFTPowerNEON processes 4 float32 lanes per pass and finishes with the same
+	// overlapping 4-wide remainder block realFFTUnpackNEON uses, so it needs n > 4
+	// (the block anchors at k = n-4 and mirror-reads z[1..4]).
+	if hasNEON && n > 4 {
+		realFFTPowerNEON(dst, zRe, zIm, twRe, twIm, n)
+		return
+	}
+	realFFTPower32Go(dst, zRe, zIm, twRe, twIm, n)
+}
+
 //go:noescape
 func mulComplexNEON(dstRe, dstIm, aRe, aIm, bRe, bIm []float32)
 
@@ -956,6 +967,9 @@ func butterflyComplexStage4NEON(re, im []float32, span, blocks int, tw1Re, tw1Im
 
 //go:noescape
 func realFFTUnpackNEON(outRe, outIm, zRe, zIm, twRe, twIm []float32, n int)
+
+//go:noescape
+func realFFTPowerNEON(dst, zRe, zIm, twRe, twIm []float32, n int)
 
 func reverse32(dst, src []float32) {
 	if hasNEON && len(dst) >= 4 {

--- a/f32/f32_arm64.s
+++ b/f32/f32_arm64.s
@@ -3552,6 +3552,159 @@ realfft_neon_done:
     RET
 
 // ============================================================================
+// REALFFTPOWER - FUSED REAL-FFT POWER SPECTRUM (|X[k]|^2)
+// ============================================================================
+
+// func realFFTPowerNEON(dst, zRe, zIm, twRe, twIm []float32, n int)
+// Fused power-writing counterpart of realFFTUnpackNEON: unpacks each bin exactly as
+// that kernel does, then writes dst[k] = |X[k]|^2 instead of the complex X[k]. The
+// magnitude-squared is fused with FMLA. Processes 4 float32 bins per pass and
+// finishes with the same overlapping 4-wide remainder block, so it needs n > 4.
+// See #245 and the f64 realFFTPowerNEON in #233.
+// Frame: dst(24) + zRe(24) + zIm(24) + twRe(24) + twIm(24) + n(8) = 128 bytes.
+TEXT ·realFFTPowerNEON(SB), NOSPLIT, $0-128
+    // Load parameters
+    MOVD dst_base+0(FP), R0          // R0 = dst pointer
+    MOVD zRe_base+24(FP), R2         // R2 = zRe pointer (forward)
+    MOVD zIm_base+48(FP), R3         // R3 = zIm pointer (forward)
+    MOVD twRe_base+72(FP), R4        // R4 = twRe pointer
+    MOVD twIm_base+96(FP), R5        // R5 = twIm pointer
+    MOVD n+120(FP), R6               // R6 = n
+
+    // Calculate number of iterations: (n-1) / 4
+    SUB $1, R6, R7                   // R7 = n - 1
+    MOVD R7, R14                     // R14 = n - 1 (save for remainder; g is R28)
+    LSR $2, R7                       // R7 = (n-1) / 4 = number of SIMD iterations
+    // Dispatch guarantees n > 4, so R7 = (n-1)/4 >= 1 and the main loop always runs.
+    // A caller that ignores the threshold arrives with R7 = 0 (n <= 4), where the
+    // overlapping remainder below would anchor at k = n-4 <= 0 and over-read z while
+    // underflowing the twiddles; writing nothing is the memory-safe answer. Mirrors
+    // realFFTUnpackNEON (#220).
+    CBZ R7, realfftpow_neon_done     // n <= 4: nothing safe to do
+
+    // Set up reverse pointers: zRe[n-4], zIm[n-4]
+    SUB $4, R6, R8                   // R8 = n - 4
+    LSL $2, R8                       // R8 = (n-4) * 4 = byte offset
+    MOVD zRe_base+24(FP), R9
+    ADD R8, R9                       // R9 = &zRe[n-4]
+    MOVD zIm_base+48(FP), R10
+    ADD R8, R10                      // R10 = &zIm[n-4]
+
+    // Offset forward and output pointers to start at index 1
+    ADD $4, R2                       // R2 = &zRe[1]
+    ADD $4, R3                       // R3 = &zIm[1]
+    ADD $4, R0                       // R0 = &dst[1]
+
+    // Load 0.5 constant into V30
+    MOVW $0x3F000000, R11            // 0.5 in IEEE 754
+    FMOVS R11, F30
+    WORD $0x4E0407DE                 // DUP V30.4S, V30.S[0]
+
+realfftpow_neon_loop4:
+    // Load forward Z[k:k+4]
+    VLD1.P 16(R2), [V0.S4]           // V0 = zRe[k:k+4] (forward)
+    VLD1.P 16(R3), [V1.S4]           // V1 = zIm[k:k+4] (forward)
+
+    // Load reverse Z[n-k-3:n-k+1] and reverse the order
+    VLD1 (R9), [V2.S4]               // V2 = zRe[n-k-3:n-k+1] (to be reversed)
+    VLD1 (R10), [V3.S4]              // V3 = zIm[n-k-3:n-k+1] (to be reversed)
+    WORD $0x4EA00842                 // REV64 V2.4S, V2.4S  (swap pairs: [1,0,3,2])
+    WORD $0x6E024042                 // EXT V2.16B, V2.16B, V2.16B, #8  ([3,2,1,0])
+    WORD $0x4EA00863                 // REV64 V3.4S, V3.4S
+    WORD $0x6E034063                 // EXT V3.16B, V3.16B, V3.16B, #8
+
+    // For conjugate: znkIm = -zIm[n-k]
+    WORD $0x6EA0F863                 // FNEG V3.4S, V3.4S  (negate for conjugate)
+
+    // even = 0.5 * (Z[k] + conj(Z[n-k]))
+    WORD $0x4E22D404                 // FADD V4.4S, V0.4S, V2.4S  (zkRe + znkRe)
+    WORD $0x6E3EDC84                 // FMUL V4.4S, V4.4S, V30.4S  (evenRe)
+    WORD $0x4E23D425                 // FADD V5.4S, V1.4S, V3.4S  (zkIm + znkIm)
+    WORD $0x6E3EDCA5                 // FMUL V5.4S, V5.4S, V30.4S  (evenIm)
+
+    // diff = Z[k] - conj(Z[n-k])
+    WORD $0x4EA2D406                 // FSUB V6.4S, V0.4S, V2.4S  (diffRe)
+    WORD $0x4EA3D427                 // FSUB V7.4S, V1.4S, V3.4S  (diffIm)
+
+    // Load twiddles W[k]
+    VLD1.P 16(R4), [V8.S4]           // V8 = twRe (wr)
+    VLD1.P 16(R5), [V9.S4]           // V9 = twIm (wi)
+
+    // oddRe = 0.5 * (wr*diffIm + wi*diffRe)
+    WORD $0x6E27DD0A                 // FMUL V10.4S, V8.4S, V7.4S   (wr * diffIm)
+    WORD $0x4E26CD2A                 // FMLA V10.4S, V9.4S, V6.4S   (V10 += wi * diffRe)
+    WORD $0x6E3EDD4A                 // FMUL V10.4S, V10.4S, V30.4S (oddRe)
+
+    // oddIm = 0.5 * (wi*diffIm - wr*diffRe)
+    WORD $0x6E27DD2B                 // FMUL V11.4S, V9.4S, V7.4S   (wi * diffIm)
+    WORD $0x4EA6CD0B                 // FMLS V11.4S, V8.4S, V6.4S   (V11 -= wr * diffRe)
+    WORD $0x6E3EDD6B                 // FMUL V11.4S, V11.4S, V30.4S (oddIm)
+
+    // X[k] = even + odd
+    WORD $0x4E2AD480                 // FADD V0.4S, V4.4S, V10.4S  (outRe)
+    WORD $0x4E2BD4A1                 // FADD V1.4S, V5.4S, V11.4S  (outIm)
+
+    // dst[k] = outRe^2 + outIm^2 (fused magnitude-squared)
+    WORD $0x6E20DC0C                 // FMUL V12.4S, V0.4S, V0.4S  (outRe^2)
+    WORD $0x4E21CC2C                 // FMLA V12.4S, V1.4S, V1.4S  (V12 += outIm^2)
+    VST1.P [V12.S4], 16(R0)          // Store power[k:k+4]
+
+    // Move reverse pointers backward
+    SUB $16, R9                      // reverse zRe -= 4
+    SUB $16, R10                     // reverse zIm -= 4
+
+    SUB $1, R7
+    CBNZ R7, realfftpow_neon_loop4
+
+realfftpow_neon_remainder:
+    // Handle the remaining (n-1) % 4 bins with one more FULL 4-wide block anchored
+    // at k = n-4, overlapping the block just written. Bin k reads inputs only (z at
+    // k and the mirror n-k, twiddles at k-1) and nothing a previous bin produced, so
+    // recomputing the last 4 stores identical values; relies on dst not overlapping
+    // the inputs. Mirrors realFFTUnpackNEON (#220, #215).
+    AND $3, R14                      // R14 = leftover bins (0..3)
+    CBZ R14, realfftpow_neon_done
+
+    // Zero the leftover count before re-entering the loop: the block below ends on
+    // the loop's own SUB/CBNZ and falls through here a second time, where it must
+    // find nothing left to do.
+    MOVD ZR, R14
+
+    // Reload the five slice bases the main loop advanced. R6 still holds n.
+    MOVD dst_base+0(FP), R0
+    MOVD zRe_base+24(FP), R2
+    MOVD zIm_base+48(FP), R3
+    MOVD twRe_base+72(FP), R4
+    MOVD twIm_base+96(FP), R5
+    MOVD n+120(FP), R6
+
+    // Mirror pointers first, while R2/R3 still hold the bases. At k = n-4 the block
+    // reads z[n-k-3 .. n-k] = z[1 .. 4], one element in from the start. Index 4 is
+    // why the block needs n >= 5, which the n > 4 threshold gives.
+    ADD $4, R2, R9                   // R9 = &zRe[1]
+    ADD $4, R3, R10                  // R10 = &zIm[1]
+
+    // Forward and output pointers to the anchor k = n-4.
+    SUB $4, R6, R8                   // R8 = n - 4 = k
+    LSL $2, R8                       // R8 = k * 4 = byte offset
+    ADD R8, R2                       // R2 = &zRe[k]
+    ADD R8, R3                       // R3 = &zIm[k]
+    ADD R8, R0                       // R0 = &dst[k]
+
+    // Twiddles are indexed k-1, so they top out at n-2 against a length n-1 slice.
+    SUB $4, R8                       // R8 = (k-1) * 4
+    ADD R8, R4                       // R4 = &twRe[k-1]
+    ADD R8, R5                       // R5 = &twIm[k-1]
+
+    // V30 still holds 0.5: the main loop above always ran (dispatch needs n > 4) and
+    // its body reads V30 but never writes it, so no reload is needed.
+    MOVD $1, R7                      // exactly one more iteration
+    B    realfftpow_neon_loop4
+
+realfftpow_neon_done:
+    RET
+
+// ============================================================================
 // REVERSE - REVERSE SLICE ELEMENTS
 // ============================================================================
 

--- a/f32/f32_go.go
+++ b/f32/f32_go.go
@@ -1045,6 +1045,46 @@ func realFFTUnpack32Go(outRe, outIm, zRe, zIm, twRe, twIm []float32, n int) {
 	}
 }
 
+// realFFTPower32Go is the pure-Go reference for RealFFTPower: it unpacks each bin
+// exactly as realFFTUnpack32Go does and writes the power |X[k]|^2 for k in [1, n-1].
+// The magnitude-squared is a separate multiply and add here; the Go compiler may
+// contract it into an FMA on some architectures (arm64) and not others (amd64), so
+// dst[k] equals squaring realFFTUnpack32Go's output only to within rounding, and
+// the exact bits are not portable. The dispatched SIMD kernels fuse it with an FMA,
+// so they too agree with this reference only to within rounding. See RealFFTPower.
+func realFFTPower32Go(dst, zRe, zIm, twRe, twIm []float32, n int) {
+	if n < realFFTUnpackMinN {
+		return
+	}
+	// Reslice to exactly the range the loop touches so the prover can discharge the
+	// bounds checks from the loop condition alone; the mirror index n-k otherwise
+	// defeats it, the same way realFFTUnpack32Go handles it. The caller has already
+	// validated these lengths, so the reslices cannot panic.
+	zRe, zIm = zRe[:n], zIm[:n]
+	dst = dst[:n]
+	twRe, twIm = twRe[:n-1], twIm[:n-1]
+
+	for k := 1; k < n; k++ {
+		nk := n - k // Mirror index
+
+		zkRe, zkIm := zRe[k], zIm[k]
+		znkRe, znkIm := zRe[nk], -zIm[nk] // conj(Z[n-k])
+
+		evenRe := realFFTUnpackHalf * (zkRe + znkRe)
+		evenIm := realFFTUnpackHalf * (zkIm + znkIm)
+		diffRe := zkRe - znkRe
+		diffIm := zkIm - znkIm
+
+		wr, wi := twRe[k-1], twIm[k-1]
+		oddRe := realFFTUnpackHalf * (wr*diffIm + wi*diffRe)
+		oddIm := realFFTUnpackHalf * (wi*diffIm - wr*diffRe)
+
+		xRe := evenRe + oddRe
+		xIm := evenIm + oddIm
+		dst[k] = xRe*xRe + xIm*xIm
+	}
+}
+
 // reverse32Go reverses a slice in pure Go.
 // dst[i] = src[n-1-i] for i in [0, n)
 func reverse32Go(dst, src []float32) {

--- a/f32/f32_other.go
+++ b/f32/f32_other.go
@@ -102,6 +102,9 @@ func butterflyComplexStage4x32(re, im []float32, span, blocks int,
 func realFFTUnpack32(outRe, outIm, zRe, zIm, twRe, twIm []float32, n int) {
 	realFFTUnpack32Go(outRe, outIm, zRe, zIm, twRe, twIm, n)
 }
+func realFFTPower32(dst, zRe, zIm, twRe, twIm []float32, n int) {
+	realFFTPower32Go(dst, zRe, zIm, twRe, twIm, n)
+}
 func reverse32(dst, src []float32)             { reverse32Go(dst, src) }
 func addSub32(sumDst, diffDst, a, b []float32) { addSub32Go(sumDst, diffDst, a, b) }
 

--- a/f32/realfftpower_test.go
+++ b/f32/realfftpower_test.go
@@ -1,0 +1,519 @@
+package f32
+
+import (
+	"fmt"
+	"math"
+	"testing"
+)
+
+// =============================================================================
+// REAL FFT POWER TESTS (float32)
+// =============================================================================
+//
+// RealFFTPower is the fused, power-writing counterpart of RealFFTUnpack: it emits
+// dst[k] = |X[k]|^2 for k in [1, n-1] in a single pass, unpacking each bin exactly
+// as RealFFTUnpack does and squaring in registers. The SIMD kernels fuse the
+// magnitude-squared with an FMA, so they agree with the pure-Go reference only to
+// within rounding; the Go reference squares realFFTUnpack32Go's output with a
+// separate multiply and add. See RealFFTPower and realFFTPower32Go.
+
+// realFFTPowerRef is a test-local oracle for RealFFTPower, transcribed independently
+// of realFFTPower32Go: it unpacks every bin through the independently written
+// realFFTUnpackRef and squares. A bug copied into both realFFTPower32Go and its
+// derivation would still be caught here. For k in [1, n-1] it computes |X[k]|^2.
+func realFFTPowerRef(dst, zRe, zIm, twRe, twIm []float32, n int) {
+	outRe := make([]float32, n)
+	outIm := make([]float32, n)
+	realFFTUnpackRef(outRe, outIm, zRe, zIm, twRe, twIm, n)
+	for k := 1; k < n; k++ {
+		dst[k] = outRe[k]*outRe[k] + outIm[k]*outIm[k]
+	}
+}
+
+// Tolerances for realFFTPowerClose. The dispatched kernel fuses the odd term and
+// the magnitude-squared with FMA while the reference uses separate multiply-adds,
+// and squaring a value with relative error e produces relative error ~2e, so the
+// two agree to within float32 rounding rather than exactly.
+//
+// MEASURED by instrumenting the dispatched kernel against realFFTPowerRef over the
+// ramp and sinusoid fixtures this suite uses (sizes 2..1000): worst relative
+// divergence 3.353e-6 on amd64. On arm64 the divergence is exactly 0, because the
+// Go compiler contracts the reference's separate multiply-adds into the same FMAs
+// the NEON kernel uses, so the two match bit-for-bit there; the amd64 figure is the
+// cross-arch worst. realFFTPowerRelTol sits about 30x above it and matches the
+// unpack predicate's rel 1e-4 (see f32_test.go), which already covers the odd-term
+// FMA that dominates here. The absolute floor only guards outputs that cancel to
+// near zero, which these smooth fixtures do not produce, so it is effectively
+// unexercised; the relative arm decides every case.
+const (
+	realFFTPowerAbsTol = 1e-3
+	realFFTPowerRelTol = 1e-4
+)
+
+// realFFTPowerClose reports whether got is within the float32 tolerance of want.
+func realFFTPowerClose(got, want float32) bool {
+	diff := math.Abs(float64(got - want))
+	return diff <= realFFTPowerAbsTol || diff <= math.Abs(float64(want))*realFFTPowerRelTol
+}
+
+// makePowerTwiddles fills a valid unpack twiddle table W[k] = exp(-i*pi*k/n) at
+// index k-1, matching the twiddles the f32 unpack tests use.
+func makePowerTwiddles(twRe, twIm []float32, n int) {
+	for k := 1; k < n; k++ {
+		angle := -2 * math.Pi * float64(k) / float64(2*n)
+		twRe[k-1] = float32(math.Cos(angle))
+		twIm[k-1] = float32(math.Sin(angle))
+	}
+}
+
+func TestRealFFTPower(t *testing.T) {
+	// The odd sizes exercise the odd-n mirror; 9 and 10 give the first AVX remainder
+	// lengths (n>8), 5..8 the NEON remainder lengths (n>4). n=2 is the smallest case.
+	sizes := []int{2, 3, 4, 5, 6, 8, 9, 10, 16, 17, 31, 32, 33, 63, 64, 65, 128, 256, 512, 1000}
+
+	for _, n := range sizes {
+		t.Run(fmt.Sprintf("n=%d", n), func(t *testing.T) {
+			zRe := make([]float32, n)
+			zIm := make([]float32, n)
+			twRe := make([]float32, n-1)
+			twIm := make([]float32, n-1)
+			dst := make([]float32, n)
+			ref := make([]float32, n)
+
+			for i := range n {
+				zRe[i] = float32(i+1) * 0.1
+				zIm[i] = float32(i+2) * 0.2
+			}
+			makePowerTwiddles(twRe, twIm, n)
+
+			RealFFTPower(dst, zRe, zIm, twRe, twIm)
+			realFFTPowerRef(ref, zRe, zIm, twRe, twIm, n)
+
+			for k := 1; k < n; k++ {
+				if !realFFTPowerClose(dst[k], ref[k]) {
+					t.Errorf("dst[%d] = %v, want %v, diff=%v", k, dst[k], ref[k], dst[k]-ref[k])
+				}
+				if dst[k] < 0 {
+					t.Errorf("dst[%d] = %v is negative; power must be >= 0", k, dst[k])
+				}
+			}
+		})
+	}
+}
+
+// TestRealFFTPower_GoVsSIMD checks the dispatched kernel against the pure-Go
+// reference. On amd64 the AVX path needs n>8, on arm64 the NEON path needs n>4;
+// 5..8 exercise one NEON (n-1)%4 cycle and 9..16 one AVX (n-1)%8 cycle. Where the
+// dispatcher declines SIMD this arm goes inert (it then calls realFFTPower32Go on
+// both sides); TestRealFFTPower, which checks the dispatched kernel against the
+// independently transcribed realFFTPowerRef oracle, is the arm that holds on every
+// tier.
+func TestRealFFTPower_GoVsSIMD(t *testing.T) {
+	sizes := []int{5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 32, 64, 128, 256, 512}
+
+	for _, n := range sizes {
+		t.Run(fmt.Sprintf("n=%d", n), func(t *testing.T) {
+			zRe := make([]float32, n)
+			zIm := make([]float32, n)
+			twRe := make([]float32, n-1)
+			twIm := make([]float32, n-1)
+			dstSIMD := make([]float32, n)
+			dstGo := make([]float32, n)
+
+			for i := range n {
+				zRe[i] = float32(math.Sin(float64(i)*0.7) * 10)
+				zIm[i] = float32(math.Cos(float64(i)*0.9) * 10)
+			}
+			makePowerTwiddles(twRe, twIm, n)
+
+			RealFFTPower(dstSIMD, zRe, zIm, twRe, twIm)
+			realFFTPower32Go(dstGo, zRe, zIm, twRe, twIm, n)
+
+			for k := 1; k < n; k++ {
+				if !realFFTPowerClose(dstSIMD[k], dstGo[k]) {
+					t.Errorf("k=%d: SIMD=%v, Go=%v, diff=%v", k, dstSIMD[k], dstGo[k], dstSIMD[k]-dstGo[k])
+				}
+			}
+		})
+	}
+}
+
+// TestRealFFTPower_GoMatchesUnpackSquare pins the pure-Go reference against the
+// documented unpack math: realFFTPower32Go must match squaring realFFTUnpack32Go's
+// X[k] on every bin. The comparison is tolerance-based rather than bit-for-bit: the
+// Go compiler contracts the reference's multiply-adds into hardware FMAs on some
+// architectures (arm64) and not others (amd64), so the last bits of dst[k] are not
+// portable, though the value is always |X[k]|^2 to within rounding. A gross error
+// (a wrong index, a dropped 0.5, a swapped even/odd) moves the result well outside
+// tolerance and is still caught. It holds on every tier since it never touches the
+// dispatched kernel.
+func TestRealFFTPower_GoMatchesUnpackSquare(t *testing.T) {
+	sizes := []int{2, 3, 4, 5, 6, 7, 8, 9, 16, 17, 32, 33, 64, 65, 128, 256, 511, 512}
+
+	for _, n := range sizes {
+		t.Run(fmt.Sprintf("n=%d", n), func(t *testing.T) {
+			zRe := make([]float32, n)
+			zIm := make([]float32, n)
+			twRe := make([]float32, n-1)
+			twIm := make([]float32, n-1)
+			dst := make([]float32, n)
+			outRe := make([]float32, n)
+			outIm := make([]float32, n)
+
+			for i := range n {
+				zRe[i] = float32(math.Sin(float64(i)*0.7) * 10)
+				zIm[i] = float32(math.Cos(float64(i)*0.9) * 10)
+			}
+			makePowerTwiddles(twRe, twIm, n)
+
+			realFFTPower32Go(dst, zRe, zIm, twRe, twIm, n)
+			realFFTUnpack32Go(outRe, outIm, zRe, zIm, twRe, twIm, n)
+
+			for k := 1; k < n; k++ {
+				want := outRe[k]*outRe[k] + outIm[k]*outIm[k]
+				if !realFFTPowerClose(dst[k], want) {
+					t.Errorf("k=%d dst = %v, unpack-square = %v, diff=%v",
+						k, dst[k], want, dst[k]-want)
+				}
+			}
+		})
+	}
+}
+
+func TestRealFFTPower_EdgeCases(t *testing.T) {
+	// n < 2 must return without doing anything.
+	t.Run("n=0", func(_ *testing.T) {
+		RealFFTPower(nil, nil, nil, nil, nil)
+	})
+
+	t.Run("n=1", func(t *testing.T) {
+		dst := []float32{7}
+		zRe := []float32{1}
+		zIm := []float32{0}
+		// Below realFFTUnpackMinN, so it must return untouched.
+		RealFFTPower(dst, zRe, zIm, nil, nil)
+		if dst[0] != 7 {
+			t.Errorf("n=1 modified output: dst=%v, want unchanged", dst[0])
+		}
+	})
+
+	// The Go reference has its own n < realFFTUnpackMinN guard (the public entry
+	// point rejects small n first, so it is otherwise unreachable). Call it directly
+	// with n=1 to pin that guard against a future direct caller.
+	t.Run("go_ref_small_n", func(t *testing.T) {
+		dst := []float32{7}
+		realFFTPower32Go(dst, []float32{1}, []float32{0}, nil, nil, 1)
+		if dst[0] != 7 {
+			t.Errorf("realFFTPower32Go n=1 modified output: dst=%v, want unchanged", dst[0])
+		}
+	})
+
+	// DC (dst[0]) is the caller's job, so RealFFTPower must never write it.
+	t.Run("dc_untouched", func(t *testing.T) {
+		const n = 16
+		zRe := make([]float32, n)
+		zIm := make([]float32, n)
+		twRe := make([]float32, n-1)
+		twIm := make([]float32, n-1)
+		dst := make([]float32, n)
+		for i := range n {
+			zRe[i], zIm[i] = float32(i+1)*0.1, float32(i+2)*0.2
+		}
+		makePowerTwiddles(twRe, twIm, n)
+		const sentinel = -1.5
+		dst[0] = sentinel
+		RealFFTPower(dst, zRe, zIm, twRe, twIm)
+		if dst[0] != sentinel {
+			t.Errorf("DC bin dst[0] = %v, want untouched %v", dst[0], sentinel)
+		}
+	})
+}
+
+// TestRealFFTPower_KnownValues checks a small case against an independently unpacked
+// and squared spectrum. For n=4 the bins are k=1,2,3.
+func TestRealFFTPower_KnownValues(t *testing.T) {
+	const n = 4
+	zRe := []float32{1, 2, 3, 4}
+	zIm := []float32{0.1, 0.2, 0.3, 0.4}
+	twRe := make([]float32, n-1)
+	twIm := make([]float32, n-1)
+	makePowerTwiddles(twRe, twIm, n)
+
+	dst := make([]float32, n)
+	RealFFTPower(dst, zRe, zIm, twRe, twIm)
+
+	outRe := make([]float32, n)
+	outIm := make([]float32, n)
+	realFFTUnpackRef(outRe, outIm, zRe, zIm, twRe, twIm, n)
+	for k := 1; k < n; k++ {
+		want := outRe[k]*outRe[k] + outIm[k]*outIm[k]
+		if !realFFTPowerClose(dst[k], want) {
+			t.Errorf("k=%d dst = %v, want %v", k, dst[k], want)
+		}
+	}
+}
+
+// TestRealFFTPower_AllocFree pins the zero-allocation guarantee. The direct cpu-flag
+// dispatch keeps //go:noescape effective; routing through an init-time function
+// pointer would reintroduce heap allocations here.
+func TestRealFFTPower_AllocFree(t *testing.T) {
+	const n = 256
+	zRe := make([]float32, n)
+	zIm := make([]float32, n)
+	twRe := make([]float32, n-1)
+	twIm := make([]float32, n-1)
+	dst := make([]float32, n)
+	for i := range n {
+		zRe[i] = float32(i+1) * 0.1
+		zIm[i] = float32(i+2) * 0.2
+	}
+	makePowerTwiddles(twRe, twIm, n)
+	fn := func() { RealFFTPower(dst, zRe, zIm, twRe, twIm) }
+	if a := testing.AllocsPerRun(50, fn); a != 0 {
+		t.Errorf("RealFFTPower allocated %v times per run, want 0", a)
+	}
+}
+
+// TestRealFFTPower_ShortSlices exercises the length-validation guards: with n taken
+// from len(zRe), any operand shorter than required (zIm/dst < n, or twRe/twIm <
+// n-1) must make the call return without writing output or panicking. Each case
+// shortens exactly one operand so every clause of the guard is pinned on its own.
+func TestRealFFTPower_ShortSlices(t *testing.T) {
+	const n = 16
+	makeZ := func() ([]float32, []float32) {
+		zRe := make([]float32, n)
+		zIm := make([]float32, n)
+		for i := range n {
+			zRe[i], zIm[i] = float32(i+1)*0.1, float32(i+2)*0.2
+		}
+		return zRe, zIm
+	}
+	makeTw := func(reLen, imLen int) ([]float32, []float32) {
+		a, b := make([]float32, reLen), make([]float32, imLen)
+		for i := range a {
+			a[i] = 0.5
+		}
+		for i := range b {
+			b[i] = -0.5
+		}
+		return a, b
+	}
+	const sentinel = -1.5
+	makeDst := func(dstLen int) []float32 {
+		s := make([]float32, dstLen)
+		for i := range s {
+			s[i] = sentinel
+		}
+		return s
+	}
+	untouched := func(t *testing.T, name string, s []float32) {
+		t.Helper()
+		for i, v := range s {
+			if v != sentinel {
+				t.Errorf("%s written at [%d]=%v, want untouched (guard should have returned)", name, i, v)
+			}
+		}
+	}
+
+	cases := []struct {
+		name                             string
+		zImLen, dstLen, twReLen, twImLen int
+	}{
+		{"shortZIm", n - 1, n, n - 1, n - 1},
+		{"shortDst", n, n - 1, n - 1, n - 1},
+		{"shortTwRe", n, n, n - 2, n - 1},
+		{"shortTwIm", n, n, n - 1, n - 2},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			zRe, zImFull := makeZ()
+			zIm := zImFull[:c.zImLen]
+			twRe, twIm := makeTw(c.twReLen, c.twImLen)
+			dst := makeDst(c.dstLen)
+			RealFFTPower(dst, zRe, zIm, twRe, twIm)
+			untouched(t, "dst", dst)
+		})
+	}
+}
+
+// TestRealFFTPower_OverRead guards the reversed mirror load. The kernel reads Z[n-k]
+// descending against Z[k] ascending; a reverse pointer sized one block too far (or a
+// forward load past the end) would read outside [0,n). zRe/zIm are backed by padded
+// arrays whose guard bands hold NaN (two AVX blocks = 16 float32 on each side), then
+// sliced to exactly length n. Any out-of-range read pulls a NaN into an output lane,
+// which the parity check catches deterministically instead of a SIGSEGV or a
+// coincidental match. NaN squared is NaN, so it survives the square.
+func TestRealFFTPower_OverRead(t *testing.T) {
+	const pad = 16 // two AVX blocks of NaN guard band on each side of z
+	for _, n := range []int{5, 6, 9, 10, 16, 17, 18, 31, 32, 33, 64, 65} {
+		t.Run(fmt.Sprintf("n=%d", n), func(t *testing.T) {
+			nan := float32(math.NaN())
+			zReBack := make([]float32, pad+n+pad)
+			zImBack := make([]float32, pad+n+pad)
+			for i := range zReBack {
+				zReBack[i], zImBack[i] = nan, nan
+			}
+			zRe := zReBack[pad : pad+n]
+			zIm := zImBack[pad : pad+n]
+			for i := range n {
+				zRe[i] = float32(math.Sin(float64(i)*0.7) * 10)
+				zIm[i] = float32(math.Cos(float64(i)*0.9) * 10)
+			}
+			twRe := make([]float32, n-1)
+			twIm := make([]float32, n-1)
+			makePowerTwiddles(twRe, twIm, n)
+			dst := make([]float32, n)
+			ref := make([]float32, n)
+
+			RealFFTPower(dst, zRe, zIm, twRe, twIm)
+			realFFTPowerRef(ref, zRe, zIm, twRe, twIm, n)
+
+			for k := 1; k < n; k++ {
+				if math.IsNaN(float64(dst[k])) {
+					t.Fatalf("k=%d: NaN in output -> kernel over-read the zRe/zIm guard band", k)
+				}
+				if !realFFTPowerClose(dst[k], ref[k]) {
+					t.Errorf("k=%d dst = %v, want %v", k, dst[k], ref[k])
+				}
+			}
+		})
+	}
+}
+
+// TestRealFFTPower_SignedZero pins the even/odd sign handling. Every input is a
+// signed zero and every twiddle is +1 or -1, so every intermediate is an exact zero:
+// X[k] is zero and the power is exactly +0 on every bin (squaring collapses the sign
+// of the operands), on both the dispatched and Go paths. A masking or negation bug in
+// the reversed-load conjugate would surface here as a NaN or a non-zero.
+func TestRealFFTPower_SignedZero(t *testing.T) {
+	// 5..8 is one NEON (n-1)%4 cycle; 9..16 one AVX (n-1)%8 cycle; 64,65 add sizes
+	// with several full blocks.
+	sizes := []int{5, 6, 7, 8, 9, 12, 16, 17, 64, 65}
+
+	for _, n := range sizes {
+		t.Run(fmt.Sprintf("n=%d", n), func(t *testing.T) {
+			zRe := make([]float32, n)
+			zIm := make([]float32, n)
+			twRe := make([]float32, n-1)
+			twIm := make([]float32, n-1)
+			dst := make([]float32, n)
+			dstGo := make([]float32, n)
+
+			const signBits = 6
+			for pat := range 1 << signBits {
+				sign := func(bit uint) float64 {
+					if pat&(1<<bit) != 0 {
+						return -1
+					}
+					return 1
+				}
+				half := n / 2
+				for i := range n {
+					reBit, imBit := uint(0), uint(1)
+					if i >= half {
+						reBit, imBit = 2, 3
+					}
+					zRe[i] = float32(math.Copysign(0, sign(reBit)))
+					zIm[i] = float32(math.Copysign(0, sign(imBit)))
+				}
+				for k := 1; k < n; k++ {
+					twRe[k-1] = float32(sign(4))
+					twIm[k-1] = float32(sign(5))
+				}
+
+				RealFFTPower(dst, zRe, zIm, twRe, twIm)
+				realFFTPower32Go(dstGo, zRe, zIm, twRe, twIm, n)
+
+				for k := 1; k < n; k++ {
+					if math.Float32bits(dst[k]) != 0 {
+						t.Errorf("pat=%#02x k=%d: SIMD power = %v (%#08x), want +0",
+							pat, k, dst[k], math.Float32bits(dst[k]))
+					}
+					if math.Float32bits(dstGo[k]) != 0 {
+						t.Errorf("pat=%#02x k=%d: Go power = %v (%#08x), want +0",
+							pat, k, dstGo[k], math.Float32bits(dstGo[k]))
+					}
+				}
+			}
+		})
+	}
+}
+
+// Per-arm byte accounting for SetBytes, counting the distinct length-n float32
+// slices each arm touches. This is a working-set proxy, not a full multi-pass
+// traffic count: the baseline re-reads its outRe/outIm scratch across the Mul and
+// FMA passes, so its real memory traffic is higher than the count implies. The
+// point is only to stop charging both arms the same bytes; ns/op stays the
+// apples-to-apples fused-vs-baseline comparison.
+const (
+	// fusedSlicesTouched is what the fused RealFFTPower touches per call: it reads
+	// zRe, zIm, twRe, twIm and writes dst (5 distinct slices).
+	fusedSlicesTouched = 5
+	// baselineSlicesTouched is what the unpack+Mul+FMA baseline touches per call:
+	// the same five plus the outRe/outIm scratch RealFFTUnpack writes and the
+	// following Mul/FMA passes re-read (7 distinct slices).
+	baselineSlicesTouched = 7
+)
+
+// benchRealFFTPower32 runs fn at size n over freshly built inputs. slicesTouched is
+// how many length-n float32 slices this arm moves through memory per call, so each
+// arm's reported MB/s reflects its own traffic instead of a shared count.
+func benchRealFFTPower32(b *testing.B, n int, slicesTouched int64, fn func(dst, zRe, zIm, twRe, twIm []float32, n int)) {
+	b.Helper()
+	zRe := make([]float32, n)
+	zIm := make([]float32, n)
+	twRe := make([]float32, n-1)
+	twIm := make([]float32, n-1)
+	dst := make([]float32, n)
+
+	for i := range n {
+		zRe[i] = float32(i) * 0.1
+		zIm[i] = float32(i) * 0.2
+	}
+	makePowerTwiddles(twRe, twIm, n)
+
+	b.ResetTimer()
+	b.SetBytes(int64(n*4) * slicesTouched) // 4 bytes per float32 across slicesTouched slices
+
+	for range b.N {
+		fn(dst, zRe, zIm, twRe, twIm, n)
+	}
+}
+
+// realFFTPowerDispatched adapts the public entry point to the shared helper's
+// signature.
+func realFFTPowerDispatched(dst, zRe, zIm, twRe, twIm []float32, _ int) {
+	RealFFTPower(dst, zRe, zIm, twRe, twIm)
+}
+
+// realFFTPowerBaseline is the three-pass unpack + Mul + FMA the fused kernel
+// replaces: RealFFTUnpack writes the complex half-spectrum, then the power is
+// squared and summed in two more passes. It carries its own scratch so the
+// benchmark measures the extra traffic, not an allocation.
+type realFFTPowerBaseline struct {
+	outRe, outIm []float32
+}
+
+func (s *realFFTPowerBaseline) run(dst, zRe, zIm, twRe, twIm []float32, _ int) {
+	RealFFTUnpack(s.outRe, s.outIm, zRe, zIm, twRe, twIm)
+	Mul(dst, s.outRe, s.outRe)      // dst = outRe^2
+	FMA(dst, s.outIm, s.outIm, dst) // dst = outIm^2 + outRe^2
+}
+
+// BenchmarkRealFFTPower compares the fused RealFFTPower against the three-pass
+// RealFFTUnpack + Mul + FMA baseline it replaces. n is the half-size (nfft/2), so
+// the rows correspond to nfft 256/512/1024/2048.
+func BenchmarkRealFFTPower(b *testing.B) {
+	sizes := []int{128, 256, 512, 1024}
+
+	for _, n := range sizes {
+		nfft := 2 * n
+		b.Run(fmt.Sprintf("Fused_nfft%d", nfft), func(b *testing.B) {
+			benchRealFFTPower32(b, n, fusedSlicesTouched, realFFTPowerDispatched)
+		})
+		b.Run(fmt.Sprintf("UnpackMulFMA_nfft%d", nfft), func(b *testing.B) {
+			base := &realFFTPowerBaseline{outRe: make([]float32, n), outIm: make([]float32, n)}
+			benchRealFFTPower32(b, n, baselineSlicesTouched, base.run)
+		})
+	}
+}

--- a/f32/realfftpower_test.go
+++ b/f32/realfftpower_test.go
@@ -79,6 +79,12 @@ func TestRealFFTPower(t *testing.T) {
 			twIm := make([]float32, n-1)
 			dst := make([]float32, n)
 			ref := make([]float32, n)
+			// Seed every output bin with NaN so a kernel that accumulated into
+			// dst[k] (instead of assigning the power) is caught: it would leave NaN,
+			// which realFFTPowerClose rejects. dst[0] is the caller's DC bin.
+			for k := 1; k < n; k++ {
+				dst[k] = float32(math.NaN())
+			}
 
 			for i := range n {
 				zRe[i] = float32(i+1) * 0.1
@@ -159,6 +165,10 @@ func TestRealFFTPower_GoMatchesUnpackSquare(t *testing.T) {
 			dst := make([]float32, n)
 			outRe := make([]float32, n)
 			outIm := make([]float32, n)
+			// Seed with NaN so an accumulating Go reference is caught (see TestRealFFTPower).
+			for k := 1; k < n; k++ {
+				dst[k] = float32(math.NaN())
+			}
 
 			for i := range n {
 				zRe[i] = float32(math.Sin(float64(i)*0.7) * 10)


### PR DESCRIPTION
## Summary

Adds `f32.RealFFTPower`, the fused single-pass real-FFT power-spectrum kernel, as the f32 sibling of the f64 `RealFFTPower` from #233. It writes `dst[k] = |X[k]|^2` for k in [1, n-1] in one pass, unpacking each bin exactly as `RealFFTUnpack` does and squaring in registers, so a spectrogram, mel front end, or PSD consumer skips the three-pass `RealFFTUnpack + Mul + FMA` form. f32 is the primary path for the audio ML front ends this serves (mel-spectrogram and PCEN pipelines feeding CNN classifiers).

## Approach

The kernel is `RealFFTUnpack`'s exact lane layout with the two complex-half stores replaced by a fused magnitude-squared (`VMULPS` + `VFMADD231PS` on amd64, `FMUL` + `FMLA` on arm64) and a single store: the same delta the f64 `RealFFTPower` kernel applied to f64 `RealFFTUnpack`.

- AVX+FMA kernel, 8 f32 bins per pass; NEON kernel, 4 per pass, both finishing with the existing overlapping-remainder idiom; pure-Go fallback.
- Stays on the AVX+FMA tier: `VPERM2F128` + `VPERMILPS` reversed load and RODATA constants, no AVX2 encoding, so its `cpu.X86.AVX && cpu.X86.FMA` dispatch guard is sufficient. The ISA and FMA gate tests confirm it is not misclassified.
- Two new hand-encoded NEON `WORD` directives (`FMUL`/`FMLA V12.4S`) verified by the `asmcheck` arm64asm cross-check.

## Numerics

Tolerance-based parity, exactly as the f64 sibling: the kernels fuse the magnitude-squared while the Go reference writes a separate multiply and add. Measured worst relative divergence is 3.353e-6 on amd64 and exactly 0 on arm64 (the Go compiler contracts the reference into the same FMAs the NEON kernel uses), against a `realFFTPowerRelTol` of 1e-4.

## Verification

- Full f32 suite passes on amd64 (native) and arm64 (native Raspberry Pi 5).
- `asmcheck` WORD cross-check, amd64 ISA gate, FMA gate, and the no-FMA numerical contract all pass.
- Zero allocation (`TestRealFFTPower_AllocFree`); over-read guard-band, signed-zero, short-slice, and DC-untouched coverage ported from the f64 suite.
- Peer-reviewed line by line with an independent model: FP offsets, pointer arithmetic, remainder idempotence, reserved-register hygiene, WORD decodes, ISA gating, and tolerance all confirmed.

## Benchmarks (fused vs `RealFFTUnpack + Mul + FMA`)

| nfft | amd64 (i7-class) | arm64 (Pi 5) |
|------|------------------|--------------|
| 256  | 1.52x | 1.32x |
| 512  | ~1.46x | 1.28x |
| 1024 | 1.42x | 1.26x |
| 2048 | 1.45x | 1.24x |

Matches the memory-traffic win the f64 kernel demonstrated.

Fixes #245.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added `RealFFTPower` support for 32-bit floating-point real FFT data.
  - Computes magnitude-squared power directly into a destination buffer, avoiding intermediate complex outputs.
  - Includes optimized processing across supported CPU architectures with a portable fallback.
  - Validates input sizes and buffer lengths, safely ignoring invalid or undersized inputs.

- **Documentation**
  - Updated FFT primitive documentation to include `RealFFTPower` for both 32-bit and 64-bit floating-point APIs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->