### PR TITLE
i8/i32: multi-accumulator NEON reductions; i16 minMaxNEON overlapping tail (Fixes #283)

### DIFF
--- a/i16/i16_arm64.go
+++ b/i16/i16_arm64.go
@@ -95,9 +95,13 @@ func dotI16(a, b []int16) int32 {
 
 // Tier-3 thresholds: one 8-wide (.8H) vector block each. Like minNEONDot they
 // are independent literals rather than aliases of minNEONElements, so retuning
-// one op can never silently move another's cut. All three kernels are correct
-// at any length (each falls through to a scalar tail), so these are
-// performance cuts only, never a safety requirement.
+// one op can never silently move another's cut. mulQ15NEON, absNEON, maxAbsNEON
+// and sumNEON are correct at any length: each writes element-wise or accumulates
+// from zero and falls through to a scalar tail, so their thresholds are
+// performance cuts only. minMaxNEON is the exception: it seeds its min/max
+// accumulators from the first 8-wide block and folds an overlapping final block
+// in place of a scalar tail, so it needs a full block present and minNEONMinMax
+// = 8 is a correctness floor, not just a performance cut.
 const (
 	minNEONMulQ15 = 8
 	minNEONAbs    = 8

--- a/i16/i16_arm64.s
+++ b/i16/i16_arm64.s
@@ -493,11 +493,17 @@ sum_i16_done:
 // SMIN and two independent SMAX chains so the compare latency stays off the
 // loop-carried critical path (measured ~37% faster at n=4096 on Cortex-A76 than
 // the single-accumulator-pair form, #282). A possible odd trailing block folds
-// into the first pair, the two pairs are combined, SMINV/SMAXV reduce each across
-// its 8 lanes to a halfword, and a scalar tail folds the (n mod 8) remainder. The
-// dispatch gates n >= 8, so block 0 always exists. Signed min/max is idempotent
-// and has no accumulation order, so the result is bit-identical to minMaxGo;
-// seeding both accumulator pairs from block 0 double-counts it harmlessly.
+// into the first pair, the two pairs are combined, and when (n mod 8) != 0 the
+// last 8 elements a[n-8:n] are folded in as one overlapping .8H block so every
+// element stays on the SIMD path (no scalar tail); SMINV/SMAXV then reduce each
+// accumulator across its 8 lanes to a halfword. The dispatch gates n >= 8, so
+// block 0 and the a[n-8] overlap block are always in range. Signed min/max is
+// idempotent and has no accumulation order, so the result is bit-identical to
+// minMaxGo; seeding both accumulator pairs from block 0, and re-counting the
+// overlap of already-processed elements, both double-count harmlessly. The
+// overlap block replaces a scalar tail of up to 7 CSEL iterations: measured
+// roughly -24% to -41% at ragged sizes (n mod 8 != 0) on Cortex-A76, and neutral
+// when n is a multiple of 8 (no tail to replace) (#283).
 TEXT ·minMaxNEON(SB), NOSPLIT, $0-28
     MOVD a_base+0(FP), R2
     MOVD a_len+8(FP), R3
@@ -508,7 +514,9 @@ TEXT ·minMaxNEON(SB), NOSPLIT, $0-28
     VLD1 (R2), [V5.H8]           // min2 = block 0 (idempotent seed)
     VLD1.P 16(R2), [V6.H8]       // max2 = block 0 (advance past block 0)
     SUB  $1, R4                   // blocks after block 0
-    CBZ  R4, mm_i16_reduce
+    // Single block: fold pairs (harmless self-fold of block 0) then run the
+    // overlap tail, rather than jumping past both straight to the reduce.
+    CBZ  R4, mm_i16_foldpairs
 
     LSR  $1, R4, R7             // R7 = pairs = (blocks after 0) / 2
     CBZ  R7, mm_i16_odd
@@ -532,6 +540,20 @@ mm_i16_foldpairs:
     WORD $0x4E656C00             // SMIN V0.8H, V0.8H, V5.8H
     WORD $0x4E666421             // SMAX V1.8H, V1.8H, V6.8H
 
+    // Overlapping tail: when (n mod 8) != 0, fold the last 8 elements a[n-8:n] in
+    // as one .8H block before the horizontal reduce, so every element stays on the
+    // SIMD path (no scalar tail). Idempotency makes re-counting the overlap of
+    // already-processed elements harmless; the n >= 8 gate keeps a[n-8] in range.
+    AND  $7, R3, R4
+    CBZ  R4, mm_i16_reduce
+    SUB  $8, R3, R7             // R7 = n - 8 (element index of the overlap block)
+    LSL  $1, R7, R7            // R7 = (n-8)*2 bytes
+    MOVD a_base+0(FP), R2       // reload base (R2 was advanced past the full blocks)
+    ADD  R7, R2, R2            // R2 = &a[n-8]
+    VLD1 (R2), [V2.H8]
+    WORD $0x4E626C00             // SMIN V0.8H, V0.8H, V2.8H
+    WORD $0x4E626421             // SMAX V1.8H, V1.8H, V2.8H
+
 mm_i16_reduce:
     WORD $0x4E71A803             // SMINV H3, V0.8H
     WORD $0x4E70A824             // SMAXV H4, V1.8H
@@ -541,19 +563,6 @@ mm_i16_reduce:
     ASRW $16, R5, R5              // sign-extend low halfword -> int32 min
     LSLW $16, R6, R6
     ASRW $16, R6, R6              // sign-extend low halfword -> int32 max
-
-    AND  $7, R3, R4              // tail count
-    CBZ  R4, mm_i16_done
-    // R2 already points at &a[fullBlocks*8] after the loop.
-
-mm_i16_tail:
-    MOVH.P 2(R2), R7            // r (sign-extended)
-    CMPW R5, R7
-    CSEL LT, R7, R5, R5           // R5 = min(r, R5)
-    CMPW R6, R7
-    CSEL GT, R7, R6, R6           // R6 = max(r, R6)
-    SUB  $1, R4
-    CBNZ R4, mm_i16_tail
 
 mm_i16_done:
     MOVH R5, minVal+24(FP)

--- a/i32/i32_arm64.go
+++ b/i32/i32_arm64.go
@@ -172,10 +172,11 @@ func butterflyI32(lo, hi []int32) {
 func butterflyNEON(lo, hi []int32)
 
 // minMaxI32 dispatches the signed int32 min/max reduction. The NEON kernel does
-// the reduction in 4-wide SMIN/SMAX lanes with a single-instruction SMINV/SMAXV
-// across-vector fold and a scalar tail, so it gates on NEON and at least one full
-// 4-element block; shorter slices use the pure-Go reference. res is non-empty
-// (the public MinMax guards the empty case).
+// the reduction in 4-wide SMIN/SMAX lanes (a 2-block unroll with dual min/max
+// accumulator pairs) with a single-instruction SMINV/SMAXV across-vector fold and
+// a scalar tail, so it gates on NEON and at least one full 4-element block;
+// shorter slices use the pure-Go reference. res is non-empty (the public MinMax
+// guards the empty case).
 func minMaxI32(res []int32) (minVal, maxVal int32) {
 	if hasNEON && len(res) >= minNEONElements {
 		return minMaxNEON(res)

--- a/i32/i32_arm64.s
+++ b/i32/i32_arm64.s
@@ -178,28 +178,53 @@ sub_neon_done:
     RET
 
 // func minMaxNEON(res []int32) (minVal, maxVal int32)
-// Signed int32 min and max over res in one pass. The dispatch gates len(res) >=
-// 4, so at least one full 4-element (.4S) block exists: the min and max
-// accumulators start from block 0 and fold the remaining full blocks with
-// SMIN/SMAX, then SMINV/SMAXV reduce each accumulator across its 4 lanes to a
-// scalar and a scalar tail folds the (n mod 4) remainder. SMIN/SMAX/SMINV/SMAXV
-// have no Go assembler mnemonic, so they are hand-encoded WORD directives (the
-// trailing comment is the decoded form, cross-checked by asmcheck_test.go).
-// Every compare is signed, matching minMaxGo exactly.
+// Signed int32 min and max over res in one pass, with a 2-block unroll that keeps
+// two independent SMIN and two independent SMAX chains so the compare latency
+// stays off the loop-carried critical path (same rewrite as the i16 minMaxNEON,
+// #282). The dispatch gates len(res) >= 4, so block 0 always exists: it seeds both
+// accumulator pairs (min1=V0,max1=V1, min2=V5,max2=V6); the loop folds 2 blocks
+// per iteration, a possible odd trailing block folds into the first pair, the two
+// pairs are combined, SMINV/SMAXV reduce each across its 4 lanes to a scalar, and
+// a scalar tail folds the (n mod 4) remainder. SMIN/SMAX/SMINV/SMAXV have no Go
+// assembler mnemonic, so they are hand-encoded WORD directives (the trailing
+// comment is the decoded form, cross-checked by asmcheck_test.go). Every compare
+// is signed and min/max is idempotent (seeding both pairs from block 0
+// double-counts it harmlessly), so the result matches minMaxGo exactly. Measured
+// roughly -20% at n=64 up to -37% at n=4096 on Cortex-A76, with no small-n
+// regression (#283).
 TEXT ·minMaxNEON(SB), NOSPLIT, $0-32
     MOVD res_base+0(FP), R2
     MOVD res_len+8(FP), R3
+
     LSR  $2, R3, R4                  // R4 = full 4-element blocks (>=1)
-    VLD1 (R2), [V0.S4]               // V0 = block 0 (min acc), no advance
-    VLD1.P 16(R2), [V1.S4]           // V1 = block 0 (max acc), advance to block 1
-    SUB  $1, R4                      // blocks remaining after block 0
-    CBZ  R4, mm_neon_reduce          // single block: accumulators hold it; R2 at tail
+    VLD1 (R2), [V0.S4]               // min1 = block 0
+    VLD1 (R2), [V1.S4]               // max1 = block 0
+    VLD1 (R2), [V5.S4]               // min2 = block 0 (idempotent seed)
+    VLD1.P 16(R2), [V6.S4]           // max2 = block 0 (advance past block 0)
+    SUB  $1, R4                      // blocks after block 0
+    CBZ  R4, mm_neon_reduce          // single block: min1/max1 hold it; R2 at tail
+
+    LSR  $1, R4, R7                 // R7 = pairs = (blocks after 0) / 2
+    CBZ  R7, mm_neon_odd
+
 mm_neon_loop:
-    VLD1.P 16(R2), [V2.S4]           // load block + advance
+    VLD1.P 32(R2), [V2.S4, V3.S4]
     WORD $0x4EA26C00                 // SMIN V0.4S, V0.4S, V2.4S
     WORD $0x4EA26421                 // SMAX V1.4S, V1.4S, V2.4S
-    SUB  $1, R4
-    CBNZ R4, mm_neon_loop
+    WORD $0x4EA36CA5                 // SMIN V5.4S, V5.4S, V3.4S
+    WORD $0x4EA364C6                 // SMAX V6.4S, V6.4S, V3.4S
+    SUB  $1, R7
+    CBNZ R7, mm_neon_loop
+
+mm_neon_odd:
+    TBZ  $0, R4, mm_neon_foldpairs   // R4 (blocks after block 0) even => no leftover block
+    VLD1.P 16(R2), [V2.S4]
+    WORD $0x4EA26C00                 // SMIN V0.4S, V0.4S, V2.4S
+    WORD $0x4EA26421                 // SMAX V1.4S, V1.4S, V2.4S
+
+mm_neon_foldpairs:
+    WORD $0x4EA56C00                 // SMIN V0.4S, V0.4S, V5.4S
+    WORD $0x4EA66421                 // SMAX V1.4S, V1.4S, V6.4S
 
 mm_neon_reduce:
     WORD $0x4EB1A803                 // SMINV S3, V0.4S
@@ -225,29 +250,57 @@ mm_neon_done:
     RET
 
 // func sumNEON(a []int32) int32
-// Wrapping int32 sum: VADD folds 4-lane blocks into a vector accumulator,
-// ADDV reduces it to a scalar, and a 32-bit scalar tail adds the (n mod 4)
-// remainder. Every add wraps in a 32-bit lane, and wrapping addition is
-// associative, so the lane split and reduction order are bit-identical to
-// sumGo for every input, including forced overflow. The slice arrives
-// pre-clamped from the public Sum, so a_len is the trusted element count.
+// Wrapping int32 sum with four independent VADD accumulators (V16..V19), so the
+// accumulate latency stays off the loop-carried critical path: the 16-wide main
+// loop keeps four parallel int32 chains, a 4-wide cleanup loop folds the
+// (n mod 16)/4 residual blocks, ADDV reduces to a scalar, and a 32-bit scalar
+// tail adds the (n mod 4) remainder. Every add wraps in a 32-bit lane, and
+// wrapping addition is associative, so the four-way lane split and the reduction
+// order are bit-identical to sumGo for every input, including forced overflow.
+// The slice arrives pre-clamped from the public Sum, so a_len is the trusted
+// element count. Same latency-hiding rewrite as the i16 sumNEON (#282): measured
+// roughly -55% at n=1024 and -56% at n=4096 on Cortex-A76 (#283). Below n=32 the
+// two-level tail's extra addressing costs ~1-2 ns over the old single-accumulator
+// form; the win starts around n=63.
 TEXT ·sumNEON(SB), NOSPLIT, $0-28
     MOVD a_base+0(FP), R1
     MOVD a_len+8(FP), R3
 
-    VEOR V0.B16, V0.B16, V0.B16
-    LSR  $2, R3, R4            // R4 = n / 4
+    VEOR V16.B16, V16.B16, V16.B16   // primary int32 accumulator = 0
+    LSR  $4, R3, R4              // R4 = n / 16
+    CBZ  R4, sum_neon_cleanup    // no 16-wide block: single-accumulator path only
+
+    VEOR V17.B16, V17.B16, V17.B16   // three more accumulators, zeroed only when the
+    VEOR V18.B16, V18.B16, V18.B16   // 16-wide main loop runs, so small n keeps the
+    VEOR V19.B16, V19.B16, V19.B16   // single-accumulator cost
+
+sum_neon_loop16:
+    VLD1.P 64(R1), [V0.S4, V1.S4, V2.S4, V3.S4]
+    VADD V0.S4, V16.S4, V16.S4
+    VADD V1.S4, V17.S4, V17.S4
+    VADD V2.S4, V18.S4, V18.S4
+    VADD V3.S4, V19.S4, V19.S4
+    SUB  $1, R4
+    CBNZ R4, sum_neon_loop16
+
+    VADD V17.S4, V16.S4, V16.S4
+    VADD V19.S4, V18.S4, V18.S4
+    VADD V18.S4, V16.S4, V16.S4   // four chains -> V16
+
+sum_neon_cleanup:
+    AND  $15, R3, R2            // R2 = n mod 16
+    LSR  $2, R2, R4            // R4 = (n mod 16) / 4, in {0,1,2,3}
     CBZ  R4, sum_neon_reduce
 
 sum_neon_loop4:
-    VLD1.P 16(R1), [V1.S4]
-    VADD V1.S4, V0.S4, V0.S4   // accumulate (wrapping)
+    VLD1.P 16(R1), [V0.S4]
+    VADD V0.S4, V16.S4, V16.S4
     SUB  $1, R4
     CBNZ R4, sum_neon_loop4
 
 sum_neon_reduce:
-    VADDV V0.S4, V0            // ADDV S0, V0.4S
-    FMOVS F0, R5               // vector partial sum (low 32 = int32)
+    WORD $0x4EB1BA10           // ADDV S16, V16.4S
+    FMOVS F16, R5              // vector partial sum (low 32 = int32)
 
     AND  $3, R3
     CBZ  R3, sum_neon_done

--- a/i8/i8_arm64.s
+++ b/i8/i8_arm64.s
@@ -173,27 +173,61 @@ toi32_done:
     RET
 
 // func sumNEON(a []int8) int32
-// Pairwise widen-accumulate: SADDLP folds 16 int8 to 8 int16, SADALP accumulates
-// those into a 4-lane int32 accumulator; ADDV folds the lanes and a scalar tail
-// adds the (n mod 16) remainder.
+// Pairwise widen-accumulate with four independent int32 accumulators (V16..V19),
+// processing 64 int8 per iteration: SADDLP folds each 16 int8 to 8 int16 into a
+// fresh temporary (V4..V7), SADALP accumulates those into one of four parallel
+// int32 chains, a 16-wide cleanup loop folds the (n mod 64)/16 residual blocks,
+// ADDV reduces to a scalar, and a scalar tail adds the (n mod 16) remainder. The
+// widening is exact and int32 accumulation wraps and is associative, so the
+// four-way split and the reduction order are bit-identical to sumGo. Measured
+// roughly -20% at n=1024 and -24% at n=4096 on Cortex-A76 against an
+// alignment-matched baseline (#283); the win comes from the 64-wide unroll, so
+// below it the 16-wide path dominates and is alignment-sensitive as before,
+// leaving small-to-medium n unchanged in character.
 TEXT ·sumNEON(SB), NOSPLIT, $0-28
     MOVD a_base+0(FP), R1
     MOVD a_len+8(FP), R3
 
-    VEOR V2.B16, V2.B16, V2.B16   // int32 accumulator = 0
-    LSR  $4, R3, R4               // R4 = n / 16
+    VEOR V16.B16, V16.B16, V16.B16   // primary int32 accumulator = 0
+    LSR  $6, R3, R4               // R4 = n / 64
+    CBZ  R4, sum_cleanup           // no 64-wide block: single-accumulator path only
+
+    VEOR V17.B16, V17.B16, V17.B16   // three more accumulators, zeroed only when the
+    VEOR V18.B16, V18.B16, V18.B16   // 64-wide main loop runs, so small n keeps the
+    VEOR V19.B16, V19.B16, V19.B16   // single-accumulator cost
+
+sum_loop64:
+    VLD1.P 64(R1), [V0.B16, V1.B16, V2.B16, V3.B16]
+    WORD $0x4E202804             // SADDLP V4.8H, V0.16B
+    WORD $0x4E606890             // SADALP V16.4S, V4.8H
+    WORD $0x4E202825             // SADDLP V5.8H, V1.16B
+    WORD $0x4E6068B1             // SADALP V17.4S, V5.8H
+    WORD $0x4E202846             // SADDLP V6.8H, V2.16B
+    WORD $0x4E6068D2             // SADALP V18.4S, V6.8H
+    WORD $0x4E202867             // SADDLP V7.8H, V3.16B
+    WORD $0x4E6068F3             // SADALP V19.4S, V7.8H
+    SUB  $1, R4
+    CBNZ R4, sum_loop64
+
+    VADD V17.S4, V16.S4, V16.S4
+    VADD V19.S4, V18.S4, V18.S4
+    VADD V18.S4, V16.S4, V16.S4   // four chains -> V16
+
+sum_cleanup:
+    AND  $63, R3, R2             // R2 = n mod 64
+    LSR  $4, R2, R4             // R4 = (n mod 64) / 16, in {0,1,2,3}
     CBZ  R4, sum_reduce
 
 sum_loop16:
     VLD1.P 16(R1), [V0.B16]
     WORD $0x4E202801             // SADDLP V1.8H, V0.16B
-    WORD $0x4E606822             // SADALP V2.4S, V1.8H
+    WORD $0x4E606830             // SADALP V16.4S, V1.8H
     SUB  $1, R4
     CBNZ R4, sum_loop16
 
 sum_reduce:
-    WORD $0x4EB1B843             // ADDV S3, V2.4S
-    FMOVS F3, R5                  // R5 = vector total (low 32)
+    WORD $0x4EB1BA10             // ADDV S16, V16.4S
+    FMOVS F16, R5                 // R5 = vector total (low 32)
 
     AND  $15, R3
     CBZ  R3, sum_done


### PR DESCRIPTION
Extends the latency-hiding rewrites from the i16 NEON reductions (#284) to the sibling i8 and i32 kernels, and finishes the i16 `minMaxNEON` tail on the SIMD path. Fixes #283.

Each candidate was gated on a core-pinned Cortex-A76 (Raspberry Pi 5) min-of-N benchmark against an alignment-matched baseline in the same binary, so a code-layout or alignment shift could not be mistaken for a real gain. The numbers below are from that measurement. No amd64 change.

## What changed

**i32 `sumNEON`: four independent int32 accumulators.** Was a single accumulator in a 4-wide loop, so each `VADD` waited on the previous one. Now a 16-wide loop keeps four parallel `VADD` chains, moving the accumulate latency off the loop-carried critical path. The three extra accumulators are zeroed only when the 16-wide loop actually runs, so small slices keep the single-accumulator cost. Roughly -55% at n=1024 and -56% at n=4096; the win begins near n=63. Below n=32 the two-level tail's extra addressing costs about 1-2 ns over the old form.

**i32 `minMaxNEON`: 2-block unroll with dual accumulator pairs.** Was a single min/max pair folded one block at a time. Now two independent `SMIN` and two independent `SMAX` chains run per iteration, keeping the compare latency off the critical path. Roughly -20% at n=64 up to -37% at n=4096, with no small-n regression.

**i8 `sumNEON`: four independent int32 accumulators.** Was a single accumulator fed by `SADDLP`+`SADALP` in a 16-wide loop. Now four parallel chains in a 64-wide loop. Roughly -20% at n=1024 and -24% at n=4096 against an alignment-matched baseline; the win needs the 64-wide loop, so small-to-medium slices are unchanged in character.

**i16 `minMaxNEON`: overlapping tail.** The `(n mod 8)` remainder was finished with a scalar tail of up to 7 `CSEL` iterations. It is now folded in as one overlapping `.8H` block over the last 8 elements before the horizontal reduce, keeping every element on the SIMD path. Roughly -24% to -41% at ragged sizes, and neutral when n is a multiple of 8 (no tail to replace). Signed min/max is idempotent, so re-counting the overlap of already-processed elements does not change the result, and the `n >= 8` dispatch guard keeps the `a[n-8]` load in range.

## Correctness

All four kernels are bit-exact with their pure-Go references. Wrapping int32 addition is associative modulo 2^32, so the four-way lane split and the fold order leave every sum unchanged, including forced overflow. Signed min/max is idempotent and order-independent, so the dual-pair seeding and the tail overlap leave every min/max unchanged.

## Test plan

- `go test ./...` on arm64 (native NEON): parity against the Go reference, per-element bit-exactness, over-read guards, allocation-free assertions, and the `asmcheck` cross-check of every hand-encoded `WORD` against `arm64asm` all pass.
- Fuzz: `FuzzI32SumAbs`, `FuzzI32MinMax`, `FuzzI8Reduce`, `FuzzI16MinMax` each run clean over several million executions.
- `go vet ./...` and `golangci-lint run ./...` clean for both GOARCH=arm64 and GOARCH=amd64; amd64 cross-builds unchanged.
- Bit-exactness re-verified on the target Cortex-A76 hardware, not only the local host.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Performance**
  - Improved ARM64 performance for 8-bit and 32-bit summation on large inputs.
  - Improved ARM64 min/max performance through more efficient processing of larger data blocks.
  - Optimized handling of 16-bit inputs, including lengths that are not multiples of eight.

- **Correctness**
  - Preserved wrapping behavior for 32-bit summation.
  - Ensured min/max operations correctly process incomplete final blocks.

- **Documentation**
  - Clarified ARM64 processing requirements and performance thresholds.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->