### PR TITLE
f32: fused Int32ToFloat32ScaleAdd (dequantize-accumulate, two roundings) (Fixes #248)

### DIFF
--- a/asmcheck_test.go
+++ b/asmcheck_test.go
@@ -314,6 +314,8 @@ var singleRoundingKernels = []singleRoundingKernel{
 	{"f32/f32_arm64.s", "float32ToInt32ScaleClampNEON", "FMUL", "FADD"},
 	{"f32/f32_amd64.s", "float32ToInt32ScaleClampSignedAVX", "VMULPS", "VADDPS"},
 	{"f32/f32_arm64.s", "float32ToInt32ScaleClampSignedNEON", "FMUL", "FADD"},
+	{"f32/f32_amd64.s", "int32ToFloat32ScaleAddAVX", "VMULPS", "VADDPS"},
+	{"f32/f32_arm64.s", "int32ToFloat32ScaleAddNEON", "FMUL", "FADD"},
 }
 
 // asmFuncBody returns the lines of the TEXT ·fn(...) block, from its TEXT line to

--- a/doc.go
+++ b/doc.go
@@ -88,7 +88,7 @@
 // Transcendental (f32/f64): Log, Log2, Log10, Pow, PowElem (plus LogInPlace, PowInPlace),
 // SIMD-accelerated on AVX2+FMA and NEON
 //
-// Audio DSP: Interleave2, Deinterleave2, ConvolveValid, ConvolveValidMulti, ConvolveValidMaxAbs, ConvolveValidMaxAbsMulti, ConvolveDecimate, AccumulateAdd, CumulativeSum, CubicInterpDot, Int32ToFloat32Scale, Int16ToFloat32Scale, Float32ToInt16Scale
+// Audio DSP: Interleave2, Deinterleave2, ConvolveValid, ConvolveValidMulti, ConvolveValidMaxAbs, ConvolveValidMaxAbsMulti, ConvolveDecimate, AccumulateAdd, CumulativeSum, CubicInterpDot, Int32ToFloat32Scale, Int32ToFloat32ScaleAdd (fused dequantize-accumulate dst[i] = a[i] + float32(src[i])*scale, two roundings), Int16ToFloat32Scale, Float32ToInt16Scale
 //
 // Sliding-window argmin (f32): MinIdxOfSum, MinIdxOfSumRows (batched sliding-window argmin of a[i]+k[base+r*slide+i], first-index-wins ties, bit-exact across all paths)
 //

--- a/f32/f32.go
+++ b/f32/f32.go
@@ -1087,7 +1087,7 @@ func Int32ToFloat32ScaleUnsafe(dst []float32, src []int32, scale float32) {
 // The product float32(src[i])*scale is rounded to float32 before the add (two
 // roundings, never an FMA), so the result is bit-identical to Int32ToFloat32Scale
 // into a temporary followed by Add, on every dispatch path including the pure-Go
-// fallback. That single-rounding contract is the load-bearing property, in the same
+// fallback. That two-rounding contract is the load-bearing property, in the same
 // style Float32ToInt32ScaleClamp established.
 //
 // Processes min(len(dst), len(a), len(src)) elements.

--- a/f32/f32.go
+++ b/f32/f32.go
@@ -1072,6 +1072,41 @@ func Int32ToFloat32ScaleUnsafe(dst []float32, src []int32, scale float32) {
 	int32ToFloat32Scale(dst[:len(src)], src, scale)
 }
 
+// Int32ToFloat32ScaleAdd converts, scales and accumulates in one pass:
+//
+//	dst[i] = a[i] + float32(src[i])*scale
+//
+// It is the fused single-pass form of the dequantize-accumulate shape that
+// otherwise needs a temporary: Int32ToFloat32Scale(tmp, src, scale) followed by
+// Add(dst, a, tmp). This mixed-precision AXPY whose increment is quantized integer
+// data appears wherever integer counts or quantized values feed a float
+// accumulation, such as rate-distortion cost curves (distortion plus lambda times
+// an integer bit count), dequantize-and-mix paths, and dequantization of quantized
+// tensors onto a float32 accumulator.
+//
+// The product float32(src[i])*scale is rounded to float32 before the add (two
+// roundings, never an FMA), so the result is bit-identical to Int32ToFloat32Scale
+// into a temporary followed by Add, on every dispatch path including the pure-Go
+// fallback. That single-rounding contract is the load-bearing property, in the same
+// style Float32ToInt32ScaleClamp established.
+//
+// Processes min(len(dst), len(a), len(src)) elements.
+//
+// # Aliasing
+//
+// dst may overlay a exactly (the in-place accumulate dst[i] += float32(src[i])*scale,
+// since each lane reads a[i] before it rewrites dst[i]), following the AddScaled
+// aliasing rule. dst must not overlap a at a shifted offset.
+//
+// Uses AVX on AMD64 (8x int32), NEON on ARM64 (4x int32), with a pure-Go fallback.
+func Int32ToFloat32ScaleAdd(dst, a []float32, src []int32, scale float32) {
+	n := min(len(dst), len(a), len(src))
+	if n == 0 {
+		return
+	}
+	int32ToFloat32ScaleAdd(dst[:n], a[:n], src[:n], scale)
+}
+
 // Int16ToFloat32Scale converts int16 samples to float32 and scales in one pass.
 // dst[i] = float32(src[i]) * scale
 //

--- a/f32/f32_amd64.go
+++ b/f32/f32_amd64.go
@@ -1222,6 +1222,20 @@ func int32ToFloat32Scale(dst []float32, src []int32, scale float32) {
 //go:noescape
 func int32ToFloat32ScaleAVX(dst []float32, src []int32, scale float32)
 
+func int32ToFloat32ScaleAdd(dst, a []float32, src []int32, scale float32) {
+	// Plain AVX, no FMA: the kernel keeps the multiply and add separate (VMULPS then
+	// VADDPS, two roundings) so it stays bit-identical to the Go reference and the
+	// two-pass Int32ToFloat32Scale + Add composition. See #248 and the #156 contract.
+	if cpu.X86.AVX && len(dst) >= minAVXElements {
+		int32ToFloat32ScaleAddAVX(dst, a, src, scale)
+		return
+	}
+	int32ToFloat32ScaleAddGo(dst, a, src, scale)
+}
+
+//go:noescape
+func int32ToFloat32ScaleAddAVX(dst, a []float32, src []int32, scale float32)
+
 func int16ToFloat32Scale(dst []float32, src []int16, scale float32) {
 	// AVX2 is required because widening int16 to int32 uses VPMOVSXWD (ymm form).
 	if cpu.X86.AVX2 && len(dst) >= minAVXElements {

--- a/f32/f32_amd64.s
+++ b/f32/f32_amd64.s
@@ -4651,6 +4651,60 @@ i32tof32_done:
     VZEROUPPER
     RET
 
+// func int32ToFloat32ScaleAddAVX(dst, a []float32, src []int32, scale float32)
+// Fused dequantize-accumulate: dst[i] = a[i] + float32(src[i])*scale.
+// Plain AVX, no FMA: the product (VMULPS) rounds to float32 before the add (VADDPS)
+// rounds again, so the result is bit-identical to the Go reference and the two-pass
+// Int32ToFloat32Scale + Add composition. Keeping the multiply and add separate is
+// the #156 single-rounding contract (asserted by TestNoFMAContract). See #248.
+// Frame: dst(24) + a(24) + src(24) + scale(4) = 76 bytes.
+TEXT ·int32ToFloat32ScaleAddAVX(SB), NOSPLIT, $0-76
+    MOVQ dst_base+0(FP), DX        // DX = dst pointer
+    MOVQ dst_len+8(FP), CX         // CX = length
+    MOVQ a_base+24(FP), BX         // BX = a pointer (accumulator input)
+    MOVQ src_base+48(FP), SI       // SI = src pointer
+
+    // Broadcast scale to all 8 lanes (memory source keeps this AVX1, not AVX2).
+    VBROADCASTSS scale+72(FP), Y2  // Y2 = {scale, ...}
+
+    // Process 8 int32 elements per iteration
+    MOVQ CX, AX
+    SHRQ $3, AX                    // len / 8
+    JZ   i32tof32add_remainder
+
+i32tof32add_loop8:
+    VMOVDQU (SI), Y0               // Y0 = 8 x int32
+    VCVTDQ2PS Y0, Y1              // Y1 = float32(src)
+    VMULPS Y2, Y1, Y1             // Y1 = float32(src)*scale (first rounding)
+    VMOVUPS (BX), Y3              // Y3 = a[i:i+8]
+    VADDPS Y3, Y1, Y1            // Y1 = a + product (second rounding, not an FMA)
+    VMOVUPS Y1, (DX)             // store 8 x float32
+    ADDQ $32, SI
+    ADDQ $32, BX
+    ADDQ $32, DX
+    DECQ AX
+    JNZ  i32tof32add_loop8
+
+i32tof32add_remainder:
+    ANDQ $7, CX                    // remainder = len % 8
+    JZ   i32tof32add_done
+
+i32tof32add_scalar:
+    VCVTSI2SSL (SI), X0, X0        // convert single int32 to float32
+    VMULSS X2, X0, X0             // X0 = product (first rounding)
+    VMOVSS (BX), X3              // X3 = a[i]
+    VADDSS X3, X0, X0           // X0 = a + product (second rounding)
+    VMOVSS X0, (DX)             // store float32
+    ADDQ $4, SI
+    ADDQ $4, BX
+    ADDQ $4, DX
+    DECQ CX
+    JNZ  i32tof32add_scalar
+
+i32tof32add_done:
+    VZEROUPPER
+    RET
+
 // func int16ToFloat32ScaleAVX(dst []float32, src []int16, scale float32)
 // Converts int16 samples to float32 and multiplies by scale in one pass.
 // dst[i] = float32(src[i]) * scale

--- a/f32/f32_arm64.go
+++ b/f32/f32_arm64.go
@@ -804,6 +804,19 @@ func int32ToFloat32Scale(dst []float32, src []int32, scale float32) {
 //go:noescape
 func int32ToFloat32ScaleNEON(dst []float32, src []int32, scale float32)
 
+func int32ToFloat32ScaleAdd(dst, a []float32, src []int32, scale float32) {
+	// NEON keeps the multiply and add separate (FMUL then FADD, two roundings) so it
+	// stays bit-identical to the Go reference and the two-pass composition. See #248.
+	if hasNEON && len(dst) >= 4 {
+		int32ToFloat32ScaleAddNEON(dst, a, src, scale)
+		return
+	}
+	int32ToFloat32ScaleAddGo(dst, a, src, scale)
+}
+
+//go:noescape
+func int32ToFloat32ScaleAddNEON(dst, a []float32, src []int32, scale float32)
+
 func int16ToFloat32Scale(dst []float32, src []int16, scale float32) {
 	if hasNEON && len(dst) >= 4 {
 		int16ToFloat32ScaleNEON(dst, src, scale)

--- a/f32/f32_arm64.s
+++ b/f32/f32_arm64.s
@@ -2115,6 +2115,63 @@ i32tof32_neon_scalar_loop:
 i32tof32_neon_done:
     RET
 
+// func int32ToFloat32ScaleAddNEON(dst, a []float32, src []int32, scale float32)
+// Fused dequantize-accumulate: dst[i] = a[i] + float32(src[i])*scale.
+// NEON, no FMLA: the product (FMUL) rounds to float32 before the add (FADD) rounds
+// again, so the result is bit-identical to the Go reference and the two-pass
+// Int32ToFloat32Scale + Add composition. Keeping the multiply and add separate is
+// the #156 single-rounding contract (asserted by TestNoFMAContract). See #248.
+//
+// NEON opcodes (hand-encoded; the Go assembler lacks these vector forms):
+// SCVTF Vd.4S, Vn.4S:       signed int32 to float32
+// FMUL  Vd.4S, Vn.4S, Vm.4S: multiply
+// FADD  Vd.4S, Vn.4S, Vm.4S: add
+// DUP   Vd.4S, Vn.S[0]:      broadcast lane 0
+//
+// Frame: dst(24) + a(24) + src(24) + scale(4) = 76 bytes.
+TEXT ·int32ToFloat32ScaleAddNEON(SB), NOSPLIT, $0-76
+    MOVD dst_base+0(FP), R0        // R0 = dst pointer
+    MOVD dst_len+8(FP), R3         // R3 = length
+    MOVD a_base+24(FP), R2         // R2 = a pointer (accumulator input)
+    MOVD src_base+48(FP), R1       // R1 = src pointer
+    FMOVS scale+72(FP), F2         // F2 = scale
+
+    WORD $0x4E040442               // DUP V2.4S, V2.S[0]  (broadcast scale)
+
+    // Process 4 int32 elements per iteration
+    LSR $2, R3, R4                 // R4 = len / 4
+    CBZ R4, i32tof32add_neon_scalar
+
+i32tof32add_neon_loop4:
+    VLD1.P 16(R1), [V0.S4]         // V0 = 4 x int32 from src
+    WORD $0x4E21D801               // SCVTF V1.4S, V0.4S  (int32 -> float32)
+    WORD $0x6E22DC21               // FMUL V1.4S, V1.4S, V2.4S  (product, first rounding)
+    VLD1.P 16(R2), [V3.S4]         // V3 = a[i:i+4]
+    WORD $0x4E23D421               // FADD V1.4S, V1.4S, V3.4S  (a + product, second rounding)
+    VST1.P [V1.S4], 16(R0)         // store 4 x float32
+    SUB $1, R4
+    CBNZ R4, i32tof32add_neon_loop4
+
+i32tof32add_neon_scalar:
+    AND $3, R3                     // remainder = len % 4
+    CBZ R3, i32tof32add_neon_done
+
+i32tof32add_neon_scalar_loop:
+    MOVW (R1), R5                  // Load int32
+    SCVTFWS R5, F0                 // Convert int32 to float32
+    FMULS F2, F0, F0               // F0 = product (first rounding)
+    FMOVS (R2), F3                 // F3 = a[i]
+    FADDS F3, F0, F0               // F0 = a + product (second rounding)
+    FMOVS F0, (R0)                 // Store float32
+    ADD $4, R0
+    ADD $4, R1
+    ADD $4, R2
+    SUB $1, R3
+    CBNZ R3, i32tof32add_neon_scalar_loop
+
+i32tof32add_neon_done:
+    RET
+
 // func int16ToFloat32ScaleNEON(dst []float32, src []int16, scale float32)
 // Converts int16 samples to float32 and multiplies by scale in one pass.
 // dst[i] = float32(src[i]) * scale

--- a/f32/f32_go.go
+++ b/f32/f32_go.go
@@ -756,6 +756,26 @@ func int32ToFloat32ScaleGo(dst []float32, src []int32, scale float32) {
 	}
 }
 
+// int32ToFloat32ScaleAddGo is the pure-Go reference for Int32ToFloat32ScaleAdd:
+// dst[i] = a[i] + float32(src[i])*scale, with the product rounded to float32 before
+// the add (two roundings, never an FMA). The explicit float32() on the product is
+// load-bearing: without it the Go compiler may contract a[i] + float32(src[i])*scale
+// into a single fused multiply-add on architectures that have one (arm64), which
+// rounds once and would break bit-parity with the SIMD kernels and with the two-pass
+// Int32ToFloat32Scale + Add composition. Same contract as Float32ToInt32ScaleClamp
+// (#155/#156); see #248.
+func int32ToFloat32ScaleAddGo(dst, a []float32, src []int32, scale float32) {
+	n := len(dst)
+	if n == 0 {
+		return
+	}
+	a = a[:n] // hoist the a/src bounds checks out of the loop
+	src = src[:n]
+	for i := range dst {
+		dst[i] = a[i] + float32(float32(src[i])*scale)
+	}
+}
+
 // int16ToFloat32ScaleGo converts int16 samples to float32 and scales.
 // dst[i] = float32(src[i]) * scale
 // int16 values are exactly representable in float32, so this is a single

--- a/f32/f32_other.go
+++ b/f32/f32_other.go
@@ -68,6 +68,9 @@ func clampScale32(dst, src []float32, minVal, maxVal, scale float32) {
 func tanh32(dst, src []float32)                                 { tanh32Go(dst, src) }
 func exp32(dst, src []float32)                                  { exp32Go(dst, src) }
 func int32ToFloat32Scale(dst []float32, src []int32, s float32) { int32ToFloat32ScaleGo(dst, src, s) }
+func int32ToFloat32ScaleAdd(dst, a []float32, src []int32, s float32) {
+	int32ToFloat32ScaleAddGo(dst, a, src, s)
+}
 
 func int16ToFloat32Scale(dst []float32, src []int16, s float32) { int16ToFloat32ScaleGo(dst, src, s) }
 

--- a/f32/int32_to_float32_scale_add_test.go
+++ b/f32/int32_to_float32_scale_add_test.go
@@ -1,0 +1,253 @@
+package f32
+
+import (
+	"fmt"
+	"math"
+	"math/rand"
+	"testing"
+)
+
+// =============================================================================
+// INT32 -> FLOAT32 SCALE-ADD TESTS (fused dequantize-accumulate)
+// =============================================================================
+//
+// Int32ToFloat32ScaleAdd computes dst[i] = a[i] + float32(src[i])*scale with the
+// product rounded to float32 before the add (two roundings, never an FMA). The
+// contract is bit-identical results on every dispatch path AND bit-identical to the
+// two-pass Int32ToFloat32Scale + Add composition it replaces, so every comparison
+// below is exact (Float32bits), not tolerance-based.
+
+// twoPassScaleAddRef is the reference composition the fused kernel replaces:
+// tmp = float32(src)*scale, then dst = a + tmp. It carries the same two roundings,
+// so a correct fused kernel matches it bit-for-bit.
+func twoPassScaleAddRef(dst, a []float32, src []int32, scale float32) {
+	n := min(len(dst), len(a), len(src))
+	tmp := make([]float32, n)
+	Int32ToFloat32Scale(tmp, src[:n], scale)
+	Add(dst[:n], a[:n], tmp)
+}
+
+// assertBitsEqualF32 fails if got and want differ in any bit on any element.
+func assertBitsEqualF32(t *testing.T, got, want []float32, ctx string) {
+	t.Helper()
+	for i := range want {
+		if math.Float32bits(got[i]) != math.Float32bits(want[i]) {
+			t.Errorf("%s: [%d] got %v (%#08x), want %v (%#08x)",
+				ctx, i, got[i], math.Float32bits(got[i]), want[i], math.Float32bits(want[i]))
+		}
+	}
+}
+
+// fillScaleAddInputs fills a and src with deterministic pseudo-random values that
+// exercise sign, magnitude and the low int32 bits that float32 conversion rounds
+// away.
+func fillScaleAddInputs(rng *rand.Rand, a []float32, src []int32) {
+	for i := range a {
+		a[i] = (rng.Float32() - 0.5) * 1e6
+	}
+	for i := range src {
+		// Mix small counts, mid-range values and full-width int32s so the float32
+		// conversion loses low bits on some lanes (the interesting rounding case).
+		switch i % 4 {
+		case 0:
+			src[i] = int32(rng.Intn(64))
+		case 1:
+			src[i] = rng.Int31() - (1 << 30)
+		case 2:
+			src[i] = rng.Int31() // may exceed float32's 24-bit mantissa
+		default:
+			src[i] = -rng.Int31()
+		}
+	}
+}
+
+func TestInt32ToFloat32ScaleAdd(t *testing.T) {
+	// Cover the AVX block+scalar-tail boundary (amd64 n>=8), the NEON block+tail
+	// (arm64 n>=4), the pure-Go path (small n), and several full blocks.
+	sizes := []int{0, 1, 3, 4, 7, 8, 9, 15, 16, 17, 31, 32, 33, 63, 64, 100, 256, 257, 1000}
+	scales := []float32{1, 0.5, 1.0 / 32768, 1.0 / 2147483648, -2.5, 3.14159}
+	rng := rand.New(rand.NewSource(0x5add))
+
+	for _, n := range sizes {
+		for _, scale := range scales {
+			a := make([]float32, n)
+			src := make([]int32, n)
+			fillScaleAddInputs(rng, a, src)
+
+			got := make([]float32, n)
+			Int32ToFloat32ScaleAdd(got, a, src, scale)
+
+			// vs pure-Go reference (bit-exact)
+			goRef := make([]float32, n)
+			int32ToFloat32ScaleAddGo(goRef, a, src, scale)
+			assertBitsEqualF32(t, got, goRef, "dispatched vs Go")
+
+			// vs two-pass Int32ToFloat32Scale + Add (bit-exact, the motivating
+			// equivalence)
+			twoPass := make([]float32, n)
+			twoPassScaleAddRef(twoPass, a, src, scale)
+			assertBitsEqualF32(t, got, twoPass, "dispatched vs two-pass")
+		}
+	}
+}
+
+// TestInt32ToFloat32ScaleAdd_InPlace pins the documented aliasing rule: dst may
+// overlay a exactly (the in-place accumulate a[i] += float32(src[i])*scale). The
+// kernel loads a before it stores dst within each block, so the exact overlay is
+// safe; the result must match the same computation into a distinct buffer.
+func TestInt32ToFloat32ScaleAdd_InPlace(t *testing.T) {
+	sizes := []int{4, 8, 9, 17, 33, 64, 257}
+	rng := rand.New(rand.NewSource(0xacc))
+	const scale = 1.0 / 32768
+
+	for _, n := range sizes {
+		a := make([]float32, n)
+		src := make([]int32, n)
+		fillScaleAddInputs(rng, a, src)
+
+		// Expected: fresh out = a + src*scale.
+		want := make([]float32, n)
+		Int32ToFloat32ScaleAdd(want, a, src, scale)
+
+		// In place: dst aliases a exactly.
+		inPlace := make([]float32, n)
+		copy(inPlace, a)
+		Int32ToFloat32ScaleAdd(inPlace, inPlace, src, scale)
+
+		assertBitsEqualF32(t, inPlace, want, "in-place vs fresh")
+	}
+}
+
+// TestInt32ToFloat32ScaleAdd_ShortSlices pins the min-length reconciliation: the
+// number of elements processed is min(len(dst), len(a), len(src)), and elements of
+// dst beyond that count are left untouched.
+func TestInt32ToFloat32ScaleAdd_ShortSlices(t *testing.T) {
+	const full = 40
+	const scale = 0.25
+	rng := rand.New(rand.NewSource(0x511c))
+
+	cases := []struct{ dstLen, aLen, srcLen int }{
+		{full, full, full},
+		{full, full - 5, full},   // a shortest
+		{full, full, full - 7},   // src shortest
+		{full - 9, full, full},   // dst shortest
+		{full - 3, full - 6, full - 1},
+	}
+	for _, c := range cases {
+		a := make([]float32, full)
+		src := make([]int32, full)
+		fillScaleAddInputs(rng, a, src)
+		const sentinel = -7.5
+		dst := make([]float32, full)
+		for i := range dst {
+			dst[i] = sentinel
+		}
+
+		Int32ToFloat32ScaleAdd(dst[:c.dstLen], a[:c.aLen], src[:c.srcLen], scale)
+
+		n := min(c.dstLen, c.aLen, c.srcLen)
+		want := make([]float32, n)
+		twoPassScaleAddRef(want, a[:c.aLen], src[:c.srcLen], scale)
+		assertBitsEqualF32(t, dst[:n], want, "short-slice processed range")
+		for i := n; i < full; i++ {
+			if dst[i] != sentinel {
+				t.Errorf("dst[%d] = %v, want untouched sentinel %v (processed=%d)", i, dst[i], sentinel, n)
+			}
+		}
+	}
+}
+
+func TestInt32ToFloat32ScaleAdd_Empty(t *testing.T) {
+	// Nil and zero-length must return without touching anything or panicking.
+	Int32ToFloat32ScaleAdd(nil, nil, nil, 1.5)
+	dst := []float32{42}
+	Int32ToFloat32ScaleAdd(dst[:0], []float32{1}, []int32{2}, 1.5)
+	if dst[0] != 42 {
+		t.Errorf("zero-length call wrote output: dst[0] = %v, want 42", dst[0])
+	}
+}
+
+// TestInt32ToFloat32ScaleAdd_AllocFree pins the zero-allocation guarantee. Direct
+// cpu-flag dispatch keeps //go:noescape effective.
+func TestInt32ToFloat32ScaleAdd_AllocFree(t *testing.T) {
+	const n = 256
+	a := make([]float32, n)
+	src := make([]int32, n)
+	dst := make([]float32, n)
+	rng := rand.New(rand.NewSource(1))
+	fillScaleAddInputs(rng, a, src)
+	fn := func() { Int32ToFloat32ScaleAdd(dst, a, src, 1.0/32768) }
+	if got := testing.AllocsPerRun(50, fn); got != 0 {
+		t.Errorf("Int32ToFloat32ScaleAdd allocated %v times per run, want 0", got)
+	}
+}
+
+// FuzzInt32ToFloat32ScaleAdd is the differential fuzz: the dispatched kernel must
+// bit-match the pure-Go reference for arbitrary src bytes and scale.
+func FuzzInt32ToFloat32ScaleAdd(f *testing.F) {
+	f.Add([]byte{0, 0, 0, 0, 1, 2, 3, 4}, math.Float32bits(1.0/32768), uint32(0x3f000000))
+	f.Add([]byte{0xff, 0xff, 0xff, 0x7f, 0, 0, 0, 0x80}, uint32(0x3f800000), uint32(0xc0000000))
+
+	f.Fuzz(func(t *testing.T, srcBytes []byte, scaleBits, aBits uint32) {
+		n := len(srcBytes) / 4
+		if n == 0 {
+			return
+		}
+		src := make([]int32, n)
+		for i := range n {
+			src[i] = int32(uint32(srcBytes[4*i]) | uint32(srcBytes[4*i+1])<<8 |
+				uint32(srcBytes[4*i+2])<<16 | uint32(srcBytes[4*i+3])<<24)
+		}
+		scale := math.Float32frombits(scaleBits)
+		a := make([]float32, n)
+		av := math.Float32frombits(aBits)
+		for i := range a {
+			// Vary the accumulator per lane while staying deterministic in the input.
+			a[i] = av + float32(i)
+		}
+
+		got := make([]float32, n)
+		Int32ToFloat32ScaleAdd(got, a, src, scale)
+		want := make([]float32, n)
+		int32ToFloat32ScaleAddGo(want, a, src, scale)
+
+		for i := range want {
+			if math.Float32bits(got[i]) != math.Float32bits(want[i]) {
+				t.Fatalf("[%d] dispatched %#08x != Go %#08x (src=%d scale=%v a=%v)",
+					i, math.Float32bits(got[i]), math.Float32bits(want[i]), src[i], scale, a[i])
+			}
+		}
+	})
+}
+
+// BenchmarkInt32ToFloat32ScaleAdd compares the fused kernel against the two-pass
+// Int32ToFloat32Scale + Add it replaces. Small n (8..32) is where the win is the
+// dropped temporary and pass rather than vector width; the motivating call sites
+// (go-aac NMR trellis prep) run at n = 11..17.
+func BenchmarkInt32ToFloat32ScaleAdd(b *testing.B) {
+	sizes := []int{8, 12, 16, 32, 128, 1024}
+	const scale = 1.0 / 32768
+
+	for _, n := range sizes {
+		a := make([]float32, n)
+		src := make([]int32, n)
+		dst := make([]float32, n)
+		tmp := make([]float32, n)
+		rng := rand.New(rand.NewSource(int64(n)))
+		fillScaleAddInputs(rng, a, src)
+
+		b.Run(fmt.Sprintf("Fused_n%d", n), func(b *testing.B) {
+			b.SetBytes(int64(n) * 4 * 3) // reads a, src; writes dst
+			for range b.N {
+				Int32ToFloat32ScaleAdd(dst, a, src, scale)
+			}
+		})
+		b.Run(fmt.Sprintf("TwoPass_n%d", n), func(b *testing.B) {
+			b.SetBytes(int64(n) * 4 * 5) // src->tmp, then a+tmp->dst
+			for range b.N {
+				Int32ToFloat32Scale(tmp, src, scale)
+				Add(dst, a, tmp)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary

Adds `f32.Int32ToFloat32ScaleAdd`, the fused single-pass form of the mixed-precision AXPY whose increment is quantized integer data:

```
dst[i] = a[i] + float32(src[i])*scale
```

It replaces the two-pass `Int32ToFloat32Scale(tmp, src, scale)` followed by `Add(dst, a, tmp)`, dropping the temporary and the extra pass. The shape shows up wherever integer counts or quantized values feed a float accumulation: rate-distortion cost curves (distortion plus lambda times an integer bit count), dequantize-and-mix paths, and dequantization of quantized tensors onto a float32 accumulator.

## The contract: two roundings, never an FMA

The load-bearing property is that the product `float32(src[i])*scale` rounds to float32 **before** the add rounds, so the result is bit-identical to the two-pass composition and to the pure-Go reference on every dispatch path. The kernels keep the multiply and add separate (`VMULPS` + `VADDPS` on amd64, `FMUL` + `FADD` on arm64, never an FMA), and the Go reference wraps the product in an explicit `float32()` to stop the compiler contracting `a + src*scale` into a single fused multiply-add on arm64. Both kernels are registered in `singleRoundingKernels`, so `TestNoFMAContract` enforces the no-fuse property. Same contract as `Float32ToInt32ScaleClamp` (#155/#156).

## Implementation

- Plain AVX kernel (8 int32/pass, AVX1 tier, no FMA), NEON kernel (4/pass), pure-Go fallback, each with a scalar tail.
- One new hand-encoded NEON `WORD` (`FADD V1.4S`) verified by the `asmcheck` arm64asm cross-check.
- `dst` may overlay `a` exactly (the in-place accumulate `a[i] += float32(src[i])*scale`), following the `AddScaled` aliasing rule; `a` is loaded before `dst` is stored in each block.

## Verification

- Bit-exact parity vs the Go reference **and** vs the two-pass `Int32ToFloat32Scale + Add`, across sizes (block boundaries, scalar tails, small n) and scales (including negative and full-width int32 that lose precision in float32).
- In-place (`dst` aliases `a`) parity, min-length short-slice reconciliation, zero allocation, and a differential fuzz (~880k execs clean).
- Passes on amd64 (native) and arm64 (native Raspberry Pi 5); `asmcheck`, `TestNoFMAContract`, and the amd64 ISA gate all pass.

## Benchmarks (fused vs `Int32ToFloat32Scale + Add`)

| n | amd64 | arm64 (Pi 5) |
|---|-------|--------------|
| 8   | 1.69x | 1.60x |
| 12  | 1.60x | 1.61x |
| 16  | 1.70x | 1.65x |
| 32  | 1.65x | 1.53x |
| 128 | 1.68x | 1.55x |
| 1024| 1.51x | 1.62x |

The motivating call sites run at n = 11-17, where the win is the dropped temporary and pass rather than vector width.

Fixes #248.
