### PR TITLE
i32: fuse the SHRN/SHRN2 narrow into scaleQ31NEON and gainQ31NEON (Fixes #272)

### DIFF
--- a/i32/gain_arm64_test.go
+++ b/i32/gain_arm64_test.go
@@ -14,7 +14,7 @@ import (
 // sweep, over lengths the dispatcher would never route to it, so a threshold
 // change cannot quietly reduce this to a test of the Go reference against itself.
 // MinInt32 rides index 0 and MaxInt32 the last index so the SHL32/MULT32_32_Q31/
-// PSHR32 wraps are exercised at every length; the SSHL/SMULL/XTN lane order is
+// PSHR32 wraps are exercised at every length; the SSHL/SMULL/SHRN lane order is
 // checked against the oracle at every position via the value-matrix test in
 // gain_test.go.
 //

--- a/i32/i32_arm64.s
+++ b/i32/i32_arm64.s
@@ -347,20 +347,26 @@ negwhereneg_neon_done:
 
 // Fixed-point scale-by-scalar kernels (NEON / ASIMD).
 //
-// Unlike AVX2, NEON has a native 64-bit ARITHMETIC shift (SSHR .2D), so the Q31/
-// Q15 scale is a clean widen-shift-narrow: SMULL/SMULL2 multiply the int32 lanes
-// by the broadcast coefficient into int64 products (Q=0 takes lanes 0,1; Q=1 the
-// SMULL2 form takes lanes 2,3), SSHR .2D arithmetically shifts each 64-bit product
-// right by the fixed-point position, and XTN/XTN2 narrow the low 32 bits of each
-// int64 back to int32 (truncation = the int32() wrap, so a=k=MinInt32's 2^62 >> 31
-// = 2^31 lands as MinInt32). k is broadcast with DUP from a W register: MOVW
-// sign-extends the int32 for Q31, MOVH the int16 for Q15, and both leave int64(k)
-// in the register for the scalar tail (MUL then ASR then a MOVW store that keeps
-// the low 32 bits). dst may alias a exactly: each block/lane reads a before it
-// stores dst. SMULL/SMULL2/SSHR/XTN/XTN2/DUP have no Go assembler mnemonic and are
-// hand-encoded WORD directives with the decoded form in the trailing comment
-// (cross-checked against arm64asm by TestArm64WordEncodings). Frame is two slice
-// headers plus the scalar k: dst+0, a+24, k+48.
+// Both scale kernels widen with SMULL/SMULL2, multiplying the int32 lanes by the
+// broadcast coefficient into int64 products (Q=0 takes lanes 0,1; Q=1 the SMULL2
+// form takes lanes 2,3). They differ only in the shift-and-narrow:
+//   - scaleQ31NEON fuses it into SHRN/SHRN2 #31, which shift each product right 31
+//     and narrow the low 32 bits in one instruction. A logical (SHRN) and an
+//     arithmetic (SSHR) shift by 31 differ only in bits at and above 33 of the
+//     shifted product, which the 2D->2S narrow discards, so this is bit-identical
+//     to SSHR .2D #31 + XTN/XTN2 for every product, negative ones included
+//     (truncation = the int32() wrap, so a=k=MinInt32's 2^62 >> 31 = 2^31 lands as
+//     MinInt32).
+//   - scaleQ15NEON keeps the two-step form: SSHR .2D #15 arithmetically shifts each
+//     product, then XTN/XTN2 narrow the low 32 bits back to int32.
+// k is broadcast with DUP from a W register: MOVW sign-extends the int32 for Q31,
+// MOVH the int16 for Q15, and both leave int64(k) in the register for the scalar
+// tail (MUL then ASR then a MOVW store that keeps the low 32 bits). dst may alias a
+// exactly: each block/lane reads a before it stores dst. SMULL/SMULL2/SHRN/SHRN2/
+// SSHR/XTN/XTN2/DUP have no Go assembler mnemonic and are hand-encoded WORD
+// directives with the decoded form in the trailing comment (cross-checked against
+// arm64asm by TestArm64WordEncodings). Frame is two slice headers plus the scalar
+// k: dst+0, a+24, k+48.
 
 // func scaleQ31NEON(dst, a []int32, k int32)
 TEXT ·scaleQ31NEON(SB), NOSPLIT, $0-52
@@ -377,10 +383,8 @@ scaleq31_neon_loop4:
     VLD1.P 16(R1), [V0.S4]     // a[i..i+3]
     WORD $0x0EA1C002           // SMULL V2.2D, V0.2S, V1.2S   (lanes 0,1 -> 2 int64)
     WORD $0x4EA1C003           // SMULL2 V3.2D, V0.4S, V1.4S  (lanes 2,3 -> 2 int64)
-    WORD $0x4F610442           // SSHR V2.2D, V2.2D, #31
-    WORD $0x4F610463           // SSHR V3.2D, V3.2D, #31
-    WORD $0x0EA12844           // XTN V4.2S, V2.2D   (low 32 of results 0,1)
-    WORD $0x4EA12864           // XTN2 V4.4S, V3.2D  (low 32 of results 2,3)
+    WORD $0x0F218444           // SHRN V4.2S, V2.2D, #31   (results 0,1: >>31 then low 32)
+    WORD $0x4F218464           // SHRN2 V4.4S, V3.2D, #31  (results 2,3)
     VST1.P [V4.S4], 16(R0)
     SUB  $1, R4
     CBNZ R4, scaleq31_neon_loop4
@@ -401,7 +405,9 @@ scaleq31_neon_done:
     RET
 
 // func scaleQ15NEON(dst, a []int32, k int16)
-// Identical widen-shift-narrow to scaleQ31NEON with a shift of 15. k is a signed
+// Same SMULL/SMULL2 widen as scaleQ31NEON, but the shift-and-narrow stays the
+// two-step SSHR .2D #15 + XTN/XTN2 form (a SHRN immediate for #15 is a different
+// encoding, out of scope here). k is a signed
 // int16, sign-extended by MOVH to int64(k); |k * a[i]| <= 2^46, well inside the
 // int64 product.
 TEXT ·scaleQ15NEON(SB), NOSPLIT, $0-50
@@ -444,7 +450,8 @@ scaleq15_neon_done:
 // func gainQ31NEON(dst, a []int32, gain int32, preShift, postShift int)
 // Fused Q31 gain: dst[i] = PSHR32(MULT32_32_Q31(SHL32(a[i], preShift), gain), postShift).
 // The MULT32_32_Q31 core is scaleQ31NEON verbatim (SMULL/SMULL2 widen to int64,
-// SSHR #31, XTN/XTN2 narrow to the low 32 bits); this kernel wraps it in a pre-shift
+// SHRN/SHRN2 #31 shift-and-narrow to the low 32 bits; see scaleQ31NEON for why the
+// logical narrow equals the arithmetic one); this kernel wraps it in a pre-shift
 // and a rounding post-shift, all with runtime-broadcast counts:
 //   - SSHL V0.4S,V0.4S,V5.4S applies SHL32 (V5 = preShift in every lane) to the
 //     int32 lanes BEFORE the widen, so the shifted value stays in int32 range and
@@ -489,10 +496,8 @@ gainq31_neon_loop4:
     WORD $0x4EA54400            // SSHL V0.4S, V0.4S, V5.4S   (x = a << preShift, wrapping)
     WORD $0x0EA1C002           // SMULL V2.2D, V0.2S, V1.2S   (lanes 0,1 -> 2 int64)
     WORD $0x4EA1C003           // SMULL2 V3.2D, V0.4S, V1.4S  (lanes 2,3 -> 2 int64)
-    WORD $0x4F610442           // SSHR V2.2D, V2.2D, #31
-    WORD $0x4F610463           // SSHR V3.2D, V3.2D, #31
-    WORD $0x0EA12844           // XTN V4.2S, V2.2D   (low 32 of results 0,1)
-    WORD $0x4EA12864           // XTN2 V4.4S, V3.2D  (low 32 of results 2,3)
+    WORD $0x0F218444           // SHRN V4.2S, V2.2D, #31   (products 0,1: >>31 then low 32)
+    WORD $0x4F218464           // SHRN2 V4.4S, V3.2D, #31  (products 2,3)
     WORD $0x4EA78484           // ADD V4.4S, V4.4S, V7.4S    (+ bias, wrapping)
     WORD $0x4EA64484           // SSHL V4.4S, V4.4S, V6.4S   (arithmetic >> postShift)
     VST1.P [V4.S4], 16(R0)
@@ -641,8 +646,9 @@ maxabs_neon_combine:
 // split plus the VADDV fold is bit-identical to sumSqShiftedQ31Go for every input.
 // The DUP/SSHL WORDs are the gainQ31NEON encodings verbatim; the two SMULL/SMULL2 WORDs
 // are those encodings with the multiplier lane set to V0 (self-square, Rm field V1->V0);
-// the SHRN/SHRN2 WORDs are new (shift-right-narrow by immediate, U=0 opcode 10000,
-// immh:immb field = 2*esize - shift = 64 - 31 = 33). All are cross-checked against arm64asm by
+// the SHRN/SHRN2 WORDs are the scaleQ31NEON/gainQ31NEON encodings verbatim
+// (shift-right-narrow by immediate, U=0 opcode 10000, immh:immb field = 2*esize -
+// shift = 64 - 31 = 33). All are cross-checked against arm64asm by
 // TestArm64WordEncodings. The dispatch guarantees shift in [0,31]. Registers R1=a,
 // R3=n, R4=blocks, R5=total, R6=shift, R7=tail sample; V0/V2/V3/V4/V5/V6; none of
 // R16/R17/R18/R27/R28. Frame: a+0, shift+24, ret+32.

--- a/i32/scale_arm64_test.go
+++ b/i32/scale_arm64_test.go
@@ -13,7 +13,7 @@ import (
 // sweep, over lengths the dispatcher would never route to it, so a threshold
 // change cannot quietly reduce this to a test of the Go reference against itself.
 // MinInt32 rides index 0 under k=MinInt32 so the wrap is exercised at every
-// length; the SMULL/XTN lane order is checked against the oracle at every position
+// length; the SMULL/SHRN lane order is checked against the oracle at every position
 // via the value-matrix test in scale_test.go.
 //
 //nolint:dupl // The Q31/Q15 parity sweep is intentionally identical bar the kernel, ref and coefficient type.


### PR DESCRIPTION
Both Q31 NEON kernels formed their int64 products in V2/V3 and narrowed back to int32 with a two-instruction sequence: `SSHR .2D #31` to shift, then `XTN`/`XTN2` to keep the low 32 bits. `SHRN`/`SHRN2 #31` does the shift and the narrow in one instruction, dropping two vector ops per 4-wide iteration in each inner loop. This is the same swap #271 applied to `sumSqShiftedQ31NEON`; the two encodings (`0x0F218444`, `0x4F218464`) are reused verbatim, since all three Q31 kernels narrow V2/V3 into V4.

The result is bit-identical. For a 2D-to-2S narrow at shift 31 the kept low 32 bits are product bits [31:62]; a logical (`SHRN`) and an arithmetic (`SSHR`) right shift by 31 differ only in bits at and above 33 of the shifted value, which the narrow discards. So the fused form equals `SSHR #31` + `XTN` for every 64-bit product, negative ones included (`scaleQ31`/`gainQ31` products can be negative, unlike `sumSqShifted`'s non-negative squares). The `a = k = MinInt32` corner (product `2^62`, `>> 31 = 2^31`) wraps to `MinInt32`, matching the Go reference.

`scaleQ15NEON` and the Q15 FIR kernels keep the two-step `SSHR .2D #15` + `XTN`/`XTN2` form: a `SHRN` immediate for #15 is a different encoding, left out of scope here. The shared kernel comments now describe the Q31 (`SHRN`) and Q15 (`SSHR` + `XTN`) narrows separately.

## Measurements

Raspberry Pi 5 (Cortex-A76), pinned to one core, `benchstat` over n=10 runs, all p=0.000:

| benchmark | before | after | delta |
| --- | --- | --- | --- |
| ScaleQ31 n=1000 | 443.9 ns | 304.3 ns | -31.4% |
| ScaleQ31 n=1003 | 445.4 ns | 305.1 ns | -31.5% |
| GainQ31 n=1000 | 698.2 ns | 555.4 ns | -20.5% |
| GainQ31 n=1003 | 703.4 ns | 559.5 ns | -20.5% |

`scaleQ31` gains more in relative terms because `gainQ31`'s loop also carries a pre-shift, a bias add, and a post-shift that do not benefit from the swap. The Go reference paths are unchanged.

## Test plan

- `go test ./...` passes, including on native ARM64 hardware (Cortex-A76): parity against the Go reference, the value-matrix, wrap, planted-term, over-read, and allocation-free assertions.
- `TestArm64WordEncodings` cross-checks every `WORD` directive against `golang.org/x/arch/arm64asm`, so the new `SHRN`/`SHRN2` trailing comments are machine-verified to match their encodings.
- `go tool objdump` confirms both kernels emit `SHRN`/`SHRN2` (V2/V3 into V4, shift 31) with no `SSHR .2D`/`XTN` left in any Q31 kernel.
- `go vet` is clean on `GOARCH=arm64` and `GOARCH=amd64`; the Go fallback and the amd64 kernels are untouched.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Updated ARM64 NEON Q31 scaling and multiplication paths to use shift-and-narrow instructions while preserving existing results.
  - Retained the existing two-step shift-and-narrow behavior for Q15 processing.
  - Clarified documentation and parity checks for lane ordering and instruction behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->