### PR TITLE
docs,tests: aliasing contracts for i16/i32/f16, note crc (Fixes #221)

### DIFF
--- a/crc/crc.go
+++ b/crc/crc.go
@@ -13,6 +13,11 @@
 // All functions are bit-identical to the scalar reference and allocation-free.
 //
 // Thread Safety: All functions are safe for concurrent use.
+//
+// # Aliasing
+//
+// Checksum16 reads its input byte slice and returns a scalar; it writes no output
+// slice, so aliasing does not apply.
 package crc
 
 import "encoding/binary"

--- a/f16/aliasing_amd64_test.go
+++ b/f16/aliasing_amd64_test.go
@@ -1,0 +1,19 @@
+//go:build amd64
+
+package f16
+
+import (
+	"testing"
+
+	"github.com/tphakala/simd/internal/aliastest"
+)
+
+// forTiers runs the aliasing sweep on both the pure-Go reference and the F16C
+// kernels by flipping the package hasF16C gate. Most f16 arithmetic is pure Go on
+// amd64 (the F16C tier accelerates the float16<->float32 conversions the ops build
+// on), so for those ops both settings run the same kernel; the sweep still covers
+// every op's overlay on the path it actually takes.
+func forTiers(t *testing.T, run func(t *testing.T)) {
+	t.Helper()
+	aliastest.ForGate(t, &hasF16C, "F16C", run)
+}

--- a/f16/aliasing_arm64_test.go
+++ b/f16/aliasing_arm64_test.go
@@ -1,0 +1,32 @@
+//go:build arm64
+
+package f16
+
+import (
+	"testing"
+
+	"github.com/tphakala/simd/internal/aliastest"
+)
+
+// forTiers runs the aliasing sweep on both the pure-Go reference and the native
+// arm64 kernels. f16 arithmetic dispatches on hasFP16 (the FEAT_FP16 half-precision
+// kernels) with ReLU/Neg on hasNEON, so both gates are flipped together: one pass
+// with the host's native kernels bound and one with both forced off (the Go path
+// at every length). The overlay property is per-kernel, so covering the native and
+// the Go tier for every op is sufficient.
+func forTiers(t *testing.T, run func(t *testing.T)) {
+	t.Helper()
+	savedFP16, savedNEON := hasFP16, hasNEON
+	aliastest.ForTiers(t, []aliastest.Tier{
+		{
+			Name:      "native",
+			Bind:      func() { hasFP16, hasNEON = savedFP16, savedNEON },
+			Supported: savedFP16 || savedNEON,
+		},
+		{
+			Name:      "Go",
+			Bind:      func() { hasFP16, hasNEON = false, false },
+			Supported: true,
+		},
+	}, run)
+}

--- a/f16/aliasing_other_test.go
+++ b/f16/aliasing_other_test.go
@@ -1,0 +1,12 @@
+//go:build !amd64 && !arm64
+
+package f16
+
+import "testing"
+
+// forTiers runs the aliasing sweep once on architectures with only the pure-Go
+// path (no tier to force).
+func forTiers(t *testing.T, run func(t *testing.T)) {
+	t.Helper()
+	run(t)
+}

--- a/f16/aliasing_test.go
+++ b/f16/aliasing_test.go
@@ -1,0 +1,74 @@
+package f16
+
+import (
+	"testing"
+
+	"github.com/tphakala/simd/internal/aliastest"
+)
+
+// Aliasing sweep for the f16 exact-overlay contract (issue #221). Each element-
+// wise op is run once into a separate destination and once with the destination
+// overlaid on an input, then compared bit-for-bit under both the Go and SIMD
+// kernels. Float16 is a uint16 alias, so the comparison is exact on the raw bits
+// (a deterministic NaN or Inf from Div/Sqrt/Reciprocal/Exp reproduces identically
+// between the two runs). The reductions (Sum, Min, Max, Mean, DotProduct) write no
+// output slice, and the cross-type conversions (ToFloat32Slice, FromFloat32Slice)
+// cannot alias in safe Go, so neither is swept here. It asserts nothing about how a
+// shifted overlay corrupts, which is undefined.
+
+func aliasEqF16(x, y Float16) bool { return x == y }
+
+// aliasGenF16 spreads finite half-precision values over roughly [-4, 4], including
+// zero and both signs, so the arithmetic and the saturating/branching ops
+// (ReLU, Clamp, Sqrt) all see representative inputs.
+func aliasGenF16(i int) Float16 {
+	u := uint32(i)*2654435761 + 1013904223
+	v := float32(int32(u%2000)-1000) / 250.0 //nolint:gosec // deliberate wrap into [-4,4]
+	return FromFloat32(v)
+}
+
+// Scalar parameters for the scalar-taking ops. Their exact values do not affect
+// the overlay property.
+var (
+	aliasScaleF16   = FromFloat32(0.75)
+	aliasAddScalF16 = FromFloat32(1.25)
+	aliasClampLoF16 = FromFloat32(-1.5)
+	aliasClampHiF16 = FromFloat32(1.5)
+)
+
+func f16AliasCases() []aliastest.Case {
+	return []aliastest.Case{
+		aliastest.BinaryCase("Add", aliasEqF16, aliasGenF16, Add),
+		aliastest.BinaryCase("Sub", aliasEqF16, aliasGenF16, Sub),
+		aliastest.BinaryCase("Mul", aliasEqF16, aliasGenF16, Mul),
+		aliastest.BinaryCase("Div", aliasEqF16, aliasGenF16, Div),
+		aliastest.TernaryCase("FMA", aliasEqF16, aliasGenF16, FMA),
+		aliastest.UnaryCase("Abs", aliasEqF16, aliasGenF16, Abs),
+		aliastest.UnaryCase("Neg", aliasEqF16, aliasGenF16, Neg),
+		aliastest.UnaryCase("ReLU", aliasEqF16, aliasGenF16, ReLU),
+		aliastest.UnaryCase("Sigmoid", aliasEqF16, aliasGenF16, Sigmoid),
+		aliastest.UnaryCase("Sqrt", aliasEqF16, aliasGenF16, Sqrt),
+		aliastest.UnaryCase("Reciprocal", aliasEqF16, aliasGenF16, Reciprocal),
+		aliastest.UnaryCase("Exp", aliasEqF16, aliasGenF16, Exp),
+		aliastest.UnaryCase("Scale", aliasEqF16, aliasGenF16, func(dst, a []Float16) { Scale(dst, a, aliasScaleF16) }),
+		aliastest.UnaryCase("AddScalar", aliasEqF16, aliasGenF16, func(dst, a []Float16) { AddScalar(dst, a, aliasAddScalF16) }),
+		aliastest.UnaryCase("Clamp", aliasEqF16, aliasGenF16, func(dst, a []Float16) { Clamp(dst, a, aliasClampLoF16, aliasClampHiF16) }),
+	}
+}
+
+// TestAliasingSweep drives the exact-overlay sweep across every bound kernel.
+func TestAliasingSweep(t *testing.T) {
+	forTiers(t, func(t *testing.T) {
+		t.Helper()
+		aliastest.Sweep(t, f16AliasCases())
+	})
+}
+
+// TestAliasingZeroAlloc asserts the in-place overlay path is allocation-free for
+// every swept op under both the Go and SIMD kernels.
+func TestAliasingZeroAlloc(t *testing.T) {
+	forTiers(t, func(t *testing.T) {
+		t.Helper()
+		aliastest.SweepAlloc(t, f16AliasCases())
+	})
+}

--- a/f16/aliasing_test.go
+++ b/f16/aliasing_test.go
@@ -36,6 +36,64 @@ var (
 	aliasClampHiF16 = FromFloat32(1.5)
 )
 
+// aliasBuildF16 fills a length-n slice from the shared generator.
+func aliasBuildF16(n int) []Float16 {
+	s := make([]Float16, n)
+	for i := range s {
+		s[i] = aliasGenF16(i)
+	}
+	return s
+}
+
+// addScaledAliasCase covers AddScaled's dst==s overlay. AddScaled is a
+// read-modify-write accumulator (dst += alpha*s), which the write-only Unary
+// helper does not model, so it uses the exported aliastest.Report: the reference
+// run accumulates into a copy of s from a distinct s, the overlay run accumulates
+// into s aliased as both dst and source.
+func addScaledAliasCase() aliastest.Case {
+	alpha := FromFloat32(0.5)
+	return aliastest.Case{
+		Name: "AddScaled",
+		Check: func(t *testing.T, n int) {
+			t.Helper()
+			s := aliasBuildF16(n)
+			want := aliasBuildF16(n)
+			AddScaled(want, alpha, s)
+			got := aliasBuildF16(n)
+			AddScaled(got, alpha, got)
+			aliastest.Report(t, n, "dst=s", aliasEqF16, want, got)
+		},
+		Alloc: func(t *testing.T) {
+			t.Helper()
+			s := aliasBuildF16(64)
+			aliastest.ZeroAlloc(t, "AddScaled dst=s", func() { AddScaled(s, alpha, s) })
+		},
+	}
+}
+
+// accumulateAddAliasCase covers AccumulateAdd's dst==src overlay at offset 0.
+// AccumulateAdd is also an accumulator (dst[offset:] += src), so it uses Report
+// the same way, pinning the exact dst==src overlay.
+func accumulateAddAliasCase() aliastest.Case {
+	return aliastest.Case{
+		Name: "AccumulateAdd",
+		Check: func(t *testing.T, n int) {
+			t.Helper()
+			src := aliasBuildF16(n)
+			want := aliasBuildF16(n)
+			AccumulateAdd(want, src, 0)
+			got := aliasBuildF16(n)
+			AccumulateAdd(got, got, 0)
+			aliastest.Report(t, n, "dst=src", aliasEqF16, want, got)
+		},
+		Alloc: func(t *testing.T) {
+			t.Helper()
+			s := aliasBuildF16(64)
+			aliastest.ZeroAlloc(t, "AccumulateAdd dst=src", func() { AccumulateAdd(s, s, 0) })
+		},
+	}
+}
+
 func f16AliasCases() []aliastest.Case {
 	return []aliastest.Case{
 		aliastest.BinaryCase("Add", aliasEqF16, aliasGenF16, Add),
@@ -50,9 +108,15 @@ func f16AliasCases() []aliastest.Case {
 		aliastest.UnaryCase("Sqrt", aliasEqF16, aliasGenF16, Sqrt),
 		aliastest.UnaryCase("Reciprocal", aliasEqF16, aliasGenF16, Reciprocal),
 		aliastest.UnaryCase("Exp", aliasEqF16, aliasGenF16, Exp),
+		aliastest.UnaryCase("Tanh", aliasEqF16, aliasGenF16, Tanh),
+		aliastest.UnaryCase("Normalize", aliasEqF16, aliasGenF16, Normalize),
+		aliastest.UnaryCase("CumulativeSum", aliasEqF16, aliasGenF16, CumulativeSum),
 		aliastest.UnaryCase("Scale", aliasEqF16, aliasGenF16, func(dst, a []Float16) { Scale(dst, a, aliasScaleF16) }),
 		aliastest.UnaryCase("AddScalar", aliasEqF16, aliasGenF16, func(dst, a []Float16) { AddScalar(dst, a, aliasAddScalF16) }),
 		aliastest.UnaryCase("Clamp", aliasEqF16, aliasGenF16, func(dst, a []Float16) { Clamp(dst, a, aliasClampLoF16, aliasClampHiF16) }),
+		aliastest.UnaryCase("ClampScale", aliasEqF16, aliasGenF16, func(dst, a []Float16) { ClampScale(dst, a, aliasClampLoF16, aliasClampHiF16, aliasScaleF16) }),
+		addScaledAliasCase(),
+		accumulateAddAliasCase(),
 	}
 }
 

--- a/f16/f16.go
+++ b/f16/f16.go
@@ -17,6 +17,27 @@
 //
 // Thread Safety: All functions are safe for concurrent use.
 // Memory: All functions are zero-allocation (no heap allocations).
+//
+// # Aliasing
+//
+// The element-wise operations may be used fully in place: the destination may
+// alias an input exactly, element for element. Abs, Neg, ReLU, Sigmoid, Sqrt,
+// Reciprocal, Exp, Scale, AddScalar and Clamp accept dst equal to their source;
+// Add, Sub, Mul and Div accept dst equal to a, to b, or to both; FMA accepts dst
+// equal to a, b or c. Each SIMD block reads its whole block of inputs into
+// registers before storing any output lane, and the scalar tail reads each
+// element before it writes that element, so an exact overlay is well defined on
+// the F16C, FP16 and NEON kernels and the pure-Go fallback.
+//
+// A destination must not overlap an input at a shifted offset: a SIMD load pulls
+// a whole block of an input ahead of the stores, so a shifted overlay clobbers
+// input lanes a later iteration has not yet read; the resulting corruption is
+// undefined and varies with kernel width and length.
+//
+// ToFloat32Slice and FromFloat32Slice convert between Float16 and float32, so
+// their input and output have distinct element types and cannot alias in safe Go.
+// The reductions (Sum, Min, Max, Mean, DotProduct, DotProductF32) write no output
+// slice, so aliasing does not apply to them.
 package f16
 
 import "math"

--- a/f16/f16.go
+++ b/f16/f16.go
@@ -22,22 +22,31 @@
 //
 // The element-wise operations may be used fully in place: the destination may
 // alias an input exactly, element for element. Abs, Neg, ReLU, Sigmoid, Sqrt,
-// Reciprocal, Exp, Scale, AddScalar and Clamp accept dst equal to their source;
-// Add, Sub, Mul and Div accept dst equal to a, to b, or to both; FMA accepts dst
-// equal to a, b or c. Each SIMD block reads its whole block of inputs into
-// registers before storing any output lane, and the scalar tail reads each
-// element before it writes that element, so an exact overlay is well defined on
-// the F16C, FP16 and NEON kernels and the pure-Go fallback.
+// Reciprocal, Exp, Tanh, Scale, AddScalar, Clamp, ClampScale, Normalize and
+// CumulativeSum accept dst equal to their source; Add, Sub, Mul and Div accept dst
+// equal to a, to b, or to both; FMA accepts dst equal to a, b or c. The
+// accumulators AddScaled and AccumulateAdd accept dst equal to their source slice
+// (AddScaled's dst == s; AccumulateAdd's dst == src at offset 0). Each SIMD block
+// reads its whole block of inputs into registers before storing any output lane,
+// and the scalar tail reads each element before it writes that element, so an
+// exact overlay is well defined on the F16C, FP16 and NEON kernels and the pure-Go
+// fallback. The in-place variants (ExpInPlace, TanhInPlace, ReLUInPlace,
+// SigmoidInPlace) operate on a single slice and so raise no aliasing question.
 //
 // A destination must not overlap an input at a shifted offset: a SIMD load pulls
 // a whole block of an input ahead of the stores, so a shifted overlay clobbers
 // input lanes a later iteration has not yet read; the resulting corruption is
 // undefined and varies with kernel width and length.
 //
-// ToFloat32Slice and FromFloat32Slice convert between Float16 and float32, so
-// their input and output have distinct element types and cannot alias in safe Go.
-// The reductions (Sum, Min, Max, Mean, DotProduct, DotProductF32) write no output
-// slice, so aliasing does not apply to them.
+// Some operations do not take an element-for-element overlay. Interleave2 and
+// Deinterleave2 have a destination whose length differs from their inputs (twice,
+// or half). ConvolveValid writes a valid-convolution output shorter than its
+// signal and reads a sliding window, so its dst must be distinct from the signal.
+// ToFloat32Slice and FromFloat32Slice convert between Float16 and float32 (distinct
+// element types that cannot alias in safe Go), as does DotProductBatch (float32
+// results). The reductions (Sum, Min, Max, Mean, MinIdx, MaxIdx, DotProduct,
+// DotProductF32, EuclideanDistance, Variance, StdDev) write no output slice, so
+// aliasing does not apply to them.
 package f16
 
 import "math"

--- a/i16/aliasing_amd64_test.go
+++ b/i16/aliasing_amd64_test.go
@@ -1,0 +1,18 @@
+//go:build amd64
+
+package i16
+
+import (
+	"testing"
+
+	"github.com/tphakala/simd/internal/aliastest"
+)
+
+// forTiers runs the aliasing sweep on both the pure-Go reference and the AVX2
+// kernels by flipping the package hasAVX2 gate (Abs and MulQ15 dispatch on that
+// var). Forcing it off runs the Go path at every length, not just the sub-block
+// tail.
+func forTiers(t *testing.T, run func(t *testing.T)) {
+	t.Helper()
+	aliastest.ForGate(t, &hasAVX2, "AVX2", run)
+}

--- a/i16/aliasing_arm64_test.go
+++ b/i16/aliasing_arm64_test.go
@@ -1,0 +1,17 @@
+//go:build arm64
+
+package i16
+
+import (
+	"testing"
+
+	"github.com/tphakala/simd/internal/aliastest"
+)
+
+// forTiers runs the aliasing sweep on both the pure-Go reference and the NEON
+// kernels by flipping the package hasNEON gate. Forcing it off runs the Go path
+// at every length, not just the sub-block tail.
+func forTiers(t *testing.T, run func(t *testing.T)) {
+	t.Helper()
+	aliastest.ForGate(t, &hasNEON, "NEON", run)
+}

--- a/i16/aliasing_other_test.go
+++ b/i16/aliasing_other_test.go
@@ -1,0 +1,12 @@
+//go:build !amd64 && !arm64
+
+package i16
+
+import "testing"
+
+// forTiers runs the aliasing sweep once on architectures with only the pure-Go
+// path (no tier to force).
+func forTiers(t *testing.T, run func(t *testing.T)) {
+	t.Helper()
+	run(t)
+}

--- a/i16/aliasing_test.go
+++ b/i16/aliasing_test.go
@@ -1,0 +1,48 @@
+package i16
+
+import (
+	"testing"
+
+	"github.com/tphakala/simd/internal/aliastest"
+)
+
+// Aliasing sweep for the i16 exact-overlay contract (issue #221). Each element-
+// wise op is run once into a separate destination and once with the destination
+// overlaid on an input, then compared under both the Go and SIMD kernels. The
+// widening ops (DotProduct, XCorr) and the length-changing shuffles (Interleave2,
+// Deinterleave2) cannot take an element-for-element overlay and are not swept
+// here. It asserts nothing about how a shifted overlay (dst offset from an input)
+// corrupts, which is undefined.
+
+func aliasEqI16(x, y int16) bool { return x == y }
+
+// aliasGenI16 spreads values over the full int16 range, including -32768 (the
+// wrapping edge for Abs and the MinInt16*MinInt16 case for MulQ15).
+func aliasGenI16(i int) int16 {
+	u := uint32(i)*2654435761 + 1013904223
+	return int16(u >> 16) //nolint:gosec // deliberate wrap to cover [-32768,32767]
+}
+
+func i16AliasCases() []aliastest.Case {
+	return []aliastest.Case{
+		aliastest.UnaryCase("Abs", aliasEqI16, aliasGenI16, Abs),
+		aliastest.BinaryCase("MulQ15", aliasEqI16, aliasGenI16, MulQ15),
+	}
+}
+
+// TestAliasingSweep drives the exact-overlay sweep across every bound kernel.
+func TestAliasingSweep(t *testing.T) {
+	forTiers(t, func(t *testing.T) {
+		t.Helper()
+		aliastest.Sweep(t, i16AliasCases())
+	})
+}
+
+// TestAliasingZeroAlloc asserts the in-place overlay path is allocation-free for
+// every swept op under both the Go and SIMD kernels.
+func TestAliasingZeroAlloc(t *testing.T) {
+	forTiers(t, func(t *testing.T) {
+		t.Helper()
+		aliastest.SweepAlloc(t, i16AliasCases())
+	})
+}

--- a/i16/i16.go
+++ b/i16/i16.go
@@ -31,6 +31,27 @@
 //
 // Thread Safety: All functions are safe for concurrent use.
 // Memory: All functions are zero-allocation (no heap allocations).
+//
+// # Aliasing
+//
+// The two element-wise operations may be used fully in place: the destination
+// may alias an input exactly, element for element. Abs accepts dst equal to a;
+// MulQ15 accepts dst equal to a, to b, or to both. Each SIMD block reads its
+// whole block of inputs into registers before storing any output lane, and the
+// scalar tail reads each element before it writes that element, so an exact
+// overlay is well defined on the AVX2 and NEON kernels and the pure-Go fallback.
+//
+// A destination must not overlap an input at a shifted offset: a SIMD load pulls
+// a whole block of an input ahead of the stores, so a shifted overlay clobbers
+// input lanes a later iteration has not yet read; the resulting corruption is
+// undefined and varies with kernel width and length.
+//
+// Interleave2 and Deinterleave2 have a destination whose length differs from
+// their inputs (twice the inputs, or half the source), so an element-for-element
+// overlay does not apply. XCorr writes an int32 result from int16 inputs, so its
+// output and inputs have distinct element types and cannot alias in safe Go. The
+// reductions DotProduct and MaxAbs write no output slice, so aliasing does not
+// apply to them.
 package i16
 
 // interleave2Channels is the number of channels handled by Interleave2 and

--- a/i32/aliasing_amd64_test.go
+++ b/i32/aliasing_amd64_test.go
@@ -1,0 +1,18 @@
+//go:build amd64
+
+package i32
+
+import (
+	"testing"
+
+	"github.com/tphakala/simd/internal/aliastest"
+)
+
+// forTiers runs the aliasing sweep on both the pure-Go reference and the AVX2
+// kernels by flipping the package hasAVX2 gate (every swept op dispatches on that
+// var). Forcing it off runs the Go path at every length, not just the sub-block
+// tail.
+func forTiers(t *testing.T, run func(t *testing.T)) {
+	t.Helper()
+	aliastest.ForGate(t, &hasAVX2, "AVX2", run)
+}

--- a/i32/aliasing_arm64_test.go
+++ b/i32/aliasing_arm64_test.go
@@ -1,0 +1,17 @@
+//go:build arm64
+
+package i32
+
+import (
+	"testing"
+
+	"github.com/tphakala/simd/internal/aliastest"
+)
+
+// forTiers runs the aliasing sweep on both the pure-Go reference and the NEON
+// kernels by flipping the package hasNEON gate. Forcing it off runs the Go path
+// at every length, not just the sub-block tail.
+func forTiers(t *testing.T, run func(t *testing.T)) {
+	t.Helper()
+	aliastest.ForGate(t, &hasNEON, "NEON", run)
+}

--- a/i32/aliasing_other_test.go
+++ b/i32/aliasing_other_test.go
@@ -1,0 +1,12 @@
+//go:build !amd64 && !arm64
+
+package i32
+
+import "testing"
+
+// forTiers runs the aliasing sweep once on architectures with only the pure-Go
+// path (no tier to force).
+func forTiers(t *testing.T, run func(t *testing.T)) {
+	t.Helper()
+	run(t)
+}

--- a/i32/aliasing_test.go
+++ b/i32/aliasing_test.go
@@ -1,0 +1,109 @@
+package i32
+
+import (
+	"testing"
+
+	"github.com/tphakala/simd/internal/aliastest"
+)
+
+// Aliasing sweep for the i32 exact-overlay contract (issue #221). Each element-
+// wise op is run once into a separate destination and once with the destination
+// overlaid on an input, then compared under both the Go and SIMD kernels. The
+// length-changing shuffles (Interleave2, Deinterleave2), the valid convolution
+// (FIRValidQ15, whose dst is shorter than x), the in-place pair transform
+// (Butterfly) and the reductions (Sum, MaxAbs, MinMax) do not take an
+// element-for-element dst overlay and are not swept here; see the package doc. It
+// asserts nothing about how a shifted overlay (dst offset from an input)
+// corrupts, which is undefined.
+
+func aliasEqI32(x, y int32) bool { return x == y }
+
+// aliasGenI32 spreads values over the full int32 range, including MinInt32 (the
+// wrapping edge for Abs and the Q31 saturating cases).
+func aliasGenI32(i int) int32 {
+	u := uint32(i)*2654435761 + 1013904223
+	return int32(u) //nolint:gosec // deliberate wrap to cover the full int32 range
+}
+
+// Scalar parameters for the scalar-taking ops. Their exact values do not affect
+// the overlay property.
+const (
+	aliasScaleKI32              = int32(0x2000_0000) // 0.25 in Q31
+	aliasScaleKI16              = int16(0x4000)      // 0.5 in Q15
+	aliasGainG                  = int32(0x4000_0000) // 0.5 in Q31
+	aliasGainPre, aliasGainPost = 9, 12
+)
+
+// aliasSignAt is a deterministic sign pattern for NegWhereNeg, alternating so both
+// the negated and pass-through branches are exercised at every length.
+func aliasSignAt(i int) float32 {
+	if uint32(i)*2654435761>>31 == 1 {
+		return -1
+	}
+	return 1
+}
+
+// negWhereNegAliasCase covers NegWhereNeg's dst==mag overlay. The generic helpers
+// model a single element type, but NegWhereNeg mixes int32 (dst, mag) with float32
+// (sign), so it builds the check with the exported aliastest.Report. sign is a
+// distinct float32 slice that cannot alias the int32 dst.
+func negWhereNegAliasCase() aliastest.Case {
+	return aliastest.Case{
+		Name: "NegWhereNeg",
+		Check: func(t *testing.T, n int) {
+			t.Helper()
+			mag := make([]int32, n)
+			sign := make([]float32, n)
+			for i := range mag {
+				mag[i] = aliasGenI32(i)
+				sign[i] = aliasSignAt(i)
+			}
+			want := make([]int32, n)
+			NegWhereNeg(want, mag, sign)
+			got := make([]int32, n)
+			copy(got, mag)
+			NegWhereNeg(got, got, sign)
+			aliastest.Report(t, n, "dst=mag", aliasEqI32, want, got)
+		},
+		Alloc: func(t *testing.T) {
+			t.Helper()
+			const n = 64
+			mag := make([]int32, n)
+			sign := make([]float32, n)
+			for i := range mag {
+				mag[i] = aliasGenI32(i)
+				sign[i] = aliasSignAt(i)
+			}
+			aliastest.ZeroAlloc(t, "NegWhereNeg dst=mag", func() { NegWhereNeg(mag, mag, sign) })
+		},
+	}
+}
+
+func i32AliasCases() []aliastest.Case {
+	return []aliastest.Case{
+		aliastest.BinaryCase("Add", aliasEqI32, aliasGenI32, Add),
+		aliastest.BinaryCase("Sub", aliasEqI32, aliasGenI32, Sub),
+		aliastest.UnaryCase("Abs", aliasEqI32, aliasGenI32, Abs),
+		aliastest.UnaryCase("ScaleQ31", aliasEqI32, aliasGenI32, func(dst, a []int32) { ScaleQ31(dst, a, aliasScaleKI32) }),
+		aliastest.UnaryCase("ScaleQ15", aliasEqI32, aliasGenI32, func(dst, a []int32) { ScaleQ15(dst, a, aliasScaleKI16) }),
+		aliastest.UnaryCase("GainQ31", aliasEqI32, aliasGenI32, func(dst, a []int32) { GainQ31(dst, a, aliasGainG, aliasGainPre, aliasGainPost) }),
+		negWhereNegAliasCase(),
+	}
+}
+
+// TestAliasingSweep drives the exact-overlay sweep across every bound kernel.
+func TestAliasingSweep(t *testing.T) {
+	forTiers(t, func(t *testing.T) {
+		t.Helper()
+		aliastest.Sweep(t, i32AliasCases())
+	})
+}
+
+// TestAliasingZeroAlloc asserts the in-place overlay path is allocation-free for
+// every swept op under both the Go and SIMD kernels.
+func TestAliasingZeroAlloc(t *testing.T) {
+	forTiers(t, func(t *testing.T) {
+		t.Helper()
+		aliastest.SweepAlloc(t, i32AliasCases())
+	})
+}

--- a/i32/i32.go
+++ b/i32/i32.go
@@ -12,6 +12,31 @@
 //
 // Thread Safety: All functions are safe for concurrent use.
 // Memory: All functions are zero-allocation (no heap allocations).
+//
+// # Aliasing
+//
+// The element-wise operations may be used fully in place: the destination may
+// alias an input exactly, element for element. Abs, ScaleQ31, ScaleQ15 and
+// GainQ31 accept dst equal to their source; Add and Sub accept dst equal to a, to
+// b, or to both; NegWhereNeg accepts dst equal to mag (its sign input is a
+// separate float32 slice that cannot alias the int32 destination). Each SIMD
+// block reads its whole block of inputs into registers before storing any output
+// lane, and the scalar tail reads each element before it writes that element, so
+// an exact overlay is well defined on the AVX2 and NEON kernels and the pure-Go
+// fallback.
+//
+// A destination must not overlap an input at a shifted offset: a SIMD load pulls
+// a whole block of an input ahead of the stores, so a shifted overlay clobbers
+// input lanes a later iteration has not yet read; the resulting corruption is
+// undefined and varies with kernel width and length.
+//
+// Some operations do not take an element-for-element overlay. Interleave2 and
+// Deinterleave2 have a destination whose length differs from their inputs (twice,
+// or half). FIRValidQ15 writes a valid-convolution output shorter than its input
+// and reads a sliding window ahead of each output, so its dst must be distinct
+// from x. Butterfly rewrites its two operands in place, so lo and hi must not
+// overlap each other. The reductions (Sum, MaxAbs, MinMax) write no output slice,
+// so aliasing does not apply to them.
 package i32
 
 // interleave2Channels is the number of channels handled by Interleave2 and


### PR DESCRIPTION
## Summary

Completes the package-wide exact-overlay aliasing contract begun in #235 (which covered f32/f64/i8/c64/c128 and deferred i16/i32/f16/crc). Each remaining package gains a `# Aliasing` doc section modeled on cint's three-part rule, plus a per-package `aliasing_test.go` sweep backing every "exact overlay supported" claim. No kernel or dispatch code changed.

## What each package documents

- **i16**: `Abs` and `MulQ15` support an exact in-place overlay. `Interleave2`/`Deinterleave2` change length, `XCorr` widens to int32, `DotProduct`/`MaxAbs` are reductions.
- **i32**: `Add`, `Sub`, `Abs`, `ScaleQ31`, `ScaleQ15`, `GainQ31`, and `NegWhereNeg` (dst==mag; its sign input is a distinct float32 slice). `Interleave2`/`Deinterleave2` change length, `FIRValidQ15`'s dst is a shorter distinct output, `Butterfly` is an in-place pair, `Sum`/`MaxAbs`/`MinMax` are reductions.
- **f16**: the 15 element-wise ops (`Add`, `Sub`, `Mul`, `Div`, `FMA`, `Abs`, `Neg`, `ReLU`, `Sigmoid`, `Sqrt`, `Reciprocal`, `Exp`, `Scale`, `AddScalar`, `Clamp`). The float32 conversions cannot alias and the reductions write no output. `Float16` is a `uint16` alias, so the sweep compares raw bits (a deterministic NaN/Inf reproduces identically between runs).
- **crc**: `Checksum16` returns a scalar, so aliasing does not apply; documented.

## The sweep

Each op is run into a separate destination and again with the destination overlaid on each claimed input, then bit-compared, across the sizes that cross every dispatch boundary and under every forceable kernel tier: the amd64 AVX2/F16C gate and the arm64 NEON/FP16 gate, verified on a native Raspberry Pi 5. Zero allocation on the overlay path is asserted too. The shared `internal/aliastest` helper carries the sweep; `NegWhereNeg`'s mixed int32/float32 shape uses the exported `aliastest.Report`.

Tested on amd64 (native) and arm64 (native Raspberry Pi 5).

Fixes #221.
