### PR TITLE
ci: build and test with Go 1.27, bump golangci-lint to v2.13.2

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,8 +7,8 @@ on:
     branches: [main, master]
 
 env:
-  GO_VERSION: '1.26'
-  GOLANGCI_LINT_VERSION: 'v2.12.2'
+  GO_VERSION: '1.27'
+  GOLANGCI_LINT_VERSION: 'v2.13.2'
 
 # Least-privilege default token scope for all jobs. Every job here only checks
 # out code and runs build/test/lint/vet, so read-only contents is sufficient.


### PR DESCRIPTION
## Summary

Move the CI toolchain from Go 1.26 to Go 1.27 (`GO_VERSION`) and the linter from golangci-lint v2.12.2 to v2.13.2, which is built for and supports the Go 1.27 toolchain.

This changes only what CI builds and tests with. The module keeps its `go 1.25.0` minimum in `go.mod`, so the library stays consumable by projects on Go 1.25 and later, and the README "Requires Go 1.25+" line is unchanged. The benchmark-methodology notes (measured on the Go 1.26 toolchain) are also left as-is, since they record how the published numbers were produced rather than which toolchain CI uses.

## Test plan

Verified locally on go1.27.0 with golangci-lint v2.13.2:

- `go build ./...`
- `go vet ./...`
- `golangci-lint run ./...` on arm64 and with `GOARCH=amd64` (0 issues each)
- `go test ./...` across all packages

The CI matrix in this PR exercises the full build/test/lint/vet/cross-ISA set on Go 1.27.