### PR TITLE
i8/i32: overlapping-final-block tail for maxAbsNEON

### DIFF
--- a/i32/i32_arm64.go
+++ b/i32/i32_arm64.go
@@ -197,12 +197,14 @@ func minMaxI32(res []int32) (minVal, maxVal int32) {
 //go:noescape
 func minMaxNEON(res []int32) (minVal, maxVal int32)
 
-// minNEONMaxAbs is one 4-wide (.4S) block, an independent literal like the
-// tier-3 thresholds above. The kernel does the signed min/max reduction in
-// 4-wide SMIN/SMAX lanes with SMINV/SMAXV folds and a scalar tail before
-// combining to max(maxVal, -minVal), so it gates on NEON and at least one full
-// 4-element block; shorter slices use the pure-Go reference. a is non-empty (the
-// public MaxAbs guards the empty case).
+// minNEONMaxAbs is one 4-wide (.4S) block. Like minNEONMinMax it is an independent
+// literal AND a correctness floor, not just a performance cut: the maxAbsNEON kernel
+// does the signed min/max reduction in 4-wide SMIN/SMAX lanes, folds an overlapping
+// final .4S block that reloads a[n-4] in place of a scalar tail, reduces with
+// SMINV/SMAXV, then combines to max(maxVal, -minVal), so it must never run on fewer
+// than 4 elements. Keeping it separate from the shared minNEONElements means a future
+// retune of that cannot silently move this safety floor; shorter slices use the
+// pure-Go reference. a is non-empty (the public MaxAbs guards the empty case).
 const minNEONMaxAbs = 4
 
 func maxAbsI32(a []int32) int32 {

--- a/i32/i32_arm64.s
+++ b/i32/i32_arm64.s
@@ -641,32 +641,89 @@ butterfly_neon_done:
     RET
 
 // func maxAbsNEON(a []int32) int32
-// Peak magnitude with celtMaxabs32 semantics: the same signed int32 min/max
-// reduction as minMaxNEON (VLD1 block 0 into both accumulators, WORD-encoded
-// SMIN/SMAX fold, SMINV/SMAXV across-lane reduce into R5=min/R6=max via FMOVS,
-// CSEL scalar tail), then a combine to max(maxVal, -minVal). NEG forms -minVal
-// with the two's-complement wrap (-MinInt32 == MinInt32); the low 32 bits of the
-// negate are correct regardless of the accumulator's upper bits (FMOVS
-// zero-extends, the tail sign-extends), so the combine compares in 32-bit CMPW
-// and the MOVW store keeps the low 32 bits. The signed CSEL GE then picks the
-// larger of maxVal and -minVal. The SMIN/SMAX/SMINV/SMAXV WORDs are the
-// minMaxNEON encodings verbatim (cross-checked by asmcheck_test.go). The dispatch
-// gates len(a) >= 4, so at least one full 4-element block exists. Frame is one
-// slice header plus the int32 return: a+0, ret+24.
+// Peak magnitude with celtMaxabs32 semantics, built on the same signed int32
+// min/max reduction as minMaxNEON. Block 0 seeds the running min/max (V0,V1); when
+// there are two or more further blocks a wide path adds a second accumulator pair
+// (V5,V6) and folds two blocks per iteration, keeping two independent SMIN and two
+// independent SMAX chains so the compare latency stays off the loop-carried critical
+// path (same latency-hiding rewrite as minMaxNEON, #283). The second pair is set up
+// only inside that wide branch, so a small input (a single further block) keeps the
+// single-accumulator cost and pays nothing for the unroll (the same guard sumNEON
+// uses for its extra accumulators; measured to avoid a small-n regression). A
+// possible odd trailing block folds into the running accumulators, and when
+// (n mod 4) != 0 the last 4 elements a[n-4:n] are folded in as one overlapping .4S
+// block before the horizontal reduce, so every element stays on the SIMD path (no
+// scalar tail). SMINV/SMAXV then reduce into R5=min/R6=max via FMOVS, and a combine
+// forms max(maxVal, -minVal). NEG forms -minVal with the two's-complement wrap
+// (-MinInt32 == MinInt32); the low 32 bits of the negate are correct regardless of
+// the accumulator's upper bits (FMOVS zero-extends), so the combine compares in
+// 32-bit CMPW and the MOVW store keeps the low 32 bits. The signed CSEL GE picks the
+// larger of maxVal and -minVal. The dispatch gates len(a) >= 4, so block 0 and the
+// a[n-4] overlap block are always in range; signed min/max is idempotent with no
+// accumulation order (re-counting the overlap of already-processed elements, and
+// seeding the second pair from block 0, both double-count harmlessly), so the result
+// matches maxAbsGo. The SMIN/SMAX/SMINV/SMAXV WORDs are the minMaxNEON encodings
+// verbatim (cross-checked by asmcheck_test.go). On Cortex-A76 the overlap tail
+// removes the scalar CSEL remainder (up to 3 iterations) and the 2-block unroll
+// hides the SMIN/SMAX latency in the mid/large-n body: measured about -15% at n=63
+// rising to -30% at n=255 and -38% at n=1023 against the single-accumulator overlap
+// kernel, with the narrow-path guard keeping the smallest inputs (a single further
+// block) from paying for the unroll. Frame is one slice header plus the int32
+// return: a+0, ret+24.
 TEXT ·maxAbsNEON(SB), NOSPLIT, $0-28
     MOVD a_base+0(FP), R2
     MOVD a_len+8(FP), R3
-    LSR  $2, R3, R4                  // R4 = full 4-element blocks (>=1)
-    VLD1 (R2), [V0.S4]               // V0 = block 0 (min acc), no advance
-    VLD1.P 16(R2), [V1.S4]           // V1 = block 0 (max acc), advance to block 1
-    SUB  $1, R4                      // blocks remaining after block 0
-    CBZ  R4, maxabs_neon_reduce      // single block: accumulators hold it; R2 at tail
+    LSR  $2, R3, R4                  // R4 = full 4-element blocks (>=1, gate floor)
+    VLD1 (R2), [V0.S4]               // min = block 0 (R2 not advanced)
+    VLD1 (R2), [V1.S4]               // max = block 0 (R2 not advanced)
+    SUB  $1, R4                      // R4 = blocks after block 0
+    CBZ  R4, maxabs_neon_overlap     // single block: V0/V1 hold it
+    LSR  $1, R4, R7                 // R7 = pairs = (blocks after 0) / 2
+    CBZ  R7, maxabs_neon_narrow      // one further block only: single-accumulator
+
+    // Wide path: seed a second accumulator pair (V5 min, V6 max) from block 0 and
+    // fold two blocks per iteration. Set up only here, so small n keeps the
+    // single-accumulator cost.
+    VLD1 (R2), [V5.S4]               // min2 = block 0
+    VLD1.P 16(R2), [V6.S4]           // max2 = block 0, advance past block 0
 maxabs_neon_loop:
-    VLD1.P 16(R2), [V2.S4]           // load block + advance
+    VLD1.P 32(R2), [V2.S4, V3.S4]
     WORD $0x4EA26C00                 // SMIN V0.4S, V0.4S, V2.4S
     WORD $0x4EA26421                 // SMAX V1.4S, V1.4S, V2.4S
-    SUB  $1, R4
-    CBNZ R4, maxabs_neon_loop
+    WORD $0x4EA36CA5                 // SMIN V5.4S, V5.4S, V3.4S
+    WORD $0x4EA364C6                 // SMAX V6.4S, V6.4S, V3.4S
+    SUB  $1, R7
+    CBNZ R7, maxabs_neon_loop
+    WORD $0x4EA56C00                 // SMIN V0.4S, V0.4S, V5.4S   (fold the pair)
+    WORD $0x4EA66421                 // SMAX V1.4S, V1.4S, V6.4S
+    TBZ  $0, R4, maxabs_neon_overlap // R4 even => no odd trailing block
+    VLD1.P 16(R2), [V2.S4]           // odd trailing block
+    WORD $0x4EA26C00                 // SMIN V0.4S, V0.4S, V2.4S
+    WORD $0x4EA26421                 // SMAX V1.4S, V1.4S, V2.4S
+    JMP  maxabs_neon_overlap
+
+maxabs_neon_narrow:
+    // Exactly one block after block 0 (R4 == 1). Block 0 is in V0/V1 and R2 still
+    // points at block 0; advance and fold the one remaining block single-accumulator.
+    ADD  $16, R2, R2                 // advance past block 0
+    VLD1 (R2), [V2.S4]               // block 1
+    WORD $0x4EA26C00                 // SMIN V0.4S, V0.4S, V2.4S
+    WORD $0x4EA26421                 // SMAX V1.4S, V1.4S, V2.4S
+
+maxabs_neon_overlap:
+    // Overlapping tail: when (n mod 4) != 0, fold the last 4 elements a[n-4:n] in
+    // as one .4S block before the horizontal reduce, so every element stays on the
+    // SIMD path (no scalar tail). Idempotency makes re-counting the overlap of
+    // already-processed elements harmless; the n >= 4 gate keeps a[n-4] in range.
+    AND  $3, R3, R4
+    CBZ  R4, maxabs_neon_reduce
+    SUB  $4, R3, R7                  // R7 = n - 4 (element index of the overlap block)
+    LSL  $2, R7, R7                 // R7 = (n-4)*4 bytes
+    MOVD a_base+0(FP), R2            // reload base (R2 was advanced past the full blocks)
+    ADD  R7, R2, R2                 // R2 = &a[n-4]
+    VLD1 (R2), [V2.S4]
+    WORD $0x4EA26C00                 // SMIN V0.4S, V0.4S, V2.4S
+    WORD $0x4EA26421                 // SMAX V1.4S, V1.4S, V2.4S
 
 maxabs_neon_reduce:
     WORD $0x4EB1A803                 // SMINV S3, V0.4S
@@ -674,19 +731,7 @@ maxabs_neon_reduce:
     FMOVS F3, R5                     // R5 = running min (low 32 = int32)
     FMOVS F4, R6                     // R6 = running max (low 32 = int32)
 
-    // scalar tail: (n mod 4) residuals (R2 already at &a[fullBlocks*4])
-    AND  $3, R3, R4
-    CBZ  R4, maxabs_neon_combine
-maxabs_neon_tail:
-    MOVW.P 4(R2), R7                 // r (sign-extended; low 32 = int32)
-    CMPW R5, R7                      // (R7 - R5), signed 32-bit
-    CSEL LT, R7, R5, R5             // R5 = min(r, R5)
-    CMPW R6, R7
-    CSEL GT, R7, R6, R6             // R6 = max(r, R6)
-    SUB  $1, R4
-    CBNZ R4, maxabs_neon_tail
-
-maxabs_neon_combine:
+    // combine: max(maxVal, -minVal)
     NEG  R5, R7                      // R7 = -min (low 32 = wrapping int32 negate)
     CMPW R7, R6                      // (R6 - R7), signed 32-bit: max vs -min
     CSEL GE, R6, R7, R0             // R0 = max(R6, R7) = max(maxVal, -minVal)

--- a/i32/maxabs_arm64_test.go
+++ b/i32/maxabs_arm64_test.go
@@ -10,16 +10,17 @@ import (
 )
 
 // TestMaxAbsNEON_ParityWithGo drives the kernel directly across lengths that force
-// the 4-wide vector body plus every (n mod 4) tail remainder (block boundaries and
-// primes in 4..40), over lengths the dispatcher would route the same way, so a
-// threshold change cannot quietly reduce this to a test of the Go reference against
-// itself. MinInt32 rides index 0 so the wrapping -minVal combine is exercised, and
-// MaxInt32 rides the last index so the overlapping final block must fold it in.
+// the 4-wide vector body plus every (n mod 4) tail remainder: aligned lengths
+// (residue 0, overlap skipped) and residue 1/2/3 lengths (overlap runs), over
+// lengths the dispatcher would route the same way, so a threshold change cannot
+// quietly reduce this to a test of the Go reference against itself. MinInt32 rides
+// index 0 so the wrapping -minVal combine is exercised, and MaxInt32 rides the last
+// index so the overlapping final block must fold it in.
 func TestMaxAbsNEON_ParityWithGo(t *testing.T) {
 	if !cpu.ARM64.NEON {
 		t.Skip("NEON not available")
 	}
-	lens := []int{4, 5, 7, 8, 9, 11, 13, 16, 17, 19, 23, 24, 29, 31, 32, 37, 40}
+	lens := []int{4, 5, 6, 7, 8, 9, 10, 11, 13, 14, 16, 17, 19, 22, 23, 24, 26, 29, 31, 32, 34, 37, 38, 40}
 	for _, n := range lens {
 		a := genI32(n, 71)
 		a[0] = math.MinInt32

--- a/i32/maxabs_arm64_test.go
+++ b/i32/maxabs_arm64_test.go
@@ -10,11 +10,11 @@ import (
 )
 
 // TestMaxAbsNEON_ParityWithGo drives the kernel directly across lengths that force
-// the 4-wide vector body plus every scalar-tail remainder (block boundaries and
+// the 4-wide vector body plus every (n mod 4) tail remainder (block boundaries and
 // primes in 4..40), over lengths the dispatcher would route the same way, so a
 // threshold change cannot quietly reduce this to a test of the Go reference against
 // itself. MinInt32 rides index 0 so the wrapping -minVal combine is exercised, and
-// MaxInt32 rides the last index so the scalar tail must be folded in.
+// MaxInt32 rides the last index so the overlapping final block must fold it in.
 func TestMaxAbsNEON_ParityWithGo(t *testing.T) {
 	if !cpu.ARM64.NEON {
 		t.Skip("NEON not available")
@@ -62,7 +62,7 @@ func TestMaxAbsNEON_PlantedExtreme(t *testing.T) {
 // past n is poisoned with the absolute extremes MinInt32 and MaxInt32, which would
 // dominate the signed min/max reduction if read. a is backing[:n] over a backing of
 // length n+8 (two full 4-wide blocks of slack), so a kernel that reads a stray block
-// or a scalar tail past n lands in the poisoned (still allocated) memory and its
+// or an overlap block past n lands in the poisoned (still allocated) memory and its
 // result flips away from the oracle over a[:n]; a correct kernel stops at n and
 // stays equal. For a min/max reduction the poison must be MORE extreme than any
 // in-range element, the opposite of an additive kernel where a zero or an

--- a/i32/reduce_tail_bench_test.go
+++ b/i32/reduce_tail_bench_test.go
@@ -26,3 +26,25 @@ func BenchmarkMinMax_N(b *testing.B) {
 		})
 	}
 }
+
+// BenchmarkMaxAbs_N is the MaxAbs sibling of BenchmarkMinMax_N (issue #289): it
+// guards the overlapping-final-block tail on the MaxAbs reduction at ragged
+// residue sizes. Instead of serving the (n mod 4) residue with a serial
+// compare/cmov scalar chain, one overlapping final .4S block re-folds the last
+// full block (idempotent signed min/max makes the double-count harmless). The
+// fixed-size MaxAbs benchmarks are residue-free (1000) or large (1003), so the
+// small ragged residues must be measured explicitly. n=8 is the aligned sentinel
+// (overlap skipped); 5/9 are residue 1 (the worst case, where a whole .4S fold
+// replaces a single scalar iteration), 7/15 are residue 3, and the larger ragged
+// sizes show the tail shrinking to a negligible fraction of the work.
+func BenchmarkMaxAbs_N(b *testing.B) {
+	for _, n := range []int{5, 7, 8, 9, 15, 25, 63, 255, 1023} {
+		a := genI32(n, 1)
+		b.Run(fmt.Sprintf("%d", n), func(b *testing.B) {
+			b.SetBytes(int64(n) * 4)
+			for b.Loop() {
+				_ = MaxAbs(a)
+			}
+		})
+	}
+}

--- a/i8/i8_arm64.go
+++ b/i8/i8_arm64.go
@@ -119,6 +119,12 @@ func negI8(dst, a []int8) {
 	negGo(dst, a)
 }
 
+// maxAbsI8 dispatches the per-tensor abs-max reduction. The NEON kernel folds
+// 16-byte blocks through a 2-block unroll with dual UMAX-of-ABS accumulators,
+// folds an overlapping final .16B block in place of a scalar tail, then reduces
+// with UMAXV, so the n >= minNEON16 (16) gate is a correctness floor (the overlap
+// block reloads a[n-16]), not just a performance cut; shorter slices use the
+// pure-Go reference.
 func maxAbsI8(a []int8) int {
 	if hasNEON && len(a) >= minNEON16 {
 		return maxAbsNEON(a)

--- a/i8/i8_arm64.s
+++ b/i8/i8_arm64.s
@@ -603,45 +603,65 @@ neg_done:
 
 // func maxAbsNEON(a []int8) int
 // Per-tensor abs-max for dynamic quantization: ABS maps each byte to its
-// magnitude (abs(-128) -> 0x80, i.e. 128 read unsigned), UMAX folds 16-byte
-// blocks into an unsigned-max accumulator, UMAXV reduces it to a byte, and a
-// scalar tail folds the (n mod 16) remainder. The byte is read zero-extended,
-// so the result lands in [0, 128].
+// magnitude (abs(-128) -> 0x80, i.e. 128 read unsigned) and UMAX folds 16-byte
+// blocks into an unsigned-max accumulator. A 2-block unroll keeps two independent
+// UMAX chains (V2, V4) so the compare latency stays off the loop-carried critical
+// path (same latency-hiding rewrite as minMaxNEON, #283); a possible odd trailing
+// block folds into the first chain, the two chains are combined, and when
+// (n mod 16) != 0 the last 16 elements a[n-16:n] are folded in as one overlapping
+// .16B block so every element stays on the SIMD path (no scalar tail). UMAXV then
+// reduces the accumulator to a byte. The dispatch gates n >= 16, so block 0 and
+// the a[n-16] overlap block are always in range. UMAX-of-ABS is idempotent and
+// has no accumulation order, so re-counting the overlap of already-processed
+// elements double-counts harmlessly and the result is bit-identical to maxAbsGo.
+// The byte is read zero-extended, so the result lands in [0, 128]. The overlap
+// block replaces a scalar tail of up to 15 CSEL iterations.
 TEXT ·maxAbsNEON(SB), NOSPLIT, $0-32
     MOVD a_base+0(FP), R1
     MOVD a_len+8(FP), R3
 
-    VEOR V2.B16, V2.B16, V2.B16   // unsigned-max accumulator = 0
-    LSR  $4, R3, R4               // R4 = n / 16
-    CBZ  R4, maxabs_reduce
+    VEOR V2.B16, V2.B16, V2.B16   // unsigned-max accumulator 1 = 0
+    VEOR V4.B16, V4.B16, V4.B16   // unsigned-max accumulator 2 = 0
+    LSR  $4, R3, R4               // R4 = full 16-byte blocks (>=1, gate floor)
+    LSR  $1, R4, R7             // R7 = pairs = blocks / 2
+    CBZ  R7, maxabs_odd
 
-maxabs_loop16:
-    VLD1.P 16(R1), [V0.B16]
+maxabs_loop32:
+    VLD1.P 32(R1), [V0.B16, V1.B16]
     WORD $0x4E20B800             // ABS  V0.16B, V0.16B   (|a|; abs(-128)=0x80)
+    WORD $0x4E20B821             // ABS  V1.16B, V1.16B
     WORD $0x6E206442             // UMAX V2.16B, V2.16B, V0.16B
-    SUB  $1, R4
-    CBNZ R4, maxabs_loop16
+    WORD $0x6E216484             // UMAX V4.16B, V4.16B, V1.16B
+    SUB  $1, R7
+    CBNZ R7, maxabs_loop32
+
+maxabs_odd:
+    TBZ  $0, R4, maxabs_foldpairs   // R4 (full blocks) even => no leftover block
+    VLD1.P 16(R1), [V0.B16]
+    WORD $0x4E20B800             // ABS  V0.16B, V0.16B
+    WORD $0x6E206442             // UMAX V2.16B, V2.16B, V0.16B
+
+maxabs_foldpairs:
+    WORD $0x6E246442             // UMAX V2.16B, V2.16B, V4.16B   (combine the two chains)
+
+maxabs_overlap:
+    // Overlapping tail: when (n mod 16) != 0, fold the last 16 elements a[n-16:n]
+    // in as one .16B block before the horizontal reduce, so every element stays on
+    // the SIMD path (no scalar tail). Idempotency makes re-counting the overlap of
+    // already-processed elements harmless; the n >= 16 gate keeps a[n-16] in range.
+    AND  $15, R3, R4
+    CBZ  R4, maxabs_reduce
+    SUB  $16, R3, R7            // R7 = n - 16 (element index of the overlap block)
+    MOVD a_base+0(FP), R1       // reload base (R1 was advanced past the full blocks)
+    ADD  R7, R1, R1            // R1 = &a[n-16] (int8 => 1 byte per element)
+    VLD1 (R1), [V0.B16]
+    WORD $0x4E20B800             // ABS  V0.16B, V0.16B
+    WORD $0x6E206442             // UMAX V2.16B, V2.16B, V0.16B
 
 maxabs_reduce:
     WORD $0x6E30A843             // UMAXV B3, V2.16B
     FMOVS F3, R5                  // R5 = abs-max byte (zero-extended)
     AND  $0xFF, R5, R5            // defensively keep only the byte, [0, 128]
-
-    AND  $15, R3
-    CBZ  R3, maxabs_done
-
-maxabs_scalar:
-    MOVB (R1), R6                 // v (sign-extended)
-    NEG  R6, R7                   // -v
-    CMP  $0, R6
-    CSEL LT, R7, R6, R6           // |v| = v < 0 ? -v : v   (can be 128)
-    CMP  R5, R6
-    CSEL HI, R6, R5, R5           // unsigned: |v| > max ? |v| : max
-    ADD  $1, R1
-    SUB  $1, R3
-    CBNZ R3, maxabs_scalar
-
-maxabs_done:
     MOVD R5, ret+24(FP)
     RET
 

--- a/i8/maxabs_arm64_test.go
+++ b/i8/maxabs_arm64_test.go
@@ -1,0 +1,109 @@
+//go:build arm64
+
+package i8
+
+import (
+	"testing"
+
+	"github.com/tphakala/simd/cpu"
+)
+
+// TestMaxAbsNEON_ParityWithGo drives the kernel directly across lengths that force
+// the 2-block-unrolled 16-wide body plus every overlap-tail remainder (block
+// boundaries and ragged residues in 16..128), over lengths the dispatcher would
+// route the same way, so a threshold change cannot quietly reduce this to a test of
+// the Go reference against itself. -128 rides index 0 and the last index: its
+// magnitude 128 is the unique peak, so the overlap block must fold the tail lane in
+// or the result drops below 128.
+func TestMaxAbsNEON_ParityWithGo(t *testing.T) {
+	if !cpu.ARM64.NEON {
+		t.Skip("NEON not available")
+	}
+	lens := []int{16, 17, 19, 23, 31, 32, 33, 40, 47, 48, 63, 64, 65, 79, 80, 95, 127, 128}
+	for _, n := range lens {
+		a := genI8(n, 71)
+		a[0] = -128
+		a[n-1] = -128
+		if got, want := maxAbsNEON(a), maxAbsGo(a); got != want {
+			t.Fatalf("maxAbsNEON n=%d = %d, want %d (reference)", n, got, want)
+		}
+	}
+}
+
+// TestMaxAbsNEON_PlantedExtreme plants the result-driving extreme (-128, magnitude
+// 128) at every position of a two-block-plus-tail length, so a kernel that drops a
+// vector lane, mis-seeds a UMAX accumulator, or skips the overlap tail misses the
+// extreme where it lives and is caught. n=33 is two 16-wide blocks plus a residue-1
+// tail (exercises the 2-block unroll, the odd-block fold, the chain combine, and the
+// overlap block); n=17 is the single-block fast path plus a residue-1 tail.
+func TestMaxAbsNEON_PlantedExtreme(t *testing.T) {
+	if !cpu.ARM64.NEON {
+		t.Skip("NEON not available")
+	}
+	for _, n := range []int{17, 33} {
+		for pos := range n {
+			a := make([]int8, n)
+			for i := range a {
+				a[i] = int8(i%50 - 25) // tame body, magnitude <= 25
+			}
+			a[pos] = -128
+			if got, want := maxAbsNEON(a), maxAbsGo(a); got != want {
+				t.Fatalf("maxAbsNEON n=%d pos=%d = %d, want %d", n, pos, got, want)
+			}
+		}
+	}
+}
+
+// TestMaxAbsNEON_OverRead catches a kernel that reads past len(a). The in-range body
+// is tame (magnitude <= 25, so the true peak is 25), while the slack past n is
+// poisoned with -128 (magnitude 128), which would dominate the UMAX-of-ABS reduction
+// if read. a is backing[:n] over a backing of length n+16 (one full 16-wide block of
+// slack), so a kernel that reads a stray block or a scalar tail past n lands in the
+// poisoned (still allocated) memory and its result jumps to 128; a correct kernel
+// stops at n and stays at the tame peak.
+func TestMaxAbsNEON_OverRead(t *testing.T) {
+	if !cpu.ARM64.NEON {
+		t.Skip("NEON not available")
+	}
+	for _, n := range []int{16, 17, 23, 31, 33, 47, 63} {
+		backing := make([]int8, n+16)
+		for i := range backing {
+			backing[i] = int8(i%50 - 25) // tame body: magnitude <= 25
+		}
+		for i := n; i < len(backing); i++ {
+			backing[i] = -128 // poison the slack with the peak magnitude
+		}
+		a := backing[:n]
+		if got, want := maxAbsNEON(a), maxAbsGo(a); got != want {
+			t.Fatalf("maxAbsNEON n=%d = %d, want %d: kernel read past n into poisoned slack", n, got, want)
+		}
+	}
+}
+
+// TestMaxAbsNEON_AllocFree asserts the kernel runs allocation-free, the repo's
+// zero-allocation contract enforced at the kernel boundary.
+func TestMaxAbsNEON_AllocFree(t *testing.T) {
+	if !cpu.ARM64.NEON {
+		t.Skip("NEON not available")
+	}
+	a := make([]int8, 1024)
+	for i := range a {
+		a[i] = int8(i*7 - 500)
+	}
+	if got := testing.AllocsPerRun(100, func() { _ = maxAbsNEON(a) }); got != 0 {
+		t.Errorf("maxAbsNEON allocated %v times per run, want 0", got)
+	}
+}
+
+// TestMaxAbsDispatch_ReachesNEON pins the dispatch state MaxAbs depends on. It is a
+// white-box check: the NEON kernel is bit-identical to the Go reference by design, so
+// a dispatcher that silently routed every call to Go would pass every parity test.
+// It must not call t.Parallel(): it reads package-level dispatch state.
+func TestMaxAbsDispatch_ReachesNEON(t *testing.T) {
+	if hasNEON != cpu.ARM64.NEON {
+		t.Fatalf("hasNEON = %v but cpu.ARM64.NEON = %v: dispatch flag is not wired to CPU detection", hasNEON, cpu.ARM64.NEON)
+	}
+	if minNEON16 > 32 {
+		t.Fatalf("minNEON16 = %d exceeds two vector blocks: MaxAbs would not vectorize at the lengths it was written for", minNEON16)
+	}
+}

--- a/i8/maxabs_arm64_test.go
+++ b/i8/maxabs_arm64_test.go
@@ -106,4 +106,9 @@ func TestMaxAbsDispatch_ReachesNEON(t *testing.T) {
 	if minNEON16 > 32 {
 		t.Fatalf("minNEON16 = %d exceeds two vector blocks: MaxAbs would not vectorize at the lengths it was written for", minNEON16)
 	}
+	// Lower bound: the overlap tail reloads a[n-16], so the kernel must never be
+	// dispatched below one 16-byte block or it would read out of bounds.
+	if minNEON16 < 16 {
+		t.Fatalf("minNEON16 = %d is below maxAbsNEON's 16-byte block: the overlap reload of a[n-16] would read out of bounds", minNEON16)
+	}
 }

--- a/i8/reduce_tail_bench_test.go
+++ b/i8/reduce_tail_bench_test.go
@@ -9,16 +9,19 @@ import (
 // on the MaxAbs/MinMax reductions: instead of serving the (n mod width) residue
 // with a serial compare/cmov scalar chain, one overlapping final vector block
 // re-folds the last full block. amd64 got this for both MaxAbs and MinMax in #149;
-// arm64 NEON now has it for MinMax too (issue #286), while NEON MaxAbs still uses a
-// scalar tail.
+// arm64 NEON now has it for both MinMax (issue #286) and MaxAbs (issue #289).
 // The fixed 4096-byte benchmarks are residue-free and never run the overlap block,
 // so ragged residue lengths must be measured explicitly. 32 is an aligned sentinel
-// (overlap skipped on the 16- and 32-wide kernels alike). At the arm64 16-wide
-// width 40/63/95/248 are ragged and run the overlap while 48 is aligned there
+// (overlap skipped on the 16- and 32-wide kernels alike). 17 and 25 are the
+// single-block-plus-ragged-tail range: on the arm64 16-wide kernels they are one
+// block (the 2-block unroll never runs, only the odd-block fold and the overlap),
+// the most tail-dominated NEON case; on amd64 they fall below the 32-wide dispatch
+// threshold and measure the sub-threshold path there. At the arm64 16-wide width
+// 40/63/95/248 are ragged and run the overlap while 48 is aligned there
 // (48 mod 16 == 0); at the amd64 32-wide width all of 40/48/63/95/248 are ragged,
 // with 63 and 95 at the worst-case residue 31.
 func BenchmarkMaxAbs_N(b *testing.B) {
-	for _, n := range []int{32, 40, 48, 63, 95, 248} {
+	for _, n := range []int{17, 25, 32, 40, 48, 63, 95, 248} {
 		a := genI8(n, 1)
 		b.Run(fmt.Sprintf("%d", n), func(b *testing.B) {
 			b.SetBytes(int64(n))
@@ -30,7 +33,7 @@ func BenchmarkMaxAbs_N(b *testing.B) {
 }
 
 func BenchmarkMinMax_N(b *testing.B) {
-	for _, n := range []int{32, 40, 48, 63, 95, 248} {
+	for _, n := range []int{17, 25, 32, 40, 48, 63, 95, 248} {
 		a := genI8(n, 1)
 		b.Run(fmt.Sprintf("%d", n), func(b *testing.B) {
 			b.SetBytes(int64(n))


### PR DESCRIPTION
## Summary

Applies the shipped `minMaxNEON` overlapping-final-block tail (#288) to the integer `maxAbsNEON` reductions, replacing the scalar CSEL tail with one overlapping final SIMD block that re-folds the last full block. ABS is elementwise and the max fold is idempotent, so re-counting the overlap double-counts harmlessly and the result stays bit-identical to `maxAbsGo`. The `n >= width` dispatch gates are now correctness floors (the overlap reloads `a[n-width]`).

i8: a dual-accumulator 2-block (`.16B` x2) unroll plus the overlapping `.16B` tail. Core-pinned Cortex-A76 A/B vs `main`: -39% geomean, up to -60% at the worst-case residue n=63, and -7% at aligned n=32 from the unroll alone.

i32: the overlapping `.4S` tail plus a guarded dual-accumulator 2-block unroll. The second accumulator pair is seeded only inside the wide-loop branch, so small inputs keep the single-accumulator cost (the same guard `sumNEON` uses). Core-pinned Cortex-A76 A/B vs `main`: -16% geomean, with the mid/large-n body -28% to -36% (n=63..1023); the residue-1 n=5 case is about 0.4 ns slower, the same overlap tradeoff `minMaxNEON` already documents.

i16 was measured and declined: its overlap regressed small ragged n (+11.7% at n=25) with only a marginal large-n gain, so it stays on the scalar tail.

New encodings are limited to three i8 NEON WORD directives (`ABS V1.16B`, two `UMAX`), verified with `aarch64-linux-gnu-as` and cross-checked by the `asmcheck` suite; i32 reuses the `minMaxNEON` SMIN/SMAX encodings verbatim. Adds a direct-kernel i8 `maxAbsNEON` test suite (parity, planted-extreme, over-read, alloc-free, dispatch) to match the i32/i16 siblings, and an i32 ragged-size MaxAbs benchmark.

## Related Issues

Fixes #289

## Test Plan

- [x] `GOOS=linux GOARCH=arm64 go build ./...`, `go vet ./...`, `golangci-lint run ./...` (0 issues)
- [x] amd64 suite plus the `asmcheck` WORD cross-check (`TestArm64WordEncodings`, `TestNoGoroutineRegisterClobber`)
- [x] Full i8/i32 suites on native Cortex-A76 (Raspberry Pi 5): parity, planted-extreme, over-read, alloc-free, fuzz
- [x] Core-pinned A/B benchmarks on Cortex-A76 for every kept kernel

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Performance**
  * Improved ARM64 NEON acceleration for 32-bit and 8-bit maximum absolute-value calculations.
  * Optimized processing for larger inputs and lengths that are not evenly aligned to vector block sizes.
  * Maintained correct results across boundary cases, including signed integer extremes.

* **Testing**
  * Expanded ARM64 coverage for vector boundaries, irregular input lengths, memory safety, allocation behavior, and CPU feature dispatch.
  * Added benchmarks for aligned and irregular input sizes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->