### PR TITLE
i8/i16/i32: NEON min/max overlap tails and i16 sum cleanup

### DIFF
--- a/i16/i16_arm64.s
+++ b/i16/i16_arm64.s
@@ -426,25 +426,27 @@ maxabs_neon_done:
 // func sumNEON(a []int16) int32
 // Widening int16 sum. The 32-wide main loop feeds four independent SADALP chains
 // (V16..V19), each pairwise-accumulating one .8H block into a 4-lane int32
-// accumulator; keeping four accumulators in flight holds the SADALP accumulate
-// latency off the loop-carried critical path (measured ~21% faster at n=4096 on
-// Cortex-A76 than the single-accumulator form, #282). The four chains are then
-// summed, an 8-wide loop absorbs the (n mod 32) blocks, ADDV folds the lanes, and
-// a scalar tail adds the (n mod 8) remainder. Accumulation wraps in int32 exactly
-// as sumGo does, and wrapping add is associative and commutative, so any lane
-// grouping is bit-identical to Sum's pure-Go reference for every input, including
-// overflow.
+// accumulator. On Cortex-A76 SADALP has an accumulate-forwarding path and is
+// single-pipe throughput-bound, so the four accumulators mainly amortize the loop
+// overhead rather than hide accumulate latency (measured ~21% faster at n=4096 on
+// Cortex-A76 than the single-accumulator form, #282). The three extra accumulators
+// are zeroed and folded only inside the wide-loop branch, so small n keeps the
+// single-accumulator cost. The four chains are then summed, an 8-wide loop absorbs
+// the (n mod 32) blocks, ADDV folds the lanes, and a scalar tail adds the (n mod 8)
+// remainder. Accumulation wraps in int32 exactly as sumGo does, and wrapping add is
+// associative and commutative, so any lane grouping is bit-identical to Sum's
+// pure-Go reference for every input, including overflow.
 TEXT ·sumNEON(SB), NOSPLIT, $0-28
     MOVD a_base+0(FP), R1
     MOVD a_len+8(FP), R3
 
-    VEOR V16.B16, V16.B16, V16.B16   // four int32 accumulators = 0
-    VEOR V17.B16, V17.B16, V17.B16
-    VEOR V18.B16, V18.B16, V18.B16
-    VEOR V19.B16, V19.B16, V19.B16
-
+    VEOR V16.B16, V16.B16, V16.B16   // primary int32 accumulator = 0
     LSR  $5, R3, R4               // R4 = n / 32
-    CBZ  R4, sum_i16_fold
+    CBZ  R4, sum_i16_cleanup       // no 32-wide block: single-accumulator path only
+
+    VEOR V17.B16, V17.B16, V17.B16   // three more accumulators, zeroed only when the
+    VEOR V18.B16, V18.B16, V18.B16   // 32-wide main loop runs, so small n keeps the
+    VEOR V19.B16, V19.B16, V19.B16   // single-accumulator cost
 
 sum_i16_loop32:
     VLD1.P 64(R1), [V0.H8, V1.H8, V2.H8, V3.H8]
@@ -455,11 +457,11 @@ sum_i16_loop32:
     SUB  $1, R4
     CBNZ R4, sum_i16_loop32
 
-sum_i16_fold:
     VADD V17.S4, V16.S4, V16.S4
     VADD V19.S4, V18.S4, V18.S4
     VADD V18.S4, V16.S4, V16.S4   // four chains -> V16
 
+sum_i16_cleanup:
     AND  $31, R3, R2             // R2 = n mod 32
     LSR  $3, R2, R4             // R4 = (n mod 32) / 8, in {0,1,2,3}
     CBZ  R4, sum_i16_reduce
@@ -514,9 +516,11 @@ TEXT ·minMaxNEON(SB), NOSPLIT, $0-28
     VLD1 (R2), [V5.H8]           // min2 = block 0 (idempotent seed)
     VLD1.P 16(R2), [V6.H8]       // max2 = block 0 (advance past block 0)
     SUB  $1, R4                   // blocks after block 0
-    // Single block: fold pairs (harmless self-fold of block 0) then run the
-    // overlap tail, rather than jumping past both straight to the reduce.
-    CBZ  R4, mm_i16_foldpairs
+    // Single block: V0/V1 already hold block 0, so foldpairs would be a no-op
+    // self-fold. Skip it and go straight to the overlap check (which must still
+    // run so the tail is not dropped, the #285 hazard), rather than jumping past
+    // both straight to the reduce.
+    CBZ  R4, mm_i16_overlap
 
     LSR  $1, R4, R7             // R7 = pairs = (blocks after 0) / 2
     CBZ  R7, mm_i16_odd
