### PR TITLE
f32,f64: drive STFTPlan through the radix-4 core and the vector pack/unravel (Fixes #257)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,7 +8,7 @@ on:
 
 env:
   GO_VERSION: '1.25'
-  GOLANGCI_LINT_VERSION: 'v2.6.1'
+  GOLANGCI_LINT_VERSION: 'v2.12.2'
 
 # Least-privilege default token scope for all jobs. Every job here only checks
 # out code and runs build/test/lint/vet, so read-only contents is sufficient.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,7 +7,7 @@ on:
     branches: [main, master]
 
 env:
-  GO_VERSION: '1.25'
+  GO_VERSION: '1.26'
   GOLANGCI_LINT_VERSION: 'v2.12.2'
 
 # Least-privilege default token scope for all jobs. Every job here only checks

--- a/README.md
+++ b/README.md
@@ -279,9 +279,15 @@ frame with `nfft/2` of zero or reflect padding per side, matching librosa
 `center=True` (`pad_mode="constant"` / `"reflect"`). `NumFrames` reports the frame
 count for a given pad mode so you can size buffers. The centered output is pinned
 against a librosa golden vector in the tests. The plan is allocation-free across
-calls; a plan holds transform scratch, so use one plan per goroutine. This first
-cut is a correct scalar radix-2 transform (power-of-two `nfft`); vectorizing the
-inner butterfly is a profile-gated follow-up.
+calls; a plan holds transform scratch, so use one plan per goroutine. The
+transform is a power-of-two `nfft` rfft whose every arithmetic pass over the
+frame runs through the vector primitives: the frame is packed with
+`Deinterleave2` and `Mul`, the FFT core is radix-4 (`ButterflyComplexStage4`,
+with at most one trailing radix-2 `ButterflyComplexStage`), and the real-input
+unravel is `RealFFTUnpack` or, for the power spectrum, `RealFFTPower`; the
+bit-reversal reorder, padded edge frames and rows shorter than `NumBins` stay
+scalar. The output is tolerance-stable, not bit-stable, across CPU tiers and
+library versions.
 
 ### `f32` - float32 Operations
 

--- a/doc.go
+++ b/doc.go
@@ -94,7 +94,7 @@
 //
 // Spectral (f64, f32): STFTPlan (NewSTFTPlan, STFT, STFTPower, STFTPowerInto, NumFrames) - fused real-input short-time Fourier transform with optional librosa-style center=true framing (PadMode: NoPad/PadZero/PadReflect)
 //
-// FFT primitives (f64, f32): ButterflyComplex (radix-2 butterfly with twiddle multiply, split-complex), RealFFTUnpack (real-FFT even/odd unpack step), RealFFTPower (the fused power-writing counterpart of RealFFTUnpack that emits the |X_k|^2 power spectrum in one pass); f64 additionally has ButterflyComplexStage, one whole radix-2 decimation-in-time stage at any span, which picks its vectorization axis from the span
+// FFT primitives (f64, f32): ButterflyComplex (radix-2 butterfly with twiddle multiply, split-complex), RealFFTUnpack (real-FFT even/odd unpack step), RealFFTPower (the fused power-writing counterpart of RealFFTUnpack that emits the |X_k|^2 power spectrum in one pass), ButterflyComplexStage (one whole radix-2 decimation-in-time stage at any span, which picks its vectorization axis from the span) and ButterflyComplexStage4 (one whole radix-4 stage, two radix-2 stages in one pass)
 //
 // Integer DSP (i16): Interleave2, Deinterleave2, DotProduct, DotProductUnsafe, XCorr (widening int16 x int16 -> wrapping int32; ARM64 SMLAL/SMLAL2, amd64 PMADDWD/VPMADDWD; XCorr evaluates 4 correlation lags per kernel call), Abs, MaxAbs, MulQ15 (wrapping 16-bit absolute value, widened abs-max, rounding Q15 multiply)
 //

--- a/f32/stft.go
+++ b/f32/stft.go
@@ -28,10 +28,15 @@ import (
 //
 // The transform runs in float32 to match the rest of the f32 package; the
 // twiddle and unravel tables are computed in float64 and rounded once to float32
-// so the resident constants carry full precision. It is a radix-2 rfft
-// (power-of-two nfft only); its butterfly stages run through ButterflyComplexStage,
-// so they take the AVX+FMA / NEON vector paths where the span and block count
-// justify them and fall back to scalar Go otherwise. See #108 and #205.
+// so the resident constants carry full precision. It is a power-of-two rfft whose
+// every arithmetic pass over the frame runs through the package's vector
+// primitives: the frame is packed with Deinterleave2 and Mul, the size-half FFT
+// core is radix-4 (ButterflyComplexStage4, with at most one trailing radix-2
+// ButterflyComplexStage), and the real-input unravel is RealFFTUnpack or, for the
+// power spectrum, RealFFTPower. Each takes the AVX+FMA / NEON vector path where
+// its size justifies it and falls back to scalar Go otherwise; the bit-reversal
+// reorder, padded edge frames and rows shorter than NumBins stay scalar. See
+// #108, #205, #243 and #257.
 
 // ErrSTFT* describe invalid STFTPlan configurations.
 var (
@@ -77,11 +82,12 @@ type STFTPlan struct {
 
 	bitrev []int // bit-reversal permutation for the size-half FFT
 
-	// Per-stage contiguous twiddles for the size-half radix-2 FFT, so each stage
-	// can be driven through ButterflyComplexStage (which reads its twiddles
-	// contiguous in j over [0, span)). Stage m in {2,4,...,half} uses span = m/2
-	// factors W_m^j = exp(-i*2*pi*j/m) for j in [0, span); the stage with span s
-	// occupies stageTwRe[s-1 : 2*s-1], and the tables total half-1 entries.
+	// Per-stage contiguous twiddles of the size-half FFT, laid out per radix-2
+	// stage: stage m in {2,4,...,half} uses span = m/2 factors W_m^j =
+	// exp(-i*2*pi*j/m) for j in [0, span); the stage with span s occupies
+	// stageTwRe[s-1 : 2*s-1], and the tables total half-1 entries. fftHalf slices
+	// them as the tw1/tw2 inputs of ButterflyComplexStage4 and as the twiddles of
+	// the trailing ButterflyComplexStage (both read contiguous j over [0, span)).
 	stageTwRe, stageTwIm []float32
 
 	// Extra twiddle for the radix-4 FFT core: the w^(3j) power ButterflyComplexStage4
@@ -106,7 +112,8 @@ type STFTPlan struct {
 
 	// Window halves for the vector pack: winRe holds the even window samples
 	// w[2j] and winIm the odd samples w[2j+1], split by prepareWindow once per
-	// call so packFrame can apply the window with two in-place Mul calls.
+	// public call and handed to the pack as an stftWindow, so packFrame can apply
+	// the window with two in-place Mul calls.
 	winRe, winIm []float32
 }
 
@@ -248,32 +255,45 @@ func (p *STFTPlan) fftHalf() {
 	}
 }
 
-// prepareWindow splits window (nil for rectangular, else length >= nfft) into its
-// even and odd samples, winRe and winIm, so the interior-frame pack can apply it
-// with two vector multiplies on the packed halves instead of a scalar
-// multiply-and-deinterleave per sample. It runs once per STFT call, since the
-// window is fixed across the call's frames, and is not needed for a nil window.
-func (p *STFTPlan) prepareWindow(window []float32) {
-	if window == nil {
-		return
-	}
-	Deinterleave2(p.winRe, p.winIm, window[:p.nfft])
+// stftWindow is one call's analysis window in the form the frame pack consumes:
+// the even window samples w[2j] in re and the odd samples w[2j+1] in im, both
+// plan scratch filled by prepareWindow, or the zero value (nil halves) for a
+// rectangular window. Only prepareWindow produces a windowed value, so a pack
+// cannot apply a window the call did not split; a new entry point that forgets
+// to prepare gets a rectangular pack, not zeros or a previous call's window.
+type stftWindow struct {
+	re, im []float32
 }
 
-// packFrame loads frame f (signal[base : base+nfft]) into the scratch as half
+// prepareWindow normalizes and splits the caller's window for one public call:
+// nil, or a window shorter than nfft, means rectangular (the lenient public-API
+// treatment rather than a panic); otherwise the first nfft samples are split
+// into their even and odd halves, winRe and winIm, so the interior-frame pack
+// can apply the window with two vector multiplies on the packed halves instead
+// of a scalar multiply-and-deinterleave per sample. It runs once per public call
+// (STFT, STFTPower, STFTPowerInto), since the window is fixed across the call's
+// frames, and returns the stftWindow every frame of that call packs with.
+func (p *STFTPlan) prepareWindow(window []float32) stftWindow {
+	if len(window) < p.nfft {
+		return stftWindow{}
+	}
+	Deinterleave2(p.winRe, p.winIm, window[:p.nfft])
+	return stftWindow{re: p.winRe, im: p.winIm}
+}
+
+// packFrame loads the frame at signal[base : base+nfft] into the scratch as half
 // complex samples c[j] = x[2j] + i*x[2j+1]: a vector deinterleave of the frame,
-// then, when windowed, an in-place vector multiply of each half by the window
-// half prepareWindow split out (the same single-rounded products as a scalar
-// x[n]*w[n] pack). window may be nil (rectangular). The caller guarantees the
-// frame fits and that prepareWindow has run for this window.
-func (p *STFTPlan) packFrame(signal, window []float32, base int) {
+// then, when windowed, an in-place vector multiply of each half by the matching
+// window half (the same single-rounded products as a scalar x[n]*w[n] pack). The
+// caller guarantees the frame fits.
+func (p *STFTPlan) packFrame(signal []float32, w stftWindow, base int) {
 	re, im := p.re, p.im
 	Deinterleave2(re, im, signal[base:base+p.nfft])
-	if window == nil {
+	if w.re == nil {
 		return
 	}
-	Mul(re, re, p.winRe)
-	Mul(im, im, p.winIm)
+	Mul(re, re, w.re)
+	Mul(im, im, w.im)
 }
 
 // NumFrames reports how many frames a call with the given signal length, hop,
@@ -336,20 +356,21 @@ func sampleAt(signal []float32, idx int, pad PadMode) float32 {
 // may be negative for centered frames) into the scratch, applying the window and
 // pad mode. A frame fully inside the signal uses the fast packFrame path; only
 // edge frames pay for the bounds-aware sampleAt reads, so the common interior
-// frame is unaffected.
-func (p *STFTPlan) packFrameAt(signal, window []float32, base int, pad PadMode) {
+// frame is unaffected. The edge path reads the same split window halves, so
+// w[2j] and w[2j+1] multiply each sample exactly as the vector path does.
+func (p *STFTPlan) packFrameAt(signal []float32, w stftWindow, base int, pad PadMode) {
 	if base >= 0 && base+p.nfft <= len(signal) {
-		p.packFrame(signal, window, base)
+		p.packFrame(signal, w, base)
 		return
 	}
 	re, im := p.re, p.im
 	for j := range p.half {
 		s0 := sampleAt(signal, base+2*j, pad)
 		s1 := sampleAt(signal, base+2*j+1, pad)
-		if window == nil {
+		if w.re == nil {
 			re[j], im[j] = s0, s1
 		} else {
-			re[j], im[j] = s0*window[2*j], s1*window[2*j+1]
+			re[j], im[j] = s0*w.re[j], s1*w.im[j]
 		}
 	}
 }
@@ -386,8 +407,10 @@ func (p *STFTPlan) unravelBin(k int) (re, im float32) {
 // the vector path: RealFFTUnpack computes X[1..half-1] into the plan's split
 // scratch in one SIMD pass (its twiddle W[k] at index k-1 is exactly unRe/unIm
 // shifted by one, since W_N^k = exp(-i*pi*k/half)), and DC and Nyquist, both
-// real, come straight from C[0]. A shorter row keeps the per-bin scalar unravel,
-// since the vector kernel writes every interior bin.
+// real, come straight from C[0]. A shorter row keeps the per-bin scalar unravel:
+// it writes only the bins asked for, where the vector kernel would compute every
+// interior bin, and it keeps the two unravels on the same split as
+// unravelPowerRow, whose in-place kernel needs the full row.
 func (p *STFTPlan) unravelRow(row []complex64) {
 	half := p.half
 	if len(row) <= half {
@@ -397,12 +420,26 @@ func (p *STFTPlan) unravelRow(row []complex64) {
 		}
 		return
 	}
+	// Reslice row and the scratch to their exact extents before the first store
+	// so the compiler drops the bounds checks from the DC and Nyquist stores.
 	row = row[:half+1]
-	RealFFTUnpack(p.outRe, p.outIm, p.re, p.im, p.unRe[1:], p.unIm[1:])
+	outRe, outIm := p.outRe[:half], p.outIm[:half]
+	RealFFTUnpack(outRe, outIm, p.re, p.im, p.unRe[1:], p.unIm[1:])
 	c0r, c0i := p.re[0], p.im[0]
 	row[0] = complex(c0r+c0i, 0)
-	outRe, outIm := p.outRe[:half], p.outIm[:half]
-	for k := 1; k < half; k++ {
+	// Two bins per iteration, for placement robustness rather than fewer
+	// instructions: the plain one-bin loop is so short that its speed swings
+	// with where the linker lands it relative to a cache line (the same code
+	// measured 191 and 206 us per STFT at nfft 1024 in two builds), while the
+	// unrolled form stays within 2% of the best placement wherever it lands. The
+	// step-2 index keeps its bounds checks; they cost less than the placement
+	// swing.
+	k := 1
+	for ; k+1 < half; k += 2 {
+		row[k] = complex(outRe[k], outIm[k])
+		row[k+1] = complex(outRe[k+1], outIm[k+1])
+	}
+	if k < half {
 		row[k] = complex(outRe[k], outIm[k])
 	}
 	row[half] = complex(c0r-c0i, 0)
@@ -412,7 +449,8 @@ func (p *STFTPlan) unravelRow(row []complex64) {
 // |X[k]|^2 for k in [0, half] into row. A full-width row takes RealFFTPower,
 // which fuses the unpack and the magnitude-squared into one SIMD pass over the
 // interior bins and writes them in place; DC and Nyquist are squared directly.
-// A shorter row keeps the per-bin scalar unravel.
+// A shorter row keeps the per-bin scalar unravel, since RealFFTPower writes all
+// of row[1:half] in place and so needs the full-width row.
 func (p *STFTPlan) unravelPowerRow(row []float32) {
 	half := p.half
 	if len(row) <= half {
@@ -422,7 +460,7 @@ func (p *STFTPlan) unravelPowerRow(row []float32) {
 		}
 		return
 	}
-	row = row[:half+1]
+	row = row[:half+1] // exact extent, so the DC/Nyquist stores need no bounds checks
 	RealFFTPower(row[:half], p.re, p.im, p.unRe[1:], p.unIm[1:])
 	c0r, c0i := p.re[0], p.im[0]
 	dc := c0r + c0i
@@ -433,33 +471,37 @@ func (p *STFTPlan) unravelPowerRow(row []float32) {
 
 // STFT computes the real-input STFT of signal and writes one Hermitian
 // half-spectrum (NumBins complex64 values) per frame into dst. window, when
-// non-nil, must have length nfft. The pad argument selects the framing
-// convention: NoPad applies no padding (frame f is signal[f*hop : f*hop+nfft],
-// matching librosa stft(..., center=False)); PadZero and PadReflect center each
-// frame with nfft/2 of zero or reflect padding per side, matching librosa
-// center=True. See PadMode and NumFrames.
+// non-nil, should have length nfft: a shorter window is treated as rectangular
+// and only the first nfft samples of a longer one are used. The pad argument
+// selects the framing convention: NoPad applies no padding (frame f is
+// signal[f*hop : f*hop+nfft], matching librosa stft(..., center=False)); PadZero
+// and PadReflect center each frame with nfft/2 of zero or reflect padding per
+// side, matching librosa center=True. See PadMode and NumFrames.
 //
 // It writes min(len(dst), NumFrames) frames and, per frame, min(len(dst[f]),
 // NumBins) bins, and returns the number of frames written. It is allocation-free
-// and reuses the plan scratch.
+// and reuses the plan scratch. dst rows must not overlap signal (the window is
+// consumed into plan scratch before the first write).
+//
+// The output is tolerance-stable, not bit-stable: a full-width row is unravelled
+// by the vector RealFFTUnpack path and a shorter row by the scalar per-bin path,
+// the FFT core takes different vector paths per CPU tier, and any of these may
+// round the last bits differently across library versions, build targets and
+// row lengths. Compare STFT output to a tolerance, never bit for bit. The DC and
+// Nyquist bins are exactly real.
 func (p *STFTPlan) STFT(dst [][]complex64, signal, window []float32, hop int, pad PadMode) int {
 	frames := min(p.NumFrames(len(signal), hop, pad), len(dst))
 	if frames == 0 {
 		return 0
 	}
-	if window != nil && len(window) < p.nfft {
-		// Treat a short window as rectangular rather than panicking, matching the
-		// library's lenient public-API style.
-		window = nil
-	}
-	p.prepareWindow(window)
+	w := p.prepareWindow(window) // nil or short window: rectangular
 	off := 0
 	if pad != NoPad {
 		off = p.half // center: first sample of frame f is at f*hop - nfft/2
 	}
 	bins := p.NumBins()
 	for f := range frames {
-		p.packFrameAt(signal, window, f*hop-off, pad)
+		p.packFrameAt(signal, w, f*hop-off, pad)
 		p.fftHalf()
 		row := dst[f]
 		p.unravelRow(row[:min(len(row), bins)])
@@ -469,24 +511,22 @@ func (p *STFTPlan) STFT(dst [][]complex64, signal, window []float32, hop int, pa
 
 // STFTPower computes the real-input STFT power spectrum |X|^2 directly, skipping
 // materialization of the complex bins. dst, signal, window, hop, and pad follow
-// the same conventions as STFT. Returns the number of frames written.
-// Allocation-free.
+// the same conventions as STFT, including the tolerance-stable (not bit-stable)
+// output contract. Returns the number of frames written. Allocation-free. dst
+// rows must not overlap signal.
 func (p *STFTPlan) STFTPower(dst [][]float32, signal, window []float32, hop int, pad PadMode) int {
 	frames := min(p.NumFrames(len(signal), hop, pad), len(dst))
 	if frames == 0 {
 		return 0
 	}
-	if window != nil && len(window) < p.nfft {
-		window = nil
-	}
-	p.prepareWindow(window)
+	w := p.prepareWindow(window) // nil or short window: rectangular
 	off := 0
 	if pad != NoPad {
 		off = p.half
 	}
 	bins := p.NumBins()
 	for f := range frames {
-		p.packFrameAt(signal, window, f*hop-off, pad)
+		p.packFrameAt(signal, w, f*hop-off, pad)
 		p.fftHalf()
 		row := dst[f]
 		p.unravelPowerRow(row[:min(len(row), bins)])
@@ -500,7 +540,7 @@ func (p *STFTPlan) STFTPower(dst [][]float32, signal, window []float32, hop int,
 // to DotProductBatch for a mel-filterbank projection. signal, window, hop, and
 // pad follow the same conventions as STFTPower. It writes
 // min(NumFrames, len(dst)/NumBins) whole frames and returns that frame count.
-// Allocation-free.
+// Allocation-free. dst must not overlap signal.
 func (p *STFTPlan) STFTPowerInto(dst, signal, window []float32, hop int, pad PadMode) int {
 	bins := p.NumBins()
 	frames := p.NumFrames(len(signal), hop, pad)
@@ -510,16 +550,13 @@ func (p *STFTPlan) STFTPowerInto(dst, signal, window []float32, hop int, pad Pad
 	if frames == 0 {
 		return 0
 	}
-	if window != nil && len(window) < p.nfft {
-		window = nil
-	}
-	p.prepareWindow(window)
+	w := p.prepareWindow(window) // nil or short window: rectangular
 	off := 0
 	if pad != NoPad {
 		off = p.half
 	}
 	for f := range frames {
-		p.packFrameAt(signal, window, f*hop-off, pad)
+		p.packFrameAt(signal, w, f*hop-off, pad)
 		p.fftHalf()
 		// Each frame's stride is a full-width row, so it takes the vector unravel.
 		p.unravelPowerRow(dst[f*bins : (f+1)*bins])

--- a/f32/stft.go
+++ b/f32/stft.go
@@ -84,12 +84,30 @@ type STFTPlan struct {
 	// occupies stageTwRe[s-1 : 2*s-1], and the tables total half-1 entries.
 	stageTwRe, stageTwIm []float32
 
+	// Extra twiddle for the radix-4 FFT core: the w^(3j) power ButterflyComplexStage4
+	// needs beyond the two it can slice from stageTwRe/stageTwIm (tw1 = w^(2j) is the
+	// span-s radix-2 table, tw2 = w^j is the first s entries of the span-2s table).
+	// The radix-4 stage with span s (s in {1,4,16,...}) occupies stage4Tw3Re[(s-1)/3 :
+	// (s-1)/3 + s]; the offset (s-1)/3 is exact because s is a power of four. Empty
+	// when half < 4 (no radix-4 stage runs).
+	stage4Tw3Re, stage4Tw3Im []float32
+
 	// Unravel twiddles W_N^k = exp(-i*2*pi*k/nfft) for k in [0, half], used to
 	// recombine the even/odd half-spectra into the real-input spectrum.
 	unRe, unIm []float32
 
 	// Per-transform scratch (the packed complex frame, FFT'd in place).
 	re, im []float32
+
+	// Unravel scratch for STFT: RealFFTUnpack writes the split-complex bins
+	// X[1..half-1] here before they are interleaved into the caller's complex64
+	// row. Length half; index 0 is unused (DC and Nyquist are computed directly).
+	outRe, outIm []float32
+
+	// Window halves for the vector pack: winRe holds the even window samples
+	// w[2j] and winIm the odd samples w[2j+1], split by prepareWindow once per
+	// call so packFrame can apply the window with two in-place Mul calls.
+	winRe, winIm []float32
 }
 
 // NumBins returns the number of output bins per frame, nfft/2 + 1 (the Hermitian
@@ -99,6 +117,10 @@ func (p *STFTPlan) NumBins() int { return p.half + 1 }
 // NFFT returns the transform size the plan was built for.
 func (p *STFTPlan) NFFT() int { return p.nfft }
 
+// stage4Tw3Power is the twiddle power of the radix-4 stage's third factor: tw3 =
+// w^(3j) (tw1 = w^(2j) and tw2 = w^(1j) are sliced from the radix-2 tables).
+const stage4Tw3Power = 3
+
 // NewSTFTPlan builds a reusable plan for nfft-point real-input STFTs. nfft must
 // be a power of two and at least 2; otherwise ErrNotPowerOfTwo is returned.
 func NewSTFTPlan(nfft int) (*STFTPlan, error) {
@@ -107,16 +129,30 @@ func NewSTFTPlan(nfft int) (*STFTPlan, error) {
 	}
 	half := nfft >> 1
 
+	// Size the radix-4 tw3 table: the radix-4 core runs stages at spans 1, 4, 16, ...
+	// while 4*span <= half, and stage span s holds s entries, so they sum to
+	// (4^numStages - 1)/3. Zero when half < 4.
+	stage4Tw3Len := 0
+	for s := 1; butterflyStage4Radix*s <= half; s *= butterflyStage4Radix {
+		stage4Tw3Len += s
+	}
+
 	p := &STFTPlan{
-		nfft:      nfft,
-		half:      half,
-		bitrev:    make([]int, half),
-		stageTwRe: make([]float32, max(half-1, 0)),
-		stageTwIm: make([]float32, max(half-1, 0)),
-		unRe:      make([]float32, half+1),
-		unIm:      make([]float32, half+1),
-		re:        make([]float32, half),
-		im:        make([]float32, half),
+		nfft:        nfft,
+		half:        half,
+		bitrev:      make([]int, half),
+		stageTwRe:   make([]float32, max(half-1, 0)),
+		stageTwIm:   make([]float32, max(half-1, 0)),
+		stage4Tw3Re: make([]float32, stage4Tw3Len),
+		stage4Tw3Im: make([]float32, stage4Tw3Len),
+		unRe:        make([]float32, half+1),
+		unIm:        make([]float32, half+1),
+		re:          make([]float32, half),
+		im:          make([]float32, half),
+		outRe:       make([]float32, half),
+		outIm:       make([]float32, half),
+		winRe:       make([]float32, half),
+		winIm:       make([]float32, half),
 	}
 
 	// Bit-reversal permutation for a size-half FFT.
@@ -146,6 +182,22 @@ func NewSTFTPlan(nfft int) (*STFTPlan, error) {
 		}
 	}
 
+	// Radix-4 tw3 = w^(3j) with w = exp(-i*2*pi/(4*span)), for each radix-4 stage
+	// span s in {1,4,16,...}. tw1 = w^(2j) and tw2 = w^j are the span-s and span-2s
+	// radix-2 tables above, sliced in fftHalf; only w^(3j) is not already present.
+	// The offset (s-1)/(radix4-1) is the exact running sum of the earlier stage
+	// lengths because each s is a power of butterflyStage4Radix. Computed in
+	// float64, stored as float32, like the radix-2 tables.
+	for s := 1; butterflyStage4Radix*s <= half; s *= butterflyStage4Radix {
+		off := (s - 1) / (butterflyStage4Radix - 1)
+		for j := range s {
+			ang := 2 * math.Pi * float64(stage4Tw3Power*j) / float64(butterflyStage4Radix*s)
+			sin, cos := math.Sincos(ang)
+			p.stage4Tw3Re[off+j] = float32(cos)
+			p.stage4Tw3Im[off+j] = float32(-sin)
+		}
+	}
+
 	// Real-input unravel twiddles W_N^k.
 	for k := 0; k <= half; k++ {
 		ang := 2 * math.Pi * float64(k) / float64(nfft)
@@ -157,10 +209,12 @@ func NewSTFTPlan(nfft int) (*STFTPlan, error) {
 	return p, nil
 }
 
-// fftHalf runs an in-place size-half radix-2 decimation-in-time complex FFT on
-// the plan's scratch (p.re, p.im), using the resident bit-reversal and per-stage
-// twiddles. Each stage is one ButterflyComplexStage call, so the butterflies take
-// the AVX+FMA / NEON vector paths where the span and block count justify them.
+// fftHalf runs an in-place size-half decimation-in-time complex FFT on the plan's
+// scratch (p.re, p.im), using the resident bit-reversal and per-stage twiddles.
+// The core is radix-4: each ButterflyComplexStage4 call advances two radix-2
+// stages at once, with at most one trailing ButterflyComplexStage when half is
+// not a power of four, so the butterflies take the AVX+FMA / NEON vector paths
+// where the span and block count justify them.
 func (p *STFTPlan) fftHalf() {
 	re, im := p.re, p.im
 	// Bit-reversal reorder.
@@ -170,31 +224,56 @@ func (p *STFTPlan) fftHalf() {
 			im[i], im[j] = im[j], im[i]
 		}
 	}
-	// Butterfly stages. Stage m operates on span = m/2 with block stride m; its
-	// contiguous twiddles live at stageTwRe/stageTwIm[span-1 : 2*span-1].
-	for m := 2; m <= p.half; m <<= 1 {
-		span := m >> 1
-		off := span - 1
-		ButterflyComplexStage(re, im, span, p.stageTwRe[off:off+span], p.stageTwIm[off:off+span])
+	// Butterfly stages via the radix-4 core: a radix-4 stage at span s advances the
+	// transform two radix-2 stages at once (span s then span 2s), so it runs spans
+	// 1, 4, 16, ... while a full radix-4 block fits (4*s <= half). tw1 = w^(2j) is the
+	// span-s radix-2 table at stageTw[s-1 : 2s-1], tw2 = w^j is the first s entries of
+	// the span-2s table at stageTw[2s-1 : 3s-1], and tw3 = w^(3j) is the dedicated
+	// stage4Tw3 table at [(s-1)/3 : (s-1)/3 + s]. A single trailing radix-2 stage
+	// finishes the transform when half is not a power of four (odd log2(half)).
+	s := 1
+	for butterflyStage4Radix*s <= p.half {
+		o1 := s - 1                                // span-s radix-2 table
+		o2 := butterflyStageRadix*s - 1            // span-2s radix-2 table, first s taken
+		o3 := (s - 1) / (butterflyStage4Radix - 1) // dedicated w^(3j) table
+		ButterflyComplexStage4(re, im, s,
+			p.stageTwRe[o1:o1+s], p.stageTwIm[o1:o1+s],
+			p.stageTwRe[o2:o2+s], p.stageTwIm[o2:o2+s],
+			p.stage4Tw3Re[o3:o3+s], p.stage4Tw3Im[o3:o3+s])
+		s *= butterflyStage4Radix
+	}
+	if s < p.half {
+		off := s - 1
+		ButterflyComplexStage(re, im, s, p.stageTwRe[off:off+s], p.stageTwIm[off:off+s])
 	}
 }
 
-// packFrame loads frame f (signal[base : base+nfft]) into the scratch as half
-// complex samples c[j] = x[2j] + i*x[2j+1], applying the window during the pack.
-// window may be nil (rectangular). The caller guarantees the frame fits.
-func (p *STFTPlan) packFrame(signal, window []float32, base int) {
-	re, im := p.re, p.im
+// prepareWindow splits window (nil for rectangular, else length >= nfft) into its
+// even and odd samples, winRe and winIm, so the interior-frame pack can apply it
+// with two vector multiplies on the packed halves instead of a scalar
+// multiply-and-deinterleave per sample. It runs once per STFT call, since the
+// window is fixed across the call's frames, and is not needed for a nil window.
+func (p *STFTPlan) prepareWindow(window []float32) {
 	if window == nil {
-		for j := range p.half {
-			re[j] = signal[base+2*j]
-			im[j] = signal[base+2*j+1]
-		}
 		return
 	}
-	for j := range p.half {
-		re[j] = signal[base+2*j] * window[2*j]
-		im[j] = signal[base+2*j+1] * window[2*j+1]
+	Deinterleave2(p.winRe, p.winIm, window[:p.nfft])
+}
+
+// packFrame loads frame f (signal[base : base+nfft]) into the scratch as half
+// complex samples c[j] = x[2j] + i*x[2j+1]: a vector deinterleave of the frame,
+// then, when windowed, an in-place vector multiply of each half by the window
+// half prepareWindow split out (the same single-rounded products as a scalar
+// x[n]*w[n] pack). window may be nil (rectangular). The caller guarantees the
+// frame fits and that prepareWindow has run for this window.
+func (p *STFTPlan) packFrame(signal, window []float32, base int) {
+	re, im := p.re, p.im
+	Deinterleave2(re, im, signal[base:base+p.nfft])
+	if window == nil {
+		return
 	}
+	Mul(re, re, p.winRe)
+	Mul(im, im, p.winIm)
 }
 
 // NumFrames reports how many frames a call with the given signal length, hop,
@@ -302,6 +381,56 @@ func (p *STFTPlan) unravelBin(k int) (re, im float32) {
 	return re, im
 }
 
+// unravelRow writes the real-input spectrum X[0..half] of the FFT'd frame in
+// p.re/p.im into row as complex64 bins. A full-width row (len >= NumBins) takes
+// the vector path: RealFFTUnpack computes X[1..half-1] into the plan's split
+// scratch in one SIMD pass (its twiddle W[k] at index k-1 is exactly unRe/unIm
+// shifted by one, since W_N^k = exp(-i*pi*k/half)), and DC and Nyquist, both
+// real, come straight from C[0]. A shorter row keeps the per-bin scalar unravel,
+// since the vector kernel writes every interior bin.
+func (p *STFTPlan) unravelRow(row []complex64) {
+	half := p.half
+	if len(row) <= half {
+		for k := range row {
+			xr, xi := p.unravelBin(k)
+			row[k] = complex(xr, xi)
+		}
+		return
+	}
+	row = row[:half+1]
+	RealFFTUnpack(p.outRe, p.outIm, p.re, p.im, p.unRe[1:], p.unIm[1:])
+	c0r, c0i := p.re[0], p.im[0]
+	row[0] = complex(c0r+c0i, 0)
+	outRe, outIm := p.outRe[:half], p.outIm[:half]
+	for k := 1; k < half; k++ {
+		row[k] = complex(outRe[k], outIm[k])
+	}
+	row[half] = complex(c0r-c0i, 0)
+}
+
+// unravelPowerRow is the power-spectrum counterpart of unravelRow: it writes
+// |X[k]|^2 for k in [0, half] into row. A full-width row takes RealFFTPower,
+// which fuses the unpack and the magnitude-squared into one SIMD pass over the
+// interior bins and writes them in place; DC and Nyquist are squared directly.
+// A shorter row keeps the per-bin scalar unravel.
+func (p *STFTPlan) unravelPowerRow(row []float32) {
+	half := p.half
+	if len(row) <= half {
+		for k := range row {
+			xr, xi := p.unravelBin(k)
+			row[k] = xr*xr + xi*xi
+		}
+		return
+	}
+	row = row[:half+1]
+	RealFFTPower(row[:half], p.re, p.im, p.unRe[1:], p.unIm[1:])
+	c0r, c0i := p.re[0], p.im[0]
+	dc := c0r + c0i
+	ny := c0r - c0i
+	row[0] = dc * dc
+	row[half] = ny * ny
+}
+
 // STFT computes the real-input STFT of signal and writes one Hermitian
 // half-spectrum (NumBins complex64 values) per frame into dst. window, when
 // non-nil, must have length nfft. The pad argument selects the framing
@@ -323,6 +452,7 @@ func (p *STFTPlan) STFT(dst [][]complex64, signal, window []float32, hop int, pa
 		// library's lenient public-API style.
 		window = nil
 	}
+	p.prepareWindow(window)
 	off := 0
 	if pad != NoPad {
 		off = p.half // center: first sample of frame f is at f*hop - nfft/2
@@ -332,11 +462,7 @@ func (p *STFTPlan) STFT(dst [][]complex64, signal, window []float32, hop int, pa
 		p.packFrameAt(signal, window, f*hop-off, pad)
 		p.fftHalf()
 		row := dst[f]
-		nb := min(len(row), bins)
-		for k := range nb {
-			xr, xi := p.unravelBin(k)
-			row[k] = complex(xr, xi)
-		}
+		p.unravelRow(row[:min(len(row), bins)])
 	}
 	return frames
 }
@@ -353,6 +479,7 @@ func (p *STFTPlan) STFTPower(dst [][]float32, signal, window []float32, hop int,
 	if window != nil && len(window) < p.nfft {
 		window = nil
 	}
+	p.prepareWindow(window)
 	off := 0
 	if pad != NoPad {
 		off = p.half
@@ -362,11 +489,7 @@ func (p *STFTPlan) STFTPower(dst [][]float32, signal, window []float32, hop int,
 		p.packFrameAt(signal, window, f*hop-off, pad)
 		p.fftHalf()
 		row := dst[f]
-		nb := min(len(row), bins)
-		for k := range nb {
-			xr, xi := p.unravelBin(k)
-			row[k] = xr*xr + xi*xi
-		}
+		p.unravelPowerRow(row[:min(len(row), bins)])
 	}
 	return frames
 }
@@ -390,6 +513,7 @@ func (p *STFTPlan) STFTPowerInto(dst, signal, window []float32, hop int, pad Pad
 	if window != nil && len(window) < p.nfft {
 		window = nil
 	}
+	p.prepareWindow(window)
 	off := 0
 	if pad != NoPad {
 		off = p.half
@@ -397,13 +521,8 @@ func (p *STFTPlan) STFTPowerInto(dst, signal, window []float32, hop int, pad Pad
 	for f := range frames {
 		p.packFrameAt(signal, window, f*hop-off, pad)
 		p.fftHalf()
-		// Slice the frame's stride out of dst and range over it so the compiler
-		// fully eliminates bounds checks on the inner-loop writes.
-		row := dst[f*bins : (f+1)*bins]
-		for k := range row {
-			xr, xi := p.unravelBin(k)
-			row[k] = xr*xr + xi*xi
-		}
+		// Each frame's stride is a full-width row, so it takes the vector unravel.
+		p.unravelPowerRow(dst[f*bins : (f+1)*bins])
 	}
 	return frames
 }

--- a/f32/stft_test.go
+++ b/f32/stft_test.go
@@ -80,7 +80,10 @@ func TestNewSTFTPlanErrorsF32(t *testing.T) {
 // across nfft sizes, hops, and with or without a window.
 func TestSTFTAgainstDFTF32(t *testing.T) {
 	signal := testSignalF32(5000)
-	for _, nfft := range []int{2, 4, 8, 16, 64, 256, 1024} {
+	// The size list spans both radix-4 schedule shapes: even log2(half) runs only
+	// radix-4 stages (nfft 8/32/128 = 1/2/3 stages, no trailing), odd log2(half)
+	// finishes with one trailing radix-2 stage (nfft 4/16/64/256/1024).
+	for _, nfft := range []int{2, 4, 8, 16, 32, 64, 128, 256, 1024} {
 		for _, useWin := range []bool{false, true} {
 			plan, err := NewSTFTPlan(nfft)
 			if err != nil {
@@ -284,6 +287,125 @@ func TestSTFTClampsF32(t *testing.T) {
 	rows[0] = make([]complex64, 3)
 	if n := plan.STFT(rows, signal, nil, hop, NoPad); n != 1 {
 		t.Errorf("partial-row frames = %d, want 1", n)
+	}
+}
+
+// TestSTFTShortRowsMatchFullF32 pins the two unravel paths against each other:
+// a full-width row (NumBins) takes the vector RealFFTUnpack / RealFFTPower
+// unravel, a shorter row keeps the per-bin scalar unravel. The bins a short row
+// does write must agree with the same bins of the full row, for STFT and
+// STFTPower, across row lengths on both sides of the split and across nfft sizes
+// that exercise the vector kernels' full blocks and scalar tails.
+func TestSTFTShortRowsMatchFullF32(t *testing.T) {
+	signal := testSignalF32(3000)
+	for _, nfft := range []int{2, 4, 16, 64, 512} {
+		plan, err := NewSTFTPlan(nfft)
+		if err != nil {
+			t.Fatal(err)
+		}
+		window := hannF32(nfft)
+		hop := max(nfft/4, 1)
+		bins := plan.NumBins()
+		nf := plan.NumFrames(len(signal), hop, NoPad)
+
+		full := make([][]complex64, nf)
+		fullPow := make([][]float32, nf)
+		for f := range nf {
+			full[f] = make([]complex64, bins)
+			fullPow[f] = make([]float32, bins)
+		}
+		plan.STFT(full, signal, window, hop, NoPad)
+		// The plan scratch still holds the last frame's half-size spectrum, so
+		// every bin of the last full row, DC and Nyquist included, can be checked
+		// against the scalar per-bin unravel the short-row path uses.
+		for k := range bins {
+			xr, xi := plan.unravelBin(k)
+			ctx := fmt.Sprintf("nfft=%d last frame bin=%d (vector vs scalar unravel)", nfft, k)
+			tol := 1e-5 * (1 + math.Hypot(float64(xr), float64(xi)))
+			cmplxCloseF32(t, ctx, full[nf-1][k], complex(float64(xr), float64(xi)), tol)
+		}
+		plan.STFTPower(fullPow, signal, window, hop, NoPad)
+		for k := range bins {
+			xr, xi := plan.unravelBin(k)
+			wp := xr*xr + xi*xi
+			if d := math.Abs(float64(fullPow[nf-1][k] - wp)); d > 1e-5*(1+float64(wp)) {
+				t.Fatalf("nfft=%d last frame bin=%d: vector power %v, scalar power %v", nfft, k, fullPow[nf-1][k], wp)
+			}
+		}
+
+		for _, rowLen := range []int{1, 2, bins / 2, bins - 1, bins} {
+			if rowLen < 1 || rowLen > bins {
+				continue
+			}
+			short := make([][]complex64, nf)
+			shortPow := make([][]float32, nf)
+			for f := range nf {
+				short[f] = make([]complex64, rowLen)
+				shortPow[f] = make([]float32, rowLen)
+			}
+			plan.STFT(short, signal, window, hop, NoPad)
+			plan.STFTPower(shortPow, signal, window, hop, NoPad)
+			for f := range nf {
+				for k := range rowLen {
+					// The vector and scalar unravels round differently in the last
+					// bits (FMA vs separate multiply-add), so compare to a relative
+					// tolerance scaled by the bin magnitude, not bit for bit.
+					ctx := fmt.Sprintf("nfft=%d rowLen=%d frame=%d bin=%d", nfft, rowLen, f, k)
+					want := full[f][k]
+					tol := 1e-5 * (1 + math.Hypot(float64(real(want)), float64(imag(want))))
+					cmplxCloseF32(t, ctx, short[f][k], complex128(want), tol)
+					wp := fullPow[f][k]
+					if d := math.Abs(float64(shortPow[f][k] - wp)); d > 1e-5*(1+float64(wp)) {
+						t.Fatalf("%s: short-row power %v, full-row power %v", ctx, shortPow[f][k], wp)
+					}
+				}
+			}
+		}
+	}
+}
+
+// TestSTFTWindowReuseF32 runs one plan through a sequence of calls with different
+// windows (Hann, rectangular, then a different window) and checks each call's
+// output is bit-identical to a fresh plan's. The plan splits the window into
+// per-call scratch for the vector pack, so a stale split would leak a previous
+// call's window into the next call's frames.
+func TestSTFTWindowReuseF32(t *testing.T) {
+	const nfft = 64
+	signal := testSignalF32(2000)
+	hop := 16
+	hann := hannF32(nfft)
+	ramp := make([]float32, nfft)
+	for i := range ramp {
+		ramp[i] = float32(i+1) / float32(nfft)
+	}
+	shared, _ := NewSTFTPlan(nfft)
+	nf := shared.NumFrames(len(signal), hop, PadReflect)
+	bins := shared.NumBins()
+	alloc := func() ([][]complex64, []float32) {
+		spec := make([][]complex64, nf)
+		for f := range spec {
+			spec[f] = make([]complex64, bins)
+		}
+		return spec, make([]float32, nf*bins)
+	}
+	for i, window := range [][]float32{hann, nil, ramp, nil, hann} {
+		fresh, _ := NewSTFTPlan(nfft)
+		gotSpec, gotPow := alloc()
+		wantSpec, wantPow := alloc()
+		shared.STFT(gotSpec, signal, window, hop, PadReflect)
+		fresh.STFT(wantSpec, signal, window, hop, PadReflect)
+		shared.STFTPowerInto(gotPow, signal, window, hop, PadReflect)
+		fresh.STFTPowerInto(wantPow, signal, window, hop, PadReflect)
+		for f := range nf {
+			for k := range bins {
+				if gotSpec[f][k] != wantSpec[f][k] {
+					t.Fatalf("call %d frame %d bin %d: shared plan %v, fresh plan %v", i, f, k, gotSpec[f][k], wantSpec[f][k])
+				}
+				if gotPow[f*bins+k] != wantPow[f*bins+k] {
+					t.Fatalf("call %d frame %d bin %d: shared plan power %v, fresh plan %v", i, f, k, gotPow[f*bins+k], wantPow[f*bins+k])
+				}
+			}
+		}
 	}
 }
 

--- a/f32/stft_test.go
+++ b/f32/stft_test.go
@@ -599,6 +599,21 @@ func TestSTFTAllocFreeF32(t *testing.T) {
 	if a := testing.AllocsPerRun(5, func() { plan.STFT(cspec, signal, window, hop, PadReflect) }); a != 0 {
 		t.Errorf("centered STFT allocated %v times per run, want 0", a)
 	}
+
+	// Rows shorter than NumBins take the scalar unravel branch, which must also be
+	// allocation-free.
+	sspec := make([][]complex64, nf)
+	spow := make([][]float32, nf)
+	for f := range sspec {
+		sspec[f] = make([]complex64, 3)
+		spow[f] = make([]float32, 3)
+	}
+	if a := testing.AllocsPerRun(5, func() { plan.STFT(sspec, signal, window, hop, NoPad) }); a != 0 {
+		t.Errorf("short-row STFT allocated %v times per run, want 0", a)
+	}
+	if a := testing.AllocsPerRun(5, func() { plan.STFTPower(spow, signal, window, hop, NoPad) }); a != 0 {
+		t.Errorf("short-row STFTPower allocated %v times per run, want 0", a)
+	}
 }
 
 // FuzzSTFT is a differential fuzz target: every STFT bin must match a direct DFT

--- a/f32/stft_test.go
+++ b/f32/stft_test.go
@@ -41,7 +41,8 @@ func testSignalF32(n int) []float32 {
 	return s
 }
 
-// stftTolF32 bounds the error of an nfft-point float32 radix-2 transform against
+// stftTolF32 bounds the error of an nfft-point float32 rfft (radix-4 core with a
+// trailing radix-2 stage, vector pack and unravel) against
 // the true (float64) DFT: the relative error grows roughly with log2(nfft)*eps32,
 // scaled by the sum of frame magnitudes that bounds the bin, plus a floor.
 func stftTolF32(nfft int, scale float64) float64 {
@@ -127,8 +128,9 @@ func TestSTFTAgainstDFTF32(t *testing.T) {
 	}
 }
 
-// TestSTFTStageTwiddles pins the per-stage contiguous twiddle layout that
-// fftHalf and ButterflyComplexStage share: the table holds max(half-1, 0)
+// TestSTFTStageTwiddles pins the per-stage contiguous twiddle layout fftHalf
+// slices for ButterflyComplexStage4 (tw1/tw2) and the trailing
+// ButterflyComplexStage: the table holds max(half-1, 0)
 // entries, and stage m in {2,4,...,half} keeps its span=m/2 factors
 // W_m^j = (cos(2*pi*j/m), -sin(2*pi*j/m)) at offset span-1. An off-by-one in the
 // offset or a wrong table length would put the wrong factor at [off+j] and fail
@@ -165,6 +167,50 @@ func TestSTFTStageTwiddles(t *testing.T) {
 					t.Errorf("nfft=%d m=%d j=%d: stageTwIm=%g want %g", nfft, m, j, p.stageTwIm[off+j], wantIm)
 				}
 			}
+		}
+	}
+}
+
+// TestSTFTStage4Tw3TwiddlesF32 pins the layout of the radix-4 core's third
+// twiddle table, the one fftHalf cannot slice from the radix-2 tables: the
+// radix-4 stage with span s in {1,4,16,...} (while 4*s <= half) keeps s factors
+// w^(3j) = (cos(2*pi*3j/(4s)), -sin(2*pi*3j/(4s))) at offset (s-1)/3, and the
+// table totals (4^stages - 1)/3 entries, zero when half < 4. A wrong offset,
+// length or power would fail here, localized, rather than only as a spectrum
+// mismatch downstream. Exact bits, as in TestSTFTStageTwiddles: NewSTFTPlan
+// stores float32(cos)/float32(-sin) of this same float64 sincos.
+func TestSTFTStage4Tw3TwiddlesF32(t *testing.T) {
+	for _, nfft := range []int{2, 4, 8, 16, 32, 128, 256, 1024} {
+		p, err := NewSTFTPlan(nfft)
+		if err != nil {
+			t.Fatalf("nfft=%d: NewSTFTPlan: %v", nfft, err)
+		}
+		half := nfft >> 1
+		wantLen := 0
+		for s := 1; 4*s <= half; s *= 4 {
+			wantLen += s
+		}
+		if len(p.stage4Tw3Re) != wantLen || len(p.stage4Tw3Im) != wantLen {
+			t.Fatalf("nfft=%d: stage4Tw3 table len = (%d,%d), want %d",
+				nfft, len(p.stage4Tw3Re), len(p.stage4Tw3Im), wantLen)
+		}
+		off := 0
+		for s := 1; 4*s <= half; s *= 4 {
+			if off != (s-1)/3 {
+				t.Fatalf("nfft=%d s=%d: running offset %d, want (s-1)/3 = %d", nfft, s, off, (s-1)/3)
+			}
+			for j := range s {
+				ang := 2 * math.Pi * float64(3*j) / float64(4*s)
+				sin, cos := math.Sincos(ang)
+				wantRe, wantIm := float32(cos), float32(-sin)
+				if math.Float32bits(p.stage4Tw3Re[off+j]) != math.Float32bits(wantRe) {
+					t.Errorf("nfft=%d s=%d j=%d: stage4Tw3Re=%g want %g", nfft, s, j, p.stage4Tw3Re[off+j], wantRe)
+				}
+				if math.Float32bits(p.stage4Tw3Im[off+j]) != math.Float32bits(wantIm) {
+					t.Errorf("nfft=%d s=%d j=%d: stage4Tw3Im=%g want %g", nfft, s, j, p.stage4Tw3Im[off+j], wantIm)
+				}
+			}
+			off += s
 		}
 	}
 }
@@ -288,6 +334,49 @@ func TestSTFTClampsF32(t *testing.T) {
 	if n := plan.STFT(rows, signal, nil, hop, NoPad); n != 1 {
 		t.Errorf("partial-row frames = %d, want 1", n)
 	}
+
+	// Rows longer than NumBins: exactly NumBins bins written, the rest untouched,
+	// and the written bins identical to a NumBins-wide row (same path).
+	bins := plan.NumBins()
+	const sentinel = complex64(complex(-7, 7))
+	long := [][]complex64{make([]complex64, bins+3)}
+	for k := range long[0] {
+		long[0][k] = sentinel
+	}
+	exact := [][]complex64{make([]complex64, bins)}
+	if n := plan.STFT(long, signal, nil, hop, NoPad); n != 1 {
+		t.Errorf("long-row frames = %d, want 1", n)
+	}
+	plan.STFT(exact, signal, nil, hop, NoPad)
+	for k := range bins {
+		if long[0][k] != exact[0][k] {
+			t.Fatalf("long row bin %d = %v, want %v", k, long[0][k], exact[0][k])
+		}
+	}
+	for k := bins; k < len(long[0]); k++ {
+		if long[0][k] != sentinel {
+			t.Fatalf("long row bin %d beyond NumBins was written: %v", k, long[0][k])
+		}
+	}
+	longPow := [][]float32{make([]float32, bins+3)}
+	for k := range longPow[0] {
+		longPow[0][k] = -7
+	}
+	if n := plan.STFTPower(longPow, signal, nil, hop, NoPad); n != 1 {
+		t.Errorf("long-row power frames = %d, want 1", n)
+	}
+	exactPow := [][]float32{make([]float32, bins)}
+	plan.STFTPower(exactPow, signal, nil, hop, NoPad)
+	for k := range bins {
+		if longPow[0][k] != exactPow[0][k] {
+			t.Fatalf("long power row bin %d = %v, want %v", k, longPow[0][k], exactPow[0][k])
+		}
+	}
+	for k := bins; k < len(longPow[0]); k++ {
+		if longPow[0][k] != -7 {
+			t.Fatalf("long power row bin %d beyond NumBins was written: %v", k, longPow[0][k])
+		}
+	}
 }
 
 // TestSTFTShortRowsMatchFullF32 pins the two unravel paths against each other:
@@ -295,9 +384,13 @@ func TestSTFTClampsF32(t *testing.T) {
 // unravel, a shorter row keeps the per-bin scalar unravel. The bins a short row
 // does write must agree with the same bins of the full row, for STFT and
 // STFTPower, across row lengths on both sides of the split and across nfft sizes
-// that exercise the vector kernels' full blocks and scalar tails.
+// that exercise the vector kernels' full blocks and scalar tails. It also proves
+// the full-width row really took the vector path: the plan's unpack scratch is
+// poisoned with NaN before the call and the row's interior bins must be the
+// bits that scratch holds afterwards (only RealFFTUnpack writes it).
 func TestSTFTShortRowsMatchFullF32(t *testing.T) {
 	signal := testSignalF32(3000)
+	nan := float32(math.NaN())
 	for _, nfft := range []int{2, 4, 16, 64, 512} {
 		plan, err := NewSTFTPlan(nfft)
 		if err != nil {
@@ -306,6 +399,7 @@ func TestSTFTShortRowsMatchFullF32(t *testing.T) {
 		window := hannF32(nfft)
 		hop := max(nfft/4, 1)
 		bins := plan.NumBins()
+		half := bins - 1
 		nf := plan.NumFrames(len(signal), hop, NoPad)
 
 		full := make([][]complex64, nf)
@@ -314,29 +408,46 @@ func TestSTFTShortRowsMatchFullF32(t *testing.T) {
 			full[f] = make([]complex64, bins)
 			fullPow[f] = make([]float32, bins)
 		}
+		for k := range plan.outRe {
+			plan.outRe[k], plan.outIm[k] = nan, nan
+		}
 		plan.STFT(full, signal, window, hop, NoPad)
+		// Positive control: the last full row's interior bins are exactly the
+		// unpack scratch the vector path wrote (NaN would mean it never ran).
+		for k := 1; k < half; k++ {
+			if got, wr, wi := full[nf-1][k], plan.outRe[k], plan.outIm[k]; math.IsNaN(float64(wr)) || math.IsNaN(float64(wi)) ||
+				math.Float32bits(real(got)) != math.Float32bits(wr) || math.Float32bits(imag(got)) != math.Float32bits(wi) {
+				t.Fatalf("nfft=%d bin=%d: full row %v is not the vector unpack scratch (%v,%v)", nfft, k, got, wr, wi)
+			}
+		}
+		// The rounding gap between the FMA vector unpack and the scalar unravel
+		// scales with the packed spectrum's magnitude, not with the bin being
+		// compared (a near-null bin is a cancellation of large terms), so the
+		// tolerance is relative to the row's largest bin.
+		rowMax := 0.0
+		for k := range bins {
+			rowMax = max(rowMax, math.Hypot(float64(real(full[nf-1][k])), float64(imag(full[nf-1][k]))))
+		}
+		tol := 1e-5 * (1 + rowMax)
 		// The plan scratch still holds the last frame's half-size spectrum, so
 		// every bin of the last full row, DC and Nyquist included, can be checked
 		// against the scalar per-bin unravel the short-row path uses.
 		for k := range bins {
 			xr, xi := plan.unravelBin(k)
 			ctx := fmt.Sprintf("nfft=%d last frame bin=%d (vector vs scalar unravel)", nfft, k)
-			tol := 1e-5 * (1 + math.Hypot(float64(xr), float64(xi)))
 			cmplxCloseF32(t, ctx, full[nf-1][k], complex(float64(xr), float64(xi)), tol)
 		}
 		plan.STFTPower(fullPow, signal, window, hop, NoPad)
+		powTol := 1e-5 * (1 + rowMax*rowMax)
 		for k := range bins {
 			xr, xi := plan.unravelBin(k)
 			wp := xr*xr + xi*xi
-			if d := math.Abs(float64(fullPow[nf-1][k] - wp)); d > 1e-5*(1+float64(wp)) {
+			if d := math.Abs(float64(fullPow[nf-1][k] - wp)); d > powTol {
 				t.Fatalf("nfft=%d last frame bin=%d: vector power %v, scalar power %v", nfft, k, fullPow[nf-1][k], wp)
 			}
 		}
 
 		for _, rowLen := range []int{1, 2, bins / 2, bins - 1, bins} {
-			if rowLen < 1 || rowLen > bins {
-				continue
-			}
 			short := make([][]complex64, nf)
 			shortPow := make([][]float32, nf)
 			for f := range nf {
@@ -347,16 +458,10 @@ func TestSTFTShortRowsMatchFullF32(t *testing.T) {
 			plan.STFTPower(shortPow, signal, window, hop, NoPad)
 			for f := range nf {
 				for k := range rowLen {
-					// The vector and scalar unravels round differently in the last
-					// bits (FMA vs separate multiply-add), so compare to a relative
-					// tolerance scaled by the bin magnitude, not bit for bit.
 					ctx := fmt.Sprintf("nfft=%d rowLen=%d frame=%d bin=%d", nfft, rowLen, f, k)
-					want := full[f][k]
-					tol := 1e-5 * (1 + math.Hypot(float64(real(want)), float64(imag(want))))
-					cmplxCloseF32(t, ctx, short[f][k], complex128(want), tol)
-					wp := fullPow[f][k]
-					if d := math.Abs(float64(shortPow[f][k] - wp)); d > 1e-5*(1+float64(wp)) {
-						t.Fatalf("%s: short-row power %v, full-row power %v", ctx, shortPow[f][k], wp)
+					cmplxCloseF32(t, ctx, short[f][k], complex128(full[f][k]), tol)
+					if d := math.Abs(float64(shortPow[f][k] - fullPow[f][k])); d > powTol {
+						t.Fatalf("%s: short-row power %v, full-row power %v", ctx, shortPow[f][k], fullPow[f][k])
 					}
 				}
 			}
@@ -364,11 +469,15 @@ func TestSTFTShortRowsMatchFullF32(t *testing.T) {
 	}
 }
 
-// TestSTFTWindowReuseF32 runs one plan through a sequence of calls with different
-// windows (Hann, rectangular, then a different window) and checks each call's
-// output is bit-identical to a fresh plan's. The plan splits the window into
-// per-call scratch for the vector pack, so a stale split would leak a previous
-// call's window into the next call's frames.
+// TestSTFTWindowReuseF32 pins that every public call applies exactly the window
+// it was given: the plan splits the window into per-call scratch for the vector
+// pack, so a stale split would leak a previous call's window into the next. One
+// shared plan runs a sequence of calls that changes the window on EVERY call
+// (Hann to ramp directly, to and from rectangular, a window longer than nfft)
+// and rotates through STFT, STFTPowerInto and STFTPower, and each call is
+// compared bit for bit against a plan created for that one call only (a fresh
+// plan replaying the same sequence would carry the same stale split and hide
+// the defect). A window longer than nfft must behave as its first nfft samples.
 func TestSTFTWindowReuseF32(t *testing.T) {
 	const nfft = 64
 	signal := testSignalF32(2000)
@@ -378,32 +487,71 @@ func TestSTFTWindowReuseF32(t *testing.T) {
 	for i := range ramp {
 		ramp[i] = float32(i+1) / float32(nfft)
 	}
+	hannLong := append(append([]float32(nil), hann...), 9, 9, 9, 9, 9)
 	shared, _ := NewSTFTPlan(nfft)
 	nf := shared.NumFrames(len(signal), hop, PadReflect)
 	bins := shared.NumBins()
-	alloc := func() ([][]complex64, []float32) {
+	newSpec := func() [][]complex64 {
 		spec := make([][]complex64, nf)
 		for f := range spec {
 			spec[f] = make([]complex64, bins)
 		}
-		return spec, make([]float32, nf*bins)
+		return spec
 	}
-	for i, window := range [][]float32{hann, nil, ramp, nil, hann} {
+	newPow := func() [][]float32 {
+		pow := make([][]float32, nf)
+		for f := range pow {
+			pow[f] = make([]float32, bins)
+		}
+		return pow
+	}
+	windows := [][]float32{hann, ramp, hann, ramp, hann, ramp, nil, hannLong, ramp}
+	for i, window := range windows {
 		fresh, _ := NewSTFTPlan(nfft)
-		gotSpec, gotPow := alloc()
-		wantSpec, wantPow := alloc()
-		shared.STFT(gotSpec, signal, window, hop, PadReflect)
-		fresh.STFT(wantSpec, signal, window, hop, PadReflect)
-		shared.STFTPowerInto(gotPow, signal, window, hop, PadReflect)
-		fresh.STFTPowerInto(wantPow, signal, window, hop, PadReflect)
-		for f := range nf {
-			for k := range bins {
-				if gotSpec[f][k] != wantSpec[f][k] {
-					t.Fatalf("call %d frame %d bin %d: shared plan %v, fresh plan %v", i, f, k, gotSpec[f][k], wantSpec[f][k])
+		switch i % 3 {
+		case 0:
+			got, want := newSpec(), newSpec()
+			shared.STFT(got, signal, window, hop, PadReflect)
+			fresh.STFT(want, signal, window, hop, PadReflect)
+			for f := range nf {
+				for k := range bins {
+					if got[f][k] != want[f][k] {
+						t.Fatalf("call %d (STFT) frame %d bin %d: shared plan %v, fresh plan %v", i, f, k, got[f][k], want[f][k])
+					}
 				}
-				if gotPow[f*bins+k] != wantPow[f*bins+k] {
-					t.Fatalf("call %d frame %d bin %d: shared plan power %v, fresh plan %v", i, f, k, gotPow[f*bins+k], wantPow[f*bins+k])
+			}
+		case 1:
+			got, want := make([]float32, nf*bins), make([]float32, nf*bins)
+			shared.STFTPowerInto(got, signal, window, hop, PadReflect)
+			fresh.STFTPowerInto(want, signal, window, hop, PadReflect)
+			for j := range got {
+				if got[j] != want[j] {
+					t.Fatalf("call %d (STFTPowerInto) flat index %d: shared plan %v, fresh plan %v", i, j, got[j], want[j])
 				}
+			}
+		case 2:
+			got, want := newPow(), newPow()
+			shared.STFTPower(got, signal, window, hop, PadReflect)
+			fresh.STFTPower(want, signal, window, hop, PadReflect)
+			for f := range nf {
+				for k := range bins {
+					if got[f][k] != want[f][k] {
+						t.Fatalf("call %d (STFTPower) frame %d bin %d: shared plan %v, fresh plan %v", i, f, k, got[f][k], want[f][k])
+					}
+				}
+			}
+		}
+	}
+	// A window longer than nfft is its first nfft samples: bit-identical to Hann.
+	longPlan, _ := NewSTFTPlan(nfft)
+	hannPlan, _ := NewSTFTPlan(nfft)
+	got, want := newSpec(), newSpec()
+	longPlan.STFT(got, signal, hannLong, hop, PadReflect)
+	hannPlan.STFT(want, signal, hann, hop, PadReflect)
+	for f := range nf {
+		for k := range bins {
+			if got[f][k] != want[f][k] {
+				t.Fatalf("long window frame %d bin %d: %v, want Hann-prefix %v", f, k, got[f][k], want[f][k])
 			}
 		}
 	}
@@ -832,7 +980,7 @@ func TestSTFTLibrosaParityF32(t *testing.T) {
 				maxRel = rel
 			}
 		}
-		// float32 radix-2 rfft vs librosa's float64 pocketfft: the error is
+		// float32 rfft vs librosa's float64 pocketfft: the error is
 		// dominated by float32 rounding (observed ~2e-6 relative after squaring to
 		// power). The 1e-4 bound keeps ~50x margin while a convention error (wrong
 		// centering, window, or normalization) would be orders of magnitude larger.

--- a/f64/stft.go
+++ b/f64/stft.go
@@ -25,10 +25,15 @@ import (
 //     frame is packed into the FFT input, and STFTPower emits |X|^2 directly
 //     without materializing the complex bins.
 //
-// The transform is a radix-2 rfft (power-of-two nfft only); its butterfly stages
-// run through ButterflyComplexStage, so they take the AVX+FMA / NEON vector paths
-// where the span and block count justify them and fall back to scalar Go
-// otherwise. See #108 and #205.
+// The transform is a power-of-two rfft whose every arithmetic pass over the
+// frame runs through the package's vector primitives: the frame is packed with
+// Deinterleave2 and Mul, the size-half FFT core is radix-4
+// (ButterflyComplexStage4, with at most one trailing radix-2
+// ButterflyComplexStage), and the real-input unravel is RealFFTUnpack or, for the
+// power spectrum, RealFFTPower. Each takes the AVX+FMA / NEON vector path where
+// its size justifies it and falls back to scalar Go otherwise; the bit-reversal
+// reorder, padded edge frames and rows shorter than NumBins stay scalar. See
+// #108, #205, #243 and #257.
 
 // ErrSTFT* describe invalid STFTPlan configurations.
 var (
@@ -74,11 +79,12 @@ type STFTPlan struct {
 
 	bitrev []int // bit-reversal permutation for the size-half FFT
 
-	// Per-stage contiguous twiddles for the size-half radix-2 FFT, so each stage
-	// can be driven through ButterflyComplexStage (which reads its twiddles
-	// contiguous in j over [0, span)). Stage m in {2,4,...,half} uses span = m/2
-	// factors W_m^j = exp(-i*2*pi*j/m) for j in [0, span); the stage with span s
-	// occupies stageTwRe[s-1 : 2*s-1], and the tables total half-1 entries.
+	// Per-stage contiguous twiddles of the size-half FFT, laid out per radix-2
+	// stage: stage m in {2,4,...,half} uses span = m/2 factors W_m^j =
+	// exp(-i*2*pi*j/m) for j in [0, span); the stage with span s occupies
+	// stageTwRe[s-1 : 2*s-1], and the tables total half-1 entries. fftHalf slices
+	// them as the tw1/tw2 inputs of ButterflyComplexStage4 and as the twiddles of
+	// the trailing ButterflyComplexStage (both read contiguous j over [0, span)).
 	stageTwRe, stageTwIm []float64
 
 	// Extra twiddle for the radix-4 FFT core: the w^(3j) power ButterflyComplexStage4
@@ -103,7 +109,8 @@ type STFTPlan struct {
 
 	// Window halves for the vector pack: winRe holds the even window samples
 	// w[2j] and winIm the odd samples w[2j+1], split by prepareWindow once per
-	// call so packFrame can apply the window with two in-place Mul calls.
+	// public call and handed to the pack as an stftWindow, so packFrame can apply
+	// the window with two in-place Mul calls.
 	winRe, winIm []float64
 }
 
@@ -243,32 +250,45 @@ func (p *STFTPlan) fftHalf() {
 	}
 }
 
-// prepareWindow splits window (nil for rectangular, else length >= nfft) into its
-// even and odd samples, winRe and winIm, so the interior-frame pack can apply it
-// with two vector multiplies on the packed halves instead of a scalar
-// multiply-and-deinterleave per sample. It runs once per STFT call, since the
-// window is fixed across the call's frames, and is not needed for a nil window.
-func (p *STFTPlan) prepareWindow(window []float64) {
-	if window == nil {
-		return
-	}
-	Deinterleave2(p.winRe, p.winIm, window[:p.nfft])
+// stftWindow is one call's analysis window in the form the frame pack consumes:
+// the even window samples w[2j] in re and the odd samples w[2j+1] in im, both
+// plan scratch filled by prepareWindow, or the zero value (nil halves) for a
+// rectangular window. Only prepareWindow produces a windowed value, so a pack
+// cannot apply a window the call did not split; a new entry point that forgets
+// to prepare gets a rectangular pack, not zeros or a previous call's window.
+type stftWindow struct {
+	re, im []float64
 }
 
-// packFrame loads frame f (signal[base : base+nfft]) into the scratch as half
+// prepareWindow normalizes and splits the caller's window for one public call:
+// nil, or a window shorter than nfft, means rectangular (the lenient public-API
+// treatment rather than a panic); otherwise the first nfft samples are split
+// into their even and odd halves, winRe and winIm, so the interior-frame pack
+// can apply the window with two vector multiplies on the packed halves instead
+// of a scalar multiply-and-deinterleave per sample. It runs once per public call
+// (STFT, STFTPower, STFTPowerInto), since the window is fixed across the call's
+// frames, and returns the stftWindow every frame of that call packs with.
+func (p *STFTPlan) prepareWindow(window []float64) stftWindow {
+	if len(window) < p.nfft {
+		return stftWindow{}
+	}
+	Deinterleave2(p.winRe, p.winIm, window[:p.nfft])
+	return stftWindow{re: p.winRe, im: p.winIm}
+}
+
+// packFrame loads the frame at signal[base : base+nfft] into the scratch as half
 // complex samples c[j] = x[2j] + i*x[2j+1]: a vector deinterleave of the frame,
-// then, when windowed, an in-place vector multiply of each half by the window
-// half prepareWindow split out (the same single-rounded products as a scalar
-// x[n]*w[n] pack). window may be nil (rectangular). The caller guarantees the
-// frame fits and that prepareWindow has run for this window.
-func (p *STFTPlan) packFrame(signal, window []float64, base int) {
+// then, when windowed, an in-place vector multiply of each half by the matching
+// window half (the same single-rounded products as a scalar x[n]*w[n] pack). The
+// caller guarantees the frame fits.
+func (p *STFTPlan) packFrame(signal []float64, w stftWindow, base int) {
 	re, im := p.re, p.im
 	Deinterleave2(re, im, signal[base:base+p.nfft])
-	if window == nil {
+	if w.re == nil {
 		return
 	}
-	Mul(re, re, p.winRe)
-	Mul(im, im, p.winIm)
+	Mul(re, re, w.re)
+	Mul(im, im, w.im)
 }
 
 // NumFrames reports how many frames a call with the given signal length, hop,
@@ -331,20 +351,21 @@ func sampleAt(signal []float64, idx int, pad PadMode) float64 {
 // may be negative for centered frames) into the scratch, applying the window and
 // pad mode. A frame fully inside the signal uses the fast packFrame path; only
 // edge frames pay for the bounds-aware sampleAt reads, so the common interior
-// frame is unaffected.
-func (p *STFTPlan) packFrameAt(signal, window []float64, base int, pad PadMode) {
+// frame is unaffected. The edge path reads the same split window halves, so
+// w[2j] and w[2j+1] multiply each sample exactly as the vector path does.
+func (p *STFTPlan) packFrameAt(signal []float64, w stftWindow, base int, pad PadMode) {
 	if base >= 0 && base+p.nfft <= len(signal) {
-		p.packFrame(signal, window, base)
+		p.packFrame(signal, w, base)
 		return
 	}
 	re, im := p.re, p.im
 	for j := range p.half {
 		s0 := sampleAt(signal, base+2*j, pad)
 		s1 := sampleAt(signal, base+2*j+1, pad)
-		if window == nil {
+		if w.re == nil {
 			re[j], im[j] = s0, s1
 		} else {
-			re[j], im[j] = s0*window[2*j], s1*window[2*j+1]
+			re[j], im[j] = s0*w.re[j], s1*w.im[j]
 		}
 	}
 }
@@ -381,8 +402,10 @@ func (p *STFTPlan) unravelBin(k int) (re, im float64) {
 // the vector path: RealFFTUnpack computes X[1..half-1] into the plan's split
 // scratch in one SIMD pass (its twiddle W[k] at index k-1 is exactly unRe/unIm
 // shifted by one, since W_N^k = exp(-i*pi*k/half)), and DC and Nyquist, both
-// real, come straight from C[0]. A shorter row keeps the per-bin scalar unravel,
-// since the vector kernel writes every interior bin.
+// real, come straight from C[0]. A shorter row keeps the per-bin scalar unravel:
+// it writes only the bins asked for, where the vector kernel would compute every
+// interior bin, and it keeps the two unravels on the same split as
+// unravelPowerRow, whose in-place kernel needs the full row.
 func (p *STFTPlan) unravelRow(row []complex128) {
 	half := p.half
 	if len(row) <= half {
@@ -392,12 +415,26 @@ func (p *STFTPlan) unravelRow(row []complex128) {
 		}
 		return
 	}
+	// Reslice row and the scratch to their exact extents before the first store
+	// so the compiler drops the bounds checks from the DC and Nyquist stores.
 	row = row[:half+1]
-	RealFFTUnpack(p.outRe, p.outIm, p.re, p.im, p.unRe[1:], p.unIm[1:])
+	outRe, outIm := p.outRe[:half], p.outIm[:half]
+	RealFFTUnpack(outRe, outIm, p.re, p.im, p.unRe[1:], p.unIm[1:])
 	c0r, c0i := p.re[0], p.im[0]
 	row[0] = complex(c0r+c0i, 0)
-	outRe, outIm := p.outRe[:half], p.outIm[:half]
-	for k := 1; k < half; k++ {
+	// Two bins per iteration, for placement robustness rather than fewer
+	// instructions: the plain one-bin loop is so short that its speed swings
+	// with where the linker lands it relative to a cache line (measured on the
+	// f32 twin: the same code ran 191 and 206 us per STFT at nfft 1024 in two
+	// builds), while the unrolled form stays within 2% of the best placement
+	// wherever it lands. The step-2 index keeps its bounds checks; they cost less
+	// than the placement swing.
+	k := 1
+	for ; k+1 < half; k += 2 {
+		row[k] = complex(outRe[k], outIm[k])
+		row[k+1] = complex(outRe[k+1], outIm[k+1])
+	}
+	if k < half {
 		row[k] = complex(outRe[k], outIm[k])
 	}
 	row[half] = complex(c0r-c0i, 0)
@@ -407,7 +444,8 @@ func (p *STFTPlan) unravelRow(row []complex128) {
 // |X[k]|^2 for k in [0, half] into row. A full-width row takes RealFFTPower,
 // which fuses the unpack and the magnitude-squared into one SIMD pass over the
 // interior bins and writes them in place; DC and Nyquist are squared directly.
-// A shorter row keeps the per-bin scalar unravel.
+// A shorter row keeps the per-bin scalar unravel, since RealFFTPower writes all
+// of row[1:half] in place and so needs the full-width row.
 func (p *STFTPlan) unravelPowerRow(row []float64) {
 	half := p.half
 	if len(row) <= half {
@@ -417,7 +455,7 @@ func (p *STFTPlan) unravelPowerRow(row []float64) {
 		}
 		return
 	}
-	row = row[:half+1]
+	row = row[:half+1] // exact extent, so the DC/Nyquist stores need no bounds checks
 	RealFFTPower(row[:half], p.re, p.im, p.unRe[1:], p.unIm[1:])
 	c0r, c0i := p.re[0], p.im[0]
 	dc := c0r + c0i
@@ -428,33 +466,37 @@ func (p *STFTPlan) unravelPowerRow(row []float64) {
 
 // STFT computes the real-input STFT of signal and writes one Hermitian
 // half-spectrum (NumBins complex128 values) per frame into dst. window, when
-// non-nil, must have length nfft. The pad argument selects the framing
-// convention: NoPad applies no padding (frame f is signal[f*hop : f*hop+nfft],
-// matching librosa stft(..., center=False)); PadZero and PadReflect center each
-// frame with nfft/2 of zero or reflect padding per side, matching librosa
-// center=True. See PadMode and NumFrames.
+// non-nil, should have length nfft: a shorter window is treated as rectangular
+// and only the first nfft samples of a longer one are used. The pad argument
+// selects the framing convention: NoPad applies no padding (frame f is
+// signal[f*hop : f*hop+nfft], matching librosa stft(..., center=False)); PadZero
+// and PadReflect center each frame with nfft/2 of zero or reflect padding per
+// side, matching librosa center=True. See PadMode and NumFrames.
 //
 // It writes min(len(dst), NumFrames) frames and, per frame, min(len(dst[f]),
 // NumBins) bins, and returns the number of frames written. It is allocation-free
-// and reuses the plan scratch.
+// and reuses the plan scratch. dst rows must not overlap signal (the window is
+// consumed into plan scratch before the first write).
+//
+// The output is tolerance-stable, not bit-stable: a full-width row is unravelled
+// by the vector RealFFTUnpack path and a shorter row by the scalar per-bin path,
+// the FFT core takes different vector paths per CPU tier, and any of these may
+// round the last bits differently across library versions, build targets and
+// row lengths. Compare STFT output to a tolerance, never bit for bit. The DC and
+// Nyquist bins are exactly real.
 func (p *STFTPlan) STFT(dst [][]complex128, signal, window []float64, hop int, pad PadMode) int {
 	frames := min(p.NumFrames(len(signal), hop, pad), len(dst))
 	if frames == 0 {
 		return 0
 	}
-	if window != nil && len(window) < p.nfft {
-		// Treat a short window as rectangular rather than panicking, matching the
-		// library's lenient public-API style.
-		window = nil
-	}
-	p.prepareWindow(window)
+	w := p.prepareWindow(window) // nil or short window: rectangular
 	off := 0
 	if pad != NoPad {
 		off = p.half // center: first sample of frame f is at f*hop - nfft/2
 	}
 	bins := p.NumBins()
 	for f := range frames {
-		p.packFrameAt(signal, window, f*hop-off, pad)
+		p.packFrameAt(signal, w, f*hop-off, pad)
 		p.fftHalf()
 		row := dst[f]
 		p.unravelRow(row[:min(len(row), bins)])
@@ -464,24 +506,22 @@ func (p *STFTPlan) STFT(dst [][]complex128, signal, window []float64, hop int, p
 
 // STFTPower computes the real-input STFT power spectrum |X|^2 directly, skipping
 // materialization of the complex bins. dst, signal, window, hop, and pad follow
-// the same conventions as STFT. Returns the number of frames written.
-// Allocation-free.
+// the same conventions as STFT, including the tolerance-stable (not bit-stable)
+// output contract. Returns the number of frames written. Allocation-free. dst
+// rows must not overlap signal.
 func (p *STFTPlan) STFTPower(dst [][]float64, signal, window []float64, hop int, pad PadMode) int {
 	frames := min(p.NumFrames(len(signal), hop, pad), len(dst))
 	if frames == 0 {
 		return 0
 	}
-	if window != nil && len(window) < p.nfft {
-		window = nil
-	}
-	p.prepareWindow(window)
+	w := p.prepareWindow(window) // nil or short window: rectangular
 	off := 0
 	if pad != NoPad {
 		off = p.half
 	}
 	bins := p.NumBins()
 	for f := range frames {
-		p.packFrameAt(signal, window, f*hop-off, pad)
+		p.packFrameAt(signal, w, f*hop-off, pad)
 		p.fftHalf()
 		row := dst[f]
 		p.unravelPowerRow(row[:min(len(row), bins)])
@@ -495,7 +535,7 @@ func (p *STFTPlan) STFTPower(dst [][]float64, signal, window []float64, hop int,
 // to DotProductBatch for a mel-filterbank projection. signal, window, hop, and
 // pad follow the same conventions as STFTPower. It writes
 // min(NumFrames, len(dst)/NumBins) whole frames and returns that frame count.
-// Allocation-free.
+// Allocation-free. dst must not overlap signal.
 func (p *STFTPlan) STFTPowerInto(dst, signal, window []float64, hop int, pad PadMode) int {
 	bins := p.NumBins()
 	frames := p.NumFrames(len(signal), hop, pad)
@@ -505,16 +545,13 @@ func (p *STFTPlan) STFTPowerInto(dst, signal, window []float64, hop int, pad Pad
 	if frames == 0 {
 		return 0
 	}
-	if window != nil && len(window) < p.nfft {
-		window = nil
-	}
-	p.prepareWindow(window)
+	w := p.prepareWindow(window) // nil or short window: rectangular
 	off := 0
 	if pad != NoPad {
 		off = p.half
 	}
 	for f := range frames {
-		p.packFrameAt(signal, window, f*hop-off, pad)
+		p.packFrameAt(signal, w, f*hop-off, pad)
 		p.fftHalf()
 		// Each frame's stride is a full-width row, so it takes the vector unravel.
 		p.unravelPowerRow(dst[f*bins : (f+1)*bins])

--- a/f64/stft.go
+++ b/f64/stft.go
@@ -95,6 +95,16 @@ type STFTPlan struct {
 
 	// Per-transform scratch (the packed complex frame, FFT'd in place).
 	re, im []float64
+
+	// Unravel scratch for STFT: RealFFTUnpack writes the split-complex bins
+	// X[1..half-1] here before they are interleaved into the caller's complex128
+	// row. Length half; index 0 is unused (DC and Nyquist are computed directly).
+	outRe, outIm []float64
+
+	// Window halves for the vector pack: winRe holds the even window samples
+	// w[2j] and winIm the odd samples w[2j+1], split by prepareWindow once per
+	// call so packFrame can apply the window with two in-place Mul calls.
+	winRe, winIm []float64
 }
 
 // NumBins returns the number of output bins per frame, nfft/2 + 1 (the Hermitian
@@ -136,6 +146,10 @@ func NewSTFTPlan(nfft int) (*STFTPlan, error) {
 		unIm:        make([]float64, half+1),
 		re:          make([]float64, half),
 		im:          make([]float64, half),
+		outRe:       make([]float64, half),
+		outIm:       make([]float64, half),
+		winRe:       make([]float64, half),
+		winIm:       make([]float64, half),
 	}
 
 	// Bit-reversal permutation for a size-half FFT.
@@ -190,10 +204,12 @@ func NewSTFTPlan(nfft int) (*STFTPlan, error) {
 	return p, nil
 }
 
-// fftHalf runs an in-place size-half radix-2 decimation-in-time complex FFT on
-// the plan's scratch (p.re, p.im), using the resident bit-reversal and per-stage
-// twiddles. Each stage is one ButterflyComplexStage call, so the butterflies take
-// the AVX+FMA / NEON vector paths where the span and block count justify them.
+// fftHalf runs an in-place size-half decimation-in-time complex FFT on the plan's
+// scratch (p.re, p.im), using the resident bit-reversal and per-stage twiddles.
+// The core is radix-4: each ButterflyComplexStage4 call advances two radix-2
+// stages at once, with at most one trailing ButterflyComplexStage when half is
+// not a power of four, so the butterflies take the AVX+FMA / NEON vector paths
+// where the span and block count justify them.
 func (p *STFTPlan) fftHalf() {
 	re, im := p.re, p.im
 	// Bit-reversal reorder.
@@ -212,9 +228,9 @@ func (p *STFTPlan) fftHalf() {
 	// finishes the transform when half is not a power of four (odd log2(half)).
 	s := 1
 	for butterflyStage4Radix*s <= p.half {
-		o1 := s - 1                                 // span-s radix-2 table
-		o2 := butterflyStageRadix*s - 1             // span-2s radix-2 table, first s taken
-		o3 := (s - 1) / (butterflyStage4Radix - 1)  // dedicated w^(3j) table
+		o1 := s - 1                                // span-s radix-2 table
+		o2 := butterflyStageRadix*s - 1            // span-2s radix-2 table, first s taken
+		o3 := (s - 1) / (butterflyStage4Radix - 1) // dedicated w^(3j) table
 		ButterflyComplexStage4(re, im, s,
 			p.stageTwRe[o1:o1+s], p.stageTwIm[o1:o1+s],
 			p.stageTwRe[o2:o2+s], p.stageTwIm[o2:o2+s],
@@ -227,22 +243,32 @@ func (p *STFTPlan) fftHalf() {
 	}
 }
 
-// packFrame loads frame f (signal[f*hop : f*hop+nfft]) into the scratch as half
-// complex samples c[j] = x[2j] + i*x[2j+1], applying the window during the pack.
-// window may be nil (rectangular). The caller guarantees the frame fits.
-func (p *STFTPlan) packFrame(signal, window []float64, base int) {
-	re, im := p.re, p.im
+// prepareWindow splits window (nil for rectangular, else length >= nfft) into its
+// even and odd samples, winRe and winIm, so the interior-frame pack can apply it
+// with two vector multiplies on the packed halves instead of a scalar
+// multiply-and-deinterleave per sample. It runs once per STFT call, since the
+// window is fixed across the call's frames, and is not needed for a nil window.
+func (p *STFTPlan) prepareWindow(window []float64) {
 	if window == nil {
-		for j := range p.half {
-			re[j] = signal[base+2*j]
-			im[j] = signal[base+2*j+1]
-		}
 		return
 	}
-	for j := range p.half {
-		re[j] = signal[base+2*j] * window[2*j]
-		im[j] = signal[base+2*j+1] * window[2*j+1]
+	Deinterleave2(p.winRe, p.winIm, window[:p.nfft])
+}
+
+// packFrame loads frame f (signal[base : base+nfft]) into the scratch as half
+// complex samples c[j] = x[2j] + i*x[2j+1]: a vector deinterleave of the frame,
+// then, when windowed, an in-place vector multiply of each half by the window
+// half prepareWindow split out (the same single-rounded products as a scalar
+// x[n]*w[n] pack). window may be nil (rectangular). The caller guarantees the
+// frame fits and that prepareWindow has run for this window.
+func (p *STFTPlan) packFrame(signal, window []float64, base int) {
+	re, im := p.re, p.im
+	Deinterleave2(re, im, signal[base:base+p.nfft])
+	if window == nil {
+		return
 	}
+	Mul(re, re, p.winRe)
+	Mul(im, im, p.winIm)
 }
 
 // NumFrames reports how many frames a call with the given signal length, hop,
@@ -350,6 +376,56 @@ func (p *STFTPlan) unravelBin(k int) (re, im float64) {
 	return re, im
 }
 
+// unravelRow writes the real-input spectrum X[0..half] of the FFT'd frame in
+// p.re/p.im into row as complex128 bins. A full-width row (len >= NumBins) takes
+// the vector path: RealFFTUnpack computes X[1..half-1] into the plan's split
+// scratch in one SIMD pass (its twiddle W[k] at index k-1 is exactly unRe/unIm
+// shifted by one, since W_N^k = exp(-i*pi*k/half)), and DC and Nyquist, both
+// real, come straight from C[0]. A shorter row keeps the per-bin scalar unravel,
+// since the vector kernel writes every interior bin.
+func (p *STFTPlan) unravelRow(row []complex128) {
+	half := p.half
+	if len(row) <= half {
+		for k := range row {
+			xr, xi := p.unravelBin(k)
+			row[k] = complex(xr, xi)
+		}
+		return
+	}
+	row = row[:half+1]
+	RealFFTUnpack(p.outRe, p.outIm, p.re, p.im, p.unRe[1:], p.unIm[1:])
+	c0r, c0i := p.re[0], p.im[0]
+	row[0] = complex(c0r+c0i, 0)
+	outRe, outIm := p.outRe[:half], p.outIm[:half]
+	for k := 1; k < half; k++ {
+		row[k] = complex(outRe[k], outIm[k])
+	}
+	row[half] = complex(c0r-c0i, 0)
+}
+
+// unravelPowerRow is the power-spectrum counterpart of unravelRow: it writes
+// |X[k]|^2 for k in [0, half] into row. A full-width row takes RealFFTPower,
+// which fuses the unpack and the magnitude-squared into one SIMD pass over the
+// interior bins and writes them in place; DC and Nyquist are squared directly.
+// A shorter row keeps the per-bin scalar unravel.
+func (p *STFTPlan) unravelPowerRow(row []float64) {
+	half := p.half
+	if len(row) <= half {
+		for k := range row {
+			xr, xi := p.unravelBin(k)
+			row[k] = xr*xr + xi*xi
+		}
+		return
+	}
+	row = row[:half+1]
+	RealFFTPower(row[:half], p.re, p.im, p.unRe[1:], p.unIm[1:])
+	c0r, c0i := p.re[0], p.im[0]
+	dc := c0r + c0i
+	ny := c0r - c0i
+	row[0] = dc * dc
+	row[half] = ny * ny
+}
+
 // STFT computes the real-input STFT of signal and writes one Hermitian
 // half-spectrum (NumBins complex128 values) per frame into dst. window, when
 // non-nil, must have length nfft. The pad argument selects the framing
@@ -371,6 +447,7 @@ func (p *STFTPlan) STFT(dst [][]complex128, signal, window []float64, hop int, p
 		// library's lenient public-API style.
 		window = nil
 	}
+	p.prepareWindow(window)
 	off := 0
 	if pad != NoPad {
 		off = p.half // center: first sample of frame f is at f*hop - nfft/2
@@ -380,11 +457,7 @@ func (p *STFTPlan) STFT(dst [][]complex128, signal, window []float64, hop int, p
 		p.packFrameAt(signal, window, f*hop-off, pad)
 		p.fftHalf()
 		row := dst[f]
-		nb := min(len(row), bins)
-		for k := range nb {
-			xr, xi := p.unravelBin(k)
-			row[k] = complex(xr, xi)
-		}
+		p.unravelRow(row[:min(len(row), bins)])
 	}
 	return frames
 }
@@ -401,6 +474,7 @@ func (p *STFTPlan) STFTPower(dst [][]float64, signal, window []float64, hop int,
 	if window != nil && len(window) < p.nfft {
 		window = nil
 	}
+	p.prepareWindow(window)
 	off := 0
 	if pad != NoPad {
 		off = p.half
@@ -410,11 +484,7 @@ func (p *STFTPlan) STFTPower(dst [][]float64, signal, window []float64, hop int,
 		p.packFrameAt(signal, window, f*hop-off, pad)
 		p.fftHalf()
 		row := dst[f]
-		nb := min(len(row), bins)
-		for k := range nb {
-			xr, xi := p.unravelBin(k)
-			row[k] = xr*xr + xi*xi
-		}
+		p.unravelPowerRow(row[:min(len(row), bins)])
 	}
 	return frames
 }
@@ -438,6 +508,7 @@ func (p *STFTPlan) STFTPowerInto(dst, signal, window []float64, hop int, pad Pad
 	if window != nil && len(window) < p.nfft {
 		window = nil
 	}
+	p.prepareWindow(window)
 	off := 0
 	if pad != NoPad {
 		off = p.half
@@ -445,13 +516,8 @@ func (p *STFTPlan) STFTPowerInto(dst, signal, window []float64, hop int, pad Pad
 	for f := range frames {
 		p.packFrameAt(signal, window, f*hop-off, pad)
 		p.fftHalf()
-		// Slice the frame's stride out of dst so the compiler can prove the
-		// inner-loop writes are in bounds (consistent with STFTPower).
-		row := dst[f*bins : (f+1)*bins]
-		for k := range bins {
-			xr, xi := p.unravelBin(k)
-			row[k] = xr*xr + xi*xi
-		}
+		// Each frame's stride is a full-width row, so it takes the vector unravel.
+		p.unravelPowerRow(dst[f*bins : (f+1)*bins])
 	}
 	return frames
 }

--- a/f64/stft_test.go
+++ b/f64/stft_test.go
@@ -234,6 +234,49 @@ func TestSTFTClamps(t *testing.T) {
 	if n := plan.STFT(rows, signal, nil, hop, NoPad); n != 1 {
 		t.Errorf("partial-row frames = %d, want 1", n)
 	}
+
+	// Rows longer than NumBins: exactly NumBins bins written, the rest untouched,
+	// and the written bins identical to a NumBins-wide row (same path).
+	bins := plan.NumBins()
+	const sentinel = complex(-7, 7)
+	long := [][]complex128{make([]complex128, bins+3)}
+	for k := range long[0] {
+		long[0][k] = sentinel
+	}
+	exact := [][]complex128{make([]complex128, bins)}
+	if n := plan.STFT(long, signal, nil, hop, NoPad); n != 1 {
+		t.Errorf("long-row frames = %d, want 1", n)
+	}
+	plan.STFT(exact, signal, nil, hop, NoPad)
+	for k := range bins {
+		if long[0][k] != exact[0][k] {
+			t.Fatalf("long row bin %d = %v, want %v", k, long[0][k], exact[0][k])
+		}
+	}
+	for k := bins; k < len(long[0]); k++ {
+		if long[0][k] != sentinel {
+			t.Fatalf("long row bin %d beyond NumBins was written: %v", k, long[0][k])
+		}
+	}
+	longPow := [][]float64{make([]float64, bins+3)}
+	for k := range longPow[0] {
+		longPow[0][k] = -7
+	}
+	if n := plan.STFTPower(longPow, signal, nil, hop, NoPad); n != 1 {
+		t.Errorf("long-row power frames = %d, want 1", n)
+	}
+	exactPow := [][]float64{make([]float64, bins)}
+	plan.STFTPower(exactPow, signal, nil, hop, NoPad)
+	for k := range bins {
+		if longPow[0][k] != exactPow[0][k] {
+			t.Fatalf("long power row bin %d = %v, want %v", k, longPow[0][k], exactPow[0][k])
+		}
+	}
+	for k := bins; k < len(longPow[0]); k++ {
+		if longPow[0][k] != -7 {
+			t.Fatalf("long power row bin %d beyond NumBins was written: %v", k, longPow[0][k])
+		}
+	}
 }
 
 // TestSTFTShortRowsMatchFull pins the two unravel paths against each other: a
@@ -241,9 +284,13 @@ func TestSTFTClamps(t *testing.T) {
 // unravel, a shorter row keeps the per-bin scalar unravel. The bins a short row
 // does write must agree with the same bins of the full row, for STFT and
 // STFTPower, across row lengths on both sides of the split and across nfft sizes
-// that exercise the vector kernels' full blocks and scalar tails.
+// that exercise the vector kernels' full blocks and scalar tails. It also proves
+// the full-width row really took the vector path: the plan's unpack scratch is
+// poisoned with NaN before the call and the row's interior bins must be the
+// bits that scratch holds afterwards (only RealFFTUnpack writes it).
 func TestSTFTShortRowsMatchFull(t *testing.T) {
 	signal := testSignal(3000)
+	nan := math.NaN()
 	for _, nfft := range []int{2, 4, 16, 64, 512} {
 		plan, err := NewSTFTPlan(nfft)
 		if err != nil {
@@ -252,6 +299,7 @@ func TestSTFTShortRowsMatchFull(t *testing.T) {
 		window := hann(nfft)
 		hop := max(nfft/4, 1)
 		bins := plan.NumBins()
+		half := bins - 1
 		nf := plan.NumFrames(len(signal), hop, NoPad)
 
 		full := make([][]complex128, nf)
@@ -260,28 +308,52 @@ func TestSTFTShortRowsMatchFull(t *testing.T) {
 			full[f] = make([]complex128, bins)
 			fullPow[f] = make([]float64, bins)
 		}
+		for k := range plan.outRe {
+			plan.outRe[k], plan.outIm[k] = nan, nan
+		}
 		plan.STFT(full, signal, window, hop, NoPad)
+		// Positive control: the last full row's interior bins are exactly the
+		// unpack scratch the vector path wrote (NaN would mean it never ran).
+		for k := 1; k < half; k++ {
+			if got, wr, wi := full[nf-1][k], plan.outRe[k], plan.outIm[k]; math.IsNaN(wr) || math.IsNaN(wi) ||
+				math.Float64bits(real(got)) != math.Float64bits(wr) || math.Float64bits(imag(got)) != math.Float64bits(wi) {
+				t.Fatalf("nfft=%d bin=%d: full row %v is not the vector unpack scratch (%v,%v)", nfft, k, got, wr, wi)
+			}
+		}
+		// The rounding gap between the FMA vector unpack and the scalar unravel
+		// scales with the packed spectrum's magnitude, not with the bin being
+		// compared (a near-null bin is a cancellation of large terms), so the
+		// tolerance is relative to the row's largest bin; 1e-12 is ~1e4 ulps of
+		// float64 against a measured gap of a few ulps.
+		rowMax := 0.0
+		for k := range bins {
+			rowMax = max(rowMax, math.Hypot(real(full[nf-1][k]), imag(full[nf-1][k])))
+		}
+		tol := 1e-12 * (1 + rowMax)
+		closeTo := func(ctx string, got, want complex128) {
+			t.Helper()
+			if d := math.Hypot(real(got)-real(want), imag(got)-imag(want)); d > tol {
+				t.Fatalf("%s: got %v want %v (|diff|=%g tol=%g)", ctx, got, want, d, tol)
+			}
+		}
 		// The plan scratch still holds the last frame's half-size spectrum, so
 		// every bin of the last full row, DC and Nyquist included, can be checked
 		// against the scalar per-bin unravel the short-row path uses.
 		for k := range bins {
 			xr, xi := plan.unravelBin(k)
-			ctx := fmt.Sprintf("nfft=%d last frame bin=%d (vector vs scalar unravel)", nfft, k)
-			cmplxClose(t, ctx, full[nf-1][k], complex(xr, xi), math.Hypot(xr, xi))
+			closeTo(fmt.Sprintf("nfft=%d last frame bin=%d (vector vs scalar unravel)", nfft, k), full[nf-1][k], complex(xr, xi))
 		}
 		plan.STFTPower(fullPow, signal, window, hop, NoPad)
+		powTol := 1e-12 * (1 + rowMax*rowMax)
 		for k := range bins {
 			xr, xi := plan.unravelBin(k)
 			wp := xr*xr + xi*xi
-			if d := math.Abs(fullPow[nf-1][k] - wp); d > 1e-9*(1+wp) {
+			if d := math.Abs(fullPow[nf-1][k] - wp); d > powTol {
 				t.Fatalf("nfft=%d last frame bin=%d: vector power %v, scalar power %v", nfft, k, fullPow[nf-1][k], wp)
 			}
 		}
 
 		for _, rowLen := range []int{1, 2, bins / 2, bins - 1, bins} {
-			if rowLen < 1 || rowLen > bins {
-				continue
-			}
 			short := make([][]complex128, nf)
 			shortPow := make([][]float64, nf)
 			for f := range nf {
@@ -292,15 +364,10 @@ func TestSTFTShortRowsMatchFull(t *testing.T) {
 			plan.STFTPower(shortPow, signal, window, hop, NoPad)
 			for f := range nf {
 				for k := range rowLen {
-					// The vector and scalar unravels round differently in the last
-					// bits (FMA vs separate multiply-add), so compare to a relative
-					// tolerance scaled by the bin magnitude, not bit for bit.
 					ctx := fmt.Sprintf("nfft=%d rowLen=%d frame=%d bin=%d", nfft, rowLen, f, k)
-					want := full[f][k]
-					cmplxClose(t, ctx, short[f][k], want, math.Hypot(real(want), imag(want)))
-					wp := fullPow[f][k]
-					if d := math.Abs(shortPow[f][k] - wp); d > 1e-9*(1+wp) {
-						t.Fatalf("%s: short-row power %v, full-row power %v", ctx, shortPow[f][k], wp)
+					closeTo(ctx, short[f][k], full[f][k])
+					if d := math.Abs(shortPow[f][k] - fullPow[f][k]); d > powTol {
+						t.Fatalf("%s: short-row power %v, full-row power %v", ctx, shortPow[f][k], fullPow[f][k])
 					}
 				}
 			}
@@ -308,11 +375,15 @@ func TestSTFTShortRowsMatchFull(t *testing.T) {
 	}
 }
 
-// TestSTFTWindowReuse runs one plan through a sequence of calls with different
-// windows (Hann, rectangular, then a different window) and checks each call's
-// output is bit-identical to a fresh plan's. The plan splits the window into
-// per-call scratch for the vector pack, so a stale split would leak a previous
-// call's window into the next call's frames.
+// TestSTFTWindowReuse pins that every public call applies exactly the window it
+// was given: the plan splits the window into per-call scratch for the vector
+// pack, so a stale split would leak a previous call's window into the next. One
+// shared plan runs a sequence of calls that changes the window on EVERY call
+// (Hann to ramp directly, to and from rectangular, a window longer than nfft)
+// and rotates through STFT, STFTPowerInto and STFTPower, and each call is
+// compared bit for bit against a plan created for that one call only (a fresh
+// plan replaying the same sequence would carry the same stale split and hide
+// the defect). A window longer than nfft must behave as its first nfft samples.
 func TestSTFTWindowReuse(t *testing.T) {
 	const nfft = 64
 	signal := testSignal(2000)
@@ -322,32 +393,71 @@ func TestSTFTWindowReuse(t *testing.T) {
 	for i := range ramp {
 		ramp[i] = float64(i+1) / float64(nfft)
 	}
+	hannLong := append(append([]float64(nil), hannWin...), 9, 9, 9, 9, 9)
 	shared, _ := NewSTFTPlan(nfft)
 	nf := shared.NumFrames(len(signal), hop, PadReflect)
 	bins := shared.NumBins()
-	alloc := func() ([][]complex128, []float64) {
+	newSpec := func() [][]complex128 {
 		spec := make([][]complex128, nf)
 		for f := range spec {
 			spec[f] = make([]complex128, bins)
 		}
-		return spec, make([]float64, nf*bins)
+		return spec
 	}
-	for i, window := range [][]float64{hannWin, nil, ramp, nil, hannWin} {
+	newPow := func() [][]float64 {
+		pow := make([][]float64, nf)
+		for f := range pow {
+			pow[f] = make([]float64, bins)
+		}
+		return pow
+	}
+	windows := [][]float64{hannWin, ramp, hannWin, ramp, hannWin, ramp, nil, hannLong, ramp}
+	for i, window := range windows {
 		fresh, _ := NewSTFTPlan(nfft)
-		gotSpec, gotPow := alloc()
-		wantSpec, wantPow := alloc()
-		shared.STFT(gotSpec, signal, window, hop, PadReflect)
-		fresh.STFT(wantSpec, signal, window, hop, PadReflect)
-		shared.STFTPowerInto(gotPow, signal, window, hop, PadReflect)
-		fresh.STFTPowerInto(wantPow, signal, window, hop, PadReflect)
-		for f := range nf {
-			for k := range bins {
-				if gotSpec[f][k] != wantSpec[f][k] {
-					t.Fatalf("call %d frame %d bin %d: shared plan %v, fresh plan %v", i, f, k, gotSpec[f][k], wantSpec[f][k])
+		switch i % 3 {
+		case 0:
+			got, want := newSpec(), newSpec()
+			shared.STFT(got, signal, window, hop, PadReflect)
+			fresh.STFT(want, signal, window, hop, PadReflect)
+			for f := range nf {
+				for k := range bins {
+					if got[f][k] != want[f][k] {
+						t.Fatalf("call %d (STFT) frame %d bin %d: shared plan %v, fresh plan %v", i, f, k, got[f][k], want[f][k])
+					}
 				}
-				if gotPow[f*bins+k] != wantPow[f*bins+k] {
-					t.Fatalf("call %d frame %d bin %d: shared plan power %v, fresh plan %v", i, f, k, gotPow[f*bins+k], wantPow[f*bins+k])
+			}
+		case 1:
+			got, want := make([]float64, nf*bins), make([]float64, nf*bins)
+			shared.STFTPowerInto(got, signal, window, hop, PadReflect)
+			fresh.STFTPowerInto(want, signal, window, hop, PadReflect)
+			for j := range got {
+				if got[j] != want[j] {
+					t.Fatalf("call %d (STFTPowerInto) flat index %d: shared plan %v, fresh plan %v", i, j, got[j], want[j])
 				}
+			}
+		case 2:
+			got, want := newPow(), newPow()
+			shared.STFTPower(got, signal, window, hop, PadReflect)
+			fresh.STFTPower(want, signal, window, hop, PadReflect)
+			for f := range nf {
+				for k := range bins {
+					if got[f][k] != want[f][k] {
+						t.Fatalf("call %d (STFTPower) frame %d bin %d: shared plan %v, fresh plan %v", i, f, k, got[f][k], want[f][k])
+					}
+				}
+			}
+		}
+	}
+	// A window longer than nfft is its first nfft samples: bit-identical to Hann.
+	longPlan, _ := NewSTFTPlan(nfft)
+	hannPlan, _ := NewSTFTPlan(nfft)
+	got, want := newSpec(), newSpec()
+	longPlan.STFT(got, signal, hannLong, hop, PadReflect)
+	hannPlan.STFT(want, signal, hannWin, hop, PadReflect)
+	for f := range nf {
+		for k := range bins {
+			if got[f][k] != want[f][k] {
+				t.Fatalf("long window frame %d bin %d: %v, want Hann-prefix %v", f, k, got[f][k], want[f][k])
 			}
 		}
 	}
@@ -755,7 +865,7 @@ func TestSTFTLibrosaParity(t *testing.T) {
 				maxRel = rel
 			}
 		}
-		// librosa uses pocketfft and we use a radix-2 rfft, so the bins differ at
+		// librosa uses pocketfft and we use a radix-4 rfft, so the bins differ at
 		// the float64 algorithm-noise level (~5e-8 relative; squaring to power
 		// roughly doubles the amplitude error). A convention error (wrong
 		// centering, window, or normalization) would be orders of magnitude
@@ -822,8 +932,9 @@ func TestSTFTGuards(t *testing.T) {
 	}
 }
 
-// TestSTFTStageTwiddles pins the per-stage contiguous twiddle layout that lets
-// fftHalf drive each radix-2 stage through ButterflyComplexStage (issue #205).
+// TestSTFTStageTwiddles pins the per-stage contiguous twiddle layout fftHalf
+// slices for ButterflyComplexStage4 (tw1/tw2) and the trailing
+// ButterflyComplexStage (issues #205 and #243).
 // Stage m in {2,4,...,half} must hold span = m/2 factors W_m^j = exp(-i*2*pi*j/m)
 // at offset span-1, and the tables must total exactly half-1 entries.
 func TestSTFTStageTwiddles(t *testing.T) {
@@ -851,6 +962,49 @@ func TestSTFTStageTwiddles(t *testing.T) {
 					t.Errorf("nfft=%d m=%d j=%d: stageTwIm=%g want %g", nfft, m, j, p.stageTwIm[off+j], -s)
 				}
 			}
+		}
+	}
+}
+
+// TestSTFTStage4Tw3Twiddles pins the layout of the radix-4 core's third twiddle
+// table, the one fftHalf cannot slice from the radix-2 tables: the radix-4 stage
+// with span s in {1,4,16,...} (while 4*s <= half) keeps s factors
+// w^(3j) = (cos(2*pi*3j/(4s)), -sin(2*pi*3j/(4s))) at offset (s-1)/3, and the
+// table totals (4^stages - 1)/3 entries, zero when half < 4. A wrong offset,
+// length or power would fail here, localized, rather than only as a spectrum
+// mismatch downstream. Exact bits: NewSTFTPlan stores cos/-sin of this same
+// float64 sincos.
+func TestSTFTStage4Tw3Twiddles(t *testing.T) {
+	for _, nfft := range []int{2, 4, 8, 16, 32, 128, 256, 1024} {
+		p, err := NewSTFTPlan(nfft)
+		if err != nil {
+			t.Fatalf("nfft=%d: NewSTFTPlan: %v", nfft, err)
+		}
+		half := nfft >> 1
+		wantLen := 0
+		for s := 1; 4*s <= half; s *= 4 {
+			wantLen += s
+		}
+		if len(p.stage4Tw3Re) != wantLen || len(p.stage4Tw3Im) != wantLen {
+			t.Fatalf("nfft=%d: stage4Tw3 table len = (%d,%d), want %d",
+				nfft, len(p.stage4Tw3Re), len(p.stage4Tw3Im), wantLen)
+		}
+		off := 0
+		for s := 1; 4*s <= half; s *= 4 {
+			if off != (s-1)/3 {
+				t.Fatalf("nfft=%d s=%d: running offset %d, want (s-1)/3 = %d", nfft, s, off, (s-1)/3)
+			}
+			for j := range s {
+				ang := 2 * math.Pi * float64(3*j) / float64(4*s)
+				sin, cos := math.Sincos(ang)
+				if math.Float64bits(p.stage4Tw3Re[off+j]) != math.Float64bits(cos) {
+					t.Errorf("nfft=%d s=%d j=%d: stage4Tw3Re=%g want %g", nfft, s, j, p.stage4Tw3Re[off+j], cos)
+				}
+				if math.Float64bits(p.stage4Tw3Im[off+j]) != math.Float64bits(-sin) {
+					t.Errorf("nfft=%d s=%d j=%d: stage4Tw3Im=%g want %g", nfft, s, j, p.stage4Tw3Im[off+j], -sin)
+				}
+			}
+			off += s
 		}
 	}
 }

--- a/f64/stft_test.go
+++ b/f64/stft_test.go
@@ -236,6 +236,123 @@ func TestSTFTClamps(t *testing.T) {
 	}
 }
 
+// TestSTFTShortRowsMatchFull pins the two unravel paths against each other: a
+// full-width row (NumBins) takes the vector RealFFTUnpack / RealFFTPower
+// unravel, a shorter row keeps the per-bin scalar unravel. The bins a short row
+// does write must agree with the same bins of the full row, for STFT and
+// STFTPower, across row lengths on both sides of the split and across nfft sizes
+// that exercise the vector kernels' full blocks and scalar tails.
+func TestSTFTShortRowsMatchFull(t *testing.T) {
+	signal := testSignal(3000)
+	for _, nfft := range []int{2, 4, 16, 64, 512} {
+		plan, err := NewSTFTPlan(nfft)
+		if err != nil {
+			t.Fatal(err)
+		}
+		window := hann(nfft)
+		hop := max(nfft/4, 1)
+		bins := plan.NumBins()
+		nf := plan.NumFrames(len(signal), hop, NoPad)
+
+		full := make([][]complex128, nf)
+		fullPow := make([][]float64, nf)
+		for f := range nf {
+			full[f] = make([]complex128, bins)
+			fullPow[f] = make([]float64, bins)
+		}
+		plan.STFT(full, signal, window, hop, NoPad)
+		// The plan scratch still holds the last frame's half-size spectrum, so
+		// every bin of the last full row, DC and Nyquist included, can be checked
+		// against the scalar per-bin unravel the short-row path uses.
+		for k := range bins {
+			xr, xi := plan.unravelBin(k)
+			ctx := fmt.Sprintf("nfft=%d last frame bin=%d (vector vs scalar unravel)", nfft, k)
+			cmplxClose(t, ctx, full[nf-1][k], complex(xr, xi), math.Hypot(xr, xi))
+		}
+		plan.STFTPower(fullPow, signal, window, hop, NoPad)
+		for k := range bins {
+			xr, xi := plan.unravelBin(k)
+			wp := xr*xr + xi*xi
+			if d := math.Abs(fullPow[nf-1][k] - wp); d > 1e-9*(1+wp) {
+				t.Fatalf("nfft=%d last frame bin=%d: vector power %v, scalar power %v", nfft, k, fullPow[nf-1][k], wp)
+			}
+		}
+
+		for _, rowLen := range []int{1, 2, bins / 2, bins - 1, bins} {
+			if rowLen < 1 || rowLen > bins {
+				continue
+			}
+			short := make([][]complex128, nf)
+			shortPow := make([][]float64, nf)
+			for f := range nf {
+				short[f] = make([]complex128, rowLen)
+				shortPow[f] = make([]float64, rowLen)
+			}
+			plan.STFT(short, signal, window, hop, NoPad)
+			plan.STFTPower(shortPow, signal, window, hop, NoPad)
+			for f := range nf {
+				for k := range rowLen {
+					// The vector and scalar unravels round differently in the last
+					// bits (FMA vs separate multiply-add), so compare to a relative
+					// tolerance scaled by the bin magnitude, not bit for bit.
+					ctx := fmt.Sprintf("nfft=%d rowLen=%d frame=%d bin=%d", nfft, rowLen, f, k)
+					want := full[f][k]
+					cmplxClose(t, ctx, short[f][k], want, math.Hypot(real(want), imag(want)))
+					wp := fullPow[f][k]
+					if d := math.Abs(shortPow[f][k] - wp); d > 1e-9*(1+wp) {
+						t.Fatalf("%s: short-row power %v, full-row power %v", ctx, shortPow[f][k], wp)
+					}
+				}
+			}
+		}
+	}
+}
+
+// TestSTFTWindowReuse runs one plan through a sequence of calls with different
+// windows (Hann, rectangular, then a different window) and checks each call's
+// output is bit-identical to a fresh plan's. The plan splits the window into
+// per-call scratch for the vector pack, so a stale split would leak a previous
+// call's window into the next call's frames.
+func TestSTFTWindowReuse(t *testing.T) {
+	const nfft = 64
+	signal := testSignal(2000)
+	hop := 16
+	hannWin := hann(nfft)
+	ramp := make([]float64, nfft)
+	for i := range ramp {
+		ramp[i] = float64(i+1) / float64(nfft)
+	}
+	shared, _ := NewSTFTPlan(nfft)
+	nf := shared.NumFrames(len(signal), hop, PadReflect)
+	bins := shared.NumBins()
+	alloc := func() ([][]complex128, []float64) {
+		spec := make([][]complex128, nf)
+		for f := range spec {
+			spec[f] = make([]complex128, bins)
+		}
+		return spec, make([]float64, nf*bins)
+	}
+	for i, window := range [][]float64{hannWin, nil, ramp, nil, hannWin} {
+		fresh, _ := NewSTFTPlan(nfft)
+		gotSpec, gotPow := alloc()
+		wantSpec, wantPow := alloc()
+		shared.STFT(gotSpec, signal, window, hop, PadReflect)
+		fresh.STFT(wantSpec, signal, window, hop, PadReflect)
+		shared.STFTPowerInto(gotPow, signal, window, hop, PadReflect)
+		fresh.STFTPowerInto(wantPow, signal, window, hop, PadReflect)
+		for f := range nf {
+			for k := range bins {
+				if gotSpec[f][k] != wantSpec[f][k] {
+					t.Fatalf("call %d frame %d bin %d: shared plan %v, fresh plan %v", i, f, k, gotSpec[f][k], wantSpec[f][k])
+				}
+				if gotPow[f*bins+k] != wantPow[f*bins+k] {
+					t.Fatalf("call %d frame %d bin %d: shared plan power %v, fresh plan %v", i, f, k, gotPow[f*bins+k], wantPow[f*bins+k])
+				}
+			}
+		}
+	}
+}
+
 func TestSTFTAllocFree(t *testing.T) {
 	plan, _ := NewSTFTPlan(512)
 	signal := testSignal(8192)

--- a/f64/stft_test.go
+++ b/f64/stft_test.go
@@ -505,6 +505,21 @@ func TestSTFTAllocFree(t *testing.T) {
 	if a := testing.AllocsPerRun(5, func() { plan.STFT(cspec, signal, window, hop, PadReflect) }); a != 0 {
 		t.Errorf("centered STFT allocated %v times per run, want 0", a)
 	}
+
+	// Rows shorter than NumBins take the scalar unravel branch, which must also be
+	// allocation-free.
+	sspec := make([][]complex128, nf)
+	spow := make([][]float64, nf)
+	for f := range sspec {
+		sspec[f] = make([]complex128, 3)
+		spow[f] = make([]float64, 3)
+	}
+	if a := testing.AllocsPerRun(5, func() { plan.STFT(sspec, signal, window, hop, NoPad) }); a != 0 {
+		t.Errorf("short-row STFT allocated %v times per run, want 0", a)
+	}
+	if a := testing.AllocsPerRun(5, func() { plan.STFTPower(spow, signal, window, hop, NoPad) }); a != 0 {
+		t.Errorf("short-row STFTPower allocated %v times per run, want 0", a)
+	}
 }
 
 // FuzzSTFT is a differential fuzz target: every STFT bin must match a direct DFT


### PR DESCRIPTION
## Summary

Ports the radix-4 `ButterflyComplexStage4` core into the `f32` `STFTPlan` (mirroring the `f64` change in #243), then folds in two further changes to the same frame pipeline in both `f32` and `f64`, because a profile showed the radix-4 core alone is only a small win: at nfft 1024 the butterflies were ~11% of the `f32` STFT while the scalar `unravelBin` loop was 45% and the scalar `packFrame` 21%.

The unravel now goes through the library's existing SIMD primitives: `RealFFTUnpack` for `STFT` (into plan scratch, then interleaved into the caller's complex row) and `RealFFTPower` for `STFTPower`/`STFTPowerInto` (written in place), with DC and Nyquist computed directly from C[0]; rows shorter than `NumBins` keep the per-bin scalar unravel. The interior-frame pack is a `Deinterleave2` of the frame plus, when windowed, two in-place `Mul` calls against the window halves that `prepareWindow` splits once per call; padded edge frames keep the bounds-aware scalar path.

The window split is threaded as an explicit `stftWindow` value that the pack functions require, so an entry point cannot pack a windowed frame it never split (a hazard the review caught: a fresh plan would otherwise pack zeros, a later call a stale window). The DC and Nyquist bins are now exactly real, and the output is tolerance-stable rather than bit-stable across CPU tiers and library versions (it already was tier-dependent since #205); the STFT docs, README and doc.go are updated to match, and the stale "radix-2 rfft via ButterflyComplexStage" prose is corrected.

Measured speedup over v1.8.0 (GOMAXPROCS=1, pinned, allocation-free throughout):

| arch | STFT | STFTPower |
| --- | --- | --- |
| amd64 f32 (i7-1260P) | 2.45x | 2.95x |
| amd64 f64 (i7-1260P) | 1.78x | 2.08x |
| arm64 f32 (Pi 5, NEON) | 1.92x | 2.11x |
| arm64 f64 (Pi 5, NEON) | 1.44x | 1.52x |

New tests pin the radix-4 `stage4Tw3` twiddle table layout bit for bit (the `f64` side had no such pin since #243), verify the vector and scalar unravels agree for every bin including DC and Nyquist and across row lengths (with a NaN-poison control proving the vector path actually ran), check plan reuse across different and longer-than-nfft windows against fresh plans, and cover rows longer than `NumBins`. Every new assertion was mutation-checked.

## Related Issues

Fixes #257

## Test Plan

- [x] `go test ./f32/ ./f64/` on amd64 (native AVX2+FMA)
- [x] `SIMD_DISABLE=avx2`, `SIMD_DISABLE=avx`, `SIMD_DISABLE=all` (SSE and pure-Go tiers)
- [x] `go test -race ./f32/ ./f64/`
- [x] Full `f32` and `f64` suites on a native Raspberry Pi 5 (NEON and Go fallback)
- [x] `gofmt`, `go vet`, `golangci-lint run ./...` (0 issues)
- [x] Cross-compile `linux/arm64`, `linux/riscv64`, `js/wasm`, `windows/amd64`, `darwin/arm64`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Performance**
  * Improved STFT and power-spectrum processing with vectorized FFT operations.
  * Added radix-4 FFT support with optional radix-2 processing for broader input sizes.
  * Optimized full-width output rows while preserving short-row compatibility.

* **Bug Fixes**
  * Improved consistency across output formats, window sizes, and repeated window reuse.
  * Clarified tolerance-based output stability across supported CPU configurations.

* **Documentation**
  * Updated FFT and STFT documentation to describe radix-4 and vectorized processing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->