### PR TITLE
i32: VEX VMOVD gainQ31AVX2 shift loads, fuse SumSqShiftedQ31 reductions (Fixes #268, #269)

### DIFF
--- a/i32/gain_amd64_test.go
+++ b/i32/gain_amd64_test.go
@@ -92,29 +92,28 @@ func TestGainQ31Dispatch_ReachesSIMD(t *testing.T) {
 	if hasAVX2 != cpu.X86.AVX2 {
 		t.Fatalf("hasAVX2 = %v but cpu.X86.AVX2 = %v: dispatch flag is not wired to CPU detection", hasAVX2, cpu.X86.AVX2)
 	}
-	// minAVX2GainQ31 is the measured SIMD/scalar crossover (#251), far above the one
-	// or two blocks the scale kernels use, because the AVX2 GainQ31 path carries a
-	// large fixed per-call cost that makes SIMD lose below ~160. Guard only that it
-	// stays in a sane range: high enough to skip that small-n region, low enough that
-	// realistic buffers (a few hundred samples and up, e.g. nfft 256/512/1024) still
-	// vectorize.
-	if minAVX2GainQ31 < 8 || minAVX2GainQ31 > 512 {
-		t.Fatalf("minAVX2GainQ31 = %d outside the sane [8, 512] range; see #251 for the ~160 crossover", minAVX2GainQ31)
+	// minAVX2GainQ31 is the measured SIMD/scalar crossover. Since #268 the AVX2 kernel
+	// has no fixed per-call cost and beats gainQ31Go from the first 8-wide block, so the
+	// cut is one block. Guard that the const stays within two blocks: a re-tune back to
+	// the old ~160 cut would leave realistic short bands on the slower Go path, and is
+	// caught here.
+	if minAVX2GainQ31 > 16 {
+		t.Fatalf("minAVX2GainQ31 = %d exceeds two vector blocks: since #268 the kernel wins from the first block, so this should be one block (8)", minAVX2GainQ31)
 	}
 }
 
 // BenchmarkGainQ31CrossoverAVX2 sweeps the AVX2 kernel directly against the Go
 // reference across the SIMD/scalar crossover region so minAVX2GainQ31 (#251) can be
 // re-tuned on other hardware. It benchmarks the kernel directly rather than the
-// dispatched GainQ31, so the threshold under test does not gate the measurement. On
-// the amd64 parts this was tuned against, the kernel's large fixed per-call cost
-// (~80-90 ns, absent on arm64 NEON) puts the crossover near n=160: gainQ31Go wins
-// below it, the two are at parity near 160, and the kernel pulls ahead above ~176.
+// dispatched GainQ31, so the threshold under test does not gate the measurement.
+// Since #268 the kernel has no fixed per-call cost and beats gainQ31Go from the first
+// 8-wide block (n=8), so the crossover is one block; before #268 a ~80-90 ns AVX-SSE
+// transition assist put it near n=160.
 func BenchmarkGainQ31CrossoverAVX2(b *testing.B) {
 	if !cpu.X86.AVX2 {
 		b.Skip("AVX2 not available")
 	}
-	for _, n := range []int{64, 128, 160, 192, 256, 512} {
+	for _, n := range []int{8, 16, 32, 64, 128, 160, 256, 512} {
 		b.Run(fmt.Sprintf("AVX2_n%d", n), func(b *testing.B) { benchmarkGainQ31(b, n, gainQ31AVX2) })
 		b.Run(fmt.Sprintf("Go_n%d", n), func(b *testing.B) { benchmarkGainQ31(b, n, gainQ31Go) })
 	}

--- a/i32/gain_arm64_test.go
+++ b/i32/gain_arm64_test.go
@@ -99,9 +99,8 @@ func TestGainQ31Dispatch_ReachesNEON(t *testing.T) {
 
 // BenchmarkGainQ31CrossoverNEON sweeps the NEON kernel directly against the Go
 // reference across small n so minNEONGainQ31 (#251) can be re-tuned on other
-// hardware. Unlike the amd64 AVX2 path, the NEON kernel has no large fixed per-call
-// cost, so it beats gainQ31Go from the smallest sizes and the threshold stays at one
-// block (4).
+// hardware. The NEON kernel has no large fixed per-call cost, so it beats gainQ31Go
+// from the smallest sizes and the threshold stays at one block (4).
 func BenchmarkGainQ31CrossoverNEON(b *testing.B) {
 	if !cpu.ARM64.NEON {
 		b.Skip("NEON not available")

--- a/i32/i32_amd64.go
+++ b/i32/i32_amd64.go
@@ -147,26 +147,24 @@ func scaleQ31AVX2(dst, a []int32, k int32)
 //go:noescape
 func scaleQ15AVX2(dst, a []int32, k int16)
 
-// minAVX2GainQ31 gates the AVX2 GainQ31 kernel on total length. The kernel is
-// correct at any length (it falls through to a scalar tail), so this is a
-// performance cut only, never a safety requirement. It gates on AVX2 because the
-// VPMULDQ Q31 core plus the VPSLLD/VPADDD/VPSRAD pre- and post-shift stages are
-// all 256-bit integer ops.
+// minAVX2GainQ31 is one 8-wide (256-bit) block. The kernel is correct at any length
+// (it falls through to a scalar tail), so this is a performance cut only, never a
+// safety requirement. It gates on AVX2 because the VPMULDQ Q31 core plus the
+// VPSLLD/VPADDD/VPSRAD pre- and post-shift stages are all 256-bit integer ops.
 //
-// Unlike ScaleQ31 (whose single-broadcast prologue lets it win from one block),
-// the AVX2 GainQ31 path carries a large fixed per-call cost that dwarfs its
-// per-element work at small n: MEASURED as ~80-90 ns flat across n = 8..128 on two
-// amd64 hosts (an i7-class and a Xeon-class part), while gainQ31Go scales linearly
-// from ~6 ns (n=8). The kernel's own per-element work is cheap (~0.2 ns/elem vs Go's
-// ~0.75), so the crossover is set entirely by that fixed cost: gainQ31Go is faster
-// through n=144, the two are at parity near n=160, and the kernel pulls ahead from
-// n=176 (reaching ~2x by n=320). The arm64 NEON path shows no such fixed cost and
-// stays at minNEONGainQ31 = 4; the amd64-only gap is consistent with the 256-bit
-// AVX transition/warmup penalty each call pays after its closing VZEROUPPER (a
-// caller that keeps the upper YMM state warm would cross lower, so 160 is the
-// conservative crossover for a kernel invoked from scalar Go). See #251; the #250
-// masking speedup to gainQ31Go pushed the crossover out further still.
-const minAVX2GainQ31 = 160
+// This sat at 160 until #268. The kernel loaded its two runtime shift counts into XMM
+// with legacy MOVQ after the VEX gain broadcast had already dirtied the upper YMM
+// state, so every call paid two AVX-SSE transition assists, MEASURED as ~80-90 ns flat
+// across n = 8..128 (the earlier note blaming a post-VZEROUPPER warmup was wrong: every
+// AVX2 kernel here ends in VZEROUPPER and only this one carried the cost). Loading the
+// counts with VEX VMOVD instead (#268) removes both assists, and the kernel now wins
+// from the first 8-wide block like sumSqShiftedQ31AVX2. MEASURED on the i7-1260P (AVX2,
+// taskset P-core, 20 process rounds, benchstat medians): the AVX2 kernel beats
+// gainQ31Go at every size from n=8 up (n=8: 3.5 vs 6.4 ns, 1.8x; n=16: 4.0 vs 11.3;
+// n=64: 8.4 vs 46.6, 5.6x; direct before/after: n=64 fell from 98.9 to 8.4 ns), so the
+// cut drops to one block, like the scale kernels and minAVX2SumSqShiftedQ31 = 8. The
+// arm64 NEON path stays at minNEONGainQ31 = 4. See #268 and #251.
+const minAVX2GainQ31 = 8
 
 func gainQ31I32(dst, a []int32, gain int32, preShift, postShift int) {
 	if hasAVX2 && len(dst) >= minAVX2GainQ31 {
@@ -233,18 +231,14 @@ func maxAbsAVX2(a []int32) int32
 // only, never a safety requirement. It gates on AVX2 because the VPSLLD pre-shift,
 // the VPMULDQ Q31 square and the VPADDD accumulate are all 256-bit integer ops.
 //
-// Unlike GainQ31 (whose AVX2 kernel pays a large fixed per-call cost and sits at
-// 160), this kernel is MEASURED to win from the first 8-wide block, so the cut stays
-// at one block, matching Sum and MaxAbs. On the amd64 A/B host (i7-1260P, AVX2,
-// taskset P-core) it beats sumSqShiftedQ31Go at every size from n=8 up (n=8: 2.4 vs
-// 4.3 ns, 1.8x; n=16: 2.8 vs 7.7; n=64: 6.8 vs 34.6, 5x), with the Go side scaling
-// ~4x steeper, so there is no small-n regime where SIMD loses. One verified
-// structural difference from gainQ31AVX2 is that this kernel loads its single shift
-// count with VEX VMOVD before any YMM op, rather than a legacy MOVQ-to-XMM issued
-// after a VEX broadcast; keeping that count load off the legacy-SSE path avoids an
-// AVX-SSE assist and is the likely reason it shows no fixed per-call cost (the exact
-// source of gainQ31's cost was not isolated here). The arm64 NEON path likewise
-// stays at minNEONSumSqShiftedQ31 = 4.
+// This kernel is MEASURED to win from the first 8-wide block, so the cut stays at one
+// block, matching Sum and MaxAbs. On the amd64 A/B host (i7-1260P, AVX2, taskset
+// P-core) it beats sumSqShiftedQ31Go at every size from n=8 up (n=8: 2.4 vs 4.3 ns,
+// 1.8x; n=16: 2.8 vs 7.7; n=64: 6.8 vs 34.6, 5x), with the Go side scaling ~4x
+// steeper, so there is no small-n regime where SIMD loses. Like gainQ31AVX2 since
+// #268, it loads its runtime shift count with VEX VMOVD (not legacy MOVQ), so it pays
+// no AVX-SSE transition assist and has no fixed per-call cost. The arm64 NEON path
+// likewise stays at minNEONSumSqShiftedQ31 = 4.
 const minAVX2SumSqShiftedQ31 = 8
 
 func sumSqShiftedQ31I32(a []int32, shift int) int32 {

--- a/i32/i32_amd64.s
+++ b/i32/i32_amd64.s
@@ -577,7 +577,9 @@ scaleq15_avx2_done:
 // MOVLQSX (sign-extend AFTER the wrapping shift), IMULQ, SARQ $31, ADDL bias,
 // SARL to close out lengths that are not a multiple of 8. Registers: DX/SI/DI the
 // slices, BX=int64(gain), R8=preShift, R9=postShift, R10=bias, CX stages the CL
-// shift counts, Y3=gain, Y5=bias, X6/X7 the vector shift counts; no R14/R15/BP.
+// shift counts, Y3=gain, Y5=bias, X6/X7 the vector shift counts (loaded by VEX VMOVD,
+// not legacy MOVQ, so the upper YMM state the gain broadcast dirtied costs no AVX-SSE
+// transition assist, see #268); no R14/R15/BP.
 // preShift and postShift must be in [0, 31]. Frame: dst+0, a+24, gain+48, preShift+56,
 // postShift+64.
 TEXT ·gainQ31AVX2(SB), NOSPLIT, $0-72
@@ -594,8 +596,12 @@ TEXT ·gainQ31AVX2(SB), NOSPLIT, $0-72
 
     VMOVD   BX, X3
     VPBROADCASTD X3, Y3              // gain in all 8 int32 lanes
-    MOVQ    R8, X6                   // preShift count (VPSLLD, low 64 bits)
-    MOVQ    R9, X7                   // postShift count (VPSRAD, low 64 bits)
+    VMOVD   R8, X6                   // preShift count for VPSLLD (reads the low 64 bits). VEX
+                                     // VMOVD, not legacy MOVQ, so the upper YMM state the
+                                     // VPBROADCASTD above dirtied costs no AVX-SSE transition
+                                     // assist (#268). VMOVD zero-extends the 32-bit count, so
+                                     // the low 64 is identical to MOVQ for shifts in [0,31].
+    VMOVD   R9, X7                   // postShift count for VPSRAD (same VEX rationale)
     VMOVD   R10, X5
     VPBROADCASTD X5, Y5              // bias in all 8 int32 lanes
 
@@ -783,9 +789,12 @@ maxabs_ret_max:
 // even-lane squares x0,x2,x4,x6 as int64, VPSRLQ $32 slides the already-shifted odd
 // lanes down for a second VPMULDQ, each product is shifted right 31 (VPSRLQ $31 --
 // the square is non-negative so bit 63 is clear and the logical shift equals the
-// arithmetic one, low 32 = the MULT32_32_Q31 term), and VPSLLQ $32 + VPBLENDD $0xAA
-// reassemble the eight int32 terms. VPADDD accumulates them into an 8-lane int32
-// accumulator (wrapping). After the loop the accumulator folds to a single int32
+// arithmetic one, low 32 = the MULT32_32_Q31 term). Because this is a reduction the
+// terms are never reassembled into lane order: each >>31 result is <= 2^31 so the odd
+// int32 half of every int64 lane is zero, and two VPADDD (32-bit lanes, deliberately not
+// VPADDQ, so no carry crosses into those zero halves) accumulate the even (Y4) and odd
+// (Y5) term vectors straight into the 8-lane int32 accumulator (wrapping); lanes 1,3,5,7
+// stay zero. After the loop the accumulator folds to a single int32
 // exactly like sumAVX2 (VEXTRACTI128 + VPADDD + two VPSHUFD folds), and the scalar
 // tail closes out the (n mod 8) residuals: SHLL wraps x in 32 bits, MOVLQSX sign-
 // extends it, IMULQ forms x*x (|x| <= 2^31 so |p| <= 2^62 fits int64), SARQ $31
@@ -794,7 +803,8 @@ maxabs_ret_max:
 // sumSqShiftedQ31Go for every input. The dispatch guarantees shift in [0,31], so
 // VPSLLD (saturates to 0 past 31) and SHLL (masks the count to 5 bits) never
 // disagree on an out-of-range count. Registers SI/DI/CX/AX/DX/R8 and
-// X6/Y0/Y1/Y2/Y4/Y5/Y7; no R14/R15/BP. Frame: a+0, shift+24, ret+32.
+// X6/Y0/Y1/Y4/Y5/Y7 (Y2 no longer used since the reduction accumulates the term
+// halves directly); no R14/R15/BP. Frame: a+0, shift+24, ret+32.
 TEXT ·sumSqShiftedQ31AVX2(SB), NOSPLIT, $0-36
     MOVQ a_base+0(FP), SI
     MOVQ shift+24(FP), R8
@@ -815,9 +825,8 @@ sumsq_avx2_loop8:
     VPMULDQ  Y1, Y1, Y5         // odd lanes x1,x3,x5,x7 squared -> 4x int64
     VPSRLQ   $31, Y4, Y4         // low 32 of each int64 = even Q31 terms
     VPSRLQ   $31, Y5, Y5         // low 32 of each int64 = odd Q31 terms
-    VPSLLQ   $32, Y5, Y5         // lift odd terms to int32 positions 1,3,5,7
-    VPBLENDD $0xAA, Y5, Y4, Y2   // 8 int32 terms: 0,2,4,6 <- Y4, 1,3,5,7 <- Y5
-    VPADDD   Y2, Y7, Y7          // accumulate (wrapping int32 lanes)
+    VPADDD   Y4, Y7, Y7          // accumulate even terms (int32 lanes 0,2,4,6; 1,3,5,7 add 0)
+    VPADDD   Y5, Y7, Y7          // accumulate odd terms into the same lanes (wrapping int32)
     ADDQ $32, SI
     DECQ CX
     JNZ  sumsq_avx2_loop8

--- a/i32/i32_arm64.go
+++ b/i32/i32_arm64.go
@@ -136,12 +136,11 @@ func scaleQ15NEON(dst, a []int32, k int16)
 // thresholds above. The kernel is correct at any length (it falls through to a
 // scalar tail), so this is a performance cut only, never a safety requirement.
 //
-// This stays at one block, unlike the much larger amd64 minAVX2GainQ31: MEASURED on
-// a Raspberry Pi 5, the NEON GainQ31 kernel scales cleanly with n and already beats
-// gainQ31Go from the smallest sizes (n=8: ~15.8 vs 16.4 ns; n=16: ~20.4 vs 29.3),
-// with no fixed per-call cost. NEON has no analogue of the 256-bit AVX
-// transition/warmup penalty that pushes the amd64 crossover out to ~160, so one
-// block remains the right threshold here. See #251.
+// This stays at one block: MEASURED on a Raspberry Pi 5, the NEON GainQ31 kernel
+// scales cleanly with n and already beats gainQ31Go from the smallest sizes (n=8:
+// ~15.8 vs 16.4 ns; n=16: ~20.4 vs 29.3), with no fixed per-call cost. NEON never had
+// the AVX-SSE transition assist that once pushed the amd64 gain crossover out to 160
+// (removed in #268), so one block has always been the right threshold here. See #251.
 const minNEONGainQ31 = 4
 
 func gainQ31I32(dst, a []int32, gain int32, preShift, postShift int) {
@@ -212,11 +211,11 @@ func maxAbsNEON(a []int32) int32
 // reference. The kernel is correct at any length via the scalar tail, so this is a
 // performance cut only, never a safety requirement.
 //
-// This stays at one block: NEON has no analogue of an AVX per-call penalty, so the
-// kernel does not need to amortise a fixed cost. MEASURED on Apple Silicon (arm64,
-// -benchtime pinned): the kernel is on par with sumSqShiftedQ31Go at one block
-// (n=4, ~2.0 ns either way) and pulls ahead from n=8 (2.3 vs 3.2 ns, 1.4x), the
-// same shape as the other NEON reductions, so one block is the right cut.
+// This stays at one block: there is no fixed per-call cost to amortise here. MEASURED
+// on Apple Silicon (arm64, -benchtime pinned): the kernel is on par with
+// sumSqShiftedQ31Go at one block (n=4, ~2.0 ns either way) and pulls ahead from n=8
+// (2.3 vs 3.2 ns, 1.4x), the same shape as the other NEON reductions, so one block is
+// the right cut.
 const minNEONSumSqShiftedQ31 = 4
 
 func sumSqShiftedQ31I32(a []int32, shift int) int32 {

--- a/i32/i32_arm64.s
+++ b/i32/i32_arm64.s
@@ -628,19 +628,21 @@ maxabs_neon_combine:
 // Wrapping int32 sum of pre-shifted Q31 squares, 4 int32 per iteration. Each block
 // left-shifts the four int32 lanes by the runtime shift count (SSHL .4S applies
 // SHL32 in 32-bit lanes, so the value stays in int32 range BEFORE the widen), then
-// squares them with the scaleQ31NEON widen-shift-narrow: SMULL/SMULL2 multiply each
-// shifted lane by ITSELF into int64 (lanes 0,1 then 2,3), SSHR .2D #31 arithmetically
-// shifts each product right 31 (the square is non-negative so this is a plain
-// truncate), and XTN/XTN2 narrow the low 32 bits back to int32 (a shifted lane of
-// MinInt32 gives 2^62 >> 31 = 2^31, whose low 32 = MinInt32). VADD .4S accumulates
+// squares them with a widen-shift-narrow: SMULL/SMULL2 multiply each
+// shifted lane by ITSELF into int64 (lanes 0,1 then 2,3), then SHRN/SHRN2 #31 shift each
+// product right 31 and narrow the low 32 bits back to int32 in one instruction (the
+// square is non-negative and <= 2^62, so the logical shift equals the arithmetic one and
+// the <= 2^31 result narrows exactly: a shifted lane of MinInt32 gives 2^62 >> 31 = 2^31,
+// whose low 32 = MinInt32). VADD .4S accumulates
 // the four terms into a wrapping int32 accumulator, VADDV folds it to a scalar, and
 // the scalar tail closes out (n mod 4): LSLW wraps x in 32 bits, MOVW re-sign-extends
 // it, MUL forms x*x (|x| <= 2^31 so |p| <= 2^62), ASR #31 takes the term, and ADDW
 // accumulates it wrapping. Because wrapping int32 addition is associative, the 4-lane
 // split plus the VADDV fold is bit-identical to sumSqShiftedQ31Go for every input.
-// The DUP/SSHL/SSHR/XTN/XTN2 WORDs are the gainQ31NEON/scaleQ31NEON encodings
-// verbatim; the two SMULL/SMULL2 WORDs are those encodings with the multiplier lane
-// set to V0 (self-square, Rm field V1->V0). All are cross-checked against arm64asm by
+// The DUP/SSHL WORDs are the gainQ31NEON encodings verbatim; the two SMULL/SMULL2 WORDs
+// are those encodings with the multiplier lane set to V0 (self-square, Rm field V1->V0);
+// the SHRN/SHRN2 WORDs are new (shift-right-narrow by immediate, U=0 opcode 10000,
+// immh:immb field = 2*esize - shift = 64 - 31 = 33). All are cross-checked against arm64asm by
 // TestArm64WordEncodings. The dispatch guarantees shift in [0,31]. Registers R1=a,
 // R3=n, R4=blocks, R5=total, R6=shift, R7=tail sample; V0/V2/V3/V4/V5/V6; none of
 // R16/R17/R18/R27/R28. Frame: a+0, shift+24, ret+32.
@@ -659,10 +661,8 @@ sumsq_neon_loop4:
     WORD $0x4EA54400            // SSHL V0.4S, V0.4S, V5.4S    (x = a << shift, wrapping)
     WORD $0x0EA0C002           // SMULL V2.2D, V0.2S, V0.2S   (lanes 0,1 squared -> 2 int64)
     WORD $0x4EA0C003           // SMULL2 V3.2D, V0.4S, V0.4S  (lanes 2,3 squared -> 2 int64)
-    WORD $0x4F610442           // SSHR V2.2D, V2.2D, #31
-    WORD $0x4F610463           // SSHR V3.2D, V3.2D, #31
-    WORD $0x0EA12844           // XTN V4.2S, V2.2D    (low 32 of terms 0,1)
-    WORD $0x4EA12864           // XTN2 V4.4S, V3.2D   (low 32 of terms 2,3)
+    WORD $0x0F218444           // SHRN V4.2S, V2.2D, #31   (terms 0,1: >>31 then low 32)
+    WORD $0x4F218464           // SHRN2 V4.4S, V3.2D, #31  (terms 2,3)
     VADD V4.S4, V6.S4, V6.S4   // accumulate (wrapping int32 lanes)
     SUB  $1, R4
     CBNZ R4, sumsq_neon_loop4

--- a/i32/sumsq_amd64_test.go
+++ b/i32/sumsq_amd64_test.go
@@ -118,9 +118,8 @@ func TestSumSqShiftedQ31Dispatch_ReachesSIMD(t *testing.T) {
 		t.Fatalf("hasAVX2 = %v but cpu.X86.AVX2 = %v: dispatch flag is not wired to CPU detection", hasAVX2, cpu.X86.AVX2)
 	}
 	// The threshold stays within two 8-wide blocks (measured: this kernel wins from
-	// the first block, so it does not need GainQ31's ~160 cut), so a regression to a
-	// large GainQ31-style threshold that left realistic short bands on the slower Go
-	// path is caught here.
+	// the first block), so a regression to a large threshold that left realistic short
+	// bands on the slower Go path is caught here.
 	if minAVX2SumSqShiftedQ31 > 16 {
 		t.Fatalf("minAVX2SumSqShiftedQ31 = %d exceeds two vector blocks: it would not vectorize at the lengths it was written for", minAVX2SumSqShiftedQ31)
 	}


### PR DESCRIPTION
`gainQ31AVX2` loaded its two runtime shift counts into XMM with legacy `MOVQ` after the VEX gain broadcast had already dirtied the upper YMM state, paying two AVX-SSE transition assists per call (the same defect class as #208 and #214). Both loads now use VEX `VMOVD`. For shift counts in [0, 31] the 32-bit zero-extending move yields the same low-64 count that `VPSLLD`/`VPSRAD` read, so the kernel stays bit-identical, and both encodings are 5 bytes, so no code moves. The fixed per-call cost is gone: measured on an i7-1260P (AVX2, pinned P-core, powersave governor, 20 process rounds, benchstat medians), `gainQ31AVX2` at n=64 fell from 98.9 to 8.4 ns/op (-91.5%), and the kernel now beats `gainQ31Go` from the first 8-wide block (n=8: 3.5 vs 6.4 ns, 1.8x; n=64: 8.4 vs 46.6 ns, 5.6x). `minAVX2GainQ31` drops from 160 to 8, matching `SumSqShiftedQ31`, and the threshold comments on both architectures are reconciled with the measured cause (the assist, not a post-`VZEROUPPER` warmup).

`sumSqShiftedQ31AVX2` accumulated its Q31 terms after reassembling them into lane order (`VPSLLQ` + `VPBLENDD`). A reduction does not need lane order: each `>>31` term is at most 2^31, so the odd int32 half of every int64 lane is zero, and two `VPADDD` now add the even and odd term vectors straight into the accumulator (one fewer vector op per block, shorter dependency chain). The final fold sums all lanes, so the result is unchanged: -7% to -8% from n=32 up on the same host, no regression at smaller n.

`sumSqShiftedQ31NEON` replaces `SSHR #31` + `XTN`/`XTN2` (four ops) with `SHRN`/`SHRN2 #31` (two ops). The square is non-negative and at most 2^62, so the logical shift-and-narrow is bit-exact. Measured on a Raspberry Pi 5 (Cortex-A76): -19% to -23% from n=16 up. The two new WORD encodings are cross-checked against `arm64asm` by the existing encoding test.

The scalar-tail `MOVQ`-to-`CX` hoist noted in #269 is declined: the tail runs at most seven iterations, the move is eliminated at rename, and keeping it preserves an identical tail idiom across `gainQ31AVX2` and `sumSqShiftedQ31AVX2`.

## Test plan

- `go test ./...` and `go vet` for GOARCH amd64 and arm64.
- `golangci-lint run ./...` (0 issues).
- Full `i32` suite on amd64 (i7-1260P, real AVX2) and arm64 (Apple Silicon and Raspberry Pi 5): parity against the Go reference and the `big.Int` oracle across the length and shift matrices, planted-term, over-read, and allocation-free assertions.
- Benchmarks as above (benchstat, pinned P-core, powersave governor).

All paths remain bit-exact against the Go reference and allocation-free.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Performance**
  * Improved 32-bit integer processing performance on amd64 and arm64 platforms.
  * AVX2 processing now becomes beneficial for shorter inputs, starting at approximately 8 elements.
  * Optimized NEON squared-sum calculations by streamlining narrowing and shifting operations.
* **Documentation**
  * Updated performance guidance and dispatch-threshold documentation to reflect measured behavior across supported architectures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->