### PR TITLE
i16: add Sum and MinMax reductions (AVX2, NEON, Go)

### DIFF
--- a/README.md
+++ b/README.md
@@ -663,7 +663,7 @@ Interleaving is pure 32-bit-lane movement, so those kernels reuse the proven `f3
 
 The 16-bit integer counterpart to `i32`, serving two kinds of hot loop. First, raw-PCM movement, where the source samples are 16-bit and the cheapest place to vectorize is the channel (de)interleaving that happens before samples are widened to int32. Second, fixed-point DSP, where int16 inputs are multiplied and accumulated into int32.
 
-**Scope:** element-wise int16 add/sub still belongs in `i32`, because inter-channel decorrelation can exceed the source bit depth by one bit. What lives here is the *widening* direction (operations that read int16 and accumulate into int32, where the narrow input is the point) plus the element-wise operations that are well-defined at 16-bit width: the wrapping absolute value (`Abs`, with the `MaxAbs` reduction) and the rounding Q15 fixed-point multiply (`MulQ15`).
+**Scope:** element-wise int16 add/sub still belongs in `i32`, because inter-channel decorrelation can exceed the source bit depth by one bit. What lives here is the *widening* direction (operations that read int16 and accumulate into int32, where the narrow input is the point) plus the element-wise operations that are well-defined at 16-bit width: the wrapping absolute value (`Abs`) and the rounding Q15 fixed-point multiply (`MulQ15`). The reductions are `MaxAbs` (abs-max headroom, widening to `int`), `MinMax` (the signed range, which fits int16), and the widening `Sum` (an int16 total accumulated into int32).
 
 | Category       | Function                   | Description                                | SIMD Width                         |
 | -------------- | -------------------------- | ------------------------------------------ | ---------------------------------- |
@@ -672,6 +672,8 @@ The 16-bit integer counterpart to `i32`, serving two kinds of hot loop. First, r
 | **Reduction**  | `DotProduct(a, b)`         | Widening dot product, wrapping int32       | 16x (AVX2) / 8x (SSE2) / 16x (NEON) |
 |                | `DotProductUnsafe(a, b)`   | As above, without the empty-slice guard    | 16x (AVX2) / 8x (SSE2) / 16x (NEON) |
 |                | `MaxAbs(a) int`            | Abs-max headroom probe, range `[0, 32768]` | 16x (AVX2) / 8x (NEON) |
+|                | `Sum(a) int32`             | Widening int16 total, wrapping int32       | 16x (AVX2) / 8x (NEON) |
+|                | `MinMax(a) (min, max)`     | Signed per-slice minimum and maximum, one pass | 16x (AVX2) / 8x (NEON) |
 | **Correlation**| `XCorr(dst, x, y)`         | Dot product of x against y at every lag    | 4 lags/call, 16x (AVX2) / 8x (SSE2/NEON) |
 | **Element-wise**| `Abs(dst, a)`             | Wrapping absolute value (`abs(-32768) = -32768`) | 16x (AVX2) / 8x (NEON) |
 |                | `MulQ15(dst, a, b)`        | Rounding Q15 multiply (libopus `MULT16_16_P15`) | 16x (AVX2) / 8x (NEON) |
@@ -689,6 +691,8 @@ i16.Deinterleave2(left, right, stereo) // inverse: split back to channels
 sum := i16.DotProduct(left, right)     // sum(left[i]*right[i]) widened into int32
 
 peak := i16.MaxAbs(left)               // headroom probe: |-32768| reports 32768
+total := i16.Sum(left)                 // wrapping int32 total of the samples
+mn, mx := i16.MinMax(left)             // signed minimum and maximum in one pass
 gain := make([]int16, n)               // Q15 gains, e.g. 16384 = 0.5
 i16.MulQ15(left, left, gain)           // rounding Q15 multiply, in place
 i16.Abs(left, left)                    // wrapping |x|, in place
@@ -708,6 +712,8 @@ The interleave kernels are pure 16-bit-lane movement (AVX2/SSE2 word unpacks plu
 `XCorr` is the same arithmetic evaluated at every lag, and `dst[k]` is defined to equal `DotProduct(x, y[k:k+len(x)])` exactly. The win over calling `DotProduct` in a loop is that it loads `x` once and multiply-accumulates it against four overlapping `y` windows at a time (the libopus `xcorr_kernel` shape), rather than re-reading `x` for every lag. Only lags whose full window fits in `y` are computed, and `dst` beyond that is left untouched rather than zeroed. On CPUs with AVX-VNNI (Intel Alder Lake and later, AMD Zen 4 and later) a fourth dispatch tier fuses each `VPMADDWD`+`VPADDD` in the 16-wide loop into one `VPDPWSSD`, which is bit-identical because it accumulates with the same wrapping dword add; it is selected above the plain AVX2 tier and can be masked back to AVX2 with `SIMD_DISABLE=avxvnni`.
 
 `Abs`, `MaxAbs` and `MulQ15` are the fixed-point envelope/gain trio. `Abs` wraps rather than saturates (`abs(-32768) = -32768`, the opposite of `i8.Abs`), `MaxAbs` returns an `int` because `|-32768| = 32768` does not fit int16 (libopus `celt_maxabs16`), and `MulQ15` is the *rounding* Q15 multiply (`MULT16_16_P15`): `dst[i] = int16((a[i]*b[i] + 1<<14) >> 15)` with the single out-of-range product `(-32768)^2` wrapping to `-32768`. All three are bit-exact against their pure-Go references for every input. On amd64 these three are AVX2-or-Go (no SSE2 tier, matching `i8` and the `i32` arithmetic); on ARM64 they run NEON (`MulQ15` via `SMULL` and the fused rounding-narrow `RSHRN`, since the single-instruction `SQRDMULH` saturates the `(-32768)^2` case and would break the wrap guarantee, whereas `RSHRN` narrows by truncation and preserves it).
+
+`Sum` and `MinMax` are the two general reductions. `Sum` widens each int16 to int32 and accumulates with the same two's-complement wraparound as `DotProduct` (associative, so the lane split is bit-identical to the scalar loop even on overflowing inputs), wrapping once the running total passes 2^31, about 65536 full-scale samples. `MinMax` returns the signed minimum and maximum in one pass (`VPMINSW`/`VPMAXSW` on AVX2, `SMIN`/`SMAX` with single-instruction `SMINV`/`SMAXV` folds on NEON), the signed range probe distinct from the abs-max `MaxAbs`. Like `MaxAbs` both are AVX2-or-Go / NEON-or-Go with no SSE2 tier, bit-exact against their pure-Go references, and allocation-free.
 
 ### `i8` - int8 Operations
 

--- a/i16/benchmark_test.go
+++ b/i16/benchmark_test.go
@@ -247,3 +247,47 @@ func BenchmarkMaxAbsGo_8(b *testing.B)    { benchmarkMaxAbs(b, 8, maxAbsGo) }
 func BenchmarkMaxAbsGo_25(b *testing.B)   { benchmarkMaxAbs(b, 25, maxAbsGo) }
 func BenchmarkMaxAbsGo_1000(b *testing.B) { benchmarkMaxAbs(b, 1000, maxAbsGo) }
 func BenchmarkMaxAbsGo_1003(b *testing.B) { benchmarkMaxAbs(b, 1003, maxAbsGo) }
+
+func benchmarkSum(b *testing.B, n int, fn func(a []int16) int32) {
+	b.Helper()
+	a := make([]int16, n)
+	for i := range a {
+		a[i] = int16(i*7 - 3000)
+	}
+	b.SetBytes(int64(n) * 2)
+	for b.Loop() {
+		_ = fn(a)
+	}
+}
+
+func BenchmarkSum_8(b *testing.B)    { benchmarkSum(b, 8, Sum) }
+func BenchmarkSum_25(b *testing.B)   { benchmarkSum(b, 25, Sum) }
+func BenchmarkSum_1000(b *testing.B) { benchmarkSum(b, 1000, Sum) }
+func BenchmarkSum_1003(b *testing.B) { benchmarkSum(b, 1003, Sum) }
+
+func BenchmarkSumGo_8(b *testing.B)    { benchmarkSum(b, 8, sumGo) }
+func BenchmarkSumGo_25(b *testing.B)   { benchmarkSum(b, 25, sumGo) }
+func BenchmarkSumGo_1000(b *testing.B) { benchmarkSum(b, 1000, sumGo) }
+func BenchmarkSumGo_1003(b *testing.B) { benchmarkSum(b, 1003, sumGo) }
+
+func benchmarkMinMax(b *testing.B, n int, fn func(a []int16) (int16, int16)) {
+	b.Helper()
+	a := make([]int16, n)
+	for i := range a {
+		a[i] = int16(i*7 - 3000)
+	}
+	b.SetBytes(int64(n) * 2)
+	for b.Loop() {
+		_, _ = fn(a)
+	}
+}
+
+func BenchmarkMinMax_8(b *testing.B)    { benchmarkMinMax(b, 8, MinMax) }
+func BenchmarkMinMax_25(b *testing.B)   { benchmarkMinMax(b, 25, MinMax) }
+func BenchmarkMinMax_1000(b *testing.B) { benchmarkMinMax(b, 1000, MinMax) }
+func BenchmarkMinMax_1003(b *testing.B) { benchmarkMinMax(b, 1003, MinMax) }
+
+func BenchmarkMinMaxGo_8(b *testing.B)    { benchmarkMinMax(b, 8, minMaxGo) }
+func BenchmarkMinMaxGo_25(b *testing.B)   { benchmarkMinMax(b, 25, minMaxGo) }
+func BenchmarkMinMaxGo_1000(b *testing.B) { benchmarkMinMax(b, 1000, minMaxGo) }
+func BenchmarkMinMaxGo_1003(b *testing.B) { benchmarkMinMax(b, 1003, minMaxGo) }

--- a/i16/example_test.go
+++ b/i16/example_test.go
@@ -70,6 +70,25 @@ func ExampleMaxAbs() {
 	// Output: 32768
 }
 
+func ExampleSum() {
+	// DC-offset probe: the running total of a frame, widened to int32 so the
+	// sum does not overflow the way an int16 running total would.
+	frame := []int16{1000, -2000, 1500, -500, 3000}
+
+	fmt.Println(i16.Sum(frame))
+	// Output: 3000
+}
+
+func ExampleMinMax() {
+	// Signed range probe (peak and trough) before a normalization decision.
+	// Unlike MaxAbs this keeps the sign, so a DC-asymmetric clip is visible.
+	frame := []int16{100, -32768, 3000, 15, 32767}
+
+	lo, hi := i16.MinMax(frame)
+	fmt.Println(lo, hi)
+	// Output: -32768 32767
+}
+
 func ExampleXCorr() {
 	// Correlate a short pattern against a longer signal at every lag. The
 	// pattern occurs at lag 2, which is where the correlation peaks.

--- a/i16/fuzz_test.go
+++ b/i16/fuzz_test.go
@@ -214,6 +214,35 @@ func FuzzI16AbsMaxAbs(f *testing.F) {
 	})
 }
 
+// FuzzI16Sum differentially fuzzes the widening int16 sum against its reference,
+// including inputs long enough to wrap the int32 accumulator.
+func FuzzI16Sum(f *testing.F) {
+	addLenSeeds(f)
+	f.Fuzz(func(t *testing.T, raw []byte) {
+		a := i16sFromBits(raw)
+		if got, want := Sum(a), sumGo(a); got != want {
+			t.Fatalf("Sum = %d, want %d (len=%d)", got, want, len(a))
+		}
+	})
+}
+
+// FuzzI16MinMax differentially fuzzes the signed min/max reduction. The empty
+// case is guarded by the public wrapper, so the reference is guarded to match.
+func FuzzI16MinMax(f *testing.F) {
+	addLenSeeds(f)
+	f.Fuzz(func(t *testing.T, raw []byte) {
+		a := i16sFromBits(raw)
+		gotLo, gotHi := MinMax(a)
+		var wantLo, wantHi int16
+		if len(a) != 0 {
+			wantLo, wantHi = minMaxGo(a)
+		}
+		if gotLo != wantLo || gotHi != wantHi {
+			t.Fatalf("MinMax = (%d,%d), want (%d,%d) (len=%d)", gotLo, gotHi, wantLo, wantHi, len(a))
+		}
+	})
+}
+
 // FuzzI16XCorr differentially fuzzes multi-lag correlation. The high-value bug
 // class is the lag blocking: the kernel evaluates 4 lags per call and the
 // dispatcher finishes the remainder with the dot kernel, so arbitrary lag

--- a/i16/i16.go
+++ b/i16/i16.go
@@ -17,11 +17,12 @@
 //
 // Element-wise int16 add/sub still belongs in the i32 package, because
 // inter-channel decorrelation can exceed the source bit depth by one bit. What
-// lives here is the widening direction (DotProduct, XCorr), where the narrow
-// input is the point, plus the element-wise operations that are well-defined
-// at 16-bit width: the wrapping absolute value (Abs) and the rounding Q15
-// fixed-point multiply (MulQ15). Those two produce a result that fits int16
-// for every input except the single wrapping case each documents. The MaxAbs reduction is the
+// lives here is the widening direction (DotProduct, XCorr, Sum), where the
+// narrow input is the point, plus the element-wise operations that are
+// well-defined at 16-bit width: the wrapping absolute value (Abs) and the
+// rounding Q15 fixed-point multiply (MulQ15). Those two produce a result that
+// fits int16 for every input except the single wrapping case each documents;
+// the MinMax reduction fits int16 unconditionally. The MaxAbs reduction is the
 // deliberate exception: it widens to int, because |-32768| = 32768 is the
 // headroom value callers need and it does not fit the element type.
 //
@@ -50,8 +51,8 @@
 // their inputs (twice the inputs, or half the source), so an element-for-element
 // overlay does not apply. XCorr writes an int32 result from int16 inputs, so its
 // output and inputs have distinct element types and cannot alias in safe Go. The
-// reductions DotProduct and MaxAbs write no output slice, so aliasing does not
-// apply to them.
+// reductions (DotProduct, MaxAbs, Sum, MinMax) write no output slice, so
+// aliasing does not apply to them.
 package i16
 
 // interleave2Channels is the number of channels handled by Interleave2 and

--- a/i16/i16_amd64.go
+++ b/i16/i16_amd64.go
@@ -144,6 +144,8 @@ const (
 	minAVX2MulQ15 = 16
 	minAVX2Abs    = 16
 	minAVX2MaxAbs = 16
+	minAVX2Sum    = 16
+	minAVX2MinMax = 16
 )
 
 func mulQ15I16(dst, a, b []int16) {
@@ -168,6 +170,26 @@ func maxAbsI16(a []int16) int {
 	}
 	return maxAbsGo(a)
 }
+
+func sumI16(a []int16) int32 {
+	if hasAVX2 && len(a) >= minAVX2Sum {
+		return sumAVX2(a)
+	}
+	return sumGo(a)
+}
+
+func minMaxI16(a []int16) (minVal, maxVal int16) {
+	if hasAVX2 && len(a) >= minAVX2MinMax {
+		return minMaxAVX2(a)
+	}
+	return minMaxGo(a)
+}
+
+//go:noescape
+func sumAVX2(a []int16) int32
+
+//go:noescape
+func minMaxAVX2(a []int16) (minVal, maxVal int16)
 
 //go:noescape
 func mulQ15AVX2(dst, a, b []int16)

--- a/i16/i16_amd64.s
+++ b/i16/i16_amd64.s
@@ -1194,3 +1194,132 @@ maxabs_avx2_done:
     MOVQ AX, ret+24(FP)
     VZEROUPPER
     RET
+
+// func sumAVX2(a []int16) int32
+// Widening int16 sum: VPMADDWD against a +1 vector widens and pairwise-adds each
+// block to int32, VPADDD accumulates, a horizontal add folds the lanes, and a
+// scalar tail adds the remainder. An 8-wide XMM block before the loop absorbs 8
+// of the 0-15 remainder into the still-zero accumulator so a residue of 8-15 does
+// not fall entirely to the serial scalar tail (same shape as dotAVX2, #160).
+// Accumulation wraps in int32 exactly as sumGo, so the result is bit-identical
+// for every input including overflow.
+TEXT ·sumAVX2(SB), NOSPLIT, $0-28
+    MOVQ a_base+0(FP), SI
+    MOVQ a_len+8(FP), CX
+
+    VPXOR Y2, Y2, Y2           // int32 accumulator = 0
+    VPCMPEQW Y4, Y4, Y4        // all ones (each int16 lane = -1)
+    VPXOR Y5, Y5, Y5
+    VPSUBW Y4, Y5, Y3          // Y3 = 0 - (-1) = +1 per int16 lane
+
+    TESTQ $8, CX               // n % 16 >= 8? one XMM block absorbs the 8
+    JZ   sum_i16_blocks16
+    VMOVDQU (SI), X0           // 8 int16
+    VPMADDWD X3, X0, X1        // widen + add adjacent pairs -> 4 int32
+    VPADDD X1, X2, X2          // Y2[255:128] still zero after this
+    ADDQ $16, SI
+
+sum_i16_blocks16:
+    MOVQ CX, AX
+    SHRQ $4, AX                // AX = n / 16
+    JZ   sum_i16_reduce
+
+sum_i16_loop16:
+    VMOVDQU (SI), Y0
+    VPMADDWD Y3, Y0, Y1        // Y1 = widen + add adjacent pairs -> 8 int32
+    VPADDD Y1, Y2, Y2          // accumulate (wrapping)
+    ADDQ $32, SI
+    DECQ AX
+    JNZ  sum_i16_loop16
+
+sum_i16_reduce:
+    VEXTRACTI128 $1, Y2, X3
+    VPADDD X3, X2, X2          // fold 8 -> 4 int32
+    VPSHUFD $0x4E, X2, X3      // swap 64-bit halves
+    VPADDD X3, X2, X2
+    VPSHUFD $0xB1, X2, X3      // swap 32-bit within pairs
+    VPADDD X3, X2, X2
+    MOVQ X2, AX                // low int32 = vector total (in EAX)
+
+    ANDQ $7, CX                // the 8-wide block took n % 16 down to n % 8
+    JZ   sum_i16_done
+
+sum_i16_scalar:
+    MOVWLSX (SI), BX           // sign-extending 16-bit load
+    ADDL BX, AX                // 32-bit add: wraps like sumGo
+    ADDQ $2, SI
+    DECQ CX
+    JNZ  sum_i16_scalar
+
+sum_i16_done:
+    MOVL AX, ret+24(FP)
+    VZEROUPPER
+    RET
+
+// func minMaxAVX2(a []int16) (minVal, maxVal int16)
+// Signed int16 min and max in one pass: VPMINSW/VPMAXSW fold 32-byte blocks into
+// running accumulators seeded from block 0, a per-lane cascade reduces a 128-bit
+// lane to a single word, and an overlapping final 32-byte block folds the
+// (n mod 16) remainder (signed min/max are idempotent, so reprocessing the
+// overlap is bit-exact). The dispatch gates n >= 16, so at least one full block
+// exists. The result is bit-identical to minMaxGo.
+TEXT ·minMaxAVX2(SB), NOSPLIT, $0-28
+    MOVQ a_base+0(FP), SI
+    MOVQ a_len+8(FP), CX
+
+    VMOVDQU (SI), Y0           // min acc = block 0
+    VMOVDQU (SI), Y1           // max acc = block 0
+    MOVQ CX, AX
+    SHRQ $4, AX                // AX = full 16-int16 blocks (>=1)
+    DECQ AX                    // blocks remaining after block 0
+    JZ   mm_i16_overlap
+    LEAQ 32(SI), DI            // working ptr at block 1
+
+mm_i16_loop:
+    VMOVDQU (DI), Y2
+    VPMINSW Y2, Y0, Y0
+    VPMAXSW Y2, Y1, Y1
+    ADDQ $32, DI
+    DECQ AX
+    JNZ  mm_i16_loop
+
+mm_i16_overlap:
+    // Absorb the (n mod 16) tail with an overlapping final 32-byte block instead
+    // of a serial scalar tail. minMaxAVX2 is dispatched only for n >= 16, so
+    // a+2*n-32 is in bounds; signed min/max are idempotent, so reprocessing the
+    // overlap with the last full block is bit-exact. Guarded on a nonzero residue
+    // so aligned n pays nothing.
+    TESTQ $15, CX
+    JZ   mm_i16_reduce
+    LEAQ (SI)(CX*2), DI        // DI = a + n (int16 elements are 2 bytes)
+    VMOVDQU -32(DI), Y2        // a[n-16 .. n)
+    VPMINSW Y2, Y0, Y0
+    VPMAXSW Y2, Y1, Y1
+
+mm_i16_reduce:
+    // Fold the 256-bit min accumulator to one word.
+    VEXTRACTI128 $1, Y0, X3
+    VPMINSW X3, X0, X0         // 8 words
+    VPSRLDQ $8, X0, X3
+    VPMINSW X3, X0, X0         // 4 words
+    VPSRLDQ $4, X0, X3
+    VPMINSW X3, X0, X0         // 2 words
+    VPSRLDQ $2, X0, X3
+    VPMINSW X3, X0, X0         // 1 word
+    MOVD X0, AX                // AX low word = running min
+
+    // Fold the 256-bit max accumulator to one word.
+    VEXTRACTI128 $1, Y1, X3
+    VPMAXSW X3, X1, X1
+    VPSRLDQ $8, X1, X3
+    VPMAXSW X3, X1, X1
+    VPSRLDQ $4, X1, X3
+    VPMAXSW X3, X1, X1
+    VPSRLDQ $2, X1, X3
+    VPMAXSW X3, X1, X1
+    MOVD X1, DX                // DX low word = running max
+
+    MOVW AX, minVal+24(FP)
+    MOVW DX, maxVal+26(FP)
+    VZEROUPPER
+    RET

--- a/i16/i16_amd64_test.go
+++ b/i16/i16_amd64_test.go
@@ -563,6 +563,131 @@ func TestMaxAbsAVX2_NoOverRead(t *testing.T) {
 	}
 }
 
+// TestSumAVX2_ParityWithGo drives the kernel directly across the sweep, then
+// pins the int32 two's-complement wraparound: a long run of the type maximum
+// must wrap exactly as the reference does.
+func TestSumAVX2_ParityWithGo(t *testing.T) {
+	if !cpu.X86.AVX2 {
+		t.Skip("AVX2 not available")
+	}
+	for _, n := range tier3Lengths {
+		a := genI16(n, 145)
+		if got, want := sumAVX2(a), sumGo(a); got != want {
+			t.Errorf("sumAVX2 n=%d: got %d, want %d", n, got, want)
+		}
+	}
+	wa := make([]int16, 70000)
+	for i := range wa {
+		wa[i] = math.MaxInt16
+	}
+	if got, want := sumAVX2(wa), sumGo(wa); got != want {
+		t.Errorf("sumAVX2 wraparound: got %d, want %d", got, want)
+	}
+	if sumGo(wa) >= 0 {
+		t.Fatalf("test setup: expected the reference to wrap negative, got %d", sumGo(wa))
+	}
+}
+
+// TestSumAVX2_NoOverRead hands the kernel a prefix of a longer allocation whose
+// tail is -32768. A wrapping sum's identity is 0, so zeroed past-slice memory is
+// invisible; the planted extreme shifts the total by a nonzero multiple of
+// -32768 that a handful of over-read lanes cannot cancel, so an over-reading
+// kernel diverges from the reference over a[:n].
+func TestSumAVX2_NoOverRead(t *testing.T) {
+	if !cpu.X86.AVX2 {
+		t.Skip("AVX2 not available")
+	}
+	backing := make([]int16, 64+16)
+	for i := range backing {
+		backing[i] = math.MinInt16
+	}
+	for _, n := range []int{1, 7, 8, 9, 15, 16, 17, 24, 31, 32, 33, 64} {
+		a := backing[:n]
+		for i := range a {
+			a[i] = int16(i%50 - 25)
+		}
+		if got, want := sumAVX2(a), sumGo(a); got != want {
+			t.Fatalf("sumAVX2 n=%d: got %d, want %d (read past the operand?)", n, got, want)
+		}
+		for i := range a {
+			backing[i] = math.MinInt16
+		}
+	}
+}
+
+// TestMinMaxAVX2_ParityWithGo drives the kernel directly across the sweep, then
+// plants each type extreme at every lane position: the signed min must report
+// -32768 and the max +32767.
+func TestMinMaxAVX2_ParityWithGo(t *testing.T) {
+	if !cpu.X86.AVX2 {
+		t.Skip("AVX2 not available")
+	}
+	for _, n := range tier3Lengths {
+		if n < minAVX2MinMax {
+			continue // the kernel seeds from block 0; sub-block n routes to Go
+		}
+		a := genI16(n, 146)
+		gotLo, gotHi := minMaxAVX2(a)
+		wantLo, wantHi := minMaxGo(a)
+		if gotLo != wantLo || gotHi != wantHi {
+			t.Errorf("minMaxAVX2 n=%d: got (%d,%d), want (%d,%d)", n, gotLo, gotHi, wantLo, wantHi)
+		}
+	}
+	for _, n := range []int{16, 17, 24, 32, 33} {
+		for pos := range n {
+			a := make([]int16, n)
+			for i := range a {
+				a[i] = int16(i%100 - 50)
+			}
+			a[pos] = math.MinInt16
+			if lo, _ := minMaxAVX2(a); lo != math.MinInt16 {
+				t.Fatalf("minMaxAVX2 n=%d pos=%d min: got %d, want %d", n, pos, lo, math.MinInt16)
+			}
+			b := make([]int16, n)
+			for i := range b {
+				b[i] = int16(i%100 - 50)
+			}
+			b[pos] = math.MaxInt16
+			if _, hi := minMaxAVX2(b); hi != math.MaxInt16 {
+				t.Fatalf("minMaxAVX2 n=%d pos=%d max: got %d, want %d", n, pos, hi, math.MaxInt16)
+			}
+		}
+	}
+}
+
+// TestMinMaxAVX2_NoOverRead hands the kernel a prefix of a longer allocation
+// whose tail alternates the two type extremes. The overlapping final block reads
+// a[n-16 .. n), all in bounds for n >= 16; an over-read past a[n) would pull a
+// planted extreme into the min or max and diverge from the reference.
+func TestMinMaxAVX2_NoOverRead(t *testing.T) {
+	if !cpu.X86.AVX2 {
+		t.Skip("AVX2 not available")
+	}
+	backing := make([]int16, 64+16)
+	poison := func() {
+		for i := range backing {
+			if i%2 == 0 {
+				backing[i] = math.MinInt16
+			} else {
+				backing[i] = math.MaxInt16
+			}
+		}
+	}
+	poison()
+	for _, n := range []int{16, 17, 24, 31, 32, 33, 64} {
+		a := backing[:n]
+		for i := range a {
+			a[i] = int16(i%50 - 25)
+		}
+		gotLo, gotHi := minMaxAVX2(a)
+		wantLo, wantHi := minMaxGo(a)
+		if gotLo != wantLo || gotHi != wantHi {
+			t.Fatalf("minMaxAVX2 n=%d: got (%d,%d), want (%d,%d) (read past the operand?)", n, gotLo, gotHi, wantLo, wantHi)
+		}
+		poison()
+	}
+}
+
 // TestTier3Dispatch_ReachesSIMD pins the dispatch state the tier-3 SIMD paths
 // depend on. It has to be a white-box check: the kernels are bit-identical to
 // the Go references by design, so a dispatcher that silently routed every
@@ -582,9 +707,9 @@ func TestTier3Dispatch_ReachesSIMD(t *testing.T) {
 	if hasAVX2 != cpu.X86.AVX2 {
 		t.Fatalf("hasAVX2 = %v but cpu.X86.AVX2 = %v: dispatch flag is not wired to CPU detection", hasAVX2, cpu.X86.AVX2)
 	}
-	if minAVX2MulQ15 > 32 || minAVX2Abs > 32 || minAVX2MaxAbs > 32 {
-		t.Fatalf("tier-3 AVX2 thresholds exceed two vector blocks (MulQ15 %d, Abs %d, MaxAbs %d): the ops would not vectorize at the frame lengths they were written for",
-			minAVX2MulQ15, minAVX2Abs, minAVX2MaxAbs)
+	if minAVX2MulQ15 > 32 || minAVX2Abs > 32 || minAVX2MaxAbs > 32 || minAVX2Sum > 32 || minAVX2MinMax > 32 {
+		t.Fatalf("tier-3 AVX2 thresholds exceed two vector blocks (MulQ15 %d, Abs %d, MaxAbs %d, Sum %d, MinMax %d): the ops would not vectorize at the frame lengths they were written for",
+			minAVX2MulQ15, minAVX2Abs, minAVX2MaxAbs, minAVX2Sum, minAVX2MinMax)
 	}
 }
 
@@ -606,6 +731,8 @@ func TestTier3AVX2Kernels_AllocFree(t *testing.T) {
 		{"mulQ15AVX2", func() { mulQ15AVX2(dst, a, b) }},
 		{"absAVX2", func() { absAVX2(dst, a) }},
 		{"maxAbsAVX2", func() { _ = maxAbsAVX2(a) }},
+		{"sumAVX2", func() { _ = sumAVX2(a) }},
+		{"minMaxAVX2", func() { _, _ = minMaxAVX2(a) }},
 	}
 	for _, c := range checks {
 		if got := testing.AllocsPerRun(100, c.fn); got != 0 {

--- a/i16/i16_arm64.go
+++ b/i16/i16_arm64.go
@@ -102,6 +102,8 @@ const (
 	minNEONMulQ15 = 8
 	minNEONAbs    = 8
 	minNEONMaxAbs = 8
+	minNEONSum    = 8
+	minNEONMinMax = 8
 )
 
 func mulQ15I16(dst, a, b []int16) {
@@ -126,6 +128,26 @@ func maxAbsI16(a []int16) int {
 	}
 	return maxAbsGo(a)
 }
+
+func sumI16(a []int16) int32 {
+	if hasNEON && len(a) >= minNEONSum {
+		return sumNEON(a)
+	}
+	return sumGo(a)
+}
+
+func minMaxI16(a []int16) (minVal, maxVal int16) {
+	if hasNEON && len(a) >= minNEONMinMax {
+		return minMaxNEON(a)
+	}
+	return minMaxGo(a)
+}
+
+//go:noescape
+func sumNEON(a []int16) int32
+
+//go:noescape
+func minMaxNEON(a []int16) (minVal, maxVal int16)
 
 //go:noescape
 func mulQ15NEON(dst, a, b []int16)

--- a/i16/i16_arm64.s
+++ b/i16/i16_arm64.s
@@ -422,3 +422,90 @@ maxabs_neon_scalar:
 maxabs_neon_done:
     MOVD R5, ret+24(FP)
     RET
+
+// func sumNEON(a []int16) int32
+// Widening int16 sum: SADALP pairwise-accumulates each .8H block into a 4-lane
+// int32 accumulator, ADDV folds the lanes, and a scalar tail adds the (n mod 8)
+// remainder. Accumulation wraps in int32 exactly as sumGo does, so the result is
+// bit-identical to Sum's pure-Go reference for every input, including overflow.
+TEXT ·sumNEON(SB), NOSPLIT, $0-28
+    MOVD a_base+0(FP), R1
+    MOVD a_len+8(FP), R3
+
+    VEOR V2.B16, V2.B16, V2.B16   // int32 accumulator = 0
+    LSR  $3, R3, R4               // R4 = n / 8
+    CBZ  R4, sum_i16_reduce
+
+sum_i16_loop8:
+    VLD1.P 16(R1), [V0.H8]
+    WORD $0x4E606802             // SADALP V2.4S, V0.8H
+    SUB  $1, R4
+    CBNZ R4, sum_i16_loop8
+
+sum_i16_reduce:
+    WORD $0x4EB1B842             // ADDV S2, V2.4S
+    FMOVS F2, R5                  // R5 = vector total (low 32)
+
+    AND  $7, R3
+    CBZ  R3, sum_i16_done
+
+sum_i16_scalar:
+    MOVH.P 2(R1), R6             // sign-extending 16-bit load
+    ADDW R6, R5, R5             // 32-bit wrapping add
+    SUB  $1, R3
+    CBNZ R3, sum_i16_scalar
+
+sum_i16_done:
+    MOVW R5, ret+24(FP)
+    RET
+
+// func minMaxNEON(a []int16) (minVal, maxVal int16)
+// Signed int16 min and max in one pass: SMIN/SMAX fold 8-wide (.8H) blocks into
+// running accumulators seeded from block 0, SMINV/SMAXV reduce each across its 8
+// lanes to a halfword, and a scalar tail folds the (n mod 8) remainder. The
+// dispatch gates n >= 8, so at least one full block exists. Signed min/max has no
+// accumulation order, so the result is bit-identical to minMaxGo.
+TEXT ·minMaxNEON(SB), NOSPLIT, $0-28
+    MOVD a_base+0(FP), R2
+    MOVD a_len+8(FP), R3
+
+    LSR  $3, R3, R4               // R4 = full 8-wide blocks (>=1)
+    VLD1 (R2), [V0.H8]            // min acc = block 0 (no advance)
+    VLD1.P 16(R2), [V1.H8]        // max acc = block 0 (advance to block 1)
+    SUB  $1, R4
+    CBZ  R4, mm_i16_reduce
+
+mm_i16_loop:
+    VLD1.P 16(R2), [V2.H8]
+    WORD $0x4E626C00             // SMIN V0.8H, V0.8H, V2.8H
+    WORD $0x4E626421             // SMAX V1.8H, V1.8H, V2.8H
+    SUB  $1, R4
+    CBNZ R4, mm_i16_loop
+
+mm_i16_reduce:
+    WORD $0x4E71A803             // SMINV H3, V0.8H
+    WORD $0x4E70A824             // SMAXV H4, V1.8H
+    FMOVS F3, R5                  // min halfword (zero-extended)
+    FMOVS F4, R6                  // max halfword
+    LSLW $16, R5, R5
+    ASRW $16, R5, R5              // sign-extend low halfword -> int32 min
+    LSLW $16, R6, R6
+    ASRW $16, R6, R6              // sign-extend low halfword -> int32 max
+
+    AND  $7, R3, R4              // tail count
+    CBZ  R4, mm_i16_done
+    // R2 already points at &a[fullBlocks*8] after the loop.
+
+mm_i16_tail:
+    MOVH.P 2(R2), R7            // r (sign-extended)
+    CMPW R5, R7
+    CSEL LT, R7, R5, R5           // R5 = min(r, R5)
+    CMPW R6, R7
+    CSEL GT, R7, R6, R6           // R6 = max(r, R6)
+    SUB  $1, R4
+    CBNZ R4, mm_i16_tail
+
+mm_i16_done:
+    MOVH R5, minVal+24(FP)
+    MOVH R6, maxVal+26(FP)
+    RET

--- a/i16/i16_arm64_test.go
+++ b/i16/i16_arm64_test.go
@@ -375,6 +375,127 @@ func TestMaxAbsNEON_NoOverRead(t *testing.T) {
 	}
 }
 
+// TestSumNEON_ParityWithGo drives the kernel directly across the sweep, then
+// pins the int32 two's-complement wraparound.
+func TestSumNEON_ParityWithGo(t *testing.T) {
+	if !cpu.ARM64.NEON {
+		t.Skip("NEON not available")
+	}
+	for _, n := range tier3Lengths {
+		a := genI16(n, 147)
+		if got, want := sumNEON(a), sumGo(a); got != want {
+			t.Errorf("sumNEON n=%d: got %d, want %d", n, got, want)
+		}
+	}
+	wa := make([]int16, 70000)
+	for i := range wa {
+		wa[i] = math.MaxInt16
+	}
+	if got, want := sumNEON(wa), sumGo(wa); got != want {
+		t.Errorf("sumNEON wraparound: got %d, want %d", got, want)
+	}
+	if sumGo(wa) >= 0 {
+		t.Fatalf("test setup: expected the reference to wrap negative, got %d", sumGo(wa))
+	}
+}
+
+// TestSumNEON_NoOverRead hands the kernel a prefix of a longer allocation whose
+// tail is -32768. A wrapping sum's identity is 0, so zeroed past-slice memory is
+// invisible; the planted extreme shifts the total so an over-reading kernel
+// diverges from the reference over a[:n].
+func TestSumNEON_NoOverRead(t *testing.T) {
+	if !cpu.ARM64.NEON {
+		t.Skip("NEON not available")
+	}
+	backing := make([]int16, 64+8)
+	for i := range backing {
+		backing[i] = math.MinInt16
+	}
+	for _, n := range []int{1, 7, 8, 9, 15, 16, 17, 24, 33, 64} {
+		a := backing[:n]
+		for i := range a {
+			a[i] = int16(i%50 - 25)
+		}
+		if got, want := sumNEON(a), sumGo(a); got != want {
+			t.Fatalf("sumNEON n=%d: got %d, want %d (read past the operand?)", n, got, want)
+		}
+		for i := range a {
+			backing[i] = math.MinInt16
+		}
+	}
+}
+
+// TestMinMaxNEON_ParityWithGo drives the kernel directly across the sweep, then
+// plants each type extreme at every lane position.
+func TestMinMaxNEON_ParityWithGo(t *testing.T) {
+	if !cpu.ARM64.NEON {
+		t.Skip("NEON not available")
+	}
+	for _, n := range tier3Lengths {
+		if n < minNEONMinMax {
+			continue // the kernel seeds from block 0; sub-block n routes to Go
+		}
+		a := genI16(n, 148)
+		gotLo, gotHi := minMaxNEON(a)
+		wantLo, wantHi := minMaxGo(a)
+		if gotLo != wantLo || gotHi != wantHi {
+			t.Errorf("minMaxNEON n=%d: got (%d,%d), want (%d,%d)", n, gotLo, gotHi, wantLo, wantHi)
+		}
+	}
+	for _, n := range []int{8, 9, 16, 17, 24} {
+		for pos := range n {
+			a := make([]int16, n)
+			for i := range a {
+				a[i] = int16(i%100 - 50)
+			}
+			a[pos] = math.MinInt16
+			if lo, _ := minMaxNEON(a); lo != math.MinInt16 {
+				t.Fatalf("minMaxNEON n=%d pos=%d min: got %d, want %d", n, pos, lo, math.MinInt16)
+			}
+			b := make([]int16, n)
+			for i := range b {
+				b[i] = int16(i%100 - 50)
+			}
+			b[pos] = math.MaxInt16
+			if _, hi := minMaxNEON(b); hi != math.MaxInt16 {
+				t.Fatalf("minMaxNEON n=%d pos=%d max: got %d, want %d", n, pos, hi, math.MaxInt16)
+			}
+		}
+	}
+}
+
+// TestMinMaxNEON_NoOverRead hands the kernel a prefix of a longer allocation
+// whose tail alternates the two type extremes; an over-read past a[n) would pull
+// a planted extreme into the min or max and diverge from the reference.
+func TestMinMaxNEON_NoOverRead(t *testing.T) {
+	if !cpu.ARM64.NEON {
+		t.Skip("NEON not available")
+	}
+	backing := make([]int16, 64+8)
+	poison := func() {
+		for i := range backing {
+			if i%2 == 0 {
+				backing[i] = math.MinInt16
+			} else {
+				backing[i] = math.MaxInt16
+			}
+		}
+	}
+	poison()
+	for _, n := range []int{8, 9, 15, 16, 17, 24, 33, 64} {
+		a := backing[:n]
+		for i := range a {
+			a[i] = int16(i%50 - 25)
+		}
+		gotLo, gotHi := minMaxNEON(a)
+		wantLo, wantHi := minMaxGo(a)
+		if gotLo != wantLo || gotHi != wantHi {
+			t.Fatalf("minMaxNEON n=%d: got (%d,%d), want (%d,%d) (read past the operand?)", n, gotLo, gotHi, wantLo, wantHi)
+		}
+		poison()
+	}
+}
+
 // TestTier3Dispatch_ReachesNEON pins the dispatch state the tier-3 SIMD paths
 // depend on. It has to be a white-box check: the kernels are bit-identical to
 // the Go references by design, so a dispatcher that silently routed every
@@ -396,9 +517,9 @@ func TestTier3Dispatch_ReachesNEON(t *testing.T) {
 	if !hasNEON {
 		t.Fatal("hasNEON is false though cpu.ARM64.NEON is true: the tier-3 ops silently run the Go reference on every call")
 	}
-	if minNEONMulQ15 > 16 || minNEONAbs > 16 || minNEONMaxAbs > 16 {
-		t.Fatalf("tier-3 NEON thresholds exceed two vector blocks (MulQ15 %d, Abs %d, MaxAbs %d): the ops would not vectorize at the frame lengths they were written for",
-			minNEONMulQ15, minNEONAbs, minNEONMaxAbs)
+	if minNEONMulQ15 > 16 || minNEONAbs > 16 || minNEONMaxAbs > 16 || minNEONSum > 16 || minNEONMinMax > 16 {
+		t.Fatalf("tier-3 NEON thresholds exceed two vector blocks (MulQ15 %d, Abs %d, MaxAbs %d, Sum %d, MinMax %d): the ops would not vectorize at the frame lengths they were written for",
+			minNEONMulQ15, minNEONAbs, minNEONMaxAbs, minNEONSum, minNEONMinMax)
 	}
 }
 
@@ -420,6 +541,8 @@ func TestTier3NEONKernels_AllocFree(t *testing.T) {
 		{"mulQ15NEON", func() { mulQ15NEON(dst, a, b) }},
 		{"absNEON", func() { absNEON(dst, a) }},
 		{"maxAbsNEON", func() { _ = maxAbsNEON(a) }},
+		{"sumNEON", func() { _ = sumNEON(a) }},
+		{"minMaxNEON", func() { _, _ = minMaxNEON(a) }},
 	}
 	for _, c := range checks {
 		if got := testing.AllocsPerRun(100, c.fn); got != 0 {

--- a/i16/i16_go.go
+++ b/i16/i16_go.go
@@ -119,6 +119,39 @@ func maxAbsGo(a []int16) int {
 	return m
 }
 
+// sumGo widens each int16 to int32 and accumulates into an int32 running sum
+// with two's-complement wraparound. It is the bit-exact source of truth for the
+// Sum kernels.
+//
+// Wrapping (rather than saturating) accumulation is the contract, exactly as for
+// dotGo: wrapping addition is associative and commutative modulo 2^32, so the
+// SIMD lane grouping and horizontal reduction produce bit-identical results to
+// this sequential loop for every input, including forced overflow.
+func sumGo(a []int16) int32 {
+	var s int32
+	for _, v := range a {
+		s += int32(v)
+	}
+	return s
+}
+
+// minMaxGo returns the signed minimum and maximum of a. Both fit int16 for every
+// input (min and max of int16 values are themselves int16), so no widening is
+// needed, unlike maxAbsGo. It indexes a[0], so the public wrapper guards the
+// empty case; it is the bit-exact source of truth for the MinMax kernels.
+func minMaxGo(a []int16) (minVal, maxVal int16) {
+	lo, hi := a[0], a[0]
+	for _, v := range a[1:] {
+		if v < lo {
+			lo = v
+		}
+		if v > hi {
+			hi = v
+		}
+	}
+	return lo, hi
+}
+
 // xcorrWindow returns the y window the 4-lag kernel may read for the block at
 // lag k: lag k+3 reaches y[k+3+len(x)-1], so the block needs len(x)+3 elements
 // from y[k]. That is in bounds precisely when k+xcorrLagBlock <= m, which is

--- a/i16/i16_other.go
+++ b/i16/i16_other.go
@@ -2,10 +2,12 @@
 
 package i16
 
-func interleave2I16(dst, a, b []int16)   { interleave2Go(dst, a, b) }
-func deinterleave2I16(a, b, src []int16) { deinterleave2Go(a, b, src) }
-func dotI16(a, b []int16) int32          { return dotGo(a, b) }
-func xcorrI16(dst []int32, x, y []int16) { xcorrGo(dst, x, y) }
-func mulQ15I16(dst, a, b []int16)        { mulQ15Go(dst, a, b) }
-func absI16(dst, a []int16)              { absGo(dst, a) }
-func maxAbsI16(a []int16) int            { return maxAbsGo(a) }
+func interleave2I16(dst, a, b []int16)           { interleave2Go(dst, a, b) }
+func deinterleave2I16(a, b, src []int16)         { deinterleave2Go(a, b, src) }
+func dotI16(a, b []int16) int32                  { return dotGo(a, b) }
+func xcorrI16(dst []int32, x, y []int16)         { xcorrGo(dst, x, y) }
+func mulQ15I16(dst, a, b []int16)                { mulQ15Go(dst, a, b) }
+func absI16(dst, a []int16)                      { absGo(dst, a) }
+func maxAbsI16(a []int16) int                    { return maxAbsGo(a) }
+func sumI16(a []int16) int32                     { return sumGo(a) }
+func minMaxI16(a []int16) (minVal, maxVal int16) { return minMaxGo(a) }

--- a/i16/minmax.go
+++ b/i16/minmax.go
@@ -4,7 +4,7 @@ package i16
 //
 //	minVal = min_i a[i],  maxVal = max_i a[i]
 //
-// Both are signed comparisons. Unlike [MaxAbs] the result needs no widening: the
+// Both are signed comparisons. Unlike [MaxAbs], the result needs no widening: the
 // minimum and maximum of a set of int16 values are themselves int16, so this is
 // the signed range probe (peak and trough), distinct from the abs-max headroom
 // probe. An empty a returns (0, 0). a is read-only; the call allocates nothing.

--- a/i16/minmax.go
+++ b/i16/minmax.go
@@ -1,0 +1,21 @@
+package i16
+
+// MinMax returns the smallest and largest int16 in a:
+//
+//	minVal = min_i a[i],  maxVal = max_i a[i]
+//
+// Both are signed comparisons. Unlike [MaxAbs] the result needs no widening: the
+// minimum and maximum of a set of int16 values are themselves int16, so this is
+// the signed range probe (peak and trough), distinct from the abs-max headroom
+// probe. An empty a returns (0, 0). a is read-only; the call allocates nothing.
+//
+// The SIMD fast path uses signed-min/max vector instructions (VPMINSW/VPMAXSW on
+// amd64, SMIN/SMAX with single-instruction SMINV/SMAXV folds on arm64). Signed
+// min/max has no accumulation order, so the SIMD paths are bit-identical to the
+// pure-Go reference by construction.
+func MinMax(a []int16) (minVal, maxVal int16) {
+	if len(a) == 0 {
+		return 0, 0
+	}
+	return minMaxI16(a)
+}

--- a/i16/minmax_test.go
+++ b/i16/minmax_test.go
@@ -1,0 +1,100 @@
+package i16
+
+import (
+	"math"
+	"testing"
+)
+
+func TestMinMax(t *testing.T) {
+	if lo, hi := MinMax(nil); lo != 0 || hi != 0 {
+		t.Errorf("MinMax(nil) = (%d,%d), want (0,0)", lo, hi)
+	}
+	if lo, hi := MinMax([]int16{}); lo != 0 || hi != 0 {
+		t.Errorf("MinMax(empty) = (%d,%d), want (0,0)", lo, hi)
+	}
+	if lo, hi := MinMax([]int16{5}); lo != 5 || hi != 5 {
+		t.Errorf("MinMax([5]) = (%d,%d), want (5,5)", lo, hi)
+	}
+	if lo, hi := MinMax([]int16{0, -32768, 32767, 3, -1}); lo != -32768 || hi != 32767 {
+		t.Errorf("MinMax = (%d,%d), want (-32768,32767)", lo, hi)
+	}
+
+	// Parity across the sweep against the reference and an independent scan.
+	for _, n := range tier3Lengths {
+		if n == 0 {
+			continue
+		}
+		a := genI16(n, 92)
+		gotLo, gotHi := MinMax(a)
+		wantLo, wantHi := minMaxGo(a)
+		if gotLo != wantLo || gotHi != wantHi {
+			t.Errorf("MinMax n=%d: got (%d,%d), want (%d,%d)", n, gotLo, gotHi, wantLo, wantHi)
+		}
+		oracleLo, oracleHi := a[0], a[0]
+		for _, v := range a {
+			if v < oracleLo {
+				oracleLo = v
+			}
+			if v > oracleHi {
+				oracleHi = v
+			}
+		}
+		if gotLo != oracleLo || gotHi != oracleHi {
+			t.Errorf("MinMax n=%d: got (%d,%d), want (%d,%d) (oracle)", n, gotLo, gotHi, oracleLo, oracleHi)
+		}
+	}
+}
+
+// TestMinMax_Extremes plants the type extremes at every lane position and the
+// scalar tail, at lengths that reach the vector bodies: the signed min must
+// report -32768 and the max +32767 rather than an unsigned or swapped result.
+func TestMinMax_Extremes(t *testing.T) {
+	for _, n := range []int{1, 7, 8, 9, 15, 16, 17, 19, 24, 31, 32, 33, 64, 100} {
+		for pos := range n {
+			// Plant the minimum against a tame body; the max stays inside.
+			a := make([]int16, n)
+			for i := range a {
+				a[i] = int16(i%100 - 50)
+			}
+			a[pos] = math.MinInt16
+			if lo, _ := MinMax(a); lo != math.MinInt16 {
+				t.Fatalf("MinMax n=%d pos=%d min: got %d, want %d", n, pos, lo, math.MinInt16)
+			}
+			// Plant the maximum against the same tame body.
+			b := make([]int16, n)
+			for i := range b {
+				b[i] = int16(i%100 - 50)
+			}
+			b[pos] = math.MaxInt16
+			if _, hi := MinMax(b); hi != math.MaxInt16 {
+				t.Fatalf("MinMax n=%d pos=%d max: got %d, want %d", n, pos, hi, math.MaxInt16)
+			}
+		}
+	}
+}
+
+// TestMinMax_AllEqual: a constant slice must report (c, c). Uses INT16_MIN so a
+// kernel that seeded its max accumulator from a wrong constant would show.
+func TestMinMax_AllEqual(t *testing.T) {
+	for _, n := range []int{1, 8, 16, 17, 33, 64} {
+		for _, c := range []int16{math.MinInt16, -1, 0, 1, math.MaxInt16} {
+			a := make([]int16, n)
+			for i := range a {
+				a[i] = c
+			}
+			if lo, hi := MinMax(a); lo != c || hi != c {
+				t.Fatalf("MinMax n=%d all=%d: got (%d,%d), want (%d,%d)", n, c, lo, hi, c, c)
+			}
+		}
+	}
+}
+
+// TestMinMax_AllocFree: buffers INSIDE the closure, see TestMaxAbs_AllocFree.
+func TestMinMax_AllocFree(t *testing.T) {
+	if n := testing.AllocsPerRun(50, func() {
+		var a [240]int16
+		_, _ = MinMax(a[:])
+	}); n != 0 {
+		t.Errorf("MinMax forces %v caller allocations per run, want 0", n)
+	}
+}

--- a/i16/sum.go
+++ b/i16/sum.go
@@ -1,0 +1,20 @@
+package i16
+
+// Sum returns the sum of all elements of a, widened to and accumulated in int32
+// with two's-complement wraparound, never saturation. This is the same contract
+// as [DotProduct]: wrapping addition is associative and commutative modulo 2^32,
+// so any SIMD lane grouping and any horizontal reduction order yields the same
+// bits as the sequential loop, including on inputs engineered to overflow. That
+// reproducibility is what lets the kernels vectorize at all.
+//
+// The accumulator is int32, so a run of same-signed samples wraps once |sum|
+// passes 2^31 (about 65536 samples at full scale). A caller that needs a
+// wider running total over a long buffer should widen first (or reduce in
+// blocks); the wrap here is defined, not an error. An empty a returns 0. a is
+// read-only; the call allocates nothing.
+func Sum(a []int16) int32 {
+	if len(a) == 0 {
+		return 0
+	}
+	return sumI16(a)
+}

--- a/i16/sum_test.go
+++ b/i16/sum_test.go
@@ -1,0 +1,73 @@
+package i16
+
+import (
+	"math"
+	"testing"
+)
+
+func TestSum(t *testing.T) {
+	// Literal cases.
+	if got := Sum(nil); got != 0 {
+		t.Errorf("Sum(nil) = %d, want 0", got)
+	}
+	if got := Sum([]int16{}); got != 0 {
+		t.Errorf("Sum(empty) = %d, want 0", got)
+	}
+	if got := Sum([]int16{32767, 32767, 1, -32768}); got != 32767 {
+		t.Errorf("Sum([32767,32767,1,-32768]) = %d, want 32767", got)
+	}
+
+	// Parity across the sweep against the reference and an independent int64
+	// oracle (which cannot wrap at these lengths, so it also pins that the
+	// running total is not narrowed to int16 mid-reduction).
+	for _, n := range tier3Lengths {
+		a := genI16(n, 91)
+		got := Sum(a)
+		if want := sumGo(a); got != want {
+			t.Errorf("Sum n=%d: got %d, want %d (reference)", n, got, want)
+		}
+		var oracle int64
+		for _, v := range a {
+			oracle += int64(v)
+		}
+		if int64(got) != oracle {
+			t.Errorf("Sum n=%d: got %d, want %d (int64 oracle)", n, got, oracle)
+		}
+	}
+
+	// int32 accumulation must not narrow before the total: 300 elements of 30000
+	// sum to 9_000_000, which exceeds int16 but fits int32.
+	big := make([]int16, 300)
+	for i := range big {
+		big[i] = 30000
+	}
+	if got, want := Sum(big), int32(300*30000); got != want {
+		t.Errorf("Sum(300x30000) = %d, want %d", got, want)
+	}
+
+	// int32 two's-complement wraparound: 70000 elements of 32767 sum to
+	// 2_293_690_000, which overflows int32. The result must wrap exactly like the
+	// reference (verified here against an independent int64->int32 truncation).
+	const wn = 70000
+	wa := make([]int16, wn)
+	for i := range wa {
+		wa[i] = math.MaxInt16
+	}
+	wantWrap := int32(int64(len(wa)) * math.MaxInt16) // non-constant: truncates at runtime
+	if wantWrap >= 0 {
+		t.Fatalf("test setup: expected wraparound to a negative value, got %d", wantWrap)
+	}
+	if got := Sum(wa); got != wantWrap {
+		t.Errorf("Sum wraparound = %d, want %d", got, wantWrap)
+	}
+}
+
+// TestSum_AllocFree: buffers INSIDE the closure, see TestMaxAbs_AllocFree.
+func TestSum_AllocFree(t *testing.T) {
+	if n := testing.AllocsPerRun(50, func() {
+		var a [240]int16
+		_ = Sum(a[:])
+	}); n != 0 {
+		t.Errorf("Sum forces %v caller allocations per run, want 0", n)
+	}
+}


### PR DESCRIPTION
## What

Adds two reductions to the `i16` package, `Sum` and `MinMax`, bringing its reduction set to parity with `i8` and `i32` (which already ship both).

- `Sum(a []int16) int32` widens each `int16` to `int32` and accumulates with two's-complement wraparound, the same contract as `DotProduct`. An empty slice returns 0.
- `MinMax(a []int16) (minVal, maxVal int16)` returns the signed minimum and maximum in a single pass. An empty slice returns `(0, 0)`.

## Why

`i16` was the sparsest integer package: `MaxAbs` and `DotProduct` were its only reductions, while `i8` and `i32` both provide `Sum` and `MinMax`. `MinMax` is the signed range probe (peak and trough), distinct from the abs-max headroom probe `MaxAbs`, and `Sum` is the widening total. Both fit the package's stated discipline: `Sum` widens (the narrow int16 input is the point), and `MinMax`'s result fits int16 for every input. Element-wise int16 add/sub deliberately stays in `i32` (inter-channel decorrelation can need a 17th bit); these are reductions, not element-wise arithmetic, so they belong here.

## How

Kernels are AVX2-or-Go on amd64 and NEON-or-Go on arm64, matching the existing `MaxAbs` tiering (no SSE2 tier).

- `sumAVX2`: `VPMADDWD` against a +1 vector widens and pairwise-adds each block to int32, `VPADDD` accumulates; an 8-wide XMM pre-block absorbs the 0-15 remainder before the 16-wide loop.
- `sumNEON`: `SADALP` accumulates each `.8H` block into a 4-lane int32 accumulator, `ADDV` folds.
- `minMaxAVX2`: `VPMINSW`/`VPMAXSW` fold 32-byte blocks seeded from block 0, an overlapping final block absorbs the tail (signed min/max are idempotent, so reprocessing the overlap is exact), a per-lane cascade reduces to a word.
- `minMaxNEON`: `SMIN`/`SMAX` fold `.8H` blocks, single-instruction `SMINV`/`SMAXV` reduce.

Wrapping and signed reductions have no accumulation order, so each kernel is bit-identical to its pure-Go reference for every input, including inputs engineered to overflow the int32 accumulator. The new arm64 `WORD` encodings are cross-checked against `golang.org/x/arch/arm64asm` by the asmcheck suite.

## Test plan

- Parity (kernel-direct and through the public API) against the pure-Go reference plus an independent oracle, across a length sweep that crosses every block boundary.
- Extremes planted at each lane position (`MinInt16`/`MaxInt16`), all-equal inputs, and the empty and single-element cases.
- No-over-read checks (the operand is a prefix of a poisoned backing array, so an over-read diverges from the reference).
- Forced int32 overflow (70000 x `MaxInt16`) asserting the exact wrapped value.
- Differential fuzzing (`FuzzI16Sum`, `FuzzI16MinMax`).
- Zero-allocation assertions (`testing.AllocsPerRun == 0`).
- Exercised on linux/amd64 (AVX2), linux/arm64 and darwin/arm64 (NEON), and the pure-Go fallback. `go test ./...`, `go vet ./...`, and `golangci-lint run ./...` are clean on both GOARCHes.

Benchmarks at n=1000, over the pure-Go fallback:

- AVX2 (i7-1260P): `Sum` 17.6 ns vs 216 ns (~12x), `MinMax` 18.4 ns vs 431 ns (~23x).
- NEON (Cortex-A76): `Sum` 114 ns vs 873 ns (~7.7x), `MinMax` 110 ns vs 1569 ns (~14x).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added `i16.Sum` for allocation-free summation of `int16` values with `int32` wrapping behavior.
  - Added `i16.MinMax` to return signed minimum and maximum values, including defined behavior for empty input.
  - Added optimized SIMD support for supported platforms, with portable fallbacks.

- **Documentation**
  - Updated API documentation and examples for `Sum` and `MinMax`.

- **Tests**
  - Added comprehensive correctness, overflow, bounds-safety, fuzz, benchmark, and allocation tests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->