@@ -540,6 +544,7 @@ mm_i16_foldpairs:
     WORD $0x4E656C00             // SMIN V0.8H, V0.8H, V5.8H
     WORD $0x4E666421             // SMAX V1.8H, V1.8H, V6.8H
 
+mm_i16_overlap:
     // Overlapping tail: when (n mod 8) != 0, fold the last 8 elements a[n-8:n] in
     // as one .8H block before the horizontal reduce, so every element stays on the
     // SIMD path (no scalar tail). Idempotency makes re-counting the overlap of
@@ -557,14 +562,11 @@ mm_i16_foldpairs:
 mm_i16_reduce:
     WORD $0x4E71A803             // SMINV H3, V0.8H
     WORD $0x4E70A824             // SMAXV H4, V1.8H
-    FMOVS F3, R5                  // min halfword (zero-extended)
-    FMOVS F4, R6                  // max halfword
-    LSLW $16, R5, R5
-    ASRW $16, R5, R5              // sign-extend low halfword -> int32 min
-    LSLW $16, R6, R6
-    ASRW $16, R6, R6              // sign-extend low halfword -> int32 max
+    FMOVS F3, R5                  // min halfword in the low 16 bits
+    FMOVS F4, R6                  // max halfword in the low 16 bits
 
 mm_i16_done:
+    // MOVH stores only the low halfword, so the reduced result needs no sign-extension.
     MOVH R5, minVal+24(FP)
     MOVH R6, maxVal+26(FP)
     RET

