### PR TITLE
i32: raise minAVX2GainQ31 to the measured crossover (~160), keep NEON at 4 (Fixes #251)

### DIFF
--- a/i32/gain_amd64_test.go
+++ b/i32/gain_amd64_test.go
@@ -3,6 +3,7 @@
 package i32
 
 import (
+	"fmt"
 	"math"
 	"testing"
 
@@ -91,7 +92,30 @@ func TestGainQ31Dispatch_ReachesSIMD(t *testing.T) {
 	if hasAVX2 != cpu.X86.AVX2 {
 		t.Fatalf("hasAVX2 = %v but cpu.X86.AVX2 = %v: dispatch flag is not wired to CPU detection", hasAVX2, cpu.X86.AVX2)
 	}
-	if minAVX2GainQ31 > 16 {
-		t.Fatalf("minAVX2GainQ31 = %d exceeds two vector blocks: GainQ31 would not vectorize at the lengths it was written for", minAVX2GainQ31)
+	// minAVX2GainQ31 is the measured SIMD/scalar crossover (#251), far above the one
+	// or two blocks the scale kernels use, because the AVX2 GainQ31 path carries a
+	// large fixed per-call cost that makes SIMD lose below ~160. Guard only that it
+	// stays in a sane range: high enough to skip that small-n region, low enough that
+	// realistic buffers (a few hundred samples and up, e.g. nfft 256/512/1024) still
+	// vectorize.
+	if minAVX2GainQ31 < 8 || minAVX2GainQ31 > 512 {
+		t.Fatalf("minAVX2GainQ31 = %d outside the sane [8, 512] range; see #251 for the ~160 crossover", minAVX2GainQ31)
+	}
+}
+
+// BenchmarkGainQ31CrossoverAVX2 sweeps the AVX2 kernel directly against the Go
+// reference across the SIMD/scalar crossover region so minAVX2GainQ31 (#251) can be
+// re-tuned on other hardware. It benchmarks the kernel directly rather than the
+// dispatched GainQ31, so the threshold under test does not gate the measurement. On
+// the amd64 parts this was tuned against, the kernel's large fixed per-call cost
+// (~80-90 ns, absent on arm64 NEON) puts the crossover near n=160: gainQ31Go wins
+// below it, the two are at parity near 160, and the kernel pulls ahead above ~176.
+func BenchmarkGainQ31CrossoverAVX2(b *testing.B) {
+	if !cpu.X86.AVX2 {
+		b.Skip("AVX2 not available")
+	}
+	for _, n := range []int{64, 128, 160, 192, 256, 512} {
+		b.Run(fmt.Sprintf("AVX2_n%d", n), func(b *testing.B) { benchmarkGainQ31(b, n, gainQ31AVX2) })
+		b.Run(fmt.Sprintf("Go_n%d", n), func(b *testing.B) { benchmarkGainQ31(b, n, gainQ31Go) })
 	}
 }

--- a/i32/gain_arm64_test.go
+++ b/i32/gain_arm64_test.go
@@ -3,6 +3,7 @@
 package i32
 
 import (
+	"fmt"
 	"math"
 	"testing"
 
@@ -93,5 +94,20 @@ func TestGainQ31Dispatch_ReachesNEON(t *testing.T) {
 	}
 	if minNEONGainQ31 > 8 {
 		t.Fatalf("minNEONGainQ31 = %d exceeds two vector blocks: GainQ31 would not vectorize at the lengths it was written for", minNEONGainQ31)
+	}
+}
+
+// BenchmarkGainQ31CrossoverNEON sweeps the NEON kernel directly against the Go
+// reference across small n so minNEONGainQ31 (#251) can be re-tuned on other
+// hardware. Unlike the amd64 AVX2 path, the NEON kernel has no large fixed per-call
+// cost, so it beats gainQ31Go from the smallest sizes and the threshold stays at one
+// block (4).
+func BenchmarkGainQ31CrossoverNEON(b *testing.B) {
+	if !cpu.ARM64.NEON {
+		b.Skip("NEON not available")
+	}
+	for _, n := range []int{4, 8, 12, 16, 24, 32, 64} {
+		b.Run(fmt.Sprintf("NEON_n%d", n), func(b *testing.B) { benchmarkGainQ31(b, n, gainQ31NEON) })
+		b.Run(fmt.Sprintf("Go_n%d", n), func(b *testing.B) { benchmarkGainQ31(b, n, gainQ31Go) })
 	}
 }

--- a/i32/i32_amd64.go
+++ b/i32/i32_amd64.go
@@ -147,12 +147,26 @@ func scaleQ31AVX2(dst, a []int32, k int32)
 //go:noescape
 func scaleQ15AVX2(dst, a []int32, k int16)
 
-// minAVX2GainQ31 is one 8-wide (256-bit) block, an independent literal like the
-// scale thresholds above. The kernel is correct at any length (it falls through
-// to a scalar tail), so this is a performance cut only, never a safety
-// requirement. It gates on AVX2 because the VPMULDQ Q31 core plus the VPSLLD/
-// VPADDD/VPSRAD pre- and post-shift stages are all 256-bit integer ops.
-const minAVX2GainQ31 = 8
+// minAVX2GainQ31 gates the AVX2 GainQ31 kernel on total length. The kernel is
+// correct at any length (it falls through to a scalar tail), so this is a
+// performance cut only, never a safety requirement. It gates on AVX2 because the
+// VPMULDQ Q31 core plus the VPSLLD/VPADDD/VPSRAD pre- and post-shift stages are
+// all 256-bit integer ops.
+//
+// Unlike ScaleQ31 (whose single-broadcast prologue lets it win from one block),
+// the AVX2 GainQ31 path carries a large fixed per-call cost that dwarfs its
+// per-element work at small n: MEASURED as ~80-90 ns flat across n = 8..128 on two
+// amd64 hosts (an i7-class and a Xeon-class part), while gainQ31Go scales linearly
+// from ~6 ns (n=8). The kernel's own per-element work is cheap (~0.2 ns/elem vs Go's
+// ~0.75), so the crossover is set entirely by that fixed cost: gainQ31Go is faster
+// through n=144, the two are at parity near n=160, and the kernel pulls ahead from
+// n=176 (reaching ~2x by n=320). The arm64 NEON path shows no such fixed cost and
+// stays at minNEONGainQ31 = 4; the amd64-only gap is consistent with the 256-bit
+// AVX transition/warmup penalty each call pays after its closing VZEROUPPER (a
+// caller that keeps the upper YMM state warm would cross lower, so 160 is the
+// conservative crossover for a kernel invoked from scalar Go). See #251; the #250
+// masking speedup to gainQ31Go pushed the crossover out further still.
+const minAVX2GainQ31 = 160
 
 func gainQ31I32(dst, a []int32, gain int32, preShift, postShift int) {
 	if hasAVX2 && len(dst) >= minAVX2GainQ31 {

--- a/i32/i32_arm64.go
+++ b/i32/i32_arm64.go
@@ -132,10 +132,16 @@ func scaleQ31NEON(dst, a []int32, k int32)
 //go:noescape
 func scaleQ15NEON(dst, a []int32, k int16)
 
-// minNEONGainQ31 is one 4-wide (.4S) block, an independent literal like the
-// scale thresholds above. The kernel is correct at any length (it falls through
-// to a scalar tail), so this is a performance cut only, never a safety
-// requirement.
+// minNEONGainQ31 is one 4-wide (.4S) block, an independent literal like the scale
+// thresholds above. The kernel is correct at any length (it falls through to a
+// scalar tail), so this is a performance cut only, never a safety requirement.
+//
+// This stays at one block, unlike the much larger amd64 minAVX2GainQ31: MEASURED on
+// a Raspberry Pi 5, the NEON GainQ31 kernel scales cleanly with n and already beats
+// gainQ31Go from the smallest sizes (n=8: ~15.8 vs 16.4 ns; n=16: ~20.4 vs 29.3),
+// with no fixed per-call cost. NEON has no analogue of the 256-bit AVX
+// transition/warmup penalty that pushes the amd64 crossover out to ~160, so one
+// block remains the right threshold here. See #251.
 const minNEONGainQ31 = 4
 
 func gainQ31I32(dst, a []int32, gain int32, preShift, postShift int) {


### PR DESCRIPTION
## Summary

`GainQ31`'s SIMD dispatch thresholds (`minAVX2GainQ31=8`, `minNEONGainQ31=4`) were copied from the simpler `ScaleQ31`, but the AVX2 `GainQ31` path carries a large fixed per-call cost that `ScaleQ31`'s single-broadcast prologue does not. This raises `minAVX2GainQ31` to the measured crossover and keeps NEON at one block.

## Measurement

Benchmarked each kernel against the pure-Go reference, interleaved at high `-count` on quiesced hosts (a new `BenchmarkGainQ31CrossoverAVX2` / `...NEON` embodies the sweep so it can be re-run on other hardware).

**amd64** (two hosts, i7-class and Xeon-class): the AVX2 path runs **~82-108 ns flat** across n = 8..128, rising slowly to ~128 ns at n=320, while `gainQ31Go` scales linearly (6.4 ns at n=8, 45 at n=64, 91 at n=128, 214 at n=320). The kernel's per-element work is cheap (~0.2 ns/elem vs Go's ~0.75), so the crossover is set entirely by an ~80 ns fixed per-call cost:

| n | AVX2 | Go | winner |
|---|------|----|--------|
| 64  | ~104 | ~44  | Go (2.4x) |
| 128 | ~106 | ~91  | Go |
| 144 | ~109 | ~101 | Go |
| 160 | ~112 | ~111 | parity |
| 176 | ~113 | ~121 | SIMD |
| 256 | ~122 | ~174 | SIMD (1.4x) |
| 320 | ~128 | ~214 | SIMD (1.7x) |

So `n = 8..~150` was being dispatched to a path 2-15x **slower** than scalar.

**arm64** (Pi 5): NEON scales normally and beats Go from the smallest sizes (n=8: 15.8 vs 16.4 ns; n=16: 20.4 vs 29.3) with **no** flat fixed cost.

## Change

- `minAVX2GainQ31`: **8 → 160** (the measured crossover). The amd64-only fixed cost is consistent with the 256-bit AVX transition/warmup penalty each call pays after its closing `VZEROUPPER`; NEON has no analogue, so `minNEONGainQ31` stays **4**. The #250 masking speedup to `gainQ31Go` pushed the amd64 crossover out further still.
- Correctness is unaffected: both paths are bit-identical, and the direct-kernel parity sweeps in `gain_{amd64,arm64}_test.go` cover the AVX2/NEON kernels at every tier-3 length regardless of the dispatch threshold.
- `TestGainQ31Dispatch_ReachesSIMD`'s guard relaxes from `<=16` (the old copied-from-scale assumption) to a sane `[8, 512]` range reflecting the crossover.

Correctness-neutral, performance only. Tested on amd64 (two hosts) and arm64 (native Raspberry Pi 5).

Fixes #251.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Performance**
  * Improved Q31 gain processing on amd64 by selecting AVX2 acceleration for larger inputs while retaining the optimized general implementation for shorter inputs.
  * Added platform-specific benchmarks to evaluate crossover performance between SIMD and general implementations.
* **Documentation**
  * Clarified ARM64 NEON dispatch behavior with measured performance guidance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->