### PR TITLE
f64: drive the STFTPlan core with the radix-4 ButterflyComplexStage4 (Fixes #243)

### DIFF
--- a/f64/stft.go
+++ b/f64/stft.go
@@ -81,6 +81,14 @@ type STFTPlan struct {
 	// occupies stageTwRe[s-1 : 2*s-1], and the tables total half-1 entries.
 	stageTwRe, stageTwIm []float64
 
+	// Extra twiddle for the radix-4 FFT core: the w^(3j) power ButterflyComplexStage4
+	// needs beyond the two it can slice from stageTwRe/stageTwIm (tw1 = w^(2j) is the
+	// span-s radix-2 table, tw2 = w^j is the first s entries of the span-2s table).
+	// The radix-4 stage with span s (s in {1,4,16,...}) occupies stage4Tw3Re[(s-1)/3 :
+	// (s-1)/3 + s]; the offset (s-1)/3 is exact because s is a power of four. Empty
+	// when half < 4 (no radix-4 stage runs).
+	stage4Tw3Re, stage4Tw3Im []float64
+
 	// Unravel twiddles W_N^k = exp(-i*2*pi*k/nfft) for k in [0, half], used to
 	// recombine the even/odd half-spectra into the real-input spectrum.
 	unRe, unIm []float64
@@ -104,16 +112,26 @@ func NewSTFTPlan(nfft int) (*STFTPlan, error) {
 	}
 	half := nfft >> 1
 
+	// Size the radix-4 tw3 table: the radix-4 core runs stages at spans 1, 4, 16, ...
+	// while 4*span <= half, and stage span s holds s entries, so they sum to
+	// (4^numStages - 1)/3. Zero when half < 4.
+	stage4Tw3Len := 0
+	for s := 1; 4*s <= half; s *= 4 {
+		stage4Tw3Len += s
+	}
+
 	p := &STFTPlan{
-		nfft:      nfft,
-		half:      half,
-		bitrev:    make([]int, half),
-		stageTwRe: make([]float64, max(half-1, 0)),
-		stageTwIm: make([]float64, max(half-1, 0)),
-		unRe:      make([]float64, half+1),
-		unIm:      make([]float64, half+1),
-		re:        make([]float64, half),
-		im:        make([]float64, half),
+		nfft:        nfft,
+		half:        half,
+		bitrev:      make([]int, half),
+		stageTwRe:   make([]float64, max(half-1, 0)),
+		stageTwIm:   make([]float64, max(half-1, 0)),
+		stage4Tw3Re: make([]float64, stage4Tw3Len),
+		stage4Tw3Im: make([]float64, stage4Tw3Len),
+		unRe:        make([]float64, half+1),
+		unIm:        make([]float64, half+1),
+		re:          make([]float64, half),
+		im:          make([]float64, half),
 	}
 
 	// Bit-reversal permutation for a size-half FFT.
@@ -142,6 +160,19 @@ func NewSTFTPlan(nfft int) (*STFTPlan, error) {
 		}
 	}
 
+	// Radix-4 tw3 = w^(3j) with w = exp(-i*2*pi/(4*span)), for each radix-4 stage
+	// span s in {1,4,16,...}. tw1 = w^(2j) and tw2 = w^j are the span-s and span-2s
+	// radix-2 tables above, sliced in fftHalf; only w^(3j) is not already present.
+	for s := 1; 4*s <= half; s *= 4 {
+		off := (s - 1) / 3
+		for j := range s {
+			ang := 2 * math.Pi * float64(3*j) / float64(4*s)
+			sin, cos := math.Sincos(ang)
+			p.stage4Tw3Re[off+j] = cos
+			p.stage4Tw3Im[off+j] = -sin
+		}
+	}
+
 	// Real-input unravel twiddles W_N^k.
 	for k := 0; k <= half; k++ {
 		ang := 2 * math.Pi * float64(k) / float64(nfft)
@@ -166,12 +197,25 @@ func (p *STFTPlan) fftHalf() {
 			im[i], im[j] = im[j], im[i]
 		}
 	}
-	// Butterfly stages. Stage m operates on span = m/2 with block stride m; its
-	// contiguous twiddles live at stageTwRe/stageTwIm[span-1 : 2*span-1].
-	for m := 2; m <= p.half; m <<= 1 {
-		span := m >> 1
-		off := span - 1
-		ButterflyComplexStage(re, im, span, p.stageTwRe[off:off+span], p.stageTwIm[off:off+span])
+	// Butterfly stages via the radix-4 core: a radix-4 stage at span s advances the
+	// transform two radix-2 stages at once (span s then span 2s), so it runs spans
+	// 1, 4, 16, ... while a full radix-4 block fits (4*s <= half). tw1 = w^(2j) is the
+	// span-s radix-2 table at stageTw[s-1 : 2s-1], tw2 = w^j is the first s entries of
+	// the span-2s table at stageTw[2s-1 : 3s-1], and tw3 = w^(3j) is the dedicated
+	// stage4Tw3 table at [(s-1)/3 : (s-1)/3 + s]. A single trailing radix-2 stage
+	// finishes the transform when half is not a power of four (odd log2(half)).
+	s := 1
+	for 4*s <= p.half {
+		o1, o2, o3 := s-1, 2*s-1, (s-1)/3
+		ButterflyComplexStage4(re, im, s,
+			p.stageTwRe[o1:o1+s], p.stageTwIm[o1:o1+s],
+			p.stageTwRe[o2:o2+s], p.stageTwIm[o2:o2+s],
+			p.stage4Tw3Re[o3:o3+s], p.stage4Tw3Im[o3:o3+s])
+		s *= 4
+	}
+	if s < p.half {
+		off := s - 1
+		ButterflyComplexStage(re, im, s, p.stageTwRe[off:off+s], p.stageTwIm[off:off+s])
 	}
 }
 

--- a/f64/stft.go
+++ b/f64/stft.go
@@ -104,6 +104,10 @@ func (p *STFTPlan) NumBins() int { return p.half + 1 }
 // NFFT returns the transform size the plan was built for.
 func (p *STFTPlan) NFFT() int { return p.nfft }
 
+// stage4Tw3Power is the twiddle power of the radix-4 stage's third factor: tw3 =
+// w^(3j) (tw1 = w^(2j) and tw2 = w^(1j) are sliced from the radix-2 tables).
+const stage4Tw3Power = 3
+
 // NewSTFTPlan builds a reusable plan for nfft-point real-input STFTs. nfft must
 // be a power of two and at least 2; otherwise ErrNotPowerOfTwo is returned.
 func NewSTFTPlan(nfft int) (*STFTPlan, error) {
@@ -116,7 +120,7 @@ func NewSTFTPlan(nfft int) (*STFTPlan, error) {
 	// while 4*span <= half, and stage span s holds s entries, so they sum to
 	// (4^numStages - 1)/3. Zero when half < 4.
 	stage4Tw3Len := 0
-	for s := 1; 4*s <= half; s *= 4 {
+	for s := 1; butterflyStage4Radix*s <= half; s *= butterflyStage4Radix {
 		stage4Tw3Len += s
 	}
 
@@ -163,10 +167,12 @@ func NewSTFTPlan(nfft int) (*STFTPlan, error) {
 	// Radix-4 tw3 = w^(3j) with w = exp(-i*2*pi/(4*span)), for each radix-4 stage
 	// span s in {1,4,16,...}. tw1 = w^(2j) and tw2 = w^j are the span-s and span-2s
 	// radix-2 tables above, sliced in fftHalf; only w^(3j) is not already present.
-	for s := 1; 4*s <= half; s *= 4 {
-		off := (s - 1) / 3
+	// The offset (s-1)/(radix4-1) is the exact running sum of the earlier stage
+	// lengths because each s is a power of butterflyStage4Radix.
+	for s := 1; butterflyStage4Radix*s <= half; s *= butterflyStage4Radix {
+		off := (s - 1) / (butterflyStage4Radix - 1)
 		for j := range s {
-			ang := 2 * math.Pi * float64(3*j) / float64(4*s)
+			ang := 2 * math.Pi * float64(stage4Tw3Power*j) / float64(butterflyStage4Radix*s)
 			sin, cos := math.Sincos(ang)
 			p.stage4Tw3Re[off+j] = cos
 			p.stage4Tw3Im[off+j] = -sin
@@ -205,13 +211,15 @@ func (p *STFTPlan) fftHalf() {
 	// stage4Tw3 table at [(s-1)/3 : (s-1)/3 + s]. A single trailing radix-2 stage
 	// finishes the transform when half is not a power of four (odd log2(half)).
 	s := 1
-	for 4*s <= p.half {
-		o1, o2, o3 := s-1, 2*s-1, (s-1)/3
+	for butterflyStage4Radix*s <= p.half {
+		o1 := s - 1                                 // span-s radix-2 table
+		o2 := butterflyStageRadix*s - 1             // span-2s radix-2 table, first s taken
+		o3 := (s - 1) / (butterflyStage4Radix - 1)  // dedicated w^(3j) table
 		ButterflyComplexStage4(re, im, s,
 			p.stageTwRe[o1:o1+s], p.stageTwIm[o1:o1+s],
 			p.stageTwRe[o2:o2+s], p.stageTwIm[o2:o2+s],
 			p.stage4Tw3Re[o3:o3+s], p.stage4Tw3Im[o3:o3+s])
-		s *= 4
+		s *= butterflyStage4Radix
 	}
 	if s < p.half {
 		off := s - 1

--- a/f64/stft_test.go
+++ b/f64/stft_test.go
@@ -70,7 +70,10 @@ func TestNewSTFTPlanErrors(t *testing.T) {
 // without a window.
 func TestSTFTAgainstDFT(t *testing.T) {
 	signal := testSignal(5000)
-	for _, nfft := range []int{2, 4, 8, 16, 64, 256, 1024} {
+	// The size list spans both radix-4 schedule shapes: even log2(half) runs only
+	// radix-4 stages (nfft 8/32/128 = 1/2/3 stages, no trailing), odd log2(half)
+	// finishes with one trailing radix-2 stage (nfft 4/16/64/256/1024).
+	for _, nfft := range []int{2, 4, 8, 16, 32, 64, 128, 256, 1024} {
 		for _, useWin := range []bool{false, true} {
 			plan, err := NewSTFTPlan(nfft)
 			if err != nil {


### PR DESCRIPTION
## Summary

`STFTPlan.fftHalf` drove its size-half FFT through one radix-2 `ButterflyComplexStage` per stage (spans 1, 2, 4, ..., half/2). This wires in the radix-4 `ButterflyComplexStage4` (#198/#238): it replaces consecutive radix-2 stage pairs with a single radix-4 stage, running spans 1, 4, 16, ... in one pass each and finishing with at most one trailing radix-2 stage when `half` is not a power of four.

## Twiddles

The radix-4 stage at span `s` needs three twiddle powers, and two are already resident in the plan:

- `tw1 = w^(2j) = exp(-i·π·j/s)` is exactly the span-`s` radix-2 table, at `stageTw[s-1 : 2s-1]`.
- `tw2 = w^j = exp(-i·π·j/2s)` is the first `s` entries of the span-`2s` table, at `stageTw[2s-1 : 3s-1]`.
- `tw3 = w^(3j)` is the only new one, built into a dedicated `stage4Tw3` table (`(4^stages - 1)/3` entries; stage span `s` at offset `(s-1)/3`, exact because `s` is a power of four).

Per-transform work is unchanged; only the plan's one-time table build grows by the small `tw3` table.

## Schedule

```
s := 1
for 4*s <= half {            // radix-4 stage at span s (spans 1,4,16,...)
    ButterflyComplexStage4(re, im, s, tw1, tw2, tw3)
    s *= 4
}
if s < half {                // one trailing radix-2 stage when log2(half) is odd
    ButterflyComplexStage(re, im, s, ...)
}
```

Covers every size: `half=1` (no stages), `half=2` (trailing radix-2 only), `half=4` (one radix-4), and up.

## Correctness

Validated by the existing STFT-vs-DFT parity test, extended to `nfft` 32 and 128 so both schedule shapes are covered: even `log2(half)` runs only radix-4 stages (no trailing), odd `log2(half)` finishes with one trailing radix-2 stage. Independently reviewed the twiddle-slice indexing against the canonical radix-4 twiddle definitions.

## Benchmarks (radix-4 vs the radix-2 core)

| | STFT | STFTPower |
|--|------|-----------|
| amd64 (i7-class) | 1.14x | 1.09x |
| arm64 (Pi 5)     | 1.08x | 1.06x |

The butterfly stages are a fraction of the whole transform (bit-reversal, packing, and the unravel recombine are unchanged), so the standalone ~1.23x (amd64) / ~1.38x (arm64) radix-4 win dilutes at the STFT level. Allocation-free; tested on amd64 (native) and arm64 (native Raspberry Pi 5).

Fixes #243.