--- a/i32/i32_arm64.go
+++ b/i32/i32_arm64.go
@@ -171,14 +171,24 @@ func butterflyI32(lo, hi []int32) {
 //go:noescape
 func butterflyNEON(lo, hi []int32)
 
-// minMaxI32 dispatches the signed int32 min/max reduction. The NEON kernel does
-// the reduction in 4-wide SMIN/SMAX lanes (a 2-block unroll with dual min/max
-// accumulator pairs) with a single-instruction SMINV/SMAXV across-vector fold and
-// a scalar tail, so it gates on NEON and at least one full 4-element block;
-// shorter slices use the pure-Go reference. res is non-empty (the public MinMax
-// guards the empty case).
+// minNEONMinMax is one 4-wide (.4S) block. Unlike the shared minNEONElements it is
+// an independent literal AND a correctness floor, not just a performance cut: the
+// minMaxNEON kernel folds an overlapping final .4S block that reloads res[n-4] in
+// place of a scalar tail, so it must never run on fewer than 4 elements. Keeping it
+// separate means a future retune of the shared minNEONElements (add/sub/interleave)
+// cannot silently move this safety floor. The i16 minNEONMinMax carries the same
+// guard for the same reason.
+const minNEONMinMax = 4
+
+// minMaxI32 dispatches the signed int32 min/max reduction. The NEON kernel does the
+// reduction in 4-wide SMIN/SMAX lanes (a 2-block unroll with dual min/max
+// accumulator pairs), folds an overlapping final .4S block in place of a scalar
+// tail, then reduces with a single-instruction SMINV/SMAXV across-vector fold, so
+// the n >= minNEONMinMax gate is a correctness floor (the overlap block reloads
+// res[n-4]), not just a performance cut; shorter slices use the pure-Go reference.
+// res is non-empty (the public MinMax guards the empty case).
 func minMaxI32(res []int32) (minVal, maxVal int32) {
-	if hasNEON && len(res) >= minNEONElements {
+	if hasNEON && len(res) >= minNEONMinMax {
 		return minMaxNEON(res)
 	}
 	return minMaxGo(res)

--- a/i32/i32_arm64.s
+++ b/i32/i32_arm64.s
@@ -184,14 +184,21 @@ sub_neon_done:
 // #282). The dispatch gates len(res) >= 4, so block 0 always exists: it seeds both
 // accumulator pairs (min1=V0,max1=V1, min2=V5,max2=V6); the loop folds 2 blocks
 // per iteration, a possible odd trailing block folds into the first pair, the two
-// pairs are combined, SMINV/SMAXV reduce each across its 4 lanes to a scalar, and
-// a scalar tail folds the (n mod 4) remainder. SMIN/SMAX/SMINV/SMAXV have no Go
+// pairs are combined, and when (n mod 4) != 0 the last 4 elements res[n-4:n] are
+// folded in as one overlapping .4S block before the horizontal reduce, so every
+// element stays on the SIMD path (no scalar tail). SMINV/SMAXV then reduce each
+// accumulator across its 4 lanes to a scalar. SMIN/SMAX/SMINV/SMAXV have no Go
 // assembler mnemonic, so they are hand-encoded WORD directives (the trailing
 // comment is the decoded form, cross-checked by asmcheck_test.go). Every compare
-// is signed and min/max is idempotent (seeding both pairs from block 0
-// double-counts it harmlessly), so the result matches minMaxGo exactly. Measured
-// roughly -20% at n=64 up to -37% at n=4096 on Cortex-A76, with no small-n
-// regression (#283).
+// is signed and min/max is idempotent (seeding both pairs from block 0, and
+// re-counting the overlap of already-processed elements, both double-count
+// harmlessly), so the result matches minMaxGo exactly. The overlap block replaces
+// a scalar tail of up to 3 CSEL iterations: measured roughly -13% to -17% at
+// ragged sizes n=7..63 on Cortex-A76, tapering to neutral by n>=1023 as the tail
+// becomes a negligible fraction of the work (#286). The one exception is a
+// single-block residue-1 input (n=5), where re-folding a whole .4S block costs
+// ~0.4 ns more than the single CSEL it replaces; that is a measured tradeoff left
+// documented rather than special-cased.
 TEXT ·minMaxNEON(SB), NOSPLIT, $0-32
     MOVD res_base+0(FP), R2
     MOVD res_len+8(FP), R3
@@ -202,7 +209,11 @@ TEXT ·minMaxNEON(SB), NOSPLIT, $0-32
     VLD1 (R2), [V5.S4]               // min2 = block 0 (idempotent seed)
     VLD1.P 16(R2), [V6.S4]           // max2 = block 0 (advance past block 0)
     SUB  $1, R4                      // blocks after block 0
-    CBZ  R4, mm_neon_reduce          // single block: min1/max1 hold it; R2 at tail
+    // Single block: V0/V1 already hold block 0, so foldpairs would be a no-op
+    // self-fold. Skip it and go straight to the overlap check (which must still
+    // run so the tail is not dropped, the #285 hazard), rather than jumping past
+    // both straight to the reduce.
+    CBZ  R4, mm_neon_overlap
 
     LSR  $1, R4, R7                 // R7 = pairs = (blocks after 0) / 2
     CBZ  R7, mm_neon_odd
@@ -226,23 +237,26 @@ mm_neon_foldpairs:
     WORD $0x4EA56C00                 // SMIN V0.4S, V0.4S, V5.4S
     WORD $0x4EA66421                 // SMAX V1.4S, V1.4S, V6.4S
 
+mm_neon_overlap:
+    // Overlapping tail: when (n mod 4) != 0, fold the last 4 elements res[n-4:n]
+    // in as one .4S block before the horizontal reduce, so every element stays on
+    // the SIMD path (no scalar tail). Idempotency makes re-counting the overlap of
+    // already-processed elements harmless; the n >= 4 gate keeps res[n-4] in range.
+    AND  $3, R3, R4
+    CBZ  R4, mm_neon_reduce
+    SUB  $4, R3, R7                  // R7 = n - 4 (element index of the overlap block)
+    LSL  $2, R7, R7                 // R7 = (n-4)*4 bytes
+    MOVD res_base+0(FP), R2          // reload base (R2 was advanced past the full blocks)
+    ADD  R7, R2, R2                 // R2 = &res[n-4]
+    VLD1 (R2), [V2.S4]
+    WORD $0x4EA26C00                 // SMIN V0.4S, V0.4S, V2.4S
+    WORD $0x4EA26421                 // SMAX V1.4S, V1.4S, V2.4S
+
 mm_neon_reduce:
     WORD $0x4EB1A803                 // SMINV S3, V0.4S
     WORD $0x4EB0A824                 // SMAXV S4, V1.4S
     FMOVS F3, R5                     // R5 = running min (low 32 = int32)
     FMOVS F4, R6                     // R6 = running max (low 32 = int32)
-
-    // scalar tail: (n mod 4) residuals (R2 already at &res[fullBlocks*4])
-    AND  $3, R3, R4
-    CBZ  R4, mm_neon_done
-mm_neon_tail:
-    MOVW.P 4(R2), R7                 // r (sign-extended; low 32 = int32)
-    CMPW R5, R7                      // (R7 - R5), signed 32-bit
-    CSEL LT, R7, R5, R5             // R5 = min(r, R5)
-    CMPW R6, R7
-    CSEL GT, R7, R6, R6             // R6 = max(r, R6)
-    SUB  $1, R4
-    CBNZ R4, mm_neon_tail
 
 mm_neon_done:
     MOVW R5, minVal+24(FP)

--- a/i32/i32_arm64_test.go
+++ b/i32/i32_arm64_test.go
@@ -249,7 +249,7 @@ func TestMinMaxNEON_ParityWithGo(t *testing.T) {
 	// swaps them, covering both a dropped lane and a dropped tail on both reduces.
 	for _, n := range paritySizes {
 		if n < minNEONMinMax {
-			continue // dispatch routes these to Go; the kernel is not called
+			continue // minMaxNEON is called directly here and needs a full 4-elem block
 		}
 		for _, swap := range []bool{false, true} {
 			res := make([]int32, n)

--- a/i32/i32_arm64_test.go
+++ b/i32/i32_arm64_test.go
@@ -248,7 +248,7 @@ func TestMinMaxNEON_ParityWithGo(t *testing.T) {
 	// variant plants the extremes in a mid-block lane and in the tail, the other
 	// swaps them, covering both a dropped lane and a dropped tail on both reduces.
 	for _, n := range paritySizes {
-		if n < minNEONElements {
+		if n < minNEONMinMax {
 			continue // dispatch routes these to Go; the kernel is not called
 		}
 		for _, swap := range []bool{false, true} {

--- a/i32/minmax_overlap_arm64_test.go
+++ b/i32/minmax_overlap_arm64_test.go
@@ -1,0 +1,47 @@
+//go:build arm64
+
+package i32
+
+import (
+	"math"
+	"testing"
+
+	"github.com/tphakala/simd/cpu"
+)
+
+// TestMinMaxNEON_SmallRaggedOverlap concentrates on the single-block-plus-ragged
+// range n in [4,7] that the general paritySizes sweep misses (it has 7 but not
+// 5 or 6). Once minMaxNEON re-folds the last res[n-4:n] block instead of a scalar
+// tail, the single-block fast path must reach the overlap check (skipping the
+// no-op foldpairs) so the overlap still runs; a kernel that jumps straight to the
+// reduce would drop the last (n mod 4) elements. A unique planted extreme in the tail lane catches exactly
+// that. minMaxNEON is called directly so the kernel runs on these lengths rather
+// than being routed to the Go reference below the dispatch floor.
+func TestMinMaxNEON_SmallRaggedOverlap(t *testing.T) {
+	if !cpu.ARM64.NEON {
+		t.Skip("NEON not available")
+	}
+	for _, n := range []int{4, 5, 6, 7, 8, 9, 10, 11, 13, 15} {
+		if n < minNEONMinMax {
+			continue
+		}
+		for _, swap := range []bool{false, true} {
+			res := make([]int32, n)
+			for i := range res {
+				res[i] = int32(i%5) - 2 // tame body in [-2,2]
+			}
+			mid, tail := int32(math.MinInt32), int32(math.MaxInt32)
+			if swap {
+				mid, tail = tail, mid
+			}
+			res[n/2] = mid
+			res[n-1] = tail
+			gotMin, gotMax := minMaxNEON(res)
+			wantMin, wantMax := minMaxGo(res)
+			if gotMin != wantMin || gotMax != wantMax {
+				t.Fatalf("n=%d swap=%v: minMaxNEON = (%d, %d), want (%d, %d) (Go)",
+					n, swap, gotMin, gotMax, wantMin, wantMax)
+			}
+		}
+	}
+}

--- a/i32/reduce_tail_bench_test.go
+++ b/i32/reduce_tail_bench_test.go
@@ -5,8 +5,9 @@ import (
 	"testing"
 )
 
-// BenchmarkMinMax_N measures the overlapping-final-block tail added to minMaxNEON
-// in #286. The residue of 1..3 int32 elements (n mod 4) that a scalar CSEL tail
+// BenchmarkMinMax_N measures the overlapping-final-block tail that the i32
+// minMaxNEON kernel uses (issue #286). The residue of 1..3 int32 elements (n mod 4)
+// that a scalar CSEL tail
 // used to serve is now re-folded as one overlapping .4S block before the
 // horizontal reduce. The fixed BenchmarkMinMax_1000 (n%4==0) is residue-free and
 // never runs the overlap block, so ragged residue lengths must be measured

--- a/i32/reduce_tail_bench_test.go
+++ b/i32/reduce_tail_bench_test.go
@@ -1,0 +1,27 @@
+package i32
+
+import (
+	"fmt"
+	"testing"
+)
+
+// BenchmarkMinMax_N measures the overlapping-final-block tail added to minMaxNEON
+// in #286. The residue of 1..3 int32 elements (n mod 4) that a scalar CSEL tail
+// used to serve is now re-folded as one overlapping .4S block before the
+// horizontal reduce. The fixed BenchmarkMinMax_1000 (n%4==0) is residue-free and
+// never runs the overlap block, so ragged residue lengths must be measured
+// explicitly. 4 and 4096 are aligned sentinels (overlap skipped, the control);
+// 5/7/15/31/63/255/1023 are ragged so the overlap block runs. The i32 tail is at
+// most 3 elements, so this is the smaller-payoff sibling of the i8 overlap and is
+// adopted only if the A76 A/B shows a repeatable win.
+func BenchmarkMinMax_N(b *testing.B) {
+	for _, n := range []int{4, 5, 7, 15, 31, 63, 255, 1023, 4096} {
+		res := genI32(n, 1)
+		b.Run(fmt.Sprintf("%d", n), func(b *testing.B) {
+			b.SetBytes(int64(n) * 4)
+			for b.Loop() {
+				_, _ = MinMax(res)
+			}
+		})
+	}
+}

--- a/i8/i8_arm64.go
+++ b/i8/i8_arm64.go
@@ -66,6 +66,12 @@ func dotI8(a, b []int8) int32 {
 	}
 }
 
+// minMaxI8 dispatches the signed int8 min/max reduction. The NEON kernel folds
+// 16-byte blocks through a 2-block unroll with dual min/max accumulator pairs,
+// folds an overlapping final .16B block in place of a scalar tail, then reduces
+// with SMINV/SMAXV, so the n >= minNEON16 (16) gate is a correctness floor (the
+// overlap block reloads a[n-16]), not just a performance cut; shorter slices use
+// the pure-Go reference.
 func minMaxI8(a []int8) (minVal, maxVal int8) {
 	if hasNEON && len(a) >= minNEON16 {
 		return minMaxNEON(a)

--- a/i8/i8_arm64.s
+++ b/i8/i8_arm64.s
@@ -9,8 +9,8 @@
 // with the decoded GNU form in the trailing comment; asmcheck_test.go
 // cross-checks every WORD (arm64asm directly, or aarch64 objdump for SDOT, which
 // arm64asm cannot decode). All encodings were verified with aarch64-linux-gnu-as
-// + objdump. Scratch lives in R0-R10 and V0-V5; R28 (g), R18, R27, R16/R17, and
-// the frame/link registers are left untouched (see CLAUDE.md).
+// + objdump. Scratch lives in R0-R10, V0-V6, and V16-V19 (the reductions); R28 (g),
+// R18, R27, R16/R17, and the frame/link registers are left untouched (see CLAUDE.md).
 //
 // Saturating arithmetic (SQADD/SQSUB) clamps each byte lane to [-128, 127]; the
 // scalar tail reproduces that with a widened add/sub and a CSEL clamp. The
@@ -325,51 +325,80 @@ dots_done:
     RET
 
 // func minMaxNEON(a []int8) (minVal, maxVal int8)
-// Signed byte min and max in one pass: SMIN/SMAX fold 16-byte blocks into running
-// accumulators, SMINV/SMAXV reduce each across its 16 lanes to a byte, and a
-// scalar tail folds the (n mod 16) remainder. The dispatch gates n >= 16, so at
-// least one full block exists.
+// Signed byte min and max in one pass. Block 0 seeds two min accumulators (V0,V5)
+// and two max accumulators (V1,V6); the 2-block-unrolled main loop keeps two
+// independent SMIN and two independent SMAX chains so the compare latency stays
+// off the loop-carried critical path (same latency-hiding rewrite as the i16 and
+// i32 minMaxNEON, #283). A possible odd trailing block folds into the first pair,
+// the two pairs are combined, and when (n mod 16) != 0 the last 16 elements
+// a[n-16:n] are folded in as one overlapping .16B block so every element stays on
+// the SIMD path (no scalar tail); SMINV/SMAXV then reduce each accumulator across
+// its 16 lanes to a byte. The dispatch gates n >= 16, so block 0 and the a[n-16]
+// overlap block are always in range. Signed min/max is idempotent and has no
+// accumulation order, so the result is bit-identical to minMaxGo; seeding both
+// accumulator pairs from block 0, and re-counting the overlap of already-processed
+// elements, both double-count harmlessly. The overlap block replaces a scalar tail
+// of up to 15 CSEL iterations.
 TEXT ·minMaxNEON(SB), NOSPLIT, $0-26
     MOVD a_base+0(FP), R2
     MOVD a_len+8(FP), R3
 
     LSR  $4, R3, R4               // R4 = full 16-byte blocks (>=1)
-    VLD1 (R2), [V0.B16]           // min acc = block 0 (no advance)
-    VLD1.P 16(R2), [V1.B16]       // max acc = block 0 (advance to block 1)
-    SUB  $1, R4
-    CBZ  R4, mm_reduce
+    VLD1 (R2), [V0.B16]           // min1 = block 0
+    VLD1 (R2), [V1.B16]           // max1 = block 0
+    VLD1 (R2), [V5.B16]           // min2 = block 0 (idempotent seed)
+    VLD1.P 16(R2), [V6.B16]       // max2 = block 0 (advance past block 0)
+    SUB  $1, R4                   // blocks after block 0
+    // Single block: V0/V1 already hold block 0, so foldpairs would be a no-op
+    // self-fold. Skip it and go straight to the overlap check (which must still
+    // run so the tail is not dropped, the #285 hazard), rather than jumping past
+    // both straight to the reduce.
+    CBZ  R4, mm_i8_overlap
 
-mm_loop:
+    LSR  $1, R4, R7             // R7 = pairs = (blocks after 0) / 2
+    CBZ  R7, mm_i8_odd
+
+mm_i8_loop:
+    VLD1.P 32(R2), [V2.B16, V3.B16]
+    WORD $0x4E226C00             // SMIN V0.16B, V0.16B, V2.16B
+    WORD $0x4E226421             // SMAX V1.16B, V1.16B, V2.16B
+    WORD $0x4E236CA5             // SMIN V5.16B, V5.16B, V3.16B
+    WORD $0x4E2364C6             // SMAX V6.16B, V6.16B, V3.16B
+    SUB  $1, R7
+    CBNZ R7, mm_i8_loop
+
+mm_i8_odd:
+    TBZ  $0, R4, mm_i8_foldpairs   // R4 (blocks after block 0) even => no leftover block
     VLD1.P 16(R2), [V2.B16]
     WORD $0x4E226C00             // SMIN V0.16B, V0.16B, V2.16B
     WORD $0x4E226421             // SMAX V1.16B, V1.16B, V2.16B
-    SUB  $1, R4
-    CBNZ R4, mm_loop
 
-mm_reduce:
+mm_i8_foldpairs:
+    WORD $0x4E256C00             // SMIN V0.16B, V0.16B, V5.16B
+    WORD $0x4E266421             // SMAX V1.16B, V1.16B, V6.16B
+
+mm_i8_overlap:
+    // Overlapping tail: when (n mod 16) != 0, fold the last 16 elements a[n-16:n]
+    // in as one .16B block before the horizontal reduce, so every element stays on
+    // the SIMD path (no scalar tail). Idempotency makes re-counting the overlap of
+    // already-processed elements harmless; the n >= 16 gate keeps a[n-16] in range.
+    AND  $15, R3, R4
+    CBZ  R4, mm_i8_reduce
+    SUB  $16, R3, R7            // R7 = n - 16 (element index of the overlap block)
+    MOVD a_base+0(FP), R2       // reload base (R2 was advanced past the full blocks)
+    ADD  R7, R2, R2            // R2 = &a[n-16] (int8 => 1 byte per element)
+    VLD1 (R2), [V2.B16]
+    WORD $0x4E226C00             // SMIN V0.16B, V0.16B, V2.16B
+    WORD $0x4E226421             // SMAX V1.16B, V1.16B, V2.16B
+
+mm_i8_reduce:
     WORD $0x4E31A803             // SMINV B3, V0.16B
     WORD $0x4E30A824             // SMAXV B4, V1.16B
-    FMOVS F3, R5                  // min byte (zero-extended)
-    FMOVS F4, R6                  // max byte
-    LSLW $24, R5, R5
-    ASRW $24, R5, R5              // sign-extend low byte -> int32 min
-    LSLW $24, R6, R6
-    ASRW $24, R6, R6              // sign-extend low byte -> int32 max
+    FMOVS F3, R5                  // min byte in the low 8 bits
+    FMOVS F4, R6                  // max byte in the low 8 bits
 
-    AND  $15, R3, R4              // tail count
-    CBZ  R4, mm_done
-    // R2 already points at &a[fullBlocks*16] after the loop.
-
-mm_tail:
-    MOVB.P 1(R2), R7              // r (sign-extended)
-    CMPW R5, R7
-    CSEL LT, R7, R5, R5           // R5 = min(r, R5)
-    CMPW R6, R7
-    CSEL GT, R7, R6, R6           // R6 = max(r, R6)
-    SUB  $1, R4
-    CBNZ R4, mm_tail
-
-mm_done:
+mm_i8_done:
+    // MOVB stores only the low byte, so the reduced result needs no sign-extension.
     MOVB R5, minVal+24(FP)
     MOVB R6, maxVal+25(FP)
     RET

--- a/i8/i8_arm64.s
+++ b/i8/i8_arm64.s
@@ -9,7 +9,7 @@
 // with the decoded GNU form in the trailing comment; asmcheck_test.go
 // cross-checks every WORD (arm64asm directly, or aarch64 objdump for SDOT, which
 // arm64asm cannot decode). All encodings were verified with aarch64-linux-gnu-as
-// + objdump. Scratch lives in R0-R10, V0-V6, and V16-V19 (the reductions); R28 (g),
+// + objdump. Scratch lives in R0-R10, V0-V7, and V16-V19 (the reductions); R28 (g),
 // R18, R27, R16/R17, and the frame/link registers are left untouched (see CLAUDE.md).
 //
 // Saturating arithmetic (SQADD/SQSUB) clamps each byte lane to [-128, 127]; the

--- a/i8/minmax_arm64_test.go
+++ b/i8/minmax_arm64_test.go
@@ -31,7 +31,7 @@ func TestMinMaxNEON_ParityWithGo(t *testing.T) {
 	sizes := []int{16, 17, 18, 19, 20, 23, 24, 25, 30, 31, 32, 33, 47, 48, 49, 63, 64, 65, 95, 96, 127, 128, 255, 256, 257}
 	for _, n := range sizes {
 		if n < minNEON16 {
-			continue // dispatch routes these to Go; the kernel is not called
+			continue // minMaxNEON is called directly here and needs a full 16-elem block
 		}
 		for _, swap := range []bool{false, true} {
 			a := make([]int8, n)

--- a/i8/minmax_arm64_test.go
+++ b/i8/minmax_arm64_test.go
@@ -1,0 +1,57 @@
+//go:build arm64
+
+package i8
+
+import (
+	"math"
+	"testing"
+
+	"github.com/tphakala/simd/cpu"
+)
+
+// TestMinMaxNEON_ParityWithGo guards the overlapping-final-block tail and the
+// 2-block-unrolled body of minMaxNEON against the scalar reference. It plants a
+// unique extreme in a mid-block lane and another in the last (tail) lane, so a
+// kernel that drops a vector lane, mis-seeds an accumulator pair, or skips the
+// overlap block on the single-block fast path is caught. The swap variant covers
+// both reduces. The sizes concentrate on the single-block-plus-ragged-tail range
+// n in [16,31] where the #285 dropped-tail bug class lives (the single-block CBZ
+// must reach the overlap check, skipping the no-op foldpairs, so the tail still
+// runs), plus larger ragged
+// sizes that exercise the odd-block and pairs paths.
+//
+// minMaxNEON is called directly (not via the public MinMax) so the kernel runs on
+// exactly these lengths instead of being routed to the Go reference below the
+// dispatch floor. The n >= minNEON16 gate is a correctness floor once the overlap
+// block reloads a[n-16], so lengths below it are skipped.
+func TestMinMaxNEON_ParityWithGo(t *testing.T) {
+	if !cpu.ARM64.NEON {
+		t.Skip("NEON not available")
+	}
+	sizes := []int{16, 17, 18, 19, 20, 23, 24, 25, 30, 31, 32, 33, 47, 48, 49, 63, 64, 65, 95, 96, 127, 128, 255, 256, 257}
+	for _, n := range sizes {
+		if n < minNEON16 {
+			continue // dispatch routes these to Go; the kernel is not called
+		}
+		for _, swap := range []bool{false, true} {
+			a := make([]int8, n)
+			// A tame in-range body keeps the two planted extremes the unique
+			// min and max: int8(i%7)-3 stays within [-3,3].
+			for i := range a {
+				a[i] = int8(i%7) - 3
+			}
+			mid, tail := int8(math.MinInt8), int8(math.MaxInt8)
+			if swap {
+				mid, tail = tail, mid
+			}
+			a[n/2] = mid
+			a[n-1] = tail
+			gotMin, gotMax := minMaxNEON(a)
+			wantMin, wantMax := minMaxGo(a)
+			if gotMin != wantMin || gotMax != wantMax {
+				t.Fatalf("n=%d swap=%v: minMaxNEON = (%d, %d), want (%d, %d) (Go)",
+					n, swap, gotMin, gotMax, wantMin, wantMax)
+			}
+		}
+	}
+}

--- a/i8/reduce_tail_bench_test.go
+++ b/i8/reduce_tail_bench_test.go
@@ -6,13 +6,16 @@ import (
 )
 
 // BenchmarkMaxAbs_N and BenchmarkMinMax_N guard the overlapping-final-block tail
-// (#149) on the 32-wide MaxAbs/MinMax reductions: a residue of 1..31 bytes was
-// served by a serial compare/cmov scalar chain (up to 31 dependent steps), now
-// absorbed by one overlapping 32-wide block. The fixed 4096-byte benchmarks are
-// all n%32==0 and never run the overlap block, so residue lengths must be
-// measured explicitly. 32 is the aligned sentinel (overlap skipped, the untouched
-// control); 40/48/63/95/248 are ragged so the overlap block runs, with 63 and 95
-// at the worst-case residue 31.
+// on the MaxAbs/MinMax reductions: instead of serving the (n mod width) residue
+// with a serial compare/cmov scalar chain, one overlapping final vector block
+// re-folds the last full block. amd64 got this for both MaxAbs and MinMax in #149;
+// arm64 NEON has it for MinMax since #286 (NEON MaxAbs still uses a scalar tail).
+// The fixed 4096-byte benchmarks are residue-free and never run the overlap block,
+// so ragged residue lengths must be measured explicitly. 32 is an aligned sentinel
+// (overlap skipped on the 16- and 32-wide kernels alike). At the arm64 16-wide
+// width 40/63/95/248 are ragged and run the overlap while 48 is aligned there
+// (48 mod 16 == 0); at the amd64 32-wide width all of 40/48/63/95/248 are ragged,
+// with 63 and 95 at the worst-case residue 31.
 func BenchmarkMaxAbs_N(b *testing.B) {
 	for _, n := range []int{32, 40, 48, 63, 95, 248} {
 		a := genI8(n, 1)

--- a/i8/reduce_tail_bench_test.go
+++ b/i8/reduce_tail_bench_test.go
@@ -9,7 +9,8 @@ import (
 // on the MaxAbs/MinMax reductions: instead of serving the (n mod width) residue
 // with a serial compare/cmov scalar chain, one overlapping final vector block
 // re-folds the last full block. amd64 got this for both MaxAbs and MinMax in #149;
-// arm64 NEON has it for MinMax since #286 (NEON MaxAbs still uses a scalar tail).
+// arm64 NEON now has it for MinMax too (issue #286), while NEON MaxAbs still uses a
+// scalar tail.
 // The fixed 4096-byte benchmarks are residue-free and never run the overlap block,
 // so ragged residue lengths must be measured explicitly. 32 is an aligned sentinel
 // (overlap skipped on the 16- and 32-wide kernels alike). At the arm64 16-wide


### PR DESCRIPTION
## Summary

Follow-up to #285, bringing the remaining ARM64 NEON reduction kernels onto the overlapping-tail and multi-accumulator forms. Every performance item was gated on a core-pinned Cortex-A76 min-of-N A/B against an alignment-matched baseline; the numbers are inline below.

`i8` `minMaxNEON` gets a 2-block unroll with dual min/max accumulator pairs (two independent SMIN and two independent SMAX chains, keeping the compare latency off the loop-carried critical path) plus an overlapping final `.16B` block that re-folds `a[n-16:n]` in place of the scalar CSEL tail. Core-pinned Cortex-A76: geomean -42% (ragged residues -47% to -62%, large-n unroll -36%, aligned sizes neutral).

`i32` `minMaxNEON` gets the same overlapping final `.4S` block (re-folding `res[n-4:n]`); its 2-block unroll already landed in #285. Geomean -7.83% (ragged n=7..63 -13% to -17%). A single +0.4 ns at n=5 (a single-block, residue-1 input where re-folding a whole `.4S` block is heavier than the one CSEL it replaces) is a measured tradeoff, left documented rather than special-cased.

`i16` `sumNEON` gets the conditional accumulator zeroing the `i8` and `i32` `sumNEON` kernels already use: the three extra accumulators are zeroed and folded only inside the wide-loop branch, so small n keeps the single-accumulator cost. Bit-exact and neutral. The doc comment's SADALP mechanism claim was corrected (SADALP is single-pipe throughput-bound on the A76, so the extra accumulators amortize loop overhead rather than hide accumulate latency).

`i16` `minMaxNEON` now skips the no-op foldpairs on the single-block path and drops its dead sign-extension, so all three min/max kernels share one idiom.

Each single-block path routes to the overlap check rather than straight to the reduce, so the dispatch gate is now a correctness floor (the overlap reloads `a[n-16]` / `res[n-4]`). `i32` gains its own `minNEONMinMax = 4` literal so a future retune of the shared `minNEONElements` cannot silently move that floor, matching the existing `i16` convention.

## Testing

New planted-extreme parity tests (`i8` n=16..257, `i32` n=4..15) plant a unique extreme in a mid-block lane and in the tail lane, with a swap variant, so a dropped or double-counted tail on either reduce is caught; they cover the single-block-plus-ragged range that guards the #285 dropped-tail class. Ragged-size benchmarks were added for the overlap paths.

Verified on a native Cortex-A76 (Raspberry Pi 5, go1.27): the full `i8`, `i16`, and `i32` suites, the asmcheck WORD-vs-mnemonic cross-checks (the new `.16B` SMIN/SMAX encodings included), and differential fuzzing (1.4M+ executions per kernel) all pass.

Fixes #286


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved ARM64 NEON min/max accuracy for short, ragged, and overlapping input lengths across 8-bit, 16-bit, and 32-bit data.
  * Ensured extreme values are handled correctly across varied input sizes and placements.
  * Optimized SIMD processing by reducing unnecessary scalar tail handling.

* **Tests**
  * Added ARM64 coverage for ragged inputs and parity with scalar results.
  * Added benchmarks for aligned and ragged min/max inputs.

* **Documentation**
  * Clarified ARM64 NEON processing, thresholds, and overlapping-tail behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